### PR TITLE
[#603] Reemplazo de estilos por clases de tailwind en TooltipDirective

### DIFF
--- a/src/app/directives/tooltip.directive.scss
+++ b/src/app/directives/tooltip.directive.scss
@@ -1,80 +1,65 @@
-@use 'src/assets/scss/theme.scss';
-
 .tooltip-container {
-  @include theme.inter-body-xs-medium;
-  font-weight: theme.$inter-font-weight-semibold;
-  padding: theme.$spacing-2;
-  border-radius: theme.$rounded;
-  text-align: center;
-  z-index: 100;
-  position: fixed;
-  color: white;
-  width: auto;
-  background: #000000;
-  box-sizing: border-box;
-  opacity: 0;
-  transform: translate(-50%, -30%);
-  animation: tooltip-slide 0.18s ease-out 0.5s;
-  animation-fill-mode: forwards;
-  pointer-events: none;
-
-}
-
-.tooltip-container::before {
-  content: "";
-  position: absolute;
-  transform: rotate(45deg);
-  background-color: #000000;
-  padding: 5px;
-  z-index: 99;
+	// Layout
+	@apply fixed box-border z-50;
+	// Texto
+	@apply inter-body-xs-semibold text-center text-white bg-black opacity-0;
+	// Spacing
+	@apply p-2 rounded w-auto;
+	// Interactividad
+	@apply pointer-events-none;
+	// Transformaciones
+	@apply translate-x-1/2 translate-y-1/2;
+	&::before {
+		@apply bg-black p-1;
+		@apply z-40 absolute rotate-45;
+		@apply content-blank;
+	}
 }
 
 .top {
-  top: -40px;
-  left: -50%;
-}
-
-.top::before {
-  top: 80%;
-  left: 45%;
+	@apply -top-[40px] -left-1/2;
+	&::before {
+		top: 80%;
+		left: 45%;
+	}
 }
 
 .bottom {
-  top: 25px;
-  left: -50%;
-}
-.bottom::before {
-  top: -5%;
-  left: 45%;
+	@apply top-[25px] -left-1/2;
+	&::before {
+		top: -5%;
+		left: 45%;
+	}
 }
 
 .left {
-  top: -8px;
-  right: 120%;
-}
-
-.left::before {
-  top: 35%;
-  left: 94%;
+	@apply -top-2 end-5/4;
+	&::before {
+		top: 35%;
+		left: 94%;
+	}
 }
 
 .right {
-  top: -8px;
-  left: 120%;
+	@apply -top-2 end-5/4;
+	&::before {
+		top: 35%;
+		left: -2%;
+	}
 }
 
-.right::before {
-  top: 35%;
-  left: -2%;
+// Animaciones
+.tooltip-container {
+	animation: tooltip-slide 0.18s ease-out 0.5s;
+	animation-fill-mode: forwards;
 }
-
 @keyframes tooltip-slide {
-  0% {
-    opacity: 0;
-    transform: translate(-50%, -30%);
-  }
-  100% {
-    opacity: 1;
-    transform: translate(-50%, 0);
-  }
+	0% {
+		opacity: 0;
+		transform: translate(-50%, -30%);
+	}
+	100% {
+		opacity: 1;
+		transform: translate(-50%, 0);
+	}
 }

--- a/src/app/directives/tooltip.directive.ts
+++ b/src/app/directives/tooltip.directive.ts
@@ -44,7 +44,7 @@ export class TooltipDirective implements OnDestroy {
   }
 
   private createTooltipPopup(x: number, y: number) {
-    let popup = document.createElement('p');
+    const popup = document.createElement('p');
     popup.innerHTML = this.text;
     popup.classList.add("tooltip-container");
     popup.classList.add(this.position);

--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -88,7 +88,6 @@ $letter-spacing: 0px;
 // Info en MDN: https://developer.mozilla.org/es/docs/Learn/CSS/Building_blocks/Values_and_units
 
 $spacing-1: 4px;
-$spacing-2: 8px;
 $spacing-4: 16px;
 $spacing-6: 24px;
 $spacing-8: 32px;

--- a/src/assets/scss/typography.scss
+++ b/src/assets/scss/typography.scss
@@ -1,0 +1,81 @@
+// Clases de tipografías, según el sistema de diseño
+@layer utilities {
+	// region Inter font sizing mixins to tailwind class
+	.inter-body-base {
+		@apply font-inter text-base tracking-normal;
+	}
+
+	.inter-body-xs {
+		@apply font-inter text-xs tracking-normal;
+	}
+
+	.inter-body-sm {
+		@apply font-inter text-sm tracking-normal;
+	}
+
+	.inter-body-lg {
+		@apply font-inter text-lg tracking-normal;
+	}
+
+	.inter-body-xl {
+		@apply font-inter text-xl tracking-normal;
+	}
+
+	.inter-body-base-regular {
+		@apply inter-body-base font-normal;
+	}
+
+	.inter-body-base-medium {
+		@apply inter-body-base font-medium;
+	}
+
+	.inter-body-xs-medium {
+		@apply inter-body-xs font-medium;
+	}
+
+	.inter-body-xs-semibold {
+		@apply inter-body-xs font-semibold;
+	}
+
+	.inter-body-xs-bold {
+		@apply inter-body-xs font-bold;
+	}
+
+	.inter-body-sm-regular {
+		@apply inter-body-sm font-normal;
+	}
+
+	.inter-body-sm-semibold {
+		@apply inter-body-sm font-semibold;
+	}
+
+	.inter-body-sm-bold {
+		@apply inter-body-sm font-bold;
+	}
+
+	.inter-body-lg-semibold {
+		@apply inter-body-lg font-semibold;
+	}
+
+	.inter-body-lg-bold {
+		@apply inter-body-lg font-bold;
+	}
+
+	.inter-body-xl-bold {
+		@apply inter-body-xl font-bold;
+	}
+
+	.inter-body-base-semibold {
+		@apply inter-body-base font-semibold;
+	}
+	// endregion
+	// region Source Serif Pro font mixins to tailwind class
+	.source-serif-pro-body-lg {
+		@apply font-source-serif text-lg tracking-normal;
+	}
+
+	.source-serif-pro-body-xl {
+		@apply font-source-serif text-xl tracking-normal;
+	}
+	// endregion
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,6 @@
 // Imports de estilos globales
 @use 'assets/scss/reset' as *;
+@use 'assets/scss/typography' as *;
 @use 'assets/scss/theme' as *;
 @use 'assets/scss/transitions' as *;
 @use 'src/app/directives/tooltip.directive.scss' as *;
@@ -24,88 +25,6 @@
 	.card {
 		@apply bg-gray-50 rounded-lg shadow-lg;
 	}
-}
-
-// Clases de tipografías, según el sistema de diseño
-@layer utilities {
-	// region Inter font sizing mixins to tailwind class
-	.inter-body-base {
-		@apply font-inter text-base tracking-normal;
-	}
-
-	.inter-body-xs {
-		@apply font-inter text-xs tracking-normal;
-	}
-
-	.inter-body-sm {
-		@apply font-inter text-sm tracking-normal;
-	}
-
-	.inter-body-lg {
-		@apply font-inter text-lg tracking-normal;
-	}
-
-	.inter-body-xl {
-		@apply font-inter text-xl tracking-normal;
-	}
-
-	.inter-body-base-regular {
-		@apply inter-body-base font-normal;
-	}
-
-	.inter-body-base-medium {
-		@apply inter-body-base font-medium;
-	}
-
-	.inter-body-xs-medium {
-		@apply inter-body-xs font-medium;
-	}
-
-	.inter-body-xs-semibold {
-		@apply inter-body-xs font-semibold;
-	}
-
-	.inter-body-xs-bold {
-		@apply inter-body-xs font-bold;
-	}
-
-	.inter-body-sm-regular {
-		@apply inter-body-sm font-normal;
-	}
-
-	.inter-body-sm-semibold {
-		@apply inter-body-sm font-semibold;
-	}
-
-	.inter-body-sm-bold {
-		@apply inter-body-sm font-bold;
-	}
-
-	.inter-body-lg-semibold {
-		@apply inter-body-lg font-semibold;
-	}
-
-	.inter-body-lg-bold {
-		@apply inter-body-lg font-bold;
-	}
-
-	.inter-body-xl-bold {
-		@apply inter-body-xl font-bold;
-	}
-
-	.inter-body-base-semibold {
-		@apply inter-body-base font-semibold;
-	}
-	// endregion
-	// region Source Serif Pro font mixins to tailwind class
-	.source-serif-pro-body-lg {
-		@apply font-source-serif text-lg tracking-normal;
-	}
-
-	.source-serif-pro-body-xl {
-		@apply font-source-serif text-xl tracking-normal;
-	}
-	// endregion
 }
 
 /**

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,6 +26,9 @@ module.exports = {
 			'interactive-500': 'hsl(212, 70%, 45%)',
 			'interactive-600': 'hsl(212, 70%, 35%)',
 		},
+		content: {
+			blank: '""',
+		},
 		screens: {
 			xs: '0px',
 			sm: '640px',
@@ -52,6 +55,8 @@ module.exports = {
 				4.5: '18px',
 				15: '60px',
 				18: '72px',
+				'1/2': '50%',
+				'5/4': '120%',
 			},
 			lineHeight: {
 				0: 0,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
 	theme: {
 		colors: {
 			white: '#fff',
+			black: '#000',
 			'primary-100': 'hsl(9, 70%, 96%)',
 			'primary-200': 'hsl(11, 78%, 93%)',
 			'primary-300': 'hsl(24, 45%, 76%)',


### PR DESCRIPTION
# Resumen
* Reemplaza clases de estilos dedicadas por clases de utilidad de Tailwind.

## Otros géneros
* Agrega spacing 1/2, 5/4 y content-blank en configuración de Tailwind.
* Elimina variables en desuso de `theme.scss`.
* Crea nuevo archivo de estilos globales `typography.scss` para alojar tipografías.