### PR TITLE
[#430] Soporte para texto de múltiples párrafos en reseñas

### DIFF
--- a/cms/schemas/author.ts
+++ b/cms/schemas/author.ts
@@ -25,7 +25,7 @@ export default {
         {
             name: 'bio',
             title: 'Biografía',
-            type: 'text',
+            type: 'blockContent',
         },
         {
             name: 'fullBioUrl',

--- a/scripts/migrateTextToBlockContent.ts
+++ b/scripts/migrateTextToBlockContent.ts
@@ -1,0 +1,79 @@
+/* eslint-disable no-console */
+import { client } from '../src/api/_helpers/sanity-connector';
+
+function makeid(length: number) {
+  let result = '';
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+  let counter = 0;
+  while (counter < length) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    counter += 1;
+  }
+  return result;
+}
+
+// length(description) returns null if description isn't a (Portable Text) array
+const fetchDocuments = () =>
+  client.fetch(
+    `*[_type == 'author'] {_id, _rev, bio}`
+  );
+
+const buildPatches = (docs: any[]) =>
+  docs.map((doc) => ({
+    id: doc._id,
+    patch: {
+      set: {
+        bio: [
+          {
+            style: 'normal',
+            _type: 'block',
+            children: [
+              {
+                _type: 'span',
+                marks: [],
+                text: doc.bio,
+                _key: makeid(32)
+              },
+            ],
+            markDefs: [],
+            _key: makeid(32)
+          },
+        ],
+      },
+      // this will cause the migration to fail if any of the documents has been
+      // modified since it was fetched.
+      ifRevisionID: doc._rev,
+    },
+  }));
+
+const createTransaction = (patches: any) =>
+  patches.reduce(
+    (tx: any, patch: any) => tx.patch(patch.id, patch.patch),
+    client.transaction()
+  );
+
+const commitTransaction = (tx: any) => tx.commit();
+
+const migrateNextBatch = async (): Promise<any> => {
+  const documents = (await fetchDocuments()).filter((doc: any) => typeof(doc.bio) === 'string');
+  const patches = buildPatches(documents);
+  if (patches.length === 0) {
+    console.log('No more documents to migrate!');
+    return null;
+  }
+  console.log(
+    `Migrating batch:\n %s`,
+    patches
+      .map((patch) => `${patch.id} => ${JSON.stringify(patch.patch)}`)
+      .join('\n')
+  );
+  const transaction = createTransaction(patches);
+  await commitTransaction(transaction);
+  return migrateNextBatch();
+};
+
+migrateNextBatch().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/components/bio-summary-card/bio-summary-card.component.html
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.html
@@ -43,10 +43,10 @@
     </section>
     <section class="bio-and-summary" *ngIf="story.author as author">
         <ng-container *ngFor="let paragraph of author.biography">
-            <p>{{ paragraph }}</p>
+            <p [innerHTML]="paragraph"></p>
         </ng-container>
         <ng-container *ngFor="let paragraph of story.summary">
-            <p>{{ paragraph }}</p>
+            <p [innerHTML]="paragraph"></p>
         </ng-container>
     </section>
 </div>

--- a/src/app/components/bio-summary-card/bio-summary-card.component.html
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.html
@@ -42,9 +42,11 @@
         </ng-container>
     </section>
     <section class="bio-and-summary" *ngIf="story.author as author">
-        <p>{{ author.biography }}</p>
-        <ng-container *ngIf="story.summary as summary">
-            <p [innerHTML]="summary"></p>
+        <ng-container *ngFor="let paragraph of author.biography">
+            <p>{{ paragraph }}</p>
+        </ng-container>
+        <ng-container *ngFor="let paragraph of story.summary">
+            <p>{{ paragraph }}</p>
         </ng-container>
     </section>
 </div>

--- a/src/app/models/author.model.ts
+++ b/src/app/models/author.model.ts
@@ -3,7 +3,7 @@ export interface Author {
     name: string;
     imageUrl: string;
     nationality: AuthorNationality;
-    biography?: string;
+    biography?: string[];
     fullBioUrl: string;
 }
 

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -14,7 +14,7 @@ export interface StoryBase {
 
 export interface Story extends StoryBase {
     prologues: Prologue[];
-    summary: string;
+    summary: string[];
     paragraphs: string[];
 }
 

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -37,7 +37,7 @@ export class StoryService {
       paragraphs:
         story?.paragraphs?.map((x: string) => this.parseParagraph(x)) ?? [],
       summary:
-        story?.summary?.map((x: string) => this.parseParagraph(x))?.pop() ?? '',
+        story?.summary?.map((x: string) => this.parseParagraph(x)) ?? [],
     };
   }
 
@@ -48,10 +48,10 @@ export class StoryService {
       paragraphs:
         story?.paragraphs?.map((x: string) => this.parseParagraph(x)) ?? [],
       summary:
-        story?.summary?.map((x: string) => this.parseParagraph(x))?.pop() ?? '',
+        story?.summary?.map((x: string) => this.parseParagraph(x)) ?? [],
       author: {
         ...story.author,
-        biography: this.parseParagraph(story.author.biography),
+        biography: story.author.biography?.map(x => this.parseParagraph(x)) ?? [],
       },
     };
   }


### PR DESCRIPTION
# Resumen

- Se agrega soporte para texto en múltiples párrafos en las reseñas de historias y bios de autores.
- Se modifican modelos y schemas para reflejar los tipos correspondientes en las propiedades afectadas. Las propiedades de tipo `string` pasan a ser `string[]` en los modelos y los campos `text` pasan a ser `blockContent` en el schema de Sanity.
- Se agrega script para migración de datos en producción.