### PR TITLE
[#114] Agregar tipo BlockContent de Sanity para propiedades en interface StoryDTO

### DIFF
--- a/src/api/story.service.ts
+++ b/src/api/story.service.ts
@@ -21,12 +21,14 @@ async function fetchForRead(req: any, res: any) {
                           }[0]`;
     const story = await client.fetch(query, {});
 
+    const { body, review, author, forewords, ...properties } = story;
+
     res.json({
-      ...story,
-      summary: story.review,
-      paragraphs: story.body,
-      author: mapAuthor(story.author),
-      prologues: mapPrologues(story.forewords),
+      ...properties,
+      author: mapAuthor(author),
+      prologues: mapPrologues(forewords),
+      paragraphs: body,
+      summary: review,
     });
   }
 }

--- a/src/app/models/block-content.model.ts
+++ b/src/app/models/block-content.model.ts
@@ -1,0 +1,27 @@
+/**
+ * Interfaces utilizadas para el manejo de los bloques de texto en el CMS
+ * "BlockContent" es un tipo de dato que se utiliza para almacenar los bloques de texto en Sanity.
+ *
+ * A fin de hacer más robusto el manejo de los bloques de texto, se declara esta interfaz y sus dependencias.
+ */
+
+export interface BlockContent {
+    _type: 'block';
+    _key: string;
+    children: Block[];
+    markDefs?: MarkDef[];
+    style?: string;
+}
+
+export interface Block {
+    _type: 'span';
+    _key: string;
+    text: string;
+    marks?: string[];
+}
+
+export interface MarkDef {
+    _type: 'link';
+    _key: string;
+    href: string;
+}

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -1,30 +1,30 @@
 import { Author } from './author.model';
 import { Prologue } from './prologue.model';
+import { BlockContent } from '@models/block-content.model';
 
 export interface StoryBase {
-    id: number;
-    title: string;
-    slug: string;
-    approximateReadingTime: number;
-    author: Author;
-    originalLink?: string;
-    videoUrl?: string;
-    badLanguage?: boolean;
+  id: number;
+  title: string;
+  slug: string;
+  approximateReadingTime: number;
+  author: Author;
+  originalLink?: string;
+  videoUrl?: string;
+  badLanguage?: boolean;
 }
 
 export interface Story extends StoryBase {
-    prologues: Prologue[];
-    summary: string[];
-    paragraphs: string[];
+  prologues: Prologue[];
+  summary: string[];
+  paragraphs: string[];
 }
 
-// ToDo: Agregar tipo BlockContent para tratar datos de texto que vienen desde Sanity (#114)
 export interface StoryDTO extends StoryBase {
-    prologues: any[];
-    summary: any[];
-    paragraphs: any[];
+  prologues: any[];
+  summary: BlockContent[];
+  paragraphs: BlockContent[];
 }
 
 export interface StoryCard extends Story {
-    author: Omit<Author, 'biography'>;
+  author: Omit<Author, 'biography'>;
 }

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -7,7 +7,8 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { environment } from '../environments/environment';
 
 // Models
-import { Story, StoryCard, StoryDTO } from '../models/story.model';
+import { Story, StoryCard, StoryDTO } from '@models/story.model';
+import {BlockContent} from "@models/block-content.model";
 
 @Injectable({ providedIn: 'root' })
 export class StoryService {
@@ -35,9 +36,9 @@ export class StoryService {
       ...story,
       prologues: story.prologues ?? [],
       paragraphs:
-        story?.paragraphs?.map((x: string) => this.parseParagraph(x)) ?? [],
+        story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
       summary:
-        story?.summary?.map((x: string) => this.parseParagraph(x)) ?? [],
+        story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
     };
   }
 
@@ -46,9 +47,9 @@ export class StoryService {
       ...story,
       prologues: story.prologues ?? [],
       paragraphs:
-        story?.paragraphs?.map((x: string) => this.parseParagraph(x)) ?? [],
+        story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
       summary:
-        story?.summary?.map((x: string) => this.parseParagraph(x)) ?? [],
+        story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
       author: {
         ...story.author,
         biography: story.author.biography?.map(x => this.parseParagraph(x)) ?? [],
@@ -56,7 +57,7 @@ export class StoryService {
     };
   }
 
-  private parseParagraph(block: any): string {
+  private parseParagraph(block: BlockContent | string): string {
     let paragraph = '';
 
     // Condición de escape en caso de que se pase como parámetro un string plano en vez de un blockContent


### PR DESCRIPTION
# Resumen
- Agregados modelo para `BlockContent` y sus dependencias, reflejando los tipos de objetos recibidos como respuesta del endpoint `/read`
- Uso de del tipo `BlockContent` en interface `StoryDTO`.
- Uso del tipo `BlockContent` para argumentos de métodos de `StoryService`.
- Corrección en el enviado por duplicado del contenido de la historia