### PR TITLE
[#481] Agregar soporte para saltos de línea en parser

### DIFF
--- a/src/app/models/author.model.ts
+++ b/src/app/models/author.model.ts
@@ -1,10 +1,19 @@
-export interface Author {
-    id: number;
-    name: string;
-    imageUrl: string;
-    nationality: AuthorNationality;
-    biography?: string[];
-    fullBioUrl: string;
+import { BlockContent } from '@models/block-content.model';
+
+interface AuthorBase {
+  id: number;
+  name: string;
+  imageUrl: string;
+  nationality: AuthorNationality;
+  fullBioUrl: string;
+}
+
+export interface Author extends AuthorBase {
+  biography?: string[];
+}
+
+export interface AuthorDTO extends AuthorBase {
+  biography?: BlockContent[];
 }
 
 export type AuthorNationality = { country: string; flag: string };

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -1,4 +1,4 @@
-import { Author } from './author.model';
+import { Author, AuthorDTO } from './author.model';
 import { Prologue, PrologueDTO } from './prologue.model';
 import { BlockContent } from '@models/block-content.model';
 
@@ -7,7 +7,6 @@ export interface StoryBase {
   title: string;
   slug: string;
   approximateReadingTime: number;
-  author: Author;
   originalLink?: string;
   videoUrl?: string;
   badLanguage?: boolean;
@@ -15,12 +14,14 @@ export interface StoryBase {
 }
 
 export interface Story extends StoryBase {
+  author: Author;
   prologues: Prologue[];
   summary: string[];
   paragraphs: string[];
 }
 
 export interface StoryDTO extends StoryBase {
+  author: AuthorDTO;
   prologues: PrologueDTO[];
   summary: BlockContent[];
   paragraphs: BlockContent[];

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -8,7 +8,7 @@ import { environment } from '../environments/environment';
 
 // Models
 import { Story, StoryCard, StoryDTO } from '@models/story.model';
-import {BlockContent} from "@models/block-content.model";
+import { Block, BlockContent } from '@models/block-content.model';
 
 @Injectable({ providedIn: 'root' })
 export class StoryService {
@@ -27,7 +27,7 @@ export class StoryService {
   }
 
   // ToDo: Rediseñar funcionamiento del endpoint de links originales.
-  public getOriginalLinks(): Observable<any> {
+  public getOriginalLinks(): Observable<Story[]> {
     return this.http.get<Story[]>(`${this.prefix}/original-links`);
   }
 
@@ -36,7 +36,8 @@ export class StoryService {
       ...story,
       prologues: story.prologues ?? [],
       paragraphs:
-        story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
+        story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ??
+        [],
       summary:
         story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
     };
@@ -47,32 +48,32 @@ export class StoryService {
       ...story,
       prologues: story.prologues ?? [],
       paragraphs:
-        story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
+        story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ??
+        [],
       summary:
         story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
       author: {
         ...story.author,
-        biography: story.author.biography?.map(x => this.parseParagraph(x)) ?? [],
+        biography:
+          story.author.biography?.map((x) => this.parseParagraph(x)) ?? [],
       },
     };
   }
 
-  private parseParagraph(block: BlockContent | string): string {
+  private parseParagraph(block: BlockContent): string {
     let paragraph = '';
 
-    // Condición de escape en caso de que se pase como parámetro un string plano en vez de un blockContent
-    if (typeof block === 'string') {
-      return block;
-    }
-
-    block.children.forEach((x: any) => {
+    block.children.forEach((x: Block) => {
       let part = x.text;
-      if (x.marks.includes('em')) {
+      if (x.marks?.includes('em')) {
         part = this.addEmphasis(part);
       }
-      if (x.marks.includes('strong')) {
+      if (x.marks?.includes('strong')) {
         part = this.addStrong(part);
       }
+
+      part = part.replaceAll('\n', '<br/>');
+
       paragraph = paragraph.concat(part);
     });
     return paragraph;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
         "importHelpers": true,
         "target": "es2022",
         "module": "esnext",
-        "lib": ["es2017", "dom"],
+        "lib": ["es2021", "dom"],
         "skipLibCheck": true,
         "skipDefaultLibCheck": true,
         "baseUrl": ".",


### PR DESCRIPTION
# Resumen
- Agregado soporte para reemplazo de ocurrencias de `\n` como delimitador de salto de línea a `<br>` como resultado en HTML.
- Mejoras en modelado de propiedades relacionadas a `Story` y `Author`
- Mejorado tipado en métodos incluidos en `StoryService`