### PR TITLE
[#582] - Cambiada la URL de las imágenes de Sanity

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,5 +1,5 @@
 import { AppComponent } from './app.component';
-import { render } from '@testing-library/angular';
+import {render, RenderResult} from '@testing-library/angular';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideMock } from '@testing-library/angular/jest-utils';
@@ -8,7 +8,7 @@ import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
 
 describe('AppComponent', () => {
-  let component: AppComponent;
+  let component: RenderResult<AppComponent, AppComponent>;
 
   beforeEach(async () => {
     component = await render(AppComponent, {

--- a/src/app/components/storylist-card-component/storylist-card.component.stories.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.stories.ts
@@ -32,7 +32,7 @@ export const Primary: Story = {
         'La colección “Cuentos de Verano” de la primera versión de La Cuentoneta: una selección de textos publicados diariamente entre el Año Nuevo y el Martes de Carnaval de 2022',
       ],
       featuredImage:
-        'https://cdn.sanity.io/images/s4dbqkc5/production/445f726810d3b0e39216db61fa40d663aaea3aa4-627x509.png',
+        'https://cdn.sanity.io/images/s4dbqkc5/production/d1a7fc995e0a4d640c9d8e98fb56f56f209f3d89-392x318.webp',
       tags: [
         {
           title: 'Curaduría',
@@ -89,7 +89,7 @@ export const Layout = {
         'La colección “Cuentos de Verano” de la primera versión de La Cuentoneta: una selección de textos publicados diariamente entre el Año Nuevo y el Martes de Carnaval de 2022',
       ],
       featuredImage:
-        'https://cdn.sanity.io/images/s4dbqkc5/production/445f726810d3b0e39216db61fa40d663aaea3aa4-627x509.png',
+        'https://cdn.sanity.io/images/s4dbqkc5/production/d1a7fc995e0a4d640c9d8e98fb56f56f209f3d89-392x318.webp',
       tags: [
         {
           title: 'Curaduría',


### PR DESCRIPTION
Este issue ya había sido resuelto parcialmente en #497.
Hice un par de cambios para que la imagen que trae de Sanity sea en webp, de igual forma al usar el componene ngsrc se van a aplicar las optimizaciones.
Soluciona #582.