### PR TITLE
[#607] Migración de estilos restantes de StoryComponent a TailwindCSS

### DIFF
--- a/src/api/storylist.service.ts
+++ b/src/api/storylist.service.ts
@@ -178,6 +178,7 @@ async function fetchStorylist(req: any, res: any) {
 
   if (!result) {
     res.json(null);
+    return;
   }
 
   const storylistImages =

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.html
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.html
@@ -1,5 +1,5 @@
 <section class="grid grid-cols-1 gap-y-0.5 bg-gray-200 rounded-xl shadow-lg">
-	<header [attr.aria-busy]="!storylist" [lang]="storylist.language" class="bg-gray-50 py-5 px-7">
+	<header [attr.aria-busy]="!storylist" [lang]="storylist?.language" class="bg-gray-50 py-5 px-7">
 		@if (!!storylist && storylist.title) {
 			<a [routerLink]="'/' + appRouteTree['STORYLIST'] + '/' + storylist.slug">
 				<h3 class="h3 hover:text-interactive-500">{{ storylist.title }}</h3>

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.html
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.html
@@ -49,7 +49,7 @@
 		}
 	} @else {
 		@for (skeleton of dummyList; track $index) {
-			<article [attr.aria-busy]="true">
+			<article class="py-5 px-7 bg-gray-50" [attr.aria-busy]="true">
 				<ngx-skeleton-loader count="2" appearance="line"></ngx-skeleton-loader>
 			</article>
 		}

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.stories.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.stories.ts
@@ -2,13 +2,16 @@ import { Meta } from '@storybook/angular';
 import { StoryNavigationBarComponent } from './story-navigation-bar.component';
 
 export default {
-  title: 'StoryNavigationBarComponent',
-  component: StoryNavigationBarComponent,
+	title: 'StoryNavigationBarComponent',
+	component: StoryNavigationBarComponent,
 } as Meta<StoryNavigationBarComponent>;
 
 export const Primary = {
-  render: (args: StoryNavigationBarComponent) => ({
-    props: args,
-  }),
-  args: {},
+	render: (args: StoryNavigationBarComponent) => ({
+		props: args,
+	}),
+	args: {
+		storylist: undefined,
+		selectedStorySlug: '',
+	},
 };

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -8,77 +8,72 @@ import { RouterLink } from '@angular/router';
 import { NgIf, NgFor, CommonModule } from '@angular/common';
 
 @Component({
-  selector: 'cuentoneta-story-navigation-bar',
-  templateUrl: './story-navigation-bar.component.html',
-  standalone: true,
-  imports: [
-    CommonModule,
-    NgxSkeletonLoaderModule,
-    NgIf,
-    NgFor,
-    RouterLink,
-    StoryEditionDateLabelComponent,
-  ],
+	selector: 'cuentoneta-story-navigation-bar',
+	templateUrl: './story-navigation-bar.component.html',
+	standalone: true,
+	imports: [CommonModule, NgxSkeletonLoaderModule, NgIf, NgFor, RouterLink, StoryEditionDateLabelComponent],
 })
 export class StoryNavigationBarComponent implements OnChanges {
-  @Input() displayedPublications: Publication<Story>[] = [];
-  @Input() selectedStorySlug: string = '';
-  @Input() storylist!: Storylist;
+	@Input() displayedPublications: Publication<Story>[] = [];
+	@Input() selectedStorySlug: string = '';
+	@Input() storylist: Storylist | undefined;
 
-  readonly appRouteTree = APP_ROUTE_TREE;
-  dummyList: null[] = Array(10);
+	readonly appRouteTree = APP_ROUTE_TREE;
+	dummyList: null[] = Array(10);
 
-  ngOnChanges(changes: SimpleChanges) {
-    const storylist: Storylist = changes['storylist'].currentValue;
-    if (!!storylist) {
-      this.sliceDisplayedPublications(storylist.publications);
-    }
-  }
+	ngOnChanges(changes: SimpleChanges) {
+		const storylist: Storylist = changes['storylist'].currentValue;
+		if (!!storylist) {
+			this.sliceDisplayedPublications(storylist.publications);
+		}
+	}
 
-  /**
-   * Este método se encarga de mostrar la lista de publicaciones de la navbar en base a la story actualmente en vista.
-   * Si la storylist tiene más de 10 publicaciones, se muestran las 10 publicaciones más cercanas a la story actualmente
-   * en vista tomando las 5 publicaciones anteriores y las 5 siguientes en el caso por defecto y ajustando los límites en
-   * caso de que la story actualmente en vista sea una de las primeras o de las últimas.
-   * @author Ramiro Olivencia <ramiro@olivencia.com.ar>
-   */
-  sliceDisplayedPublications(publications: Publication<Story>[]): void {
-    const numberOfDisplayedPublications = 10;
+	/**
+	 * Este método se encarga de mostrar la lista de publicaciones de la navbar en base a la story actualmente en vista.
+	 * Si la storylist tiene más de 10 publicaciones, se muestran las 10 publicaciones más cercanas a la story actualmente
+	 * en vista tomando las 5 publicaciones anteriores y las 5 siguientes en el caso por defecto y ajustando los límites en
+	 * caso de que la story actualmente en vista sea una de las primeras o de las últimas.
+	 * @author Ramiro Olivencia <ramiro@olivencia.com.ar>
+	 */
+	sliceDisplayedPublications(publications: Publication<Story>[]): void {
+		if (!this.storylist) {
+			return;
+		}
 
-    if (this.storylist.publications.length <= numberOfDisplayedPublications) {
-      this.displayedPublications = this.storylist.publications;
-      return;
-    }
+		const numberOfDisplayedPublications = 10;
 
-    const selectedStoryIndex = publications.findIndex(
-      (publication) => publication.story.slug === this.selectedStorySlug
-    );
+		if (this.storylist.publications.length <= numberOfDisplayedPublications) {
+			this.displayedPublications = this.storylist.publications;
+			return;
+		}
 
-    const lowerIndex =
-      selectedStoryIndex - numberOfDisplayedPublications / 2 < 0
-        ? 0
-        : selectedStoryIndex - numberOfDisplayedPublications / 2;
-    const upperIndex =
-      selectedStoryIndex + numberOfDisplayedPublications / 2 >
-      publications.length
-        ? publications.length
-        : selectedStoryIndex + numberOfDisplayedPublications / 2;
+		const selectedStoryIndex = publications.findIndex(
+			(publication) => publication.story.slug === this.selectedStorySlug,
+		);
 
-    this.displayedPublications = this.storylist.publications.slice(
-      upperIndex === publications.length
-        ? publications.length - numberOfDisplayedPublications
-        : lowerIndex,
-      lowerIndex === 0 ? numberOfDisplayedPublications : upperIndex
-    );
-  }
+		const lowerIndex =
+			selectedStoryIndex - numberOfDisplayedPublications / 2 < 0
+				? 0
+				: selectedStoryIndex - numberOfDisplayedPublications / 2;
+		const upperIndex =
+			selectedStoryIndex + numberOfDisplayedPublications / 2 > publications.length
+				? publications.length
+				: selectedStoryIndex + numberOfDisplayedPublications / 2;
 
-  // ToDo: Separar card de cada cuento de la lista en su propio componente, para evitar usar un método en el template
-  getEditionLabel(
-    publication: Publication<Story>,
-    editionIndex: number = 0
-  ): string {
-    return `${this.storylist?.editionPrefix} ${editionIndex} ${
-      this.storylist.displayDates ? ' - ' + publication.publishingDate : ''
-    }`;
-  }
+		this.displayedPublications = this.storylist.publications.slice(
+			upperIndex === publications.length ? publications.length - numberOfDisplayedPublications : lowerIndex,
+			lowerIndex === 0 ? numberOfDisplayedPublications : upperIndex,
+		);
+	}
+
+	// ToDo: Separar card de cada cuento de la lista en su propio componente, para evitar usar un método en el template
+	getEditionLabel(publication: Publication<Story>, editionIndex: number = 0): string {
+		if (!this.storylist) {
+			return '';
+		}
+
+		return `${this.storylist?.editionPrefix} ${editionIndex} ${
+			this.storylist.displayDates ? ' - ' + publication.publishingDate : ''
+		}`;
+	}
 }

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -1,6 +1,6 @@
 <aside class="hidden md:block">
 	<cuentoneta-story-navigation-bar
-		[selectedStorySlug]="story.slug"
+		[selectedStorySlug]="story?.slug ?? ''"
 		[storylist]="storylist"
 	></cuentoneta-story-navigation-bar>
 </aside>
@@ -83,7 +83,7 @@
 			}
 		}
 
-		<section [lang]="story.language">
+		<section [lang]="story?.language">
 			@if (!!story && !fetchContentDirective.isLoading) {
 				@for (paragraph of story.paragraphs; track $index) {
 					<p

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -5,7 +5,7 @@
 	></cuentoneta-story-navigation-bar>
 </aside>
 <main>
-	<article class="bg-gray-50 p-5 md:p-15 md:rounded-xl">
+	<article class="bg-gray-50 p-5 md:p-15 md:rounded-xl md:shadow-lg">
 		<header class="flex flex-col-reverse sm:block mb-6 sm:mb-10">
 			<aside class="sm:float-right mt-6 sm:ml-12 sm:mb-12 sm:mt-0">
 				<cuentoneta-share-content
@@ -17,7 +17,7 @@
 			</aside>
 			<div>
 				@if (!!story && !fetchContentDirective.isLoading) {
-					<h1 [lang]="story.language" class="title mb-2">{{ story.title }}</h1>
+					<h1 [lang]="story.language" class="h1 mb-2">{{ story.title }}</h1>
 					<p [lang]="story.language" class="inter-body-xl mb-2">{{ story.author.name }}</p>
 					<time class="inter-body-base-medium text-gray-600">
 						{{ story.approximateReadingTime }} minutos de lectura

--- a/src/app/pages/story/story.component.scss
+++ b/src/app/pages/story/story.component.scss
@@ -1,3 +1,0 @@
-:host {
-	@apply md:grid md:mt-28 gap-x-8 md:grid-cols-[286px_1fr];
-}

--- a/src/app/pages/story/story.component.scss
+++ b/src/app/pages/story/story.component.scss
@@ -1,19 +1,3 @@
-@use 'src/assets/scss/theme.scss' as *;
-@use 'src/assets/scss/breakpoints.scss';
-
 :host {
-    @media screen and (min-width: breakpoints.$min-md-width) {
-        display: grid;
-        margin-top: $spacing-28;
-
-        // ToDo: Chequear ancho de sidebar
-        grid-template-columns: 286px 1fr;
-        column-gap: $spacing-8;
-    }
-}
-
-article {
-  @media screen and (min-width: breakpoints.$min-md-width) {
-    box-shadow: $box-shadow-card;
-  }
+	@apply md:grid md:mt-28 gap-x-8 md:grid-cols-[286px_1fr];
 }

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -35,7 +35,10 @@ import { EpigraphComponent } from '../../components/epigraph/epigraph.component'
 @Component({
 	selector: 'cuentoneta-story',
 	templateUrl: './story.component.html',
-	styleUrls: ['./story.component.scss'],
+	styles: `
+		:host {
+			@apply md:grid md:mt-28 gap-x-8 md:grid-cols-[286px_1fr];
+		}`,
 	standalone: true,
 	imports: [
 		CommonModule,

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -57,8 +57,8 @@ export class StoryComponent {
 	readonly appRouteTree = APP_ROUTE_TREE;
 	fetchContentDirective = inject(FetchContentDirective<[Story, Storylist]>);
 
-	story!: Story;
-	storylist!: Storylist;
+	story: Story | undefined;
+	storylist: Storylist | undefined;
 
 	dummyList = Array(10);
 	shareContentParams: { [key: string]: string } = {};

--- a/src/app/providers/storylist.service.ts
+++ b/src/app/providers/storylist.service.ts
@@ -7,47 +7,36 @@ import { environment } from '../environments/environment';
 import { StoryService } from './story.service';
 
 @Injectable({
-  providedIn: 'root',
+	providedIn: 'root',
 })
 export class StorylistService {
-  private readonly prefix = `${environment.apiUrl}api/storylist`;
-  private http = inject(HttpClient);
-  private storyService = inject(StoryService);
+	private readonly prefix = `${environment.apiUrl}api/storylist`;
+	private http = inject(HttpClient);
+	private storyService = inject(StoryService);
 
-  public get(
-    slug: string,
-    amount: number = 5,
-    ordering: 'asc' | 'desc' = 'asc'
-  ): Observable<Storylist> {
-    const params = new HttpParams()
-      .set('slug', slug)
-      .set('amount', amount)
-      .set('ordering', ordering);
-    return this.http
-      .get<StorylistDTO>(`${this.prefix}`, { params })
-      .pipe(
-        map((storylist) => ({
-          ...storylist,
-          publications: storylist.publications.map((publication) => ({
-            ...publication,
-            story: this.storyService.parseStoryCardContent(publication.story),
-          })) as Publication<StoryCard>[],
-        }))
-      );
-  }
+	public get(slug: string, amount: number = 5, ordering: 'asc' | 'desc' = 'asc'): Observable<Storylist> {
+		const params = new HttpParams().set('slug', slug).set('amount', amount).set('ordering', ordering);
+		return this.http.get<StorylistDTO>(`${this.prefix}`, { params }).pipe(
+			map((storylist) => ({
+				...storylist,
+				publications: (storylist?.publications ?? []).map((publication) => ({
+					...publication,
+					story: this.storyService.parseStoryCardContent(publication.story),
+				})) as Publication<StoryCard>[],
+			})),
+		);
+	}
 
-  public getPreview(slug: string): Observable<Storylist> {
-    const params = new HttpParams().set('slug', slug);
-      return this.http
-          .get<StorylistDTO>(`${this.prefix}/preview`, { params })
-          .pipe(
-              map((storylist) => ({
-                  ...storylist,
-                  publications: storylist.publications.map((publication) => ({
-                      ...publication,
-                      story: this.storyService.parseStoryCardContent(publication.story),
-                  })) as Publication<StoryCard>[],
-              }))
-          );
-  }
+	public getPreview(slug: string): Observable<Storylist> {
+		const params = new HttpParams().set('slug', slug);
+		return this.http.get<StorylistDTO>(`${this.prefix}/preview`, { params }).pipe(
+			map((storylist) => ({
+				...storylist,
+				publications: storylist.publications.map((publication) => ({
+					...publication,
+					story: this.storyService.parseStoryCardContent(publication.story),
+				})) as Publication<StoryCard>[],
+			})),
+		);
+	}
 }

--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -8,8 +8,6 @@ $inter-font-weight-semibold: 600;
 $inter-font-weight-medium: 500;
 $inter-font-weight-regular: 400;
 
-$source-serif-pro-font-weight-regular: 400;
-
 // Colors
 $primary-200: hsl(11, 78%, 93%);
 
@@ -90,11 +88,6 @@ $letter-spacing: 0px;
 @mixin inter-body-base-regular {
 	@include inter-body-base;
 	font-weight: $inter-font-weight-regular;
-}
-
-@mixin inter-body-sm-bold {
-	@include inter-body-sm;
-	font-weight: $inter-font-weight-bold;
 }
 
 @mixin inter-body-xs-bold {

--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -123,17 +123,14 @@ $letter-spacing: 0px;
 $spacing-1: 4px;
 $spacing-2: 8px;
 $spacing-4: 16px;
-$spacing-5: 20px;
 $spacing-6: 24px;
-$spacing-7: 28px;
 $spacing-8: 32px;
 $spacing-16: 64px;
-$spacing-28: 112px;
 // endregion
 
 // region Shadows & Elevations
 
-$box-shadow-card: 0px 0px 8px rgba(63, 63, 70, 0.08);
+// TODO: Incorporar sombras de hover a config de Tailwind
 $box-shadow-card-hover: 0px 12px 16px rgba(63, 63, 70, 0.12);
 
 // endregion


### PR DESCRIPTION
# Resumen
* Implementados estilos inline para `StoryComponent`, eliminando archivo dedicado de estilos.
* Transformados estilos dedicados en clases de utilidad de Tailwind.
* Eliminadas variables en desuso de `theme.scss`.

## Otros cambios
* Agregadas validaciones para errores visibles en consola al hacer fetch de storylists.
* Corregido problema donde no se visualizaban los skeletons en `StoryComponent` durante la carga inicial.