### PR TITLE
[#279] - Builder application agregado para tener prerender de las rut…

### DIFF
--- a/project.json
+++ b/project.json
@@ -1,146 +1,145 @@
 {
-  "name": "cuentoneta",
-  "$schema": "node_modules/nx/schemas/project-schema.json",
-  "projectType": "application",
-  "sourceRoot": "./src",
-  "prefix": "cuentoneta",
-  "targets": {
-    "build": {
-      "executor": "@angular-devkit/build-angular:browser-esbuild",
-      "outputs": ["{options.outputPath}"],
-      "options": {
-        "outputPath": "dist/cuentoneta/browser",
-        "index": "./src/index.html",
-        "main": "./src/main.ts",
-        "polyfills": ["zone.js"],
-        "tsConfig": "./tsconfig.app.json",
-        "inlineStyleLanguage": "scss",
-        "assets": ["./src/favicon.ico", "./src/assets"],
-        "styles": ["./src/styles.scss"],
-        "scripts": []
-      },
-      "configurations": {
-        "production": {
-          "budgets": [
-            {
-              "type": "initial",
-              "maximumWarning": "500kb",
-              "maximumError": "1mb"
-            },
-            {
-              "type": "anyComponentStyle",
-              "maximumWarning": "2kb",
-              "maximumError": "4kb"
-            }
-          ],
-          "outputHashing": "all"
-        },
-        "development": {
-          "buildOptimizer": false,
-          "optimization": false,
-          "extractLicenses": false,
-          "sourceMap": true,
-          "namedChunks": true
-        }
-      },
-      "defaultConfiguration": "production"
-    },
-    "serve": {
-      "executor": "@angular-devkit/build-angular:dev-server",
-      "configurations": {
-        "production": {
-          "buildTarget": "cuentoneta:build:production"
-        },
-        "development": {
-          "buildTarget": "cuentoneta:build:development"
-        }
-      },
-      "defaultConfiguration": "development"
-    },
-    "extract-i18n": {
-      "executor": "@angular-devkit/build-angular:extract-i18n",
-      "options": {
-        "buildTarget": "cuentoneta:build"
-      }
-    },
-    "lint": {
-      "executor": "@nx/linter:eslint",
-      "outputs": ["{options.outputFile}"],
-      "options": {
-        "lintFilePatterns": ["./src/**/*.ts", "./src/**/*.html"]
-      }
-    },
-    "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage}"],
-      "options": {
-        "jestConfig": "jest.config.ts"
-      }
-    },
-    "storybook": {
-      "executor": "@storybook/angular:start-storybook",
-      "options": {
-        "port": 4400,
-        "configDir": "./.storybook",
-        "browserTarget": "cuentoneta:build",
-        "compodoc": false,
-        "styles": ["./src/assets/scss/fonts.scss", "./src/styles.scss"]
-      },
-      "configurations": {
-        "ci": {
-          "quiet": true
-        }
-      }
-    },
-    "build-storybook": {
-      "executor": "@storybook/angular:build-storybook",
-      "outputs": ["{options.outputDir}"],
-      "options": {
-        "outputDir": "dist/storybook/cuentoneta",
-        "configDir": "./.storybook",
-        "browserTarget": "cuentoneta:build",
-        "compodoc": false
-      },
-      "configurations": {
-        "ci": {
-          "quiet": true
-        }
-      }
-    },
-    "server": {
-      "executor": "@angular-devkit/build-angular:server",
-      "options": {
-        "outputPath": "dist/cuentoneta/server",
-        "main": "src/ssr.server.ts",
-        "tsConfig": "tsconfig.server.json"
-      },
-      "configurations": {
-        "production": {
-          "outputHashing": "media"
-        },
-        "development": {
-          "optimization": false,
-          "sourceMap": true,
-          "extractLicenses": false
-        }
-      },
-      "defaultConfiguration": "production"
-    },
-    "serve-ssr": {
-      "executor": "@angular-devkit/build-angular:ssr-dev-server",
-      "configurations": {
-        "development": {
-          "browserTarget": "cuentoneta:build:development",
-          "serverTarget": "cuentoneta:server:development",
-          "open": true
-        },
-        "production": {
-          "browserTarget": "cuentoneta:build:production",
-          "serverTarget": "cuentoneta:server:production"
-        }
-      },
-      "defaultConfiguration": "development"
-    }
-  },
-  "tags": []
+	"name": "cuentoneta",
+	"$schema": "node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "./src",
+	"prefix": "cuentoneta",
+	"targets": {
+		"build": {
+			"executor": "@angular-devkit/build-angular:application",
+			"outputs": ["{options.outputPath}"],
+			"options": {
+				"outputPath": "dist/cuentoneta/",
+				"index": "./src/index.html",
+				"browser": "./src/main.ts",
+				"polyfills": ["zone.js"],
+				"tsConfig": "./tsconfig.app.json",
+				"inlineStyleLanguage": "scss",
+				"assets": ["./src/favicon.ico", "./src/assets"],
+				"styles": ["./src/styles.scss"],
+				"scripts": []
+			},
+			"configurations": {
+				"production": {
+					"budgets": [
+						{
+							"type": "initial",
+							"maximumWarning": "500kb",
+							"maximumError": "1mb"
+						},
+						{
+							"type": "anyComponentStyle",
+							"maximumWarning": "2kb",
+							"maximumError": "4kb"
+						}
+					],
+					"outputHashing": "all"
+				},
+				"development": {
+					"optimization": false,
+					"extractLicenses": false,
+					"sourceMap": true,
+					"namedChunks": true
+				}
+			},
+			"defaultConfiguration": "production"
+		},
+		"serve": {
+			"executor": "@angular-devkit/build-angular:dev-server",
+			"configurations": {
+				"production": {
+					"buildTarget": "cuentoneta:build:production"
+				},
+				"development": {
+					"buildTarget": "cuentoneta:build:development"
+				}
+			},
+			"defaultConfiguration": "development"
+		},
+		"extract-i18n": {
+			"executor": "@angular-devkit/build-angular:extract-i18n",
+			"options": {
+				"buildTarget": "cuentoneta:build"
+			}
+		},
+		"lint": {
+			"executor": "@nx/linter:eslint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": ["./src/**/*.ts", "./src/**/*.html"]
+			}
+		},
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage}"],
+			"options": {
+				"jestConfig": "jest.config.ts"
+			}
+		},
+		"storybook": {
+			"executor": "@storybook/angular:start-storybook",
+			"options": {
+				"port": 4400,
+				"configDir": "./.storybook",
+				"browserTarget": "cuentoneta:build",
+				"compodoc": false,
+				"styles": ["./src/assets/scss/fonts.scss", "./src/styles.scss"]
+			},
+			"configurations": {
+				"ci": {
+					"quiet": true
+				}
+			}
+		},
+		"build-storybook": {
+			"executor": "@storybook/angular:build-storybook",
+			"outputs": ["{options.outputDir}"],
+			"options": {
+				"outputDir": "dist/storybook/cuentoneta",
+				"configDir": "./.storybook",
+				"browserTarget": "cuentoneta:build",
+				"compodoc": false
+			},
+			"configurations": {
+				"ci": {
+					"quiet": true
+				}
+			}
+		},
+		"server": {
+			"executor": "@angular-devkit/build-angular:server",
+			"options": {
+				"outputPath": "dist/cuentoneta/server",
+				"main": "src/ssr.server.ts",
+				"tsConfig": "tsconfig.server.json"
+			},
+			"configurations": {
+				"production": {
+					"outputHashing": "media"
+				},
+				"development": {
+					"optimization": false,
+					"sourceMap": true,
+					"extractLicenses": false
+				}
+			},
+			"defaultConfiguration": "production"
+		},
+		"serve-ssr": {
+			"executor": "@angular-devkit/build-angular:ssr-dev-server",
+			"configurations": {
+				"development": {
+					"browserTarget": "cuentoneta:build:development",
+					"serverTarget": "cuentoneta:server:development",
+					"open": true
+				},
+				"production": {
+					"browserTarget": "cuentoneta:build:production",
+					"serverTarget": "cuentoneta:server:production"
+				}
+			},
+			"defaultConfiguration": "development"
+		}
+	},
+	"tags": []
 }


### PR DESCRIPTION
Cambié el builder de angular de `@angular-devkit/build-angular:browser-esbuild` a `@angular-devkit/build-angular:application` con eso pasamos a tener el prerender en build-time, aparte de que ya es el que viene por defecto en las aplicaciones de angular 17 en adelante y también con eso pasamos de usar solo esbuild a usar vite y esbuild ❤.

- [Doc Actualizada de los Builders](https://angular.dev/tools/cli/build)
- [Guía de configuración para migrar al application builder](https://angular.dev/tools/cli/esbuild#using-the-application-builder)