### PR TITLE
[#634] - Agrega script para eliminar documentos draft

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,6 +212,8 @@ Password: CuentonetaFec2023#
 #### Paso 5: ¡Listo!
 Luego de ingresar las credenciales, se abrirá una pestaña en tu navegador con el entorno de desarrollo de Sanity Studio en la URL: https://localhost:3333
 
+Acceder con este usuario te permitirá crear y editar documentos en el entorno de desarrollo de Sanity Studio con el rol de _Contributor_, el cual tiene permisos para crear y editar documentos, pero no para publicarlos.
+
 ---
 
 ### Despliegues

--- a/scripts/remove-all-unpublished-drafts.ts
+++ b/scripts/remove-all-unpublished-drafts.ts
@@ -1,0 +1,17 @@
+/* eslint-disable no-console */
+import { client } from '../src/api/_helpers/sanity-connector';
+
+async function deleteDrafts() {
+    try {
+        const drafts = await client.fetch(
+            `*[_id in path("drafts.**")]`
+        );
+        const deletePromises = drafts.map((draft: { _id: string }) => client.delete(draft._id));
+        await Promise.all(deletePromises);
+        console.log(`${drafts.length} drafts deleted successfully.`);
+    } catch (error) {
+        console.error('Error deleting drafts:', error);
+    }
+}
+
+deleteDrafts();


### PR DESCRIPTION
# Resumen
* Agrega script para eliminar todos los drafts no publicados, en caso de sabotaje de los entornos de Sanity o de polución no intencional de documentos en estado _draft_.
* Agrega aclaración en `CONTRIBUTING.md` acerca de la naturaleza del rol _Contributor_ en Sanity.