### PR TITLE
[#518] Volver opcional el campo review/summary

### DIFF
--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -119,7 +119,6 @@ export default {
       name: 'review',
       title: 'Reseña',
       type: 'blockContent',
-      validation: (Rule) => Rule.required(),
     },
   ],
   initialValue: {

--- a/src/app/components/badge/badge.component.spec.ts
+++ b/src/app/components/badge/badge.component.spec.ts
@@ -12,6 +12,8 @@ describe('BadgeComponent', () => {
 
     fixture = TestBed.createComponent(BadgeComponent);
     component = fixture.componentInstance;
+    component.tag = { title: 'test', description: 'test', icon: { svg: 'test.svg', provider: 'md', name: 'test' }, slug: 'test' }
+    component.showIcon = true
     fixture.detectChanges();
   });
 

--- a/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
@@ -22,13 +22,14 @@ const mockStory: Story = {
     approximateReadingTime: 5,
     author: mockAuthor,
     originalLink: 'https://gativideo.com/historia-de-la-pelicula',
+    language: 'es',
     videoUrl: 'https://gativideo.com/video.mp4',
     badLanguage: false,
     prologues: [],
-    summary: 'Arranca con "Fanfare for the Common Man" y la próxima canción es "Silhouette" de Kenny G.',
+    summary: [{classes: '', text: 'Arranca con "Fanfare for the Common Man" y la próxima canción es "Silhouette" de Kenny G.',}],
     paragraphs: [
-        'El presente Video-Cassette se vende para uso personal o doméstico exclusivamente, todos los demás derechos quedan reservados',
-        'Cualquier divulgación total o parcial de la obra, sea a través de copias, edición, adición, exhibición, difusión y/o emisión de difusión queda expresamente prohibida.'
+        { classes: '', text: 'El presente Video-Cassette se vende para uso personal o doméstico exclusivamente, todos los demás derechos quedan reservados' },
+        { classes: '', text: 'Cualquier divulgación total o parcial de la obra, sea a través de copias, edición, adición, exhibición, difusión y/o emisión de difusión queda expresamente prohibida.' }
     ]
 }
 

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -23,7 +23,7 @@ export interface Story extends StoryBase {
 export interface StoryDTO extends StoryBase {
   author: AuthorDTO;
   prologues: PrologueDTO[];
-  summary: BlockContent[];
+  summary?: BlockContent[];
   paragraphs: BlockContent[];
 }
 


### PR DESCRIPTION
# Resumen
* El campo `review` del schema `story` es ahora opcional.
* La propiedad `summary` del modelo `StoryDTO` se transforma en opcional.