### PR TITLE
[#96] Agregar nuevo schema para configuración de landing page

### DIFF
--- a/cms/schemas/landingPage.ts
+++ b/cms/schemas/landingPage.ts
@@ -1,0 +1,46 @@
+import { CodeBlockIcon } from '@sanity/icons';
+
+export default {
+  name: 'landingPage',
+  title: 'Página de Inicio',
+  type: 'document',
+  icon: CodeBlockIcon,
+  fields: [
+    {
+      name: 'config',
+      title: 'Configuración',
+      type: 'string',
+    },
+    {
+      name: 'active',
+      title: 'Activa',
+      type: 'boolean',
+    },
+    {
+      name: 'previews',
+      title: 'Storylists con Vista Previa',
+      type: 'array',
+      of: [
+        {
+          name: 'storylist',
+          title: 'Storylist',
+          type: 'reference',
+          to: [{ type: 'storylist' }],
+        },
+      ],
+    },
+    {
+      name: 'cards',
+      title: 'Storylists con Tarjetas',
+      type: 'array',
+      of: [
+        {
+          name: 'storylist',
+          title: 'Storylist',
+          type: 'reference',
+          to: [{ type: 'storylist' }],
+        },
+      ],
+    },
+  ],
+};

--- a/cms/schemas/landingPage.ts
+++ b/cms/schemas/landingPage.ts
@@ -26,6 +26,16 @@ export default {
       validation: (Rule) => Rule.required(),
     },
     {
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        source: 'config',
+        maxLength: 96,
+      },
+      validation: (Rule) => Rule.required(),
+    },
+    {
       name: 'active',
       title: 'Activa',
       type: 'boolean',

--- a/cms/schemas/landingPage.ts
+++ b/cms/schemas/landingPage.ts
@@ -5,16 +5,31 @@ export default {
   title: 'Página de Inicio',
   type: 'document',
   icon: CodeBlockIcon,
+  preview: {
+    select: {
+      config: 'config',
+      active: 'active',
+    },
+    prepare(selection) {
+      const { config, active } = selection;
+      return {
+        title: `${config}`,
+        subtitle: active ? 'Activa' : 'Inactiva',
+      };
+    },
+  },
   fields: [
     {
       name: 'config',
       title: 'Configuración',
       type: 'string',
+      validation: (Rule) => Rule.required(),
     },
     {
       name: 'active',
       title: 'Activa',
       type: 'boolean',
+      validation: (Rule) => Rule.required(),
     },
     {
       name: 'previews',

--- a/cms/schemas/schema.ts
+++ b/cms/schemas/schema.ts
@@ -2,21 +2,23 @@
 // Then import schema types from any plugins that might expose them
 
 // We import object and document schemas
-import blockContent from './blockContent';
-import story from './story';
 import author from './author';
+import blockContent from './blockContent';
 import country from './country';
+import landingPage from './landingPage';
+import story from './story';
 import storylist from './storylist';
-import tag from './tag'
+import tag from './tag';
 
 export default [
-    // The following are document types which will appear in the studio.
-    // When added to this list, object types can be used as
-    // { type: 'typename' } in other document schemas
-    story,
-    storylist,
-    author,
-    country,
-    blockContent,
-    tag
+  // The following are document types which will appear in the studio.
+  // When added to this list, object types can be used as
+  // { type: 'typename' } in other document schemas
+  landingPage,
+  storylist,
+  story,
+  author,
+  blockContent,
+  country,
+  tag,
 ];

--- a/src/app/components/storylist-card-component/storylist-card.component.scss
+++ b/src/app/components/storylist-card-component/storylist-card.component.scss
@@ -52,6 +52,10 @@ $image-height: 240px;
     white-space: nowrap;
   }
 
+  .description{
+    height: 72px;
+  }
+
   .subtitle {
     color: theme.$gray-600;
   }

--- a/src/app/components/storylist-card-component/storylist-card.component.scss
+++ b/src/app/components/storylist-card-component/storylist-card.component.scss
@@ -53,7 +53,7 @@ $image-height: 240px;
   }
 
   .description{
-    height: 72px;
+    min-height: 72px;
   }
 
   .subtitle {

--- a/src/app/components/storylist-card-component/storylist-card.component.stories.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.stories.ts
@@ -22,17 +22,17 @@ export const Primary: Story = {
   }),
   args: {
     storylist: {
+      slug: 'verano-2022',
+      count: 60,
+      displayDates: true,
       title: 'Cuentoneta 1.0',
+      editionPrefix: 'Día',
+      comingNextLabel: 'Próximamente',
       description: [
         'La colección “Cuentos de Verano” de la primera versión de La Cuentoneta: una selección de textos publicados diariamente entre el Año Nuevo y el Martes de Carnaval de 2022',
       ],
-      publications: [],
-      images: [
-        {
-          slug: 'image-1',
-          url: 'https://cdn.sanity.io/images/s4dbqkc5/production/445f726810d3b0e39216db61fa40d663aaea3aa4-627x509.png',
-        },
-      ],
+      featuredImage:
+        'https://cdn.sanity.io/images/s4dbqkc5/production/445f726810d3b0e39216db61fa40d663aaea3aa4-627x509.png',
       tags: [
         {
           title: 'Curaduría',
@@ -53,20 +53,21 @@ export const Loading: Story = {
   render: (args: StorylistCardComponent) => ({
     props: args,
   }),
-  args: {
-  },
+  args: {},
 };
 
 export const Layout = {
   render: (args: StoryCardComponent) => ({
     props: args,
-    styles: [`
+    styles: [
+      `
             .grid {
             display: grid;
             grid-template-columns: repeat(2, 1fr);
             grid-gap: 1rem;
             }
-        `],
+        `,
+    ],
     template: `
       <div class="grid gap-4">
           <cuentoneta-storylist-card [storylist]="storylist1">
@@ -78,17 +79,17 @@ export const Layout = {
   }),
   args: {
     storylist1: {
+      slug: 'verano-2022',
+      count: 60,
+      displayDates: true,
       title: 'Cuentoneta 1.0',
+      editionPrefix: 'Día',
+      comingNextLabel: 'Próximamente',
       description: [
         'La colección “Cuentos de Verano” de la primera versión de La Cuentoneta: una selección de textos publicados diariamente entre el Año Nuevo y el Martes de Carnaval de 2022',
       ],
-      publications: [],
-      images: [
-        {
-          slug: 'image-1',
-          url: 'https://cdn.sanity.io/images/s4dbqkc5/production/445f726810d3b0e39216db61fa40d663aaea3aa4-627x509.png',
-        },
-      ],
+      featuredImage:
+        'https://cdn.sanity.io/images/s4dbqkc5/production/445f726810d3b0e39216db61fa40d663aaea3aa4-627x509.png',
       tags: [
         {
           title: 'Curaduría',
@@ -103,17 +104,17 @@ export const Layout = {
       ],
     },
     storylist2: {
+      slug: 'fec-english-sessions',
+      count: 13,
+      displayDates: false,
       title: 'FEC English Sessions',
+      editionPrefix: '',
+      comingNextLabel: 'Próximamente',
       description: [
         'Material para uso del English Study Group de FrontendCafé. Mediante estas historias disparamos charlas y practicamos nuestro reading en las sesiones virtuales de los Martes y Jueves.',
       ],
       publications: [],
-      images: [
-        {
-          slug: 'image-1',
-          url: 'https://cdn.sanity.io/images/s4dbqkc5/development/f6be445b251ce65a33721605303069659997bfbf-602x240.jpg?w=2000&fit=max&auto=format',
-        },
-      ],
+      featuredImage: 'https://cdn.sanity.io/images/s4dbqkc5/development/f6be445b251ce65a33721605303069659997bfbf-602x240.jpg?w=2000&fit=max&auto=format',
       tags: [
         {
           title: 'Colaborativa',

--- a/src/app/components/storylist-card-component/storylist-card.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.ts
@@ -26,7 +26,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
       >
         <header>
           <img
-            [ngSrc]="storylist?.images?.[0]?.url ?? ''"
+            [ngSrc]="storylist.featuredImage ?? ''"
             width="602"
             height="240"
           />
@@ -38,10 +38,11 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
         </section>
       </div>
       <footer class="flex justify-end pt-4 px-5 pb-5">
-        @if (storylist?.tags?.length > 0) { @for (tag of storylist?.tags;track
-        tag.slug) {
-        <cuentoneta-badge [tag]="tag" [showIcon]="true" class="ml-3" />
-        } }
+        @if (storylist.tags.length > 0) { 
+          @for (tag of storylist?.tags; track tag.slug) {
+            <cuentoneta-badge [tag]="tag" [showIcon]="true" class="ml-3" />
+          } 
+        }
       </footer>
     </article>
     } @else {
@@ -122,7 +123,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StorylistCardComponent {
-  @Input() storylist: Partial<StorylistCard> | null = null;
+  @Input() storylist: StorylistCard | null = null;
 
   protected readonly appRouteTree = APP_ROUTE_TREE;
 }

--- a/src/app/models/storylist.model.ts
+++ b/src/app/models/storylist.model.ts
@@ -12,7 +12,7 @@ interface StorylistBase {
   description?: string[];
   language?: string;
   featuredImage?: SanityImageSource;
-  tags?: Tag[];
+  tags: Tag[];
   images?: {
     slug: string;
     url: SanityImageSource;
@@ -24,6 +24,8 @@ interface StorylistBase {
   gridConfig?: StorylistGridConfig;
   previewGridConfig?: StorylistGridConfig;
 }
+
+export type StorylistCard = Omit<StorylistBase, 'images' | 'previewImages' | 'gridConfig' | 'previewGridConfig'>
 
 export interface Storylist extends StorylistBase {
   publications: Publication<Story>[];
@@ -55,8 +57,4 @@ export interface GridItemPlacementConfig {
   endCol?: number | string | null;
   startRow?: number | string | null;
   endRow?: number | string | null;
-}
-
-export interface StorylistCard extends Storylist {
-
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -33,13 +33,22 @@
         />
         <ng-container *ngIf="!!storylistDeck.storylist">
           <a
-                  [routerLink]="['/' + appRouteTree['STORYLIST']]"
-                  [queryParams]="{ slug: storylistDeck.storylist.slug }"
-                  class="navigation-link text-right"
+            [routerLink]="['/' + appRouteTree['STORYLIST']]"
+            [queryParams]="{ slug: storylistDeck.storylist.slug }"
+            class="navigation-link text-right"
           >
             Ver Storylist
           </a>
         </ng-container>
+      </ng-container>
+    </ng-container>
+  </section>
+
+  <section class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <ng-container *ngIf="!!storylistCardDecks && storylistCardDecks.length">
+      <ng-container *ngFor="let storylistDeck of storylistCardDecks">
+        <cuentoneta-storylist-card [storylist]="storylistDeck!.storylist!">
+        </cuentoneta-storylist-card>
       </ng-container>
     </ng-container>
   </section>

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,7 +1,11 @@
 // Core
 import { Component, inject, PLATFORM_ID } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CommonModule, isPlatformBrowser, NgOptimizedImage } from '@angular/common';
+import {
+  CommonModule,
+  isPlatformBrowser,
+  NgOptimizedImage,
+} from '@angular/common';
 
 // Services
 import { ContentService } from '../../providers/content.service';
@@ -15,49 +19,53 @@ import { APP_ROUTE_TREE } from '../../app.routes';
 import { StoryCardComponent } from 'src/app/components/story-card/story-card.component';
 import { StorylistCardDeckComponent } from 'src/app/components/storylist-card-deck/storylist-card-deck.component';
 import { RouterModule } from '@angular/router';
+import { StorylistCardComponent } from '../../components/storylist-card-component/storylist-card.component';
 
 @Component({
-    selector: 'cuentoneta-home',
-    templateUrl: './home.component.html',
-    styleUrls: ['./home.component.scss'],
-    standalone: true,
-    imports: [
-        CommonModule,
-        NgOptimizedImage,
-        StoryCardComponent,
-        StorylistCardDeckComponent,
-        RouterModule
-    ],
-    hostDirectives: [FetchContentDirective],
+  selector: 'cuentoneta-home',
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    NgOptimizedImage,
+    StoryCardComponent,
+    StorylistCardDeckComponent,
+    RouterModule,
+    StorylistCardComponent,
+  ],
+  hostDirectives: [FetchContentDirective],
 })
 export class HomeComponent {
-    readonly appRouteTree = APP_ROUTE_TREE;
+  readonly appRouteTree = APP_ROUTE_TREE;
 
-    storylistCardDecks: StorylistCardDeck[] = [];
+  storylistCardDecks: StorylistCardDeck[] = [];
 
-    // Services
-    public fetchContentDirective = inject(FetchContentDirective<StorylistCardDeck[]>);
-    private contentService = inject(ContentService);
+  // Services
+  public fetchContentDirective = inject(
+    FetchContentDirective<StorylistCardDeck[]>
+  );
+  private contentService = inject(ContentService);
 
-    constructor() {
-        // Asignación inicial para dibujar skeletons
-        this.storylistCardDecks = this.contentService.contentConfig;
+  constructor() {
+    // Asignación inicial para dibujar skeletons
+    this.storylistCardDecks = this.contentService.contentConfig;
 
-        const platformId = inject(PLATFORM_ID);
-        if (!isPlatformBrowser(platformId)) {
-            return;
-        }
-
-        // En cliente-side, posteriormente, se cargan los decks con las historias, según la configuración de contenido
-        this.loadStorylistDecks();
+    const platformId = inject(PLATFORM_ID);
+    if (!isPlatformBrowser(platformId)) {
+      return;
     }
 
-    private loadStorylistDecks() {
-        this.fetchContentDirective
-            .fetchContent$(this.contentService.fetchStorylistDecks())
-            .pipe(takeUntilDestroyed())
-            .subscribe((result) => {
-                this.storylistCardDecks = result;
-            });
-    }
+    // En cliente-side, posteriormente, se cargan los decks con las historias, según la configuración de contenido
+    this.loadStorylistDecks();
+  }
+
+  private loadStorylistDecks() {
+    this.fetchContentDirective
+      .fetchContent$(this.contentService.fetchStorylistDecks())
+      .pipe(takeUntilDestroyed())
+      .subscribe((result) => {
+        this.storylistCardDecks = result;
+      });
+  }
 }


### PR DESCRIPTION
# Resumen
* Agrega schema `landingPage` a Sanity.

## Otros cambios
* Agregado de visualización preliminar de storylists en `HomeComponent`.
* Cambios en propiedades de modelos `Storylist` y `StorylistCard`.
* Adapta stories de Storybook para trabajar con inputs de tipo `StorylistCard | null` como input del `StorylistCardComponent`.