### PR TITLE
[#507] Agregar manejo de links en texto de BlockContent a parser HTML

### DIFF
--- a/src/app/models/block-content.model.ts
+++ b/src/app/models/block-content.model.ts
@@ -14,14 +14,14 @@ export interface BlockContent {
 }
 
 export interface Block {
-    _type: 'span';
+    _type: string;
     _key: string;
     text: string;
     marks?: string[];
 }
 
 export interface MarkDef {
-    _type: 'link';
+    _type: string;
     _key: string;
     href: string;
 }

--- a/src/app/pages/story/story.component.scss
+++ b/src/app/pages/story/story.component.scss
@@ -78,6 +78,4 @@ article {
     width: 100%;
   }
 
-  footer {
-  }
 }

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -17,8 +17,8 @@ export class StoryService {
   public getBySlug(slug: string): Observable<Story> {
     const params = new HttpParams().set('slug', slug);
     return this.http
-      .get<StoryDTO>(`${this.prefix}/read`, { params })
-      .pipe(map((story) => this.parseStoryContent(story)));
+        .get<StoryDTO>(`${this.prefix}/read`, { params })
+        .pipe(map((story) => this.parseStoryContent(story)));
   }
 
   public parseStoryCardContent(story: StoryDTO): StoryCard {
@@ -26,10 +26,10 @@ export class StoryService {
       ...story,
       prologues: story.prologues ?? [],
       paragraphs:
-        story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ??
-        [],
+          story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ??
+          [],
       summary:
-        story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
+          story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
     };
   }
 
@@ -38,14 +38,14 @@ export class StoryService {
       ...story,
       prologues: story.prologues ?? [],
       paragraphs:
-        story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ??
-        [],
+          story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ??
+          [],
       summary:
-        story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
+          story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
       author: {
         ...story.author,
         biography:
-          story.author.biography?.map((x) => this.parseParagraph(x)) ?? [],
+            story.author.biography?.map((x) => this.parseParagraph(x)) ?? [],
       },
     };
   }
@@ -54,16 +54,16 @@ export class StoryService {
     let paragraph = '';
     let classes: string[] = [];
 
+    block.markDefs
+
     block.children.forEach((x: Block) => {
-      let part = x.text;
+      let part = '';
 
-      // Comprobación de estilos de texto y aplicación de la transformación correspondiente
-      if (x.marks?.includes('em')) {
-        part = this.addItalics(part);
-      }
+      part = this.parseBlockMarks(x)
 
-      if (x.marks?.includes('strong')) {
-        part = this.addBold(part);
+      // Comprueba si el bloque actual debe ser un enlace
+      if(block.markDefs?.find(m => m._key === x.marks?.[0])){
+        part = `<a href="">${part}</a>`
       }
 
       // Transformación de salto de línea en texto dentro del mismo párrafo
@@ -78,6 +78,21 @@ export class StoryService {
       paragraph = paragraph.concat(part);
     });
     return { classes: classes.join(' '), text: paragraph };
+  }
+
+  private parseBlockMarks(block: Block): string {
+    let part = block.text;
+
+    // Comprobación de estilos de texto y aplicación de la transformación correspondiente
+    if (block.marks?.includes('em')) {
+      part = this.addItalics(part);
+    }
+
+    if (block.marks?.includes('strong')) {
+      part = this.addBold(part);
+    }
+
+    return part
   }
 
   private addItalics(text: string): string {

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -21,16 +21,6 @@ export class StoryService {
       .pipe(map((story) => this.parseStoryContent(story)));
   }
 
-  // ToDo: Rediseñar funcionamiento del endpoint de autores.
-  public getAuthors(): Observable<Story[]> {
-    return this.http.get<Story[]>(`${this.prefix}/authors`);
-  }
-
-  // ToDo: Rediseñar funcionamiento del endpoint de links originales.
-  public getOriginalLinks(): Observable<Story[]> {
-    return this.http.get<Story[]>(`${this.prefix}/original-links`);
-  }
-
   public parseStoryCardContent(story: StoryDTO): StoryCard {
     return {
       ...story,

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -57,9 +57,14 @@ export class StoryService {
     blockContent.markDefs;
 
     blockContent.children.forEach((block: Block) => {
-      let part = '';
+      let part = block.text;
 
-      part = this.parseBlockTextStyleMarks(block);
+      part = this.parseBlockTextStyleMarks(block, part);
+      part = this.parseBlockTextMarkDefs(
+        part,
+        block.marks ?? [],
+        blockContent.markDefs ?? []
+      );
 
       // Transformación de salto de línea en texto dentro del mismo párrafo
       part = part.replaceAll('\n', '<br/>');
@@ -80,12 +85,13 @@ export class StoryService {
    * Genera tags HTML para los estilos de texto en negrita e itálica
    * // TODO: Soportar los restantes estilos de texto del tipo BlockContent en Sanity
    * @param block
+   * @param part
    * @private
    */
-  private parseBlockTextStyleMarks(block: Block): string {
-    let part = block.text;
+  private parseBlockTextStyleMarks(block: Block, part: string = ''): string {
     const marks = block.marks ?? [];
 
+    if(block.marks?.length === 0) return part;
 
     marks.forEach((mark) => {
       switch (mark) {
@@ -103,9 +109,26 @@ export class StoryService {
     return part;
   }
 
-  private parseMarkDefs(markDefs: MarkDef[], part: string): string {
-    if (markDefs.length === 0) return part;
-    return part;
+  private parseBlockTextMarkDefs(
+      text: string,
+      marks: string[],
+      markDefs: MarkDef[]
+  ): string {
+    if (markDefs.length === 0 || marks.length === 0) return text;
+
+    markDefs.forEach((markDef) => {
+      if (marks.includes(markDef._key)) {
+        switch (markDef._type) {
+          case 'link':
+            text = this.addUrlLink(text, markDef.href);
+            break;
+          default:
+            break;
+        }
+      }
+    });
+
+    return text;
   }
 
   private addItalics(text: string): string {

--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -30,6 +30,7 @@ $gray-800: hsl(240, 4%, 16%);
 $gray-900: hsl(240, 6%, 10%);
 
 $interactive-500: hsl(212, 70%, 45%);
+$interactive-600: hsl(212, 70%, 35%);
 
 // Border radius
 $rounded: 4px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -28,3 +28,27 @@ ngx-skeleton-loader {
 * {
   //outline: 1px solid red;
 }
+
+/**
+  Sección de estilos globales aplicados a componentes
+
+  Para aplicar estilos a un componente en específico, por fuera de la ViewEncapsulation de Angular, debe
+  declararse el selector del componente en el selector de la regla CSS y, posteriormente, anidar los estilos
+  que se deseen aplicar al mismo.
+
+  Los casos de aplicación para reglas CSS globales son:
+  - Aplicar estilos a un componente que no se puede modificar (por ejemplo, un componente de un paquete externo).
+  - Aplicar estilos a HTML generado dinámicamente e inyectado en la vista mediante atributos InnerHTML o OuterHTML.
+ */
+
+cuentoneta-bio-summary-card {
+  .bio-and-summary p {
+    a {
+      color: $interactive-500;
+      text-decoration: underline;
+      &:hover {
+        color: $interactive-600;
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Resumen
Se agrega soporte para parsing de links del texto en formato BlockContent para su transformación en tags `<a>` de HTML y asignación de atributos `href` con la URL de navegación.

## Otros cambios
* Eliminación de selectores de estilos redundantes.
* Agrega color `$interactive-600`.
* Agrega estilos globales para colores de links en `BioSummaryCardComponent`.
