### PR TITLE
[#630] - Altura cambiada en el componente youtube-player

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -41,10 +41,12 @@ ngx-skeleton-loader {
  youtube-player {
   .youtube-player-placeholder {
     @apply mb-6 w-full aspect-video rounded-xl sm:mb-10  #{!important};
+    height: unset !important;
   }
 
   div iframe {
     @apply mb-6 w-full aspect-video rounded-xl sm:mb-10 #{!important};
+    height: unset !important;
   }
  }
 


### PR DESCRIPTION
Le hice un pequeño cambio al componente youtube-player, ya que en mobile seguía conservando las medidas que ya tenia el componente por defecto.