### PR TITLE
Borradas referencias a enero. Cambios para SEO.

### DIFF
--- a/src/app/pages/about/about.html
+++ b/src/app/pages/about/about.html
@@ -17,7 +17,7 @@
     <div class="about-info">
         <p class="ion-padding-start ion-padding-end ion-text-justify">
             <strong>"Cuentos de Verano"</strong> es una iniciativa colectiva que busca fomentar la lectura y compartir
-            relatos breves en el ámbito digital, mediante la publicación de un cuento por cada día de enero de 2022.
+            relatos breves en el ámbito digital, mediante la publicación de un cuento por cada día del verano de 2022.
             Para acompañarnos en las lecturas a través de los distintos cuentos que corresponden a cada día, contamos
             con <strong>La Cuentoneta</strong> — la app web que ahora estás usando — para leerlas y compartirlas.
         </p>

--- a/src/app/pages/list/list.html
+++ b/src/app/pages/list/list.html
@@ -16,17 +16,18 @@
       (click)="navigateToStory(story.day)"
     >
       <ion-avatar slot="start">
-        <img [src]="story.author.imageUrl" />
+        <img [src]="story.author.imageUrl" alt="Imagen del autor del cuento"/>
       </ion-avatar>
       <ion-label>
         <h2>{{story.title}}</h2>
         <h3>
           por {{story.author.name}}<img
+          alt="Imagen de la bandera de nacionalidad del autor del cuento"
             class="nationality-flag"
             [src]="story.author.nationality"
           />
         </h3>
-        <p>Día {{story.day}}/31</p>
+        <p>Día {{story.day}}</p>
       </ion-label>
     </ion-item>
   </ion-list>

--- a/src/index.html
+++ b/src/index.html
@@ -1,64 +1,73 @@
 <!DOCTYPE html>
 <html lang="es" dir="ltr">
-  <head>
-    <meta charset="UTF-8" />
-    <title>La Cuentoneta</title>
+    <head>
+        <meta charset="UTF-8" />
+        <title>Cuentos de Verano: La Cuentoneta</title>
 
-    <meta
-      name="viewport"
-      content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
-    <meta name="format-detection" content="telephone=no" />
-    <meta name="msapplication-tap-highlight" content="no" />
+        <meta
+            name="viewport"
+            content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
+        />
+        <meta name="format-detection" content="telephone=no" />
+        <meta name="msapplication-tap-highlight" content="no" />
 
-    <meta name="theme-color" content="#387ef5" />
+        <meta name="theme-color" content="#387ef5" />
 
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta
-      name="apple-mobile-web-app-status-bar-style"
-      content="black-translucent"
-    />
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="31 días - 31 cuentos" />
-    <meta property="og:title" content="Cuentos de Verano: La Cuentoneta" />
-    <meta property="og:image:alt" content="Cuentoneta: una minivan con libros, dejando uno por cada día de enero de 2022" />
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:creator" content="@rolivenc" />
-    <meta name="twitter:description" content="Una lectura colectiva digital de cuentos y relatos breves por cada día de enero durante el verano de 2022. Subite a la Cuentoneta.">
-    <meta name="twitter:image" content="https://inhabitat.com/wp-content/blogs.dir/1/files/2013/08/Tell-a-Story-Book-Van-lead.jpg">
-    <meta
-      property="og:image"
-      content="https://inhabitat.com/wp-content/blogs.dir/1/files/2013/08/Tell-a-Story-Book-Van-lead.jpg"
-    />
-    <meta
-      property="og:description"
-      content="Una lectura colectiva digital de cuentos y relatos breves por cada día de enero durante el verano de 2022. Subite a la Cuentoneta."
-    />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="Un cuento nuevo por cada día de verano" />
+        <meta property="og:title" content="Cuentos de Verano: La Cuentoneta" />
+        <meta
+            property="og:image:alt"
+            content="Cuentoneta: una minivan con libros, dejando uno por cada día de verano de 2022"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:creator" content="@rolivenc" />
+        <meta
+            name="twitter:description"
+            content="Una lectura colectiva digital de cuentos, narraciones y relatos breves por cada día del verano de 2022. Subite a la Cuentoneta."
+        />
+        <meta
+            name="twitter:image"
+            content="https://inhabitat.com/wp-content/blogs.dir/1/files/2013/08/Tell-a-Story-Book-Van-lead.jpg"
+        />
+        <meta
+            property="og:image"
+            content="https://inhabitat.com/wp-content/blogs.dir/1/files/2013/08/Tell-a-Story-Book-Van-lead.jpg"
+        />
+        <meta
+            property="og:description"
+            content="Una lectura colectiva digital de cuentos, narraciones y relatos breves por cada día del verano de 2022. Subite a la Cuentoneta."
+        />
 
-    <base href="/" />
+        <base href="/" />
 
-    <link rel="icon" type="image/x-icon" href="assets/img/logo.png" />
-    <link rel="apple-touch-icon" href="assets/img/logo.png" />
-    <link rel="manifest" href="manifest.json" />
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7D4QBRC7S6"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+        <link rel="icon" type="image/x-icon" href="assets/img/logo.png" />
+        <link rel="apple-touch-icon" href="assets/img/logo.png" />
+        <link rel="manifest" href="manifest.json" />
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-7D4QBRC7S6"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+                dataLayer.push(arguments);
+            }
+            gtag('js', new Date());
 
-      gtag('config', 'G-7D4QBRC7S6');
-    </script>
-  </head>
+            gtag('config', 'G-7D4QBRC7S6');
+        </script>
+    </head>
 
-  <body>
-    <app-root></app-root>
+    <body>
+        <app-root></app-root>
 
-    <!-- Replace the API key with your own, see:
+        <!-- Replace the API key with your own, see:
     https://developers.google.com/maps/documentation/javascript/get-api-key -->
-    <!-- <script async="" defer="" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB8pf6ZdFQj5qw7rc_HSGrhUwQKfIe9ICw"></script> -->
+        <!-- <script async="" defer="" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB8pf6ZdFQj5qw7rc_HSGrhUwQKfIe9ICw"></script> -->
 
-    <noscript
-      >Please enable JavaScript to continue using this application.</noscript
-    >
-  </body>
+        <noscript
+            >Una lectura colectiva digital de cuentos, narraciones y relatos breves por cada día del verano de 2022.
+            Accedé a nuestro sitio y sumate a la experiencia con La Cuentoneta.</noscript
+        >
+    </body>
 </html>


### PR DESCRIPTION
* Eliminadas referencias a enero y reemplazadas por "verano". Eliminada cuenta de 31 días en lista de cuentos
* Reemplazado el texto en "noscript", para mejorar SEO.