### PR TITLE
[#498] Adaptar contenido en formato Preview y Card para storylists en /home

### DIFF
--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -59,92 +59,95 @@ const stagingBranchUrl = 'cuentoneta-git-develop-rolivencia.vercel.app';
 const apiUrl = generateApiUrl(environment, branchUrl);
 
 // Obtiene la vista de preview para generar skeletons
-const fetchStorylistsPreviewDeckConfig = () =>
-  client.fetch(
-    `*[_type == 'storylist']
-                    { 
-                        'slug': slug.current,
-                        'title': title,
-                        'ordering': previewGridConfig.ordering,
-                        'orderInLandingPage': previewGridConfig.landingPageOrder,
-                        'previewGridSkeletonConfig': {
-                            'gridTemplateColumns': previewGridConfig.gridTemplateColumns,
-                            'titlePlacement': previewGridConfig.titlePlacement,
-                            'cardsPlacement': previewGridConfig.cardsPlacement[] {
-                              'order': order,
-                              'slug': @.publication.story->slug.current,
-                              'startCol': startCol,
-                              'imageSlug': imageSlug.current,
-                              'endCol': endCol,
-                              'startRow': startRow,
-                              'endRow': endRow,
-                            }
-                        },
-                        'gridSkeletonConfig': {
-                            'gridTemplateColumns': gridConfig.gridTemplateColumns,
-                            'titlePlacement': gridConfig.titlePlacement,
-                            'cardsPlacement': gridConfig.cardsPlacement[] {
-                              'order': order,
-                              'slug': @.publication.story->slug.current,
-                              'startCol': startCol,
-                              'imageSlug': imageSlug.current,
-                              'endCol': endCol,
-                              'startRow': startRow,
-                              'endRow': endRow,
-                            }
-                        }
-                    } | order(orderInLandingPage asc)`
-  );
+const fetchStorylistsPreviewDeckConfig = () => {
+  const previewsSubQuery = `{
+        'slug': slug.current,
+        'title': title,
+        'ordering': previewGridConfig.ordering,
+        'previewGridSkeletonConfig': {
+            'gridTemplateColumns': previewGridConfig.gridTemplateColumns,
+            'titlePlacement': previewGridConfig.titlePlacement,
+            'cardsPlacement': previewGridConfig.cardsPlacement[] {
+            'order': order,
+            'slug': @.publication.story->slug.current,
+            'startCol': startCol,
+            'imageSlug': imageSlug.current,
+            'endCol': endCol,
+            'startRow': startRow,
+            'endRow': endRow,
+            }
+        }
+  }`;
 
-fetchStorylistsPreviewDeckConfig().then((storylists: StorylistDeckConfig[]) => {
-  // Accede a las variables de entorno y genera un string
-  // correspondiente al objeto environment que utilizará Angular
-  const environmentFileContent = `
+  const cardsSubQuery = `{
+        'slug': slug.current,
+  }`;
+
+  return client.fetch(
+    `*[_type == 'landingPage'] {
+            'previews': previews[]-> ${previewsSubQuery},
+            'cards': cards[]-> ${cardsSubQuery}
+          }[0]`
+  );
+};
+
+fetchStorylistsPreviewDeckConfig().then(
+  (landingPage: {
+    previews: StorylistDeckConfig[];
+    cards: StorylistDeckConfig[];
+  }) => {
+    // Accede a las variables de entorno y genera un string
+    // correspondiente al objeto environment que utilizará Angular
+    const environmentFileContent = `
     export const environment = {
        environment: "${environment}",
-       contentConfig: ${JSON.stringify(
-         storylists
-           .filter(
-             (storylist: any) =>
-               !!storylist.previewGridSkeletonConfig.cardsPlacement
-           )
-           .map((storylist: any) => ({
-             ...storylist,
-             amount: storylist.previewGridSkeletonConfig.cardsPlacement.filter(
-               (card: any) => !!card.slug
-             ).length,
-           }))
-       )},
+       contentConfig: { 
+        previews: ${JSON.stringify(
+          landingPage.previews
+            .filter(
+              (storylist: any) =>
+                !!storylist.previewGridSkeletonConfig.cardsPlacement
+            )
+            .map((storylist: any) => ({
+              ...storylist,
+              amount: storylist.previewGridSkeletonConfig.cardsPlacement.filter(
+                (card: any) => !!card.slug
+              ).length,
+            }))
+        )},
+        cards: ${JSON.stringify(landingPage.cards)}
+       },
        website: "${process.env['CUENTONETA_WEBSITE']}",
        apiUrl: "${apiUrl}"
     };
 `;
 
-  // En caso de que no exista el directorio environments, se lo crea
-  if (!existsSync(dirPath)) {
-    mkdirSync(dirPath);
-  }
-
-  // Escribe el contenido en el archivo correspondiente environment.ts
-  writeFile(
-    targetPath,
-    environmentFileContent,
-    { flag: 'w' },
-    function (err: ErrnoException | null) {
-      if (err) {
-        console.log(err);
-        return;
-      }
-      console.log(`Variables de entorno escritas en ${targetPath}`);
-      console.log(
-        'Ambiente de Vercel - VERCEL_ENV = ',
-        process.env['VERCEL_ENV']
-      );
-      console.log(
-        'URL de branch de Vercel - VERCEL_BRANCH_URL = ',
-        process.env['VERCEL_BRANCH_URL']
-      );
-      console.log('URL de API = ', apiUrl);
+    // En caso de que no exista el directorio environments, se lo crea
+    if (!existsSync(dirPath)) {
+      mkdirSync(dirPath);
     }
-  );
-});
+
+    // Escribe el contenido en el archivo correspondiente environment.ts
+    writeFile(
+      targetPath,
+      environmentFileContent,
+      { flag: 'w' },
+      function (err: ErrnoException | null) {
+        if (err) {
+          console.log(err);
+          return;
+        }
+        console.log(`Variables de entorno escritas en ${targetPath}`);
+        console.log(
+          'Ambiente de Vercel - VERCEL_ENV = ',
+          process.env['VERCEL_ENV']
+        );
+        console.log(
+          'URL de branch de Vercel - VERCEL_BRANCH_URL = ',
+          process.env['VERCEL_BRANCH_URL']
+        );
+        console.log('URL de API = ', apiUrl);
+      }
+    );
+  }
+);

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -60,7 +60,7 @@ const apiUrl = generateApiUrl(environment, branchUrl);
 
 // Obtiene la vista de preview para generar skeletons
 const fetchStorylistsPreviewDeckConfig = () => {
-  const previewsSubQuery = `{
+  const subQuery = `{
         'slug': slug.current,
         'title': title,
         'ordering': previewGridConfig.ordering,
@@ -92,14 +92,10 @@ const fetchStorylistsPreviewDeckConfig = () => {
         }
   }`;
 
-  const cardsSubQuery = `{
-        'slug': slug.current,
-  }`;
-
   return client.fetch(
     `*[_type == 'landingPage'] {
-            'previews': previews[]-> ${previewsSubQuery},
-            'cards': cards[]-> ${cardsSubQuery}
+            'previews': previews[]-> ${subQuery},
+            'cards': cards[]-> ${subQuery}
           }[0]`
   );
 };

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -76,6 +76,19 @@ const fetchStorylistsPreviewDeckConfig = () => {
             'startRow': startRow,
             'endRow': endRow,
             }
+        },
+        'gridSkeletonConfig': {
+            'gridTemplateColumns': gridConfig.gridTemplateColumns,
+            'titlePlacement': gridConfig.titlePlacement,
+            'cardsPlacement': gridConfig.cardsPlacement[] {
+            'order': order,
+            'slug': @.publication.story->slug.current,
+            'startCol': startCol,
+            'imageSlug': imageSlug.current,
+            'endCol': endCol,
+            'startRow': startRow,
+            'endRow': endRow,
+            }
         }
   }`;
 

--- a/src/api/content.controller.ts
+++ b/src/api/content.controller.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import { fetchLandingPageContent } from './content.service';
+const router = express.Router();
+
+// Routes
+router.get('/landing-page', getLandingPageContent);
+
+export default router;
+
+function getLandingPageContent(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) {
+  fetchLandingPageContent(req, res)
+    .then((result) => res.json(result))
+    .catch((err) => next(err));
+}

--- a/src/api/content.service.ts
+++ b/src/api/content.service.ts
@@ -1,0 +1,24 @@
+import { client } from './_helpers/sanity-connector';
+import express from 'express';
+
+export async function fetchLandingPageContent(
+  req: express.Request,
+  res: express.Response
+) {
+  const query = `*[_type == 'landingPage'] {
+            'previews': previews[]->,
+            'cards': cards[]->
+        }[0]`;
+
+  const result = await client.fetch(query, {});
+
+  if (!result) {
+    res.json(null);
+  }
+
+  return res.json(result);
+}
+
+module.exports = {
+  fetchLandingPageContent,
+};

--- a/src/api/content.service.ts
+++ b/src/api/content.service.ts
@@ -18,7 +18,3 @@ export async function fetchLandingPageContent(
 
   return res.json(result);
 }
-
-module.exports = {
-  fetchLandingPageContent,
-};

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,9 +1,13 @@
+import contentController from './content.controller';
 import ogController from './og.controller';
 import storyController from './story.controller';
 import storylistController from './storylist.controller';
 
-
 export default [
+  {
+    path: '/content',
+    controller: contentController,
+  },
   {
     path: '/og',
     controller: ogController,

--- a/src/app/components/storylist-card-component/storylist-card.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.ts
@@ -38,7 +38,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
         </section>
       </div>
       <footer class="flex justify-end pt-4 px-5 pb-5">
-        @if (storylist.tags.length > 0) { 
+        @if (!!storylist.tags && storylist.tags.length > 0) { 
           @for (tag of storylist?.tags; track tag.slug) {
             <cuentoneta-badge [tag]="tag" [showIcon]="true" class="ml-3" />
           } 
@@ -123,7 +123,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StorylistCardComponent {
-  @Input() storylist: StorylistCard | null = null;
+  @Input() storylist: StorylistCard | undefined;
 
   protected readonly appRouteTree = APP_ROUTE_TREE;
 }

--- a/src/app/directives/fetch-content.directive.ts
+++ b/src/app/directives/fetch-content.directive.ts
@@ -45,7 +45,7 @@ export class FetchContentDirective<T> {
      * al realizar la llamada async a la fuente y luego de terminada ésta.
      * @param source$
      */
-    public fetchContent$(source$: Observable<T>): Observable<T> {
+    public fetchContent$<T>(source$: Observable<T>): Observable<T> {
         this.isLoading = true;
         return source$.pipe(tap(() => (this.isLoading = false)));
     }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -18,9 +18,9 @@
     </div>
   </section>
 
-  <section class="card-decks">
-    <ng-container *ngIf="!!storylistCardDecks && storylistCardDecks.length">
-      <ng-container *ngFor="let storylistDeck of storylistCardDecks">
+  <section class="card-decks mb-16">
+    <ng-container *ngIf="!!previews && previews.length">
+      <ng-container *ngFor="let storylistDeck of previews">
         <cuentoneta-storylist-card-deck
           class="mb-3"
           [canNavigateToStorylist]="true"
@@ -44,10 +44,22 @@
     </ng-container>
   </section>
 
-  <section class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-    <ng-container *ngIf="!!storylistCardDecks && storylistCardDecks.length">
-      <ng-container *ngFor="let storylistDeck of storylistCardDecks">
-        <cuentoneta-storylist-card [storylist]="storylistDeck!.storylist!">
+  <div class="flex content-between items-center mb-4">
+    <hr class="flex-grow" />
+    <h2 class="mx-8">¿Buscás otras lecturas?</h2>
+    <hr class="flex-grow" />
+  </div>
+  <div class="flex justify-center mb-8">
+    <h3 class="subtitle">
+      En este apartado podrás encontrar todas las storylists publicadas hasta el
+      momento en La Cuentoneta
+    </h3>
+  </div>
+
+  <section class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+    <ng-container *ngIf="!!cards && cards.length">
+      <ng-container *ngFor="let deck of cards">
+        <cuentoneta-storylist-card [storylist]="deck.storylist">
         </cuentoneta-storylist-card>
       </ng-container>
     </ng-container>

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -39,7 +39,8 @@ import { StorylistCardComponent } from '../../components/storylist-card-componen
 export class HomeComponent {
   readonly appRouteTree = APP_ROUTE_TREE;
 
-  storylistCardDecks: StorylistCardDeck[] = [];
+  cards: StorylistCardDeck[] = [];
+  previews: StorylistCardDeck[] = [];
 
   // Services
   public fetchContentDirective = inject(
@@ -49,7 +50,8 @@ export class HomeComponent {
 
   constructor() {
     // Asignación inicial para dibujar skeletons
-    this.storylistCardDecks = this.contentService.contentConfig;
+    this.cards = this.contentService.contentConfig.cards;
+    this.previews = this.contentService.contentConfig.previews;
 
     const platformId = inject(PLATFORM_ID);
     if (!isPlatformBrowser(platformId)) {
@@ -62,10 +64,13 @@ export class HomeComponent {
 
   private loadStorylistDecks() {
     this.fetchContentDirective
-      .fetchContent$(this.contentService.fetchStorylistDecks())
+      .fetchContent$<[StorylistCardDeck[], StorylistCardDeck[]]>(
+        this.contentService.fetchStorylistDecks()
+      )
       .pipe(takeUntilDestroyed())
-      .subscribe((result) => {
-        this.storylistCardDecks = result;
+      .subscribe(([previews, cards]) => {
+        this.previews = previews;
+        this.cards = cards;
       });
   }
 }

--- a/src/app/pages/storylist/storylist.component.ts
+++ b/src/app/pages/storylist/storylist.component.ts
@@ -52,7 +52,8 @@ export class StorylistComponent {
       activatedRoute.queryParams.pipe(
         tap(({ slug }) => {
           this.storylist = undefined;
-          this.skeletonConfig = contentService.contentConfig.find(
+          const decks = [...contentService.contentConfig.cards, ...contentService.contentConfig.previews]
+          this.skeletonConfig = decks.find(
             (config) =>
               config.slug === activatedRoute.snapshot.queryParams['slug']
           )?.gridSkeletonConfig;

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -49,9 +49,9 @@ export class ContentService {
   /**
    * En base a la configuración de contenido disponible, hace fetch de la lista de
    * storylists referenciada en los objetos de configuración, para luego generar
-   * un array de objetos compuestos de tipo StorylistCardDeck, los cuales contienen
-   * la configuración y la correspondiente información para renderizar un deck de
-   * cards de cada storylist.
+   * una tupa de arrays de objetos compuestos de tipo StorylistCardDeck, los cuales
+   * contienen la configuración y la correspondiente información para renderizar
+   * los decks de previews y cards de cada storylist.
    */
   public fetchStorylistDecks(): Observable<[StorylistCardDeck[], StorylistCardDeck[]]> {
     const previewConfigs = this.contentConfig.previews;
@@ -91,31 +91,5 @@ export class ContentService {
         ]);
       })
     ) as Observable<[StorylistCardDeck[], StorylistCardDeck[]]>;
-  }
-
-  /**
-   * De forma similar a fetchStorylistDecks(), este método se encarga de obtener la
-   * lista de storylists referenciada en los objetos de configuración para mostrar
-   * la información de las mismas en cards en la landing page.
-   */
-  public fetchStorylistCards(): Observable<StorylistCardDeck[]> {
-    const cardConfigs = this.contentConfig.cards;
-
-    return combineLatest(
-      [...cardConfigs].map((config) =>
-        this.storylistService.getPreview(config.slug)
-      )
-    ).pipe(
-      map((storylists) =>
-        cardConfigs.map(
-          (contentConfig): StorylistCardDeck => ({
-            ...contentConfig,
-            storylist: storylists
-              .filter((storylist) => storylist.slug === contentConfig.slug)
-              .pop() as Storylist,
-          })
-        )
-      )
-    );
   }
 }

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -3,31 +3,34 @@ import { inject, Injectable } from '@angular/core';
 import { combineLatest, map, Observable, of, tap } from 'rxjs';
 
 // Interfaces
-import {
-  StorylistCardDeck,
-  StorylistDeckConfig,
-} from '@models/content.model';
+import { StorylistCardDeck, StorylistDeckConfig } from '@models/content.model';
 import { Storylist } from '@models/storylist.model';
 
 // Providers
 import { environment } from '../environments/environment';
 import { StorylistService } from './storylist.service';
 
+interface LandingPageContent {
+  cards: StorylistDeckConfig[];
+  previews: StorylistDeckConfig[];
+}
+
 @Injectable({
   providedIn: 'root',
 })
 export class ContentService {
-  private _contentConfig: StorylistDeckConfig[] = [];
+  private readonly prefix = `${environment.apiUrl}api/content`;
+  private _contentConfig: LandingPageContent = { cards: [], previews: [] };
 
   // Services
   private storylistService = inject(StorylistService);
 
-  get contentConfig(): StorylistDeckConfig[] {
+  get contentConfig(): LandingPageContent {
     return this._contentConfig;
   }
 
-  public fetchContentConfig(): Observable<StorylistDeckConfig[]> {
-    return of(environment.contentConfig as StorylistDeckConfig[]).pipe(
+  public fetchContentConfig(): Observable<LandingPageContent> {
+    return of(environment.contentConfig as LandingPageContent).pipe(
       tap((contentConfig) => {
         this._contentConfig = contentConfig;
       })
@@ -51,14 +54,41 @@ export class ContentService {
    * cards de cada storylist.
    */
   public fetchStorylistDecks(): Observable<StorylistCardDeck[]> {
-    const configs = this.contentConfig;
+    const previewConfigs = this.contentConfig.previews;
+
     return combineLatest(
-      [...configs].map((storylistDeckConfig) =>
-        this.storylistService.getPreview(storylistDeckConfig.slug)
+      [...previewConfigs].map((config) =>
+        this.storylistService.getPreview(config.slug)
       )
     ).pipe(
       map((storylists) =>
-        configs.map(
+        previewConfigs.map(
+          (contentConfig): StorylistCardDeck => ({
+            ...contentConfig,
+            storylist: storylists
+              .filter((storylist) => storylist.slug === contentConfig.slug)
+              .pop() as Storylist,
+          })
+        )
+      )
+    );
+  }
+
+  /**
+   * De forma similar a fetchStorylistDecks(), este método se encarga de obtener la
+   * lista de storylists referenciada en los objetos de configuración para mostrar
+   * la información de las mismas en cards en la landing page.
+   */
+  public fetchStorylistCards(): Observable<StorylistCardDeck[]> {
+    const cardConfigs = this.contentConfig.cards;
+
+    return combineLatest(
+      [...cardConfigs].map((config) =>
+        this.storylistService.getPreview(config.slug)
+      )
+    ).pipe(
+      map((storylists) =>
+        cardConfigs.map(
           (contentConfig): StorylistCardDeck => ({
             ...contentConfig,
             storylist: storylists


### PR DESCRIPTION
# Resumen
* Se agregan modificaciones en controllers, services y componentes para soportar la visualización de storylists como previews y como cards en la landing page de la aplicación.
* Se actualiza script `set-environment.ts` para renderizar correctamente los skeletons de las cards.

## Screenshots
![image](https://github.com/cuentoneta/cuentoneta/assets/32349705/7ecec5a0-879d-4d32-b3f5-ef22da1169a8)
