### PR TITLE
Persistir preferencias de modo oscuro/claro

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<ion-app [class.dark-theme]="dark">
+<ion-app [class.dark-theme]="darkMode">
   <ion-split-pane contentId="main-content">
     <ion-menu contentId="main-content">
       <ion-content>
@@ -43,7 +43,7 @@
           <ion-item>
             <ion-icon slot="start" name="moon-outline"></ion-icon>
             <ion-label> Modo Oscuro </ion-label>
-            <ion-toggle [(ngModel)]="dark"></ion-toggle>
+            <ion-toggle [ngModel]="darkMode" (ionChange)="onModeChange($event)"></ion-toggle>
           </ion-item>
         </ion-list>
       </ion-content>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,8 +5,7 @@ import { MenuController, Platform } from "@ionic/angular";
 
 import { SplashScreen } from "@ionic-native/splash-screen/ngx";
 import { StatusBar } from "@ionic-native/status-bar/ngx";
-
-import { Storage } from "@ionic/storage";
+import { SettingsService } from "./providers/settings.service";
 
 @Component({
   selector: "app-root",
@@ -39,7 +38,7 @@ export class AppComponent {
   ];
 
   loggedIn = false;
-  dark = false;
+  public darkMode = false;
 
   constructor(
     private menu: MenuController,
@@ -47,7 +46,7 @@ export class AppComponent {
     private router: Router,
     private splashScreen: SplashScreen,
     private statusBar: StatusBar,
-    private storage: Storage
+    private settingsService: SettingsService
   ) {
     this.initializeApp();
   }
@@ -56,6 +55,13 @@ export class AppComponent {
     this.platform.ready().then(() => {
       this.statusBar.styleDefault();
       this.splashScreen.hide();
+      this.settingsService.darkMode$.subscribe(
+        (value) => (this.darkMode = value)
+      );
     });
+  }
+
+  public async onModeChange(event: CustomEvent) {
+    this.settingsService.setDarkModeSettings(event.detail.checked);
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,18 +1,19 @@
-import { HttpClientModule } from '@angular/common/http';
-import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { InAppBrowser } from '@ionic-native/in-app-browser/ngx';
-import { SplashScreen } from '@ionic-native/splash-screen/ngx';
-import { StatusBar } from '@ionic-native/status-bar/ngx';
-import { IonicModule } from '@ionic/angular';
-import { IonicStorageModule } from '@ionic/storage';
+import { HttpClientModule } from "@angular/common/http";
+import { NgModule } from "@angular/core";
+import { BrowserModule } from "@angular/platform-browser";
+import { InAppBrowser } from "@ionic-native/in-app-browser/ngx";
+import { SplashScreen } from "@ionic-native/splash-screen/ngx";
+import { StatusBar } from "@ionic-native/status-bar/ngx";
+import { IonicModule } from "@ionic/angular";
+import { IonicStorageModule } from "@ionic/storage-angular";
 
-import { AppRoutingModule } from './app-routing.module';
-import { AppComponent } from './app.component';
-import { ServiceWorkerModule } from '@angular/service-worker';
-import { environment } from '../environments/environment';
-import { FormsModule } from '@angular/forms';
-import {StoryService} from "./providers/story.service";
+import { AppRoutingModule } from "./app-routing.module";
+import { AppComponent } from "./app.component";
+import { ServiceWorkerModule } from "@angular/service-worker";
+import { environment } from "../environments/environment";
+import { FormsModule } from "@angular/forms";
+import { StoryService } from "./providers/story.service";
+import { SettingsService } from "./providers/settings.service";
 
 @NgModule({
   imports: [
@@ -22,12 +23,18 @@ import {StoryService} from "./providers/story.service";
     FormsModule,
     IonicModule.forRoot(),
     IonicStorageModule.forRoot(),
-    ServiceWorkerModule.register('ngsw-worker.js', {
-      enabled: environment.production
-    })
+    ServiceWorkerModule.register("ngsw-worker.js", {
+      enabled: environment.production,
+    }),
   ],
   declarations: [AppComponent],
-  providers: [InAppBrowser, SplashScreen, StatusBar, StoryService],
-  bootstrap: [AppComponent]
+  providers: [
+    InAppBrowser,
+    SettingsService,
+    SplashScreen,
+    StatusBar,
+    StoryService,
+  ],
+  bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/providers/settings.service.ts
+++ b/src/app/providers/settings.service.ts
@@ -1,0 +1,32 @@
+import {Injectable} from "@angular/core";
+import {BehaviorSubject} from "rxjs";
+import {Storage} from "@ionic/storage-angular";
+
+@Injectable({ providedIn: "root" })
+export class SettingsService {
+  private _storage: Storage | null = null;
+  public darkMode$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
+    false
+  );
+
+  constructor(private storage: Storage) {
+    this.load();
+  }
+
+  public async load() {
+    this._storage = await this.storage.create();
+    this.getDarkModeSettings();
+  }
+
+  public async getDarkModeSettings() {
+    const darkMode = await this._storage.get("darkMode");
+    if (darkMode) {
+      this.darkMode$.next(darkMode);
+    }
+  }
+
+  public async setDarkModeSettings(value: boolean) {
+    await this._storage.set("darkMode", value);
+    this.darkMode$.next(value);
+  }
+}


### PR DESCRIPTION
Agregada funcionalidad para guardar settings de darkMode en ionic-storage. Agregado provider con un behaviorSubject para mantener la configuración y, de ser necesario, guardarla luego de un cambio.