### PR TITLE
[#509] - Reemplazar directivas estructurales por sintaxis de control de flujo en storylist-card-deck.component.html

### DIFF
--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.html
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.html
@@ -10,41 +10,69 @@
 
 <ng-template #storylistTemplate>
   <!-- Renderizado de título y descripción -->
-  <ng-container *ngIf="displayTitle">
-    <ng-container *ngIf="!!storylist; else titleSkeletonTemplate">
-      <div
-        class="story-card-container title-container"
-        [ngStyle]="{
+  @if(displayTitle) { @if(!!storylist){
+  <div
+    class="story-card-container title-container"
+    [ngStyle]="{
             order: storylist.gridConfig?.titlePlacement?.order,
             'grid-column-start': storylist.gridConfig?.titlePlacement?.startCol,
             'grid-column-end': storylist.gridConfig?.titlePlacement?.endCol,
           }"
+  >
+    <h1 class="title">
+      <a
+        [ngClass]="{ 'nav-link': canNavigateToStorylist }"
+        [routerLink]="
+          canNavigateToStorylist ? '/' + appRouteTree['STORYLIST'] : null
+        "
+        [queryParams]="{ slug: storylist.slug }"
+        >{{ storylist.title }}</a
       >
-        <h1 class="title">
-          <a
-            [ngClass]="{ 'nav-link': canNavigateToStorylist }"
-            [routerLink]="
-              canNavigateToStorylist ? '/' + appRouteTree['STORYLIST'] : null
-            "
-            [queryParams]="{ slug: storylist.slug }"
-            >{{ storylist.title }}</a
-          >
-        </h1>
-        <h3 class="subtitle">{{ storylist.description }}</h3>
-      </div>
-    </ng-container>
-  </ng-container>
+    </h1>
+    <h3 class="subtitle">{{ storylist.description }}</h3>
+  </div>
+  }@else {
+  <div
+    class="story-card-container title-container"
+    [ngStyle]="{
+            order: skeletonConfig?.titlePlacement?.order,
+            'grid-column-start': skeletonConfig?.titlePlacement?.startCol,
+            'grid-column-end': skeletonConfig?.titlePlacement?.endCol,
+          }"
+  >
+    <ngx-skeleton-loader
+      [theme]="{
+        'margin-bottom.px': 20,
+        'height.px': 40,
+        width: '100%',
+        'background-color': '#D4D4D8'
+      }"
+      count="1"
+      appearance="line"
+    ></ngx-skeleton-loader>
+    <ngx-skeleton-loader
+      [theme]="{
+        'margin-bottom.px': 10,
+        'height.px': 20,
+        width: '100%',
+        'background-color': '#D4D4D8'
+      }"
+      count="3"
+      appearance="line"
+    ></ngx-skeleton-loader>
+  </div>
+  } }
 
   <!-- Renderizado de imágenes alusivas -->
-  <ng-container *ngIf="!!storylist?.images">
-    <div
-      *ngFor="let image of storylist?.images"
-      class="story-card-container"
-      [ngStyle]="imagesCardConfig[image.slug]"
-    >
-      <img [src]="image.url" alt="" />
-    </div>
-  </ng-container>
+  @if(!!storylist?.images){
+  <div
+    class="story-card-container"
+    *ngFor="let image of storylist?.images"
+    [ngStyle]="imagesCardConfig[image.slug]"
+  >
+    <img [src]="image.url" alt="" />
+  </div>
+  }
 
   <!-- Renderizado de tarjetas de stories -->
   <ng-container
@@ -55,90 +83,58 @@
   </ng-container>
 </ng-template>
 
-<ng-template #titleSkeletonTemplate>
-  <div
-    class="story-card-container title-container"
-    [ngStyle]="{
-            order: skeletonConfig?.titlePlacement?.order,
-            'grid-column-start': skeletonConfig?.titlePlacement?.startCol,
-            'grid-column-end': skeletonConfig?.titlePlacement?.endCol,
-          }"
-  >
-    <ngx-skeleton-loader
-      count="1"
-      appearance="line"
-      [theme]="{
-        'margin-bottom.px': 20,
-        'height.px': 40,
-        width: '100%',
-        'background-color': '#D4D4D8'
-      }"
-    ></ngx-skeleton-loader>
-    <ngx-skeleton-loader
-      count="3"
-      appearance="line"
-      [theme]="{
-        'margin-bottom.px': 10,
-        'height.px': 20,
-        width: '100%',
-        'background-color': '#D4D4D8'
-      }"
-    ></ngx-skeleton-loader>
-  </div>
-</ng-template>
-
 <ng-template #skeletonsTemplate>
-  <ng-container *ngFor="let skeleton of skeletonConfig?.cardsPlacement">
-    <ng-container *ngIf="!!skeleton.slug">
-      <cuentoneta-story-card
-        [ngStyle]="{
+  @for(skeleton of skeletonConfig?.cardsPlacement; track $index){
+  @if(!!skeleton.slug){
+  <cuentoneta-story-card
+    [ngStyle]="{
           'order': skeleton?.order,
           'grid-column-start': skeleton?.startCol,
           'grid-column-end': skeleton?.endCol,
           }"
-      />
-    </ng-container>
-    <ng-container *ngIf="!!skeleton.imageSlug">
-      <ngx-skeleton-loader
-        count="1"
-        appearance="line"
-        [ngStyle]="{
+  />
+
+  @if(!!skeleton.imageSlug) {
+  <ngx-skeleton-loader
+    [ngStyle]="{
           'order': skeleton?.order,
           'grid-column-start': skeleton?.startCol,
           'grid-column-end': skeleton?.endCol,
           }"
-        [theme]="{
-          height: '100%',
-          width: '100%',
-          'background-color': '#D4D4D8'
-        }"
-      ></ngx-skeleton-loader>
-    </ng-container>
-  </ng-container>
+    [theme]="{
+      height: '100%',
+      width: '100%',
+      'background-color': '#D4D4D8'
+    }"
+    count="1"
+    appearance="line"
+  ></ngx-skeleton-loader>
+  } } }
 </ng-template>
 
 <ng-template #publicationsTemplate>
-  <ng-container *ngIf="!!storylist">
-    <ng-container *ngFor="let publication of storylist.publications">
-      <a
-        class="story-card-container"
-        [ngStyle]="storiesCardConfig[publication.story.slug]"
-        [class.disabled]="!publication || !publication.published"
-        [routerLink]="
-          !!publication && publication.published
-            ? ['/', appRouteTree['STORY']]
-            : null
-        "
-        [queryParams]="{ slug: publication.story.slug, list: storylist.slug }"
-      >
-        <cuentoneta-story-card
-          [displayDate]="storylist.displayDates"
-          [editionPrefix]="storylist.editionPrefix"
-          [publication]="publication"
-          [editionIndex]="publication.publishingOrder"
-          [comingNextLabel]="storylist.comingNextLabel"
-        />
-      </a>
-    </ng-container>
-  </ng-container>
+  @if(!!storylist){ @for(publication of storylist.publications; track $index){
+  @defer(on viewport) {
+  <a
+    class="story-card-container"
+    [ngStyle]="storiesCardConfig[publication.story.slug]"
+    [class.disabled]="!publication || !publication.published"
+    [routerLink]="
+      !!publication && publication.published
+        ? ['/', appRouteTree['STORY']]
+        : null
+    "
+    [queryParams]="{ slug: publication.story.slug, list: storylist.slug }"
+  >
+    <cuentoneta-story-card
+      [displayDate]="storylist.displayDates"
+      [editionPrefix]="storylist.editionPrefix"
+      [publication]="publication"
+      [editionIndex]="publication.publishingOrder"
+      [comingNextLabel]="storylist.comingNextLabel"
+    />
+  </a>
+  }@placeholder {
+  <div></div>
+  } } }
 </ng-template>

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.html
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.html
@@ -10,58 +10,60 @@
 
 <ng-template #storylistTemplate>
   <!-- Renderizado de título y descripción -->
-  @if(displayTitle) { @if(!!storylist){
-  <div
-    class="story-card-container title-container"
-    [ngStyle]="{
-            order: storylist.gridConfig?.titlePlacement?.order,
-            'grid-column-start': storylist.gridConfig?.titlePlacement?.startCol,
-            'grid-column-end': storylist.gridConfig?.titlePlacement?.endCol,
-          }"
-  >
-    <h1 class="title">
-      <a
-        [ngClass]="{ 'nav-link': canNavigateToStorylist }"
-        [routerLink]="
-          canNavigateToStorylist ? '/' + appRouteTree['STORYLIST'] : null
-        "
-        [queryParams]="{ slug: storylist.slug }"
-        >{{ storylist.title }}</a
+  @if(displayTitle) {
+      @if(!!storylist) {
+          <div
+            class="story-card-container title-container"
+            [ngStyle]="{
+                    order: storylist.gridConfig?.titlePlacement?.order,
+                    'grid-column-start': storylist.gridConfig?.titlePlacement?.startCol,
+                    'grid-column-end': storylist.gridConfig?.titlePlacement?.endCol,
+                  }"
+          >
+            <h1 class="title">
+              <a
+                [ngClass]="{ 'nav-link': canNavigateToStorylist }"
+                [routerLink]="
+                  canNavigateToStorylist ? '/' + appRouteTree['STORYLIST'] : null
+                "
+                [queryParams]="{ slug: storylist.slug }"
+                >{{ storylist.title }}</a
+              >
+            </h1>
+            <h3 class="subtitle">{{ storylist.description }}</h3>
+          </div>
+    } @else {
+      <div
+        class="story-card-container title-container"
+        [ngStyle]="{
+                order: skeletonConfig?.titlePlacement?.order,
+                'grid-column-start': skeletonConfig?.titlePlacement?.startCol,
+                'grid-column-end': skeletonConfig?.titlePlacement?.endCol,
+              }"
       >
-    </h1>
-    <h3 class="subtitle">{{ storylist.description }}</h3>
-  </div>
-  }@else {
-  <div
-    class="story-card-container title-container"
-    [ngStyle]="{
-            order: skeletonConfig?.titlePlacement?.order,
-            'grid-column-start': skeletonConfig?.titlePlacement?.startCol,
-            'grid-column-end': skeletonConfig?.titlePlacement?.endCol,
+        <ngx-skeleton-loader
+          [theme]="{
+            'margin-bottom.px': 20,
+            'height.px': 40,
+            width: '100%',
+            'background-color': '#D4D4D8'
           }"
-  >
-    <ngx-skeleton-loader
-      [theme]="{
-        'margin-bottom.px': 20,
-        'height.px': 40,
-        width: '100%',
-        'background-color': '#D4D4D8'
-      }"
-      count="1"
-      appearance="line"
-    ></ngx-skeleton-loader>
-    <ngx-skeleton-loader
-      [theme]="{
-        'margin-bottom.px': 10,
-        'height.px': 20,
-        width: '100%',
-        'background-color': '#D4D4D8'
-      }"
-      count="3"
-      appearance="line"
-    ></ngx-skeleton-loader>
-  </div>
-  } }
+          count="1"
+          appearance="line"
+        ></ngx-skeleton-loader>
+        <ngx-skeleton-loader
+          [theme]="{
+            'margin-bottom.px': 10,
+            'height.px': 20,
+            width: '100%',
+            'background-color': '#D4D4D8'
+          }"
+          count="3"
+          appearance="line"
+        ></ngx-skeleton-loader>
+      </div>
+    }
+  }
 
   <!-- Renderizado de imágenes alusivas -->
   @if(!!storylist?.images){
@@ -84,57 +86,57 @@
 </ng-template>
 
 <ng-template #skeletonsTemplate>
-  @for(skeleton of skeletonConfig?.cardsPlacement; track $index){
-  @if(!!skeleton.slug){
-  <cuentoneta-story-card
-    [ngStyle]="{
-          'order': skeleton?.order,
-          'grid-column-start': skeleton?.startCol,
-          'grid-column-end': skeleton?.endCol,
-          }"
-  />
-
-  @if(!!skeleton.imageSlug) {
-  <ngx-skeleton-loader
-    [ngStyle]="{
-          'order': skeleton?.order,
-          'grid-column-start': skeleton?.startCol,
-          'grid-column-end': skeleton?.endCol,
-          }"
-    [theme]="{
-      height: '100%',
-      width: '100%',
-      'background-color': '#D4D4D8'
-    }"
-    count="1"
-    appearance="line"
-  ></ngx-skeleton-loader>
-  } } }
+  @for(skeleton of skeletonConfig?.cardsPlacement; track $index) {
+      @if(!!skeleton.slug) {
+          <cuentoneta-story-card
+            [ngStyle]="{
+                  'order': skeleton?.order,
+                  'grid-column-start': skeleton?.startCol,
+                  'grid-column-end': skeleton?.endCol,
+                  }"
+          />
+      }
+      @if(!!skeleton.imageSlug) {
+          <ngx-skeleton-loader
+            [ngStyle]="{
+                  'order': skeleton?.order,
+                  'grid-column-start': skeleton?.startCol,
+                  'grid-column-end': skeleton?.endCol,
+                  }"
+            [theme]="{
+              height: '100%',
+              width: '100%',
+              'background-color': '#D4D4D8'
+            }"
+            count="1"
+            appearance="line"
+          ></ngx-skeleton-loader>
+      }
+  }
 </ng-template>
 
 <ng-template #publicationsTemplate>
-  @if(!!storylist){ @for(publication of storylist.publications; track $index){
-  @defer(on viewport) {
-  <a
-    class="story-card-container"
-    [ngStyle]="storiesCardConfig[publication.story.slug]"
-    [class.disabled]="!publication || !publication.published"
-    [routerLink]="
-      !!publication && publication.published
-        ? ['/', appRouteTree['STORY']]
-        : null
-    "
-    [queryParams]="{ slug: publication.story.slug, list: storylist.slug }"
-  >
-    <cuentoneta-story-card
-      [displayDate]="storylist.displayDates"
-      [editionPrefix]="storylist.editionPrefix"
-      [publication]="publication"
-      [editionIndex]="publication.publishingOrder"
-      [comingNextLabel]="storylist.comingNextLabel"
-    />
-  </a>
-  }@placeholder {
-  <div></div>
-  } } }
+  @if(!!storylist) {
+      @for(publication of storylist.publications; track $index) {
+          <a
+            class="story-card-container"
+            [ngStyle]="storiesCardConfig[publication.story.slug]"
+            [class.disabled]="!publication || !publication.published"
+            [routerLink]="
+              !!publication && publication.published
+                ? ['/', appRouteTree['STORY']]
+                : null
+            "
+            [queryParams]="{ slug: publication.story.slug, list: storylist.slug }"
+          >
+            <cuentoneta-story-card
+              [displayDate]="storylist.displayDates"
+              [editionPrefix]="storylist.editionPrefix"
+              [publication]="publication"
+              [editionIndex]="publication.publishingOrder"
+              [comingNextLabel]="storylist.comingNextLabel"
+            />
+          </a>
+      }
+  }
 </ng-template>

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
@@ -14,12 +14,9 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { CommonModule } from '@angular/common';
 
 // Models
-import {
-  GridItemPlacementConfig,
-  Storylist,
-} from '@models/storylist.model';
+import { GridItemPlacementConfig, Storylist } from '@models/storylist.model';
 import { APP_ROUTE_TREE } from '../../app.routes';
-import { StorylistGridSkeletonConfig } from "@models/content.model";
+import { StorylistGridSkeletonConfig } from '@models/content.model';
 import { StoryCardComponent } from '../story-card/story-card.component';
 
 @Component({
@@ -42,7 +39,7 @@ export class StorylistCardDeckComponent implements OnInit, OnChanges {
   @Input() canNavigateToStorylist: boolean = false;
   @Input() displayTitle: boolean = true;
   @Input() displayFeaturedImage: boolean = false;
-  @Input() skeletonConfig: StorylistGridSkeletonConfig | undefined
+  @Input() skeletonConfig: StorylistGridSkeletonConfig | undefined;
 
   dummyList: null[] = [];
   imagesCardConfig: { [key: string]: CardDeckCSSGridConfig } = {};
@@ -71,7 +68,7 @@ export class StorylistCardDeckComponent implements OnInit, OnChanges {
       }));
     for (const config of parsedConfigs) {
       const { slug, ...other } = config;
-      this.imagesCardConfig[config.slug!] = other;
+      this.imagesCardConfig[slug!] = other;
     }
   }
 
@@ -86,7 +83,7 @@ export class StorylistCardDeckComponent implements OnInit, OnChanges {
       }));
     for (const config of parsedConfigs) {
       const { slug, ...other } = config;
-      this.storiesCardConfig[config.slug!] = other;
+      this.storiesCardConfig[slug!] = other;
     }
   }
 
@@ -95,7 +92,7 @@ export class StorylistCardDeckComponent implements OnInit, OnChanges {
       (card) => [card.slug, card.imageSlug].includes(slug)
     );
     return {
-      order: storyCardConfig?.order! ?? 2,
+      order: storyCardConfig?.order ?? 2,
       'grid-column-start': storyCardConfig?.startCol ?? 'auto',
       'grid-column-end': storyCardConfig?.endCol ?? 'span 4',
     };


### PR DESCRIPTION
Hola @rolivencia 👋, pensaba usar el componente StoryCardSkeleton en la [línea 138](https://github.com/cuentoneta/cuentoneta/commit/f1b5866a71ce5bed4290eac9a3defb32261f33b2#diff-0be21753e78a4c854a1e2a0d4a80e8ebe6ff99fc3716cec3cbb85f205436bfc1R138) del template, pero como no tiene un ancho fijo aparece una barra de scroll horizontal a causa de eso y de igual manera la carga es tan rápida que no se nota si se pone el skelleton del la card, pero como dije antes genera un scroll horizontal.

También pensaba agregar los skelletons del template a un componente aparte para mantener el template mas simplificado, pero no se si te parezca la idea o si pueda traer problemas más adelante, así podríamos quitar el ngTemplateOutlet y usar un @if para renderizar uno u otro.