### PR TITLE
[#558] - Arreglar el responsive en la seccion storylists

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -28,7 +28,7 @@
 
 	<div class="flex content-between items-center mb-4">
 		<hr class="flex-grow" />
-		<h2 class="mx-8">¿Buscás otras lecturas?</h2>
+		<h2 class="mx-8 text-center">¿Buscás otras lecturas?</h2>
 		<hr class="flex-grow" />
 	</div>
 	<div class="flex justify-center mb-8">

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -32,12 +32,12 @@
 		<hr class="flex-grow" />
 	</div>
 	<div class="flex justify-center mb-8">
-		<h3 class="subtitle">
+		<h3 class="subtitle text-center">
 			En este apartado podrás encontrar todas las storylists publicadas hasta el momento en La Cuentoneta
 		</h3>
 	</div>
 
-	<section class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+	<section class="grid grid-cols-1 justify-items-center lg:grid-cols-2 gap-8">
 		@if (!!cards && cards.length) {
 			<ng-container *ngFor="let deck of cards">
 				<cuentoneta-storylist-card [storylist]="deck.storylist"> </cuentoneta-storylist-card>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -40,7 +40,7 @@
 	<section class="grid grid-cols-1 justify-items-center lg:grid-cols-2 gap-8">
 		@if (!!cards && cards.length) {
 			<ng-container *ngFor="let deck of cards">
-				<cuentoneta-storylist-card [storylist]="deck.storylist"> </cuentoneta-storylist-card>
+				<cuentoneta-storylist-card class="w-full" [storylist]="deck.storylist"> </cuentoneta-storylist-card>
 			</ng-container>
 		}
 	</section>


### PR DESCRIPTION
Corregí la alineación de las tarjetas y títulos en la sección **"¿Buscás otras lecturas?"** para que encajen correctamente.

Antes:
![image](https://github.com/cuentoneta/cuentoneta/assets/108735782/914b5417-4127-4b79-ba69-75d2d4c319d9)
Despues:
![image](https://github.com/cuentoneta/cuentoneta/assets/108735782/72261a92-207e-41b2-857a-20239a02a330)

El **skeleton** de las tarjetas también se mantiene en la posición y alineación correcta.