### PR TITLE
[#553] Añadida la integración con Vercel Speed Insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/express": "^4.17.17",
     "@vercel/analytics": "^1.0.0",
     "@vercel/node": "^2.10.3",
+    "@vercel/speed-insights": "^1.0.9",
     "dayjs": "^1.11.7",
     "dotenv": "^16.0.3",
     "esbuild": "0.19.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ dependencies:
   '@vercel/node':
     specifier: ^2.10.3
     version: 2.10.3(@swc/core@1.3.85)
+  '@vercel/speed-insights':
+    specifier: ^1.0.9
+    version: 1.0.9(react@18.2.0)
   dayjs:
     specifier: ^1.11.7
     version: 1.11.7
@@ -7871,6 +7874,33 @@ packages:
       - '@swc/core'
       - '@swc/wasm'
       - encoding
+    dev: false
+
+  /@vercel/speed-insights@1.0.9(react@18.2.0):
+    resolution: {integrity: sha512-f+XFP0O+aZ4Olj9h+BitkB1b4NJQaxtyCb69wWuDxytJHY6Pa4QtZPdBUftHOcajUCHRVeq062fk3MKXKtjNVQ==}
+    requiresBuild: true
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19
+      svelte: ^4
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /@vercel/static-config@2.0.15:

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -22,14 +22,14 @@ import { RouterModule } from '@angular/router';
 })
 export class AppComponent implements OnInit {
   constructor() {
-    // Import and configure the Vercel analytics package
+    // Importa y configura el paquete de analytics de Vercel.
     inject({
       mode: environment.environment === 'production' ? 'production' : 'development',
     });
   }
 
   ngOnInit(): void {
-    // Call injectSpeedInsights here to ensure it runs on the client side
+    // Invoca a injectSpeedInsights aquí para asegurarse de que se ejecute en el lado del cliente.
     injectSpeedInsights();
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { inject } from '@vercel/analytics';
+import { injectSpeedInsights } from '@vercel/speed-insights';
 import { environment } from './environments/environment';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { HeaderComponent } from './components/header/header.component';
@@ -19,12 +20,16 @@ import { RouterModule } from '@angular/router';
     RouterModule,
   ],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   constructor() {
-    // Importa y configura el paquete de analytics de Vercel
+    // Import and configure the Vercel analytics package
     inject({
-      mode:
-        environment.environment === 'production' ? 'production' : 'development',
+      mode: environment.environment === 'production' ? 'production' : 'development',
     });
+  }
+
+  ngOnInit(): void {
+    // Call injectSpeedInsights here to ensure it runs on the client side
+    injectSpeedInsights();
   }
 }


### PR DESCRIPTION
**Cambios realizados:**

1. Integrada la herramienta Vercel Speed Insights.
2. Agregado el componente SpeedInsights para iniciar el script de seguimiento de métricas.
3. Actualizado el AppComponent para llamar a injectSpeedInsights en el hook de ciclo de vida ngOnInit.

El propósito de este Pull Request es incorporar Vercel Speed Insights, una herramienta de monitoreo de rendimiento, en nuestra aplicación Angular. Esta integración nos permite hacer un seguimiento y analizar las métricas de rendimiento de la aplicación.

Resuelve el issue #553.
