### PR TITLE
[#564] - Componente youtube-player agregado al componente story-component

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@angular/platform-server": "17.1.2",
 		"@angular/router": "17.1.2",
 		"@angular/ssr": "17.1.2",
+		"@angular/youtube-player": "^17.1.2",
 		"@nx/angular": "18.0.1",
 		"@sanity/client": "^3.4.1",
 		"@sanity/image-url": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   '@angular/ssr':
     specifier: 17.1.2
     version: 17.1.2(@angular/common@17.1.2)(@angular/core@17.1.2)
+  '@angular/youtube-player':
+    specifier: ^17.1.2
+    version: 17.1.2(@angular/common@17.1.2)(@angular/core@17.1.2)(rxjs@7.5.7)
   '@nx/angular':
     specifier: 18.0.1
     version: 18.0.1(@angular-devkit/build-angular@17.1.2)(@angular-devkit/core@17.1.2)(@angular-devkit/schematics@17.1.0)(@schematics/angular@17.1.0)(@swc/core@1.3.85)(@types/node@18.16.9)(cypress@11.2.0)(esbuild@0.19.11)(eslint@8.48.0)(html-webpack-plugin@5.5.0)(nx@18.0.1)(rxjs@7.5.7)(ts-node@10.9.1)(typescript@5.3.3)
@@ -722,6 +725,20 @@ packages:
       '@angular/common': 17.1.2(@angular/core@17.1.2)(rxjs@7.5.7)
       '@angular/core': 17.1.2(rxjs@7.5.7)(zone.js@0.14.3)
       critters: 0.0.20
+      tslib: 2.6.2
+    dev: false
+
+  /@angular/youtube-player@17.1.2(@angular/common@17.1.2)(@angular/core@17.1.2)(rxjs@7.5.7):
+    resolution: {integrity: sha512-WEKuR+JAvxlBZ0Q3PFReO3EkGu9vXVipxNPUVnZGNbiGCnp91Oy3M328sR7eF9luuJSD5W3YjfdvSYWOJKe72w==}
+    peerDependencies:
+      '@angular/common': ^17.0.0 || ^18.0.0
+      '@angular/core': ^17.0.0 || ^18.0.0
+      rxjs: ^6.5.3 || ^7.4.0
+    dependencies:
+      '@angular/common': 17.1.2(@angular/core@17.1.2)(rxjs@7.5.7)
+      '@angular/core': 17.1.2(rxjs@7.5.7)(zone.js@0.14.3)
+      '@types/youtube': 0.0.42
+      rxjs: 7.5.7
       tslib: 2.6.2
     dev: false
 
@@ -7674,6 +7691,10 @@ packages:
     dependencies:
       '@types/node': 18.16.9
     optional: true
+
+  /@types/youtube@0.0.42:
+    resolution: {integrity: sha512-Nqo3HMPFPcNyZ7HNFZJjpH+N4yXqpxBItG+41e7nL9zednovMRZMXWj36CctSznbBcbj6ucvkJDo5iZ8SKqLIw==}
+    dev: false
 
   /@typescript-eslint/eslint-plugin@6.13.2(@typescript-eslint/parser@6.13.2)(eslint@8.48.0)(typescript@5.3.3):
     resolution: {integrity: sha512-3+9OGAWHhk4O1LlcwLBONbdXsAhLjyCFogJY/cWy2lxdVJ2JrcTF2pTGMaLl2AE7U1l31n8Py4a8bx5DLf/0dQ==}

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -17,8 +17,8 @@
 			</aside>
 			<div>
 				@if (!!story && !fetchContentDirective.isLoading) {
-					<h1 class="title mb-2" [lang]="story.language">{{ story.title }}</h1>
-					<p class="subtitle mb-2" [lang]="story.language">{{ story.author.name }}</p>
+					<h1 [lang]="story.language" class="title mb-2">{{ story.title }}</h1>
+					<p [lang]="story.language" class="subtitle mb-2">{{ story.author.name }}</p>
 					<time class="reading-time"> {{ story.approximateReadingTime }} minutos de lectura </time>
 
 					@if (!!story.badLanguage) {
@@ -67,14 +67,7 @@
 
 		@if (!!story && !fetchContentDirective.isLoading) {
 			@if (!!story.videoUrl) {
-				<iframe
-					[src]="sanitizerUrl(story.videoUrl)"
-					class="video mb-6 sm:mb-10"
-					title="YouTube video player"
-					frameborder="0"
-					allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-					allowfullscreen
-				></iframe>
+				<youtube-player [videoId]="story.videoUrl.split('/')[4]" placeholderImageQuality="low" />
 			}
 		}
 
@@ -88,7 +81,7 @@
 			}
 		}
 
-		<section class="content" [lang]="story.language">
+		<section [lang]="story.language" class="content">
 			@if (!!story && !fetchContentDirective.isLoading) {
 				<ng-container *ngFor="let paragraph of story.paragraphs">
 					<p [innerHTML]="paragraph.text" [ngClass]="paragraph.classes"></p>

--- a/src/app/pages/story/story.component.scss
+++ b/src/app/pages/story/story.component.scss
@@ -64,9 +64,4 @@ article {
     }
   }
 
-  .video {
-    aspect-ratio: 16 / 9;
-    width: 100%;
-  }
-
 }

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { combineLatest, switchMap } from 'rxjs';
 import { CommonModule, isPlatformBrowser, NgOptimizedImage } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { DomSanitizer } from '@angular/platform-browser';
+import { YouTubePlayer } from '@angular/youtube-player';
 
 // 3rd Party modules
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
@@ -46,6 +46,7 @@ import { EpigraphComponent } from '../../components/epigraph/epigraph.component'
 		ShareContentComponent,
 		SpaceRecordingWidgetComponent,
 		EpigraphComponent,
+		YouTubePlayer,
 	],
 	hostDirectives: [FetchContentDirective, MetaTagsDirective],
 })
@@ -59,8 +60,6 @@ export class StoryComponent {
 	dummyList = Array(10);
 	shareContentParams: { [key: string]: string } = {};
 	shareMessage: string = '';
-
-	private sanitizer: DomSanitizer = inject(DomSanitizer);
 
 	constructor() {
 		const platformId = inject(PLATFORM_ID);
@@ -97,13 +96,5 @@ export class StoryComponent {
 			this.shareContentParams = { slug: story.slug, list: storylist.slug };
 			this.shareMessage = `Leí "${story.title}" de ${story.author.name} en La Cuentoneta y te lo comparto. Sumate a leer este y otros cuentos de la colección "${storylist.title}" en este link:`;
 		});
-	}
-
-	sanitizerUrl(url: string) {
-		if (url) {
-			return this.sanitizer.bypassSecurityTrustResourceUrl(url);
-		} else {
-			return undefined;
-		}
 	}
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -26,10 +26,6 @@ ngx-skeleton-loader {
   line-height: 0;
 }
 
-* {
-  //outline: 1px solid red;
-}
-
 /**
   Sección de estilos globales aplicados a componentes
 
@@ -41,6 +37,30 @@ ngx-skeleton-loader {
   - Aplicar estilos a un componente que no se puede modificar (por ejemplo, un componente de un paquete externo).
   - Aplicar estilos a HTML generado dinámicamente e inyectado en la vista mediante atributos InnerHTML o OuterHTML.
  */
+
+ youtube-player {
+  .youtube-player-placeholder {
+    aspect-ratio: 16 / 9;
+    width: 100% !important;
+    margin-bottom: 1.5rem !important;
+  }
+
+  div iframe {
+    aspect-ratio: 16 / 9;
+    width: 100% !important;
+    margin-bottom: 1.5rem !important;
+  }
+
+  @media screen and (min-width: 640px){
+    .youtube-player-placeholder {
+      margin-bottom: 2.5rem !important;
+    }
+  
+    div iframe {
+      margin-bottom: 2.5rem !important;
+    }
+  }
+ }
 
 cuentoneta-bio-summary-card {
   .bio-and-summary p {


### PR DESCRIPTION
Para tener un código mas legible podemos agregar en sanity las url de youtube para los iframes solo con el id del video y sin el query param `si` que tienen algunas urls, así evitaríamos el `story.videoUrl.split('/')[4]` y solo usaríamos `story.videoUrl`