### PR TITLE
[#491] Agregar entidad Tag a schema, modelos de dominio y consultas relacionadas a Storylist

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -25,6 +25,7 @@
     "react-is": "^18.2.0",
     "sanity": "^3.8.1",
     "sanity-plugin-computed-field": "^2.0.1",
+    "sanity-plugin-icon-picker": "^3.2.2",
     "styled-components": "^5.3.9"
   }
 }

--- a/cms/pnpm-lock.yaml
+++ b/cms/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   sanity-plugin-computed-field:
     specifier: ^2.0.1
     version: 2.0.1(react-dom@18.2.0)(react@18.2.0)(sanity@3.8.1)
+  sanity-plugin-icon-picker:
+    specifier: ^3.2.2
+    version: 3.2.2(react-dom@18.2.0)(react@18.2.0)(sanity@3.8.1)
   styled-components:
     specifier: ^5.3.9
     version: 5.3.9(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
@@ -238,6 +241,14 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
+
+  /@babel/runtime-corejs3@7.23.6:
+    resolution: {integrity: sha512-Djs/ZTAnpyj0nyg7p1J6oiE/tZ9G2stqAFlLGZynrW+F3k2w2jGK2mLOBxzYIOcZYA89+c3d3wXKpYLcpwcU6w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      core-js-pure: 3.34.0
+      regenerator-runtime: 0.14.1
     dev: false
 
   /@babel/runtime@7.21.0:
@@ -1976,6 +1987,11 @@ packages:
       toggle-selection: 1.0.6
     dev: false
 
+  /core-js-pure@3.34.0:
+    resolution: {integrity: sha512-pmhivkYXkymswFfbXsANmBAewXx86UBfmagP+w0wkK06kLsLlTK5oQmsURPivzMkIBQiYq2cjamcZExIwlFQIg==}
+    requiresBuild: true
+    dev: false
+
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: false
@@ -2124,6 +2140,13 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 5.5.0
+    dev: false
+
+  /decamelize@3.2.0:
+    resolution: {integrity: sha512-4TgkVUsmmu7oCSyGBm5FvfMoACuoh9EOidm7V5/J2X2djAwwt57qb3F2KMP2ITqODTCSwb+YRV+0Zqrv18k/hw==}
+    engines: {node: '>=6'}
+    dependencies:
+      xregexp: 4.4.1
     dev: false
 
   /decimal.js@10.4.3:
@@ -2502,6 +2525,11 @@ packages:
     resolution: {integrity: sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==}
     dependencies:
       tslib: 2.5.0
+    dev: false
+
+  /framework7-icons@5.0.5:
+    resolution: {integrity: sha512-bvHMLyujV9TFuudehd3ORZ/EvNp19Ir3ckVzYAOf3MkLymHba/9oHLsgopCh0x5UsrYZUpkrE+fd7ggj5y4wRw==}
+    engines: {node: '>= 0.10.0'}
     dev: false
 
   /from2@2.3.0:
@@ -3116,6 +3144,10 @@ packages:
     resolution: {integrity: sha512-QBJSFpsedXUl/Lgs4ySdB2XCzUEcJ3ujpbagdZCkRaYIaC0kFnID8jhc84KEiVv6dNFtIrmW7bqow0lDxgJi6A==}
     dev: false
 
+  /memoize-one@5.2.1:
+    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+    dev: false
+
   /memoize-resolver@1.0.0:
     resolution: {integrity: sha512-mXfNXte0RSWl0rEIsQhXutfM2R2Oa7UyKDD7XoZMEbKeucTRms04y5y41U8gLqPzRx7ViN/QyYnTR2TX/5tawA==}
     dev: false
@@ -3660,6 +3692,14 @@ packages:
       use-sidecar: 1.1.2(react@18.2.0)
     dev: false
 
+  /react-icons@4.12.0(react@18.2.0):
+    resolution: {integrity: sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==}
+    peerDependencies:
+      react: '*'
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: false
@@ -3705,6 +3745,29 @@ packages:
     resolution: {integrity: sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==}
     dependencies:
       prop-types: 15.8.1
+    dev: false
+
+  /react-virtualized-auto-sizer@1.0.20(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==}
+    peerDependencies:
+      react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc
+      react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /react-window@1.8.10(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==}
+    engines: {node: '>8.0.0'}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.21.0
+      memoize-one: 5.2.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react@18.2.0:
@@ -3786,6 +3849,10 @@ packages:
 
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+    dev: false
+
+  /regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
     dev: false
 
   /require-directory@2.1.1:
@@ -3893,6 +3960,25 @@ packages:
     dependencies:
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
+      sanity: 3.8.1(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.9)
+    transitivePeerDependencies:
+      - react-dom
+    dev: false
+
+  /sanity-plugin-icon-picker@3.2.2(react-dom@18.2.0)(react@18.2.0)(sanity@3.8.1):
+    resolution: {integrity: sha512-H7U6BRrTVgvXANsppIT1U2fUo4YJivWZDUcRK2b2dap4aljmXRw81DOsaxI/5YeG7je2wCfaKQJbYqRbzT8meQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^18
+      sanity: ^3
+    dependencies:
+      '@sanity/incompatible-plugin': 1.0.4(react-dom@18.2.0)(react@18.2.0)
+      decamelize: 3.2.0
+      framework7-icons: 5.0.5
+      react: 18.2.0
+      react-icons: 4.12.0(react@18.2.0)
+      react-virtualized-auto-sizer: 1.0.20(react-dom@18.2.0)(react@18.2.0)
+      react-window: 1.8.10(react-dom@18.2.0)(react@18.2.0)
       sanity: 3.8.1(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.9)
     transitivePeerDependencies:
       - react-dom
@@ -4631,6 +4717,12 @@ packages:
 
   /xregexp@2.0.0:
     resolution: {integrity: sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==}
+    dev: false
+
+  /xregexp@4.4.1:
+    resolution: {integrity: sha512-2u9HwfadaJaY9zHtRRnH6BY6CQVNQKkYm3oLtC9gJXXzfsbACg5X5e4EZZGVAH+YIfa+QA9lsFQTTe3HURF3ag==}
+    dependencies:
+      '@babel/runtime-corejs3': 7.23.6
     dev: false
 
   /xtend@4.0.2:

--- a/cms/sanity.config.ts
+++ b/cms/sanity.config.ts
@@ -9,52 +9,55 @@ import { deskTool } from 'sanity/desk';
 import { visionTool } from '@sanity/vision';
 import { sanityComputedField } from 'sanity-plugin-computed-field';
 import { crossDatasetDuplicator } from '@sanity/cross-dataset-duplicator';
+import { iconPicker } from 'sanity-plugin-icon-picker';
 
 export default defineConfig([
-    {
-        name: 'production-workspace',
-        title: 'PROD - La Cuentoneta',
-        basePath: '/production',
-        icon: LaunchIcon,
-        projectId: process.env.SANITY_STUDIO_PROJECT_ID,
-        token: process.env.SANITY_STUDIO_API_TOKEN,
-        dataset: 'production',
-        plugins: [
-            deskTool({
-                structure: deskStructure,
-            }),
-            sanityComputedField(),
-            crossDatasetDuplicator({
-                types: ['story', 'storylist', 'author', 'nationality'],
-                tool: true,
-                follow: []
-            })
-        ],
-        schema: {
-            types: schemas,
-        },
+  {
+    name: 'production-workspace',
+    title: 'PROD - La Cuentoneta',
+    basePath: '/production',
+    icon: LaunchIcon,
+    projectId: process.env.SANITY_STUDIO_PROJECT_ID,
+    token: process.env.SANITY_STUDIO_API_TOKEN,
+    dataset: 'production',
+    plugins: [
+      deskTool({
+        structure: deskStructure,
+      }),
+      sanityComputedField(),
+      crossDatasetDuplicator({
+        types: ['story', 'storylist', 'author', 'nationality'],
+        tool: true,
+        follow: [],
+      }),
+      iconPicker(),
+    ],
+    schema: {
+      types: schemas,
     },
-    {
-        name: 'dev-workspace',
-        title: 'DEV - La Cuentoneta',
-        basePath: '/development',
-        icon: RobotIcon,
-        projectId: process.env.SANITY_STUDIO_PROJECT_ID,
-        dataset: 'development',
-        plugins: [
-            deskTool({
-                structure: deskStructure,
-            }),
-            sanityComputedField(),
-            visionTool(),
-            crossDatasetDuplicator({
-                types: ['story', 'storylist', 'author', 'nationality'],
-                tool: true,
-                follow: []
-            })
-        ],
-        schema: {
-            types: schemas,
-        },
+  },
+  {
+    name: 'dev-workspace',
+    title: 'DEV - La Cuentoneta',
+    basePath: '/development',
+    icon: RobotIcon,
+    projectId: process.env.SANITY_STUDIO_PROJECT_ID,
+    dataset: 'development',
+    plugins: [
+      deskTool({
+        structure: deskStructure,
+      }),
+      sanityComputedField(),
+      visionTool(),
+      crossDatasetDuplicator({
+        types: ['story', 'storylist', 'author', 'nationality'],
+        tool: true,
+        follow: [],
+      }),
+      iconPicker(),
+    ],
+    schema: {
+      types: schemas,
     },
+  },
 ]);

--- a/cms/schemas/author.ts
+++ b/cms/schemas/author.ts
@@ -1,10 +1,12 @@
 // Localization
 import { supportedLanguages } from '../utils/localization';
+import { UsersIcon } from '@sanity/icons'
 
 export default {
   name: 'author',
   title: 'Autor/a',
   type: 'document',
+  icon: UsersIcon,
   fields: [
     {
       name: 'name',

--- a/cms/schemas/country.ts
+++ b/cms/schemas/country.ts
@@ -1,17 +1,20 @@
+import { EarthGlobeIcon } from '@sanity/icons';
+
 export default {
-    name: 'nationality',
-    title: 'Nacionalidad',
-    type: 'document',
-    fields: [
-        {
-            name: 'country',
-            title: 'País',
-            type: 'string',
-        },
-        {
-            name: 'flag',
-            title: 'Bandera',
-            type: 'image',
-        },
-    ],
-}
+  name: 'nationality',
+  title: 'Nacionalidad',
+  type: 'document',
+  icon: EarthGlobeIcon,
+  fields: [
+    {
+      name: 'country',
+      title: 'País',
+      type: 'string',
+    },
+    {
+      name: 'flag',
+      title: 'Bandera',
+      type: 'image',
+    },
+  ],
+};

--- a/cms/schemas/schema.ts
+++ b/cms/schemas/schema.ts
@@ -7,6 +7,7 @@ import story from './story';
 import author from './author';
 import country from './country';
 import storylist from './storylist';
+import tag from './tag'
 
 export default [
     // The following are document types which will appear in the studio.
@@ -17,4 +18,5 @@ export default [
     author,
     country,
     blockContent,
+    tag
 ];

--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -1,9 +1,11 @@
 import { supportedLanguages } from '../utils/localization';
+import { DocumentTextIcon } from '@sanity/icons';
 
 export default {
   name: 'story',
   title: 'Cuento',
   type: 'document',
+  icon: DocumentTextIcon,
   fields: [
     {
       name: 'title',

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -227,6 +227,19 @@ export default {
       },
     },
     {
+      name: 'tags',
+      title: 'Etiquetas',
+      type: 'array',
+      of: [
+        {
+          name: 'tag',
+          title: 'Etiqueta',
+          type: 'reference',
+          to: [{ type: 'tag' }],
+        },
+      ],
+    },
+    {
       name: 'gridConfig',
       title:
         'Configuración de vista completa de Storylist en layout de CSS Grid',

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -1,4 +1,5 @@
 import { supportedLanguages } from '../utils/localization';
+import { DashboardIcon } from '@sanity/icons';
 
 const gridItemFields = [
   {
@@ -160,6 +161,7 @@ export default {
   name: 'storylist',
   title: 'Storylists',
   type: 'document',
+  icon: DashboardIcon,
   fields: [
     {
       name: 'title',

--- a/cms/schemas/tag.ts
+++ b/cms/schemas/tag.ts
@@ -1,25 +1,54 @@
 import { TagIcon } from '@sanity/icons';
+import { preview } from 'sanity-plugin-icon-picker';
 
 export default {
   name: 'tag',
   title: 'Etiquetas',
   type: 'document',
   icon: TagIcon,
+  preview: {
+    select: {
+      title: 'title',
+      description: 'description',
+      provider: 'icon.provider',
+      name: 'icon.name',
+    },
+    prepare(selection) {
+      return {
+        title: selection.title,
+        subtitle: selection.description,
+        media: preview(selection),
+      };
+    },
+  },
   fields: [
     {
-      name: 'name',
-      title: 'Nombre',
+      name: 'title',
+      title: 'Título',
       type: 'string',
     },
     {
       name: 'slug',
       title: 'Slug',
       type: 'slug',
+      options: {
+        source: 'title',
+        maxLength: 96,
+      },
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'description',
+      title: 'Descripción',
+      type: 'string',
     },
     {
       name: 'icon',
       title: 'Icono',
-      type: 'image',
+      type: 'iconPicker',
+      options: {
+        storeSvg: true
+      }
     },
   ],
 };

--- a/cms/schemas/tag.ts
+++ b/cms/schemas/tag.ts
@@ -26,6 +26,7 @@ export default {
       name: 'title',
       title: 'Título',
       type: 'string',
+      validation: (Rule) => Rule.required(),
     },
     {
       name: 'slug',
@@ -41,6 +42,7 @@ export default {
       name: 'description',
       title: 'Descripción',
       type: 'string',
+      validation: (Rule) => Rule.required(),
     },
     {
       name: 'icon',

--- a/cms/schemas/tag.ts
+++ b/cms/schemas/tag.ts
@@ -1,0 +1,25 @@
+import { TagIcon } from '@sanity/icons';
+
+export default {
+  name: 'tag',
+  title: 'Etiquetas',
+  type: 'document',
+  icon: TagIcon,
+  fields: [
+    {
+      name: 'name',
+      title: 'Nombre',
+      type: 'string',
+    },
+    {
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+    },
+    {
+      name: 'icon',
+      title: 'Icono',
+      type: 'image',
+    },
+  ],
+};

--- a/src/api/storylist.service.ts
+++ b/src/api/storylist.service.ts
@@ -15,6 +15,12 @@ async function fetchPreview(req: express.Request, res: express.Response) {
                         displayDates,
                         editionPrefix,
                         comingNextLabel,
+                        'tags': tags[] -> {
+                            title, 
+                            'slug': slug.current, 
+                            description, 
+                            'icon': {'name': icon.name, 'provider': icon.provider, 'svg': icon.svg}
+                        },
                         featuredImage,
                         'gridConfig': { 
                             'gridTemplateColumns': previewGridConfig.gridTemplateColumns,
@@ -125,7 +131,13 @@ async function fetchStorylist(req: any, res: any) {
                         editionPrefix,
                         comingNextLabel,
                         featuredImage,
-                        'gridConfig': { 
+                        'tags': tags[] -> {
+                            title, 
+                            'slug': slug.current, 
+                            description, 
+                            'icon': {'name': icon.name, 'provider': icon.provider, 'svg': icon.svg}
+                        },
+                        'gridConfig': {
                             'gridTemplateColumns': gridConfig.gridTemplateColumns,
                             'titlePlacement': gridConfig.titlePlacement,
                             'cardsPlacement': gridConfig.cardsPlacement[]

--- a/src/app/models/storylist.model.ts
+++ b/src/app/models/storylist.model.ts
@@ -1,5 +1,6 @@
 import { Story, StoryBase, StoryDTO } from './story.model';
 import { SanityImageSource } from '@sanity/image-url/lib/types/types';
+import { Tag } from '@models/tag.model';
 
 interface StorylistBase {
   title: string;
@@ -11,6 +12,7 @@ interface StorylistBase {
   description?: string[];
   language?: string;
   featuredImage?: SanityImageSource;
+  tags?: Tag[];
   images?: {
     slug: string;
     url: SanityImageSource;

--- a/src/app/models/tag.model.ts
+++ b/src/app/models/tag.model.ts
@@ -1,0 +1,10 @@
+export interface Tag {
+    title: string;
+    slug: string;
+    description: string;
+    icon?: {
+        name: string;
+        provider: string;
+        svg: string;
+    };
+}


### PR DESCRIPTION
# Resumen
- Agrega schema `tag` en Sanity para representar categorías en la aplicación.
- Agrega array de referencias a propiedades `tag` en schema `storylist`.
- Agrega modelo de dominio `Tag`.
- Agrega propiedad `tag` a modelo `Storylist`.
- Agrega campo `tag` a consultas `fetchPreview` y `fetchStorylist` de `/api/storylist.service.ts`.