### PR TITLE
[#588] Implementa componente para parsing de contenido en formato Portable Text

### DIFF
--- a/src/app/components/bio-summary-card/bio-summary-card.component.stories.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.stories.ts
@@ -2,81 +2,184 @@ import { Meta } from '@storybook/angular';
 import { BioSummaryCardComponent } from './bio-summary-card.component';
 
 export default {
-  title: 'BioSummaryCardComponent',
-  component: BioSummaryCardComponent,
+	title: 'BioSummaryCardComponent',
+	component: BioSummaryCardComponent,
 } as Meta<BioSummaryCardComponent>;
 
 export const Primary = {
-  render: (args: BioSummaryCardComponent) => ({
-    props: args,
-  }),
-  args: {
-    story: {
-      "badLanguage": null,
-      "approximateReadingTime": 9,
-      "language": "es",
-      "title": "Los Reyes Magos, los Hombres Sensibles y los Refutadores de Leyendas",
-      "videoUrl": null,
-      "categories": null,
-      "resources": [
-        {
-          "title": "Enlace a recurso original",
-          "url": null,
-          "resourceType": {
-            "title": "Recurso Original",
-            "description": "Recurso original de este contenido",
-            "icon": {
-              "name": "fa-medal",
-              "svg": "data:image/svg+xml,<svg stroke=\"currentColor\" fill=\"currentColor\" stroke-width=\"0\" viewBox=\"0 0 512 512\" height=\"1em\" width=\"1em\" xmlns=\"http://www.w3.org/2000/svg\" style=\"width: 1.5em; height: 1em;\"><path d=\"M223.75 130.75L154.62 15.54A31.997 31.997 0 0 0 127.18 0H16.03C3.08 0-4.5 14.57 2.92 25.18l111.27 158.96c29.72-27.77 67.52-46.83 109.56-53.39zM495.97 0H384.82c-11.24 0-21.66 5.9-27.44 15.54l-69.13 115.21c42.04 6.56 79.84 25.62 109.56 53.38L509.08 25.18C516.5 14.57 508.92 0 495.97 0zM256 160c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm92.52 157.26l-37.93 36.96 8.97 52.22c1.6 9.36-8.26 16.51-16.65 12.09L256 393.88l-46.9 24.65c-8.4 4.45-18.25-2.74-16.65-12.09l8.97-52.22-37.93-36.96c-6.82-6.64-3.05-18.23 6.35-19.59l52.43-7.64 23.43-47.52c2.11-4.28 6.19-6.39 10.28-6.39 4.11 0 8.22 2.14 10.33 6.39l23.43 47.52 52.43 7.64c9.4 1.36 13.17 12.95 6.35 19.59z\"></path></svg>",
-              "provider": "fa"
-            }
-          }
-        }
-      ],
-      "slug": "los-reyes-magos-los-hombres-sensibles-y-los-refutadores-de-leyendas",
-      "media": [],
-      "author": {
-        "id": "c42aabdc-8b18-45ae-9338-6fe8f7b7f279",
-        "nationality": {
-          "country": "Argentina",
-          "flag": "https://cdn.sanity.io/images/s4dbqkc5/production/ee6f30199738f983516909a0d6330301573a62f6-32x20.png"
-        },
-        "resources": [
-          {
-            "title": "Artículo de Alejandro Dolina en Wikipedia",
-            "url": null,
-            "resourceType": {
-              "title": "Wikipedia",
-              "description": "Enlace a artículo de Wikipedia",
-              "icon": {
-                "name": "fa-wikipedia-w",
-                "svg": "data:image/svg+xml,<svg stroke=\"currentColor\" fill=\"currentColor\" stroke-width=\"0\" viewBox=\"0 0 640 512\" height=\"1em\" width=\"1em\" xmlns=\"http://www.w3.org/2000/svg\" style=\"width: 1.5em; height: 1em;\"><path d=\"M640 51.2l-.3 12.2c-28.1.8-45 15.8-55.8 40.3-25 57.8-103.3 240-155.3 358.6H415l-81.9-193.1c-32.5 63.6-68.3 130-99.2 193.1-.3.3-15 0-15-.3C172 352.3 122.8 243.4 75.8 133.4 64.4 106.7 26.4 63.4.2 63.7c0-3.1-.3-10-.3-14.2h161.9v13.9c-19.2 1.1-52.8 13.3-43.3 34.2 21.9 49.7 103.6 240.3 125.6 288.6 15-29.7 57.8-109.2 75.3-142.8-13.9-28.3-58.6-133.9-72.8-160-9.7-17.8-36.1-19.4-55.8-19.7V49.8l142.5.3v13.1c-19.4.6-38.1 7.8-29.4 26.1 18.9 40 30.6 68.1 48.1 104.7 5.6-10.8 34.7-69.4 48.1-100.8 8.9-20.6-3.9-28.6-38.6-29.4.3-3.6 0-10.3.3-13.6 44.4-.3 111.1-.3 123.1-.6v13.6c-22.5.8-45.8 12.8-58.1 31.7l-59.2 122.8c6.4 16.1 63.3 142.8 69.2 156.7L559.2 91.8c-8.6-23.1-36.4-28.1-47.2-28.3V49.6l127.8 1.1.2.5z\"></path></svg>",
-                "provider": "fa"
-              }
-            }
-          }
-        ],
-        "imageUrl": "https://cdn.sanity.io/images/s4dbqkc5/production/c91d9010f27d5078ef787cb231395042b66db2cd-400x400.jpg",
-        "name": "Alejandro Dolina",
-        "biography": [
-          {
-            "classes": "",
-            "text": "<b>Alejandro Dolina</b> (Morse, 1944) es un músico, conductor de radio y televisión, actor y escritor argentino. Es conocido en su país natal por sus obras literarias y por su clásico programa radial <i>La Venganza Será Terrible</i>, el cual lleva más de cuatro décadas al aire."
-          },
-          {
-            "classes": "",
-            "text": "Su narrativa abarca temas filosóficos e históricos, con un estilo costumbrista, en la que pueden observarse influencias borgeanas y de la literatura fantástica. Entre sus obras más destacadas se encuentran los libros de relatos <i>Las Crónicas del Ángel Gris</i> (1988) y <i>El Libro del Fantasma</i> (1999) y su novela <i>Cartas Marcadas</i> (2012)."
-          }
-        ]
-      },
-      "prologues": [],
-      "paragraphs": [],
-      "summary": [
-        {
-          "classes": "",
-          "text": "Este cuento forma parte del volumen \"Las Crónicas del Ángel Gris\", publicado por Dolina en 1988. Las diversas historias del libro giran en torno al Ángel Gris, un curioso personaje que se encarga de repartir sueños en el barrio porteño de Flores. \"El Arte de la Impostura\", \"Leyenda del Volador de Flores\" y \"Balada de la Primera Novia\" son otros de los relatos que completan la colección."
-        }
-      ]
-    }
-  },
+	render: (args: BioSummaryCardComponent) => ({
+		props: args,
+	}),
+	args: {
+		story: {
+			badLanguage: null,
+			approximateReadingTime: 9,
+			language: 'es',
+			title: 'Los Reyes Magos, los Hombres Sensibles y los Refutadores de Leyendas',
+			videoUrl: null,
+			categories: null,
+			resources: [
+				{
+					title: 'Enlace a recurso original',
+					url: null,
+					resourceType: {
+						title: 'Recurso Original',
+						description: 'Recurso original de este contenido',
+						icon: {
+							name: 'fa-medal',
+							svg: 'data:image/svg+xml,<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style="width: 1.5em; height: 1em;"><path d="M223.75 130.75L154.62 15.54A31.997 31.997 0 0 0 127.18 0H16.03C3.08 0-4.5 14.57 2.92 25.18l111.27 158.96c29.72-27.77 67.52-46.83 109.56-53.39zM495.97 0H384.82c-11.24 0-21.66 5.9-27.44 15.54l-69.13 115.21c42.04 6.56 79.84 25.62 109.56 53.38L509.08 25.18C516.5 14.57 508.92 0 495.97 0zM256 160c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm92.52 157.26l-37.93 36.96 8.97 52.22c1.6 9.36-8.26 16.51-16.65 12.09L256 393.88l-46.9 24.65c-8.4 4.45-18.25-2.74-16.65-12.09l8.97-52.22-37.93-36.96c-6.82-6.64-3.05-18.23 6.35-19.59l52.43-7.64 23.43-47.52c2.11-4.28 6.19-6.39 10.28-6.39 4.11 0 8.22 2.14 10.33 6.39l23.43 47.52 52.43 7.64c9.4 1.36 13.17 12.95 6.35 19.59z"></path></svg>',
+							provider: 'fa',
+						},
+					},
+				},
+			],
+			slug: 'los-reyes-magos-los-hombres-sensibles-y-los-refutadores-de-leyendas',
+			media: [],
+			author: {
+				id: 'c42aabdc-8b18-45ae-9338-6fe8f7b7f279',
+				nationality: {
+					country: 'Argentina',
+					flag: 'https://cdn.sanity.io/images/s4dbqkc5/production/ee6f30199738f983516909a0d6330301573a62f6-32x20.png',
+				},
+				resources: [
+					{
+						title: 'Artículo de Alejandro Dolina en Wikipedia',
+						url: null,
+						resourceType: {
+							title: 'Wikipedia',
+							description: 'Enlace a artículo de Wikipedia',
+							icon: {
+								name: 'fa-wikipedia-w',
+								svg: 'data:image/svg+xml,<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 640 512" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style="width: 1.5em; height: 1em;"><path d="M640 51.2l-.3 12.2c-28.1.8-45 15.8-55.8 40.3-25 57.8-103.3 240-155.3 358.6H415l-81.9-193.1c-32.5 63.6-68.3 130-99.2 193.1-.3.3-15 0-15-.3C172 352.3 122.8 243.4 75.8 133.4 64.4 106.7 26.4 63.4.2 63.7c0-3.1-.3-10-.3-14.2h161.9v13.9c-19.2 1.1-52.8 13.3-43.3 34.2 21.9 49.7 103.6 240.3 125.6 288.6 15-29.7 57.8-109.2 75.3-142.8-13.9-28.3-58.6-133.9-72.8-160-9.7-17.8-36.1-19.4-55.8-19.7V49.8l142.5.3v13.1c-19.4.6-38.1 7.8-29.4 26.1 18.9 40 30.6 68.1 48.1 104.7 5.6-10.8 34.7-69.4 48.1-100.8 8.9-20.6-3.9-28.6-38.6-29.4.3-3.6 0-10.3.3-13.6 44.4-.3 111.1-.3 123.1-.6v13.6c-22.5.8-45.8 12.8-58.1 31.7l-59.2 122.8c6.4 16.1 63.3 142.8 69.2 156.7L559.2 91.8c-8.6-23.1-36.4-28.1-47.2-28.3V49.6l127.8 1.1.2.5z"></path></svg>',
+								provider: 'fa',
+							},
+						},
+					},
+				],
+				imageUrl:
+					'https://cdn.sanity.io/images/s4dbqkc5/production/c91d9010f27d5078ef787cb231395042b66db2cd-400x400.jpg',
+				name: 'Alejandro Dolina',
+				biography: [
+					{
+						markDefs: [],
+						children: [
+							{
+								text: 'Alejandro Dolina',
+								_key: 'ISAWDRYyMzcK9mJWmSbie8QpuBaABLAS',
+								_type: 'span',
+								marks: ['strong'],
+							},
+							{
+								_type: 'span',
+								marks: [],
+								text: ' (Morse, 1944) es un músico, conductor de radio y televisión, actor y escritor argentino. Es conocido en su país natal por sus obras literarias y por su clásico programa radial ',
+								_key: '7dd7964b9595',
+							},
+							{
+								text: 'La Venganza Será Terrible',
+								_key: '0d8eb948f0f7',
+								_type: 'span',
+								marks: ['em'],
+							},
+							{
+								_type: 'span',
+								marks: [],
+								text: ', el cual lleva más de cuatro décadas al aire.',
+								_key: 'deb865e7ffa2',
+							},
+						],
+						_type: 'block',
+						style: 'normal',
+						_key: 'IlPqmv3xPO00klzBVlmd6bpjCdg1AUYk',
+					},
+					{
+						markDefs: [],
+						children: [
+							{
+								marks: [],
+								text: 'Su narrativa abarca temas filosóficos e históricos, con un estilo costumbrista, en la que pueden observarse influencias borgeanas y de la literatura fantástica. Entre sus obras más destacadas se encuentran los libros de relatos ',
+								_key: 'b19bcb282046',
+								_type: 'span',
+							},
+							{
+								_key: 'cd1f9046ce20',
+								_type: 'span',
+								marks: ['em'],
+								text: 'Las Crónicas del Ángel Gris',
+							},
+							{
+								_type: 'span',
+								marks: [],
+								text: ' (1988) y ',
+								_key: 'd31228922367',
+							},
+							{
+								text: 'El Libro del Fantasma',
+								_key: '7f2f1959a5b7',
+								_type: 'span',
+								marks: ['em'],
+							},
+							{
+								_type: 'span',
+								marks: [],
+								text: ' (1999) y su novela ',
+								_key: '3aba9bcea6be',
+							},
+							{
+								_type: 'span',
+								marks: ['em'],
+								text: 'Cartas Marcadas',
+								_key: 'd97f808abfae',
+							},
+							{
+								_type: 'span',
+								marks: [],
+								text: ' (2012).',
+								_key: 'c724fcff30ba',
+							},
+						],
+						_type: 'block',
+						style: 'normal',
+						_key: '127a6271f344',
+					},
+				],
+			},
+			prologues: [],
+			paragraphs: [],
+			summary: [
+				{
+					_key: '7eddf102184a',
+					markDefs: [],
+					children: [
+						{
+							_type: 'span',
+							marks: ['strong', 'em'],
+							text: 'Máscaras',
+							_key: 'f043f548f8c4',
+						},
+						{
+							_type: 'span',
+							marks: [],
+							text: ' está incluido en el volumen ',
+							_key: '7b11663f0e03',
+						},
+						{
+							text: 'Bar del Infierno',
+							_key: '3ddad9aa76c3',
+							_type: 'span',
+							marks: ['em'],
+						},
+						{
+							_type: 'span',
+							marks: [],
+							text: ', publicado en 2005. La acción de la obra se sucede en un bar del cual no es posible salir, dado que en el universo del libro el afuera no existe. En este escenario, El Narrador de Historias, protagonista principal de esta narración enmarcada, procede a contar una variedad de relatos ubicados en distintos lugares y distintas épocas.',
+							_key: 'afc1b9c43d8c',
+						},
+					],
+					_type: 'block',
+					style: 'normal',
+				},
+			],
+		},
+	},
 };

--- a/src/app/components/bio-summary-card/bio-summary-card.component.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.ts
@@ -3,11 +3,12 @@ import { Component, Input, OnInit } from '@angular/core';
 import { NgOptimizedImage, NgIf, CommonModule } from '@angular/common';
 
 // Modelos
+import { Resource } from '@models/resource.model';
 import { Story } from '@models/story.model';
 
 // Componentes
 import { ResourceComponent } from '../resource/resource.component';
-import { Resource } from '@models/resource.model';
+import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 
 @Component({
 	selector: 'cuentoneta-bio-summary-card',
@@ -45,18 +46,23 @@ import { Resource } from '@models/resource.model';
 					}
 				</section>
 				<section [lang]="story.language" class="inter-body-base-regular text-gray-700">
-					@for (paragraph of story.author.biography; track $index) {
-						<p [innerHTML]="paragraph.text" [ngClass]="paragraph.classes" class="last:mb-0 mb-4"></p>
+					@if (!!story.author.biography) {
+						<cuentoneta-portable-text-parser
+							[paragraphs]="story.author.biography"
+							class="hidden sm:source-serif-pro-body-base sm:text-ellipsis sm:relative sm:text-justify sm:min-h-18 sm:line-clamp-3"
+						></cuentoneta-portable-text-parser>
 					}
-					@for (paragraph of story.summary; track $index) {
-						<p [innerHTML]="paragraph.text" [ngClass]="paragraph.classes" class="last:mb-0 mb-4"></p>
-					}
+
+					<cuentoneta-portable-text-parser
+						[paragraphs]="story.summary"
+						class="hidden sm:source-serif-pro-body-base sm:text-ellipsis sm:relative sm:text-justify sm:min-h-18 sm:line-clamp-3"
+					></cuentoneta-portable-text-parser>
 				</section>
 			}
 		</div>
 	`,
 	standalone: true,
-	imports: [CommonModule, NgOptimizedImage, NgIf, ResourceComponent],
+	imports: [CommonModule, NgOptimizedImage, NgIf, ResourceComponent, PortableTextParserComponent],
 })
 export class BioSummaryCardComponent implements OnInit {
 	@Input({ required: true }) story!: Story;

--- a/src/app/components/bio-summary-card/bio-summary-card.component.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.ts
@@ -49,13 +49,13 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 					@if (!!story.author.biography) {
 						<cuentoneta-portable-text-parser
 							[paragraphs]="story.author.biography"
-							class="hidden sm:source-serif-pro-body-base sm:text-ellipsis sm:relative sm:text-justify sm:min-h-18 sm:line-clamp-3"
+							[classes]="'mb-4'"
 						></cuentoneta-portable-text-parser>
 					}
 
 					<cuentoneta-portable-text-parser
 						[paragraphs]="story.summary"
-						class="hidden sm:source-serif-pro-body-base sm:text-ellipsis sm:relative sm:text-justify sm:min-h-18 sm:line-clamp-3"
+						[classes]="'mb-4 last:mb-0'"
 					></cuentoneta-portable-text-parser>
 				</section>
 			}

--- a/src/app/components/portable-text-parser/paragraph-template.directive.spec.ts
+++ b/src/app/components/portable-text-parser/paragraph-template.directive.spec.ts
@@ -1,0 +1,8 @@
+import { ParagraphTemplateDirectiveDirective } from './paragraph-template.directive';
+
+describe('ParagraphTemplateDirectiveDirective', () => {
+	it('should create an instance', () => {
+		const directive = new ParagraphTemplateDirectiveDirective();
+		expect(directive).toBeTruthy();
+	});
+});

--- a/src/app/components/portable-text-parser/paragraph-template.directive.ts
+++ b/src/app/components/portable-text-parser/paragraph-template.directive.ts
@@ -1,0 +1,16 @@
+import { Directive } from '@angular/core';
+import { BlockContent } from '@models/block-content.model';
+
+@Directive({
+	selector: 'ng-template[cuentonetaParagraphTemplateGuard]',
+	standalone: true,
+})
+export class ParagraphTemplateDirective {
+	static ngTemplateContextGuard(dir: ParagraphTemplateDirective, ctx: unknown): ctx is ParagraphContext {
+		return true;
+	}
+}
+
+interface ParagraphContext {
+	$implicit: BlockContent;
+}

--- a/src/app/components/portable-text-parser/portable-text-parser.component.spec.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PortableTextParserComponent } from './portable-text-parser.component';
+
+describe('PortableTextParserComponent', () => {
+	let component: PortableTextParserComponent;
+	let fixture: ComponentFixture<PortableTextParserComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [PortableTextParserComponent],
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(PortableTextParserComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/components/portable-text-parser/portable-text-parser.component.stories.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.stories.ts
@@ -1,0 +1,437 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { PortableTextParserComponent } from './portable-text-parser.component';
+
+const meta: Meta<PortableTextParserComponent> = {
+	component: PortableTextParserComponent,
+	title: 'PortableTextParserComponent',
+};
+export default meta;
+type Story = StoryObj<PortableTextParserComponent>;
+
+export const Primary = {
+	render: (args: PortableTextParserComponent) => ({
+		props: args,
+		template: `
+      <div class="grid grid-cols-3 gap-4">
+          <cuentoneta-portable-text-parser [paragraphs]="paragraphs"/>
+    </div>
+`,
+	}),
+	args: {
+		paragraphs: [
+			{
+				"_type": "block",
+				"style": "normal",
+				"_key": "14edf93b643f",
+				"markDefs": [],
+				"children": [
+					{
+						"text": "JUEVES 26, A LAS 5 DE LA TARDE",
+						"_key": "a38bb20057ac",
+						"_type": "span",
+						"marks": [
+							"em"
+						]
+					}
+				]
+			},
+			{
+				"style": "normal",
+				"_key": "fac851921ea3",
+				"markDefs": [],
+				"children": [
+					{
+						"_type": "span",
+						"marks": [],
+						"text": "Silvina, Sylvie, Sylvette, te llamé y nadie contestó. Por eso te escribo. Es algo muy simple (“c'est aussi simple comme une phrase musicale”",
+						"_key": "8ed9da62ad17"
+					},
+					{
+						"text": "(1)",
+						"_key": "3d50df8bb44d",
+						"_type": "span",
+						"marks": [
+							"em",
+							"strong"
+						]
+					},
+					{
+						"text": ") y que puede formularse más o menos así: la habitación se balancea y oscila como un barco. Cuando te llegue esta cartita ya no se moverá más mi cuarto, gracias a vos y un poco gracias a mí, porque te escribo en vez de quedarme “inmoble” (lo descubrí ayer). En suma, quisiera, al final de todo, poder decir como el Poeta:",
+						"_key": "4e9ad66613f9",
+						"_type": "span",
+						"marks": []
+					}
+				],
+				"_type": "block"
+			},
+			{
+				"style": "normal",
+				"_key": "50ae2cbb8108",
+				"markDefs": [],
+				"children": [
+					{
+						"_type": "span",
+						"marks": [],
+						"text": "“on n'a pas été des lâcheson a fait ce qu'on a pu”. ",
+						"_key": "4bf2b2012f88"
+					},
+					{
+						"_type": "span",
+						"marks": [
+							"em",
+							"strong"
+						],
+						"text": "(2)",
+						"_key": "f00a0a85ee86"
+					}
+				],
+				"_type": "block"
+			},
+			{
+				"children": [
+					{
+						"text": "Por otra parte, mi cuarto es poco alentador. Ayer, decidida a reparar los daños que me causó la tormenta -la traidora! con lo que me gusta!- arrojé todo o sea libros, discos y cahiers al suelo a fin de ordenar ese conjunto de un modo más inteligente. Como no me animo a regalarte discos (salvo del estilo del de Salónica) me apresuro a contarte que ya se consiguen las piezas para clave de COUPERIN. La clabicembalista (!) se llama ETA HARICH SCHNEIDER. Título general: “Música para clave de Couperin”",
+						"_key": "138fedf3b9b5",
+						"_type": "span",
+						"marks": []
+					}
+				],
+				"_type": "block",
+				"style": "normal",
+				"_key": "f1f15ed57555",
+				"markDefs": []
+			},
+			{
+				"markDefs": [],
+				"children": [
+					{
+						"_type": "span",
+						"marks": [],
+						"text": "Ignoro cómo le caerá a la edipita Edith el nombre de ETA. Además Couperin se asocia con couper ",
+						"_key": "cdb2fa1a35c3"
+					},
+					{
+						"_type": "span",
+						"marks": [
+							"em",
+							"strong"
+						],
+						"text": "(3)",
+						"_key": "f5d2b648d920"
+					},
+					{
+						"_type": "span",
+						"marks": [],
+						"text": " y Schneider si bien significa sasstre, alude también al verbo cortar.Moraleja: no darle a Edith una tijera de sastre pues no vacilará en cortar el disco en dos partes: le derrière et le devant",
+						"_key": "6d93af40d7c6"
+					},
+					{
+						"text": "(4).",
+						"_key": "42727a257823",
+						"_type": "span",
+						"marks": [
+							"em",
+							"strong"
+						]
+					},
+					{
+						"_type": "span",
+						"marks": [],
+						"text": " Le derrière es algo que no se toca sin ser un instrumento. Le devant es algo que se que se que se (se acabó la cinta, oh mi complejo de Persefone, oh mis ganas de Amaltea, etc.).",
+						"_key": "47035018e342"
+					}
+				],
+				"_type": "block",
+				"style": "normal",
+				"_key": "a47861f6917d"
+			},
+			{
+				"children": [
+					{
+						"_key": "2f1dd0e86157",
+						"_type": "span",
+						"marks": [],
+						"text": "Ahora me siento mejor, Sylvette (no habrá ninguna igual) y te bendigo desde el fondo de los fondos de mi casa y de mi raza (de la que me siento desunida, sin embargo los oigo allá lejos cantarme sus ensalmos). Dije ensalmos y el barco se detuvo. Silvina, chérie, escribí mucho: si no lo hacés vos ¿quién lo hará, entonces? Te lo reitero, lo sé; volveré a decirlo, ahora y siempre. Algún día me contarás un cuento con caballos de calesita? “Yo he sufrido tanto.¿Me lo contarás algún día?” Gracias (estoy muy bien)\ny un abrazo matemático de"
+					},
+					{
+						"text": "\nA.",
+						"_key": "395dd1c5c729",
+						"_type": "span",
+						"marks": [
+							"em"
+						]
+					}
+				],
+				"_type": "block",
+				"style": "normal",
+				"_key": "f0c0f887818a",
+				"markDefs": []
+			},
+			{
+				"_type": "block",
+				"style": "normal",
+				"_key": "aacdba6c6d51",
+				"markDefs": [],
+				"children": [
+					{
+						"text": "P.S.\n",
+						"_key": "0c67e716f8a1",
+						"_type": "span",
+						"marks": []
+					},
+					{
+						"_type": "span",
+						"marks": [
+							"em"
+						],
+						"text": "Matemático",
+						"_key": "2c688ec8e3c9"
+					},
+					{
+						"_type": "span",
+						"marks": [],
+						"text": " porque releí el bellísimo “Les nombres d'or”.",
+						"_key": "967aafd8aa21"
+					}
+				]
+			},
+			{
+				"_type": "block",
+				"style": "normal",
+				"_key": "020d94ff3809",
+				"markDefs": [],
+				"children": [
+					{
+						"_key": "cb37c348e299",
+						"_type": "span",
+						"marks": [],
+						"text": "P.S. (b)\neste jardincito se formó mientras te escribía, S. tan esto y aquello, tan Sylvette y además tan de salir de sí por eso Sylvette “cuaja” (sic mis amigos de Españia) a las maravillas.Jardín de Sylvette a la hora de las maravillas"
+					}
+				]
+			},
+			{
+				"style": "normal",
+				"_key": "fb2ee98522e7",
+				"markDefs": [],
+				"children": [
+					{
+						"_type": "span",
+						"marks": [
+							"em"
+						],
+						"text": "* La tarjeta muestra un campo en fondo rojo con flores rosas y naranjas. *",
+						"_key": "34f9c7173a55"
+					}
+				],
+				"_type": "block"
+			},
+			{
+				"_key": "9803c9dd05c8",
+				"markDefs": [],
+				"children": [
+					{
+						"_type": "span",
+						"marks": [
+							"strong"
+						],
+						"text": "***",
+						"_key": "c2851853c1ab"
+					}
+				],
+				"_type": "block",
+				"style": "normal"
+			},
+			{
+				"children": [
+					{
+						"_type": "span",
+						"marks": [
+							"em",
+							"strong"
+						],
+						"text": "(1)",
+						"_key": "bb174f4c9e93"
+					},
+					{
+						"_type": "span",
+						"marks": [],
+						"text": ". “Es tan simple como una frase musical”.\n",
+						"_key": "b76a46097b2c"
+					},
+					{
+						"_key": "d69fc76ebb0e",
+						"_type": "span",
+						"marks": [
+							"strong",
+							"em"
+						],
+						"text": "(2)"
+					},
+					{
+						"text": ". “No hemos sido cobardes Hemos hecho lo que pudimos.”\n",
+						"_key": "01c5f324a5e1",
+						"_type": "span",
+						"marks": []
+					},
+					{
+						"_type": "span",
+						"marks": [
+							"em",
+							"strong"
+						],
+						"text": "(3)",
+						"_key": "349b08c5c32e"
+					},
+					{
+						"_type": "span",
+						"marks": [],
+						"text": ". “Cortar”\n",
+						"_key": "0be1be4c0ccd"
+					},
+					{
+						"text": "(4)",
+						"_key": "28e442ab4c5b",
+						"_type": "span",
+						"marks": [
+							"em",
+							"strong"
+						]
+					},
+					{
+						"text": ". “El trasero y el frente”.",
+						"_key": "69b9e9f0f655",
+						"_type": "span",
+						"marks": []
+					}
+				],
+				"_type": "block",
+				"style": "normal",
+				"_key": "f982443e3cbb",
+				"markDefs": []
+			}
+		],
+	},
+};
+
+export const Summary = {
+	render: (args: PortableTextParserComponent) => ({
+		props: args,
+		template: `
+      <div class="grid grid-cols-3 gap-4">
+          <cuentoneta-portable-text-parser [paragraphs]="paragraphs"/>
+    </div>
+`,
+	}),
+	args: {
+		paragraphs: [
+			{
+				"children": [
+					{
+						"marks": [
+							"strong",
+							"em"
+						],
+						"text": "¿Quién Sabe?",
+						"_key": "f83599c71483",
+						"_type": "span"
+					},
+					{
+						"_type": "span",
+						"marks": [],
+						"text": " (título original ",
+						"_key": "b813ac7b89c7"
+					},
+					{
+						"_type": "span",
+						"marks": [
+							"em"
+						],
+						"text": "Qui Sait?",
+						"_key": "4cb337ec4dec"
+					},
+					{
+						"_key": "22ba989c1cc2",
+						"_type": "span",
+						"marks": [],
+						"text": ") fue publicado originalmente en la edición del 6 de abril de 1890 del periódico francés "
+					},
+					{
+						"text": "L'Echo de Paris",
+						"_key": "18eebbae1cae",
+						"_type": "span",
+						"marks": [
+							"em"
+						]
+					},
+					{
+						"_type": "span",
+						"marks": [],
+						"text": " y posteriormente como parte de la colección de relatos ",
+						"_key": "834583a7b72d"
+					},
+					{
+						"marks": [
+							"em"
+						],
+						"text": "La Belleza Inútil",
+						"_key": "c84775db5686",
+						"_type": "span"
+					},
+					{
+						"_key": "5d7391f9b547",
+						"_type": "span",
+						"marks": [],
+						"text": ", editada aquel mismo año."
+					}
+				],
+				"_type": "block",
+				"style": "normal",
+				"_key": "4c94bc6a92a3",
+				"markDefs": []
+			},
+			{
+				"children": [
+					{
+						"_type": "span",
+						"marks": [],
+						"text": "Créditos a ",
+						"_key": "09e7167e6079"
+					},
+					{
+						"_type": "span",
+						"marks": [
+							"em",
+							"56fb7dd837a3"
+						],
+						"text": "setogenico",
+						"_key": "0920cdcab931"
+					},
+					{
+						"_type": "span",
+						"marks": [
+							"em"
+						],
+						"text": " ",
+						"_key": "cebe6118c6f1"
+					},
+					{
+						"_type": "span",
+						"marks": [],
+						"text": "por el relato del cuento disponible en su canal de YouTube.",
+						"_key": "2a42216ff69b"
+					}
+				],
+				"_type": "block",
+				"style": "normal",
+				"_key": "7b444b26bc54",
+				"markDefs": [
+					{
+						"_type": "link",
+						"href": "https://www.youtube.com/@setogenico",
+						"_key": "56fb7dd837a3"
+					}
+				]
+			}
+		],
+	},
+};

--- a/src/app/components/portable-text-parser/portable-text-parser.component.stories.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.stories.ts
@@ -13,11 +13,12 @@ export const Primary = {
 		props: args,
 		template: `
       <div class="grid grid-cols-3 gap-4">
-          <cuentoneta-portable-text-parser [paragraphs]="paragraphs"/>
+          <cuentoneta-portable-text-parser [classes]="classes" [paragraphs]="paragraphs"/>
     </div>
 `,
 	}),
 	args: {
+		classes: 'source-serif-pro-body-xl mb-8 last:mb-0',
 		paragraphs: [
 			{
 				"_type": "block",
@@ -318,11 +319,12 @@ export const Summary = {
 		props: args,
 		template: `
       <div class="grid grid-cols-3 gap-4">
-          <cuentoneta-portable-text-parser [paragraphs]="paragraphs"/>
+          <cuentoneta-portable-text-parser [classes]="classes" [paragraphs]="paragraphs"/>
     </div>
 `,
 	}),
 	args: {
+		classes: 'mb-4 last:mb-0',
 		paragraphs: [
 			{
 				"children": [

--- a/src/app/components/portable-text-parser/portable-text-parser.component.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.ts
@@ -8,22 +8,37 @@ import { PortableTextMarksSerializerComponent } from '../portable-text-styles-ma
 	standalone: true,
 	imports: [CommonModule, PortableTextMarksSerializerComponent],
 	template: `
-		@for (paragraph of paragraphs(); track $index) {
-			<p [ngClass]="appendClasses(paragraph)" class="source-serif-pro-body-xl mb-8 leading-8">
-				@for (block of paragraph.children; track $index) {
-					<cuentoneta-portable-text-marks-serializer
-						[text]="block.text"
-						[marks]="block.marks ?? []"
-						[markDefs]="paragraph.markDefs ?? []"
-					></cuentoneta-portable-text-marks-serializer>
-				}
-			</p>
+		@if (type() === 'paragraph') {
+			@for (paragraph of paragraphs(); track $index) {
+				<p [ngClass]="appendClasses(paragraph)">
+					@for (block of paragraph.children; track $index) {
+						<cuentoneta-portable-text-marks-serializer
+							[text]="block.text"
+							[marks]="block.marks ?? []"
+							[markDefs]="paragraph.markDefs ?? []"
+						></cuentoneta-portable-text-marks-serializer>
+					}
+				</p>
+			}
+		} @else if (type() === 'span') {
+			@for (paragraph of paragraphs(); track $index) {
+				<span [ngClass]="appendClasses(paragraph)">
+					@for (block of paragraph.children; track $index) {
+						<cuentoneta-portable-text-marks-serializer
+							[text]="block.text"
+							[marks]="block.marks ?? []"
+							[markDefs]="paragraph.markDefs ?? []"
+						></cuentoneta-portable-text-marks-serializer>
+					}
+				</span>
+			}
 		}
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PortableTextParserComponent {
 	paragraphs = input.required<BlockContent[]>();
+	type = input<'paragraph' | 'span'>('paragraph');
 
 	appendClasses(paragraph: BlockContent): string {
 		const blocks = paragraph.children;

--- a/src/app/components/portable-text-parser/portable-text-parser.component.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.ts
@@ -11,28 +11,26 @@ import { PortableTextMarksSerializerComponent } from '../portable-text-styles-ma
 		@if (type() === 'paragraph') {
 			@for (paragraph of paragraphs(); track $index) {
 				<p [ngClass]="appendClasses(paragraph)">
-					@for (block of paragraph.children; track $index) {
-						<cuentoneta-portable-text-marks-serializer
-							[text]="block.text"
-							[marks]="block.marks ?? []"
-							[markDefs]="paragraph.markDefs ?? []"
-						></cuentoneta-portable-text-marks-serializer>
-					}
+					<ng-container *ngTemplateOutlet="serializer; context: { $implicit: paragraph }"></ng-container>
 				</p>
 			}
 		} @else if (type() === 'span') {
 			@for (paragraph of paragraphs(); track $index) {
 				<span [ngClass]="appendClasses(paragraph)">
-					@for (block of paragraph.children; track $index) {
-						<cuentoneta-portable-text-marks-serializer
-							[text]="block.text"
-							[marks]="block.marks ?? []"
-							[markDefs]="paragraph.markDefs ?? []"
-						></cuentoneta-portable-text-marks-serializer>
-					}
+					<ng-container *ngTemplateOutlet="serializer; context: { $implicit: paragraph }"></ng-container>
 				</span>
 			}
 		}
+
+		<ng-template #serializer let-paragraph>
+			@for (block of paragraph.children; track $index) {
+				<cuentoneta-portable-text-marks-serializer
+					[text]="block.text"
+					[marks]="block.marks ?? []"
+					[markDefs]="paragraph.markDefs ?? []"
+				></cuentoneta-portable-text-marks-serializer>
+			}
+		</ng-template>
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/app/components/portable-text-parser/portable-text-parser.component.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { BlockContent, MarkDef } from '@models/block-content.model';
+import { BlockContent } from '@models/block-content.model';
 import { PortableTextMarksSerializerComponent } from '../portable-text-styles-marks-serializer/portable-text-marks-serializer.component';
 
 @Component({
@@ -20,7 +20,6 @@ import { PortableTextMarksSerializerComponent } from '../portable-text-styles-ma
 			</p>
 		}
 	`,
-	styles: ``,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PortableTextParserComponent {

--- a/src/app/components/portable-text-parser/portable-text-parser.component.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.ts
@@ -1,0 +1,156 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BlockContent, MarkDef } from '@models/block-content.model';
+
+@Component({
+	selector: 'cuentoneta-portable-text-parser',
+	standalone: true,
+	imports: [CommonModule],
+	template: `
+		@for (paragraph of paragraphs(); track $index) {
+			<p [ngClass]="appendClasses(paragraph)" class="source-serif-pro-body-xl mb-8 leading-8">
+				@for (block of paragraph.children; track $index) {
+					<ng-container
+						*ngTemplateOutlet="
+							blockTextStyleMarksParser;
+							context: { contextItem: { text: block.text, marks: block.marks ?? [], markDefs: paragraph.markDefs } }
+						"
+					></ng-container>
+				}
+			</p>
+		}
+
+		<ng-template #applyBold let-block="contextItem">
+			<b
+				><ng-container
+					*ngTemplateOutlet="
+						blockTextStyleMarksParser;
+						context: { contextItem: { text: block.text, marks: block.marks, markDefs: block.markDefs } }
+					"
+				></ng-container
+			></b>
+		</ng-template>
+
+		<ng-template #applyItalics let-block="contextItem">
+			<i
+				><ng-container
+					*ngTemplateOutlet="
+						blockTextStyleMarksParser;
+						context: { contextItem: { text: block.text, marks: block.marks, markDefs: block.markDefs } }
+					"
+				></ng-container
+			></i>
+		</ng-template>
+
+		<ng-template #blockTextStyleMarksParser let-block="contextItem">
+			<!-- Caso base: no se aplica ningún estilo y se interpola la cadena de texto -->
+			@if (block.marks.length === 0) {
+				<!-- Chequeo de saltos de línea -->
+				@for (text of splitLineBreaks(block.text); let index = $index; track index) {
+					{{ text }}
+					@if (index !== splitLineBreaks(block.text).length - 1) {
+						<br />
+					}
+				}
+			} @else if (block.marks[0] === 'strong') {
+				<!-- Comienza a recorrer el arreglo de marks aplicando negrita -->
+				<ng-container
+					*ngTemplateOutlet="
+						applyBold;
+						context: {
+							contextItem: {
+								text: block.text,
+								currentMark: block.marks[0],
+								marks: block.marks.slice(1),
+								markDefs: block.markDefs
+							}
+						}
+					"
+				>
+				</ng-container>
+			} @else if (block.marks[0] === 'em') {
+				<!-- Comienza a recorrer el arreglo de marks aplicando itálicas -->
+				<ng-container
+					*ngTemplateOutlet="
+						applyItalics;
+						context: {
+							contextItem: {
+								text: block.text,
+								currentMark: block.marks[0],
+								marks: block.marks.slice(1),
+								markDefs: block.markDefs
+							}
+						}
+					"
+				></ng-container>
+			} @else if (block.marks[0]) {
+				<!-- Comienza a recorrer el arreglo de marks aplicando markDefs -->
+				@for (markDef of block.markDefs; track $index) {
+					@if (markDef._key === block.marks[0]) {
+						@switch (markDef._type) {
+							@case ('link') {
+								<ng-container
+									*ngTemplateOutlet="
+										applyUrl;
+										context: {
+											contextItem: {
+												text: block.text,
+												currentMark: block.marks[0],
+												marks: block.marks.slice(1),
+												markDefs: block.markDefs
+											}
+										}
+									"
+								></ng-container>
+							}
+						}
+					}
+				}
+			}
+		</ng-template>
+
+		<ng-template #applyUrl let-block="contextItem">
+			<a class="underline" [href]="findUrlFromMarks(block.markDefs, block.currentMark)"
+				><ng-container
+					*ngTemplateOutlet="
+						blockTextStyleMarksParser;
+						context: {
+							contextItem: {
+								text: block.text,
+								currentMark: block.marks[0],
+								marks: block.marks,
+								markDefs: block.markDefs
+							}
+						}
+					"
+				></ng-container
+			></a>
+		</ng-template>
+	`,
+	styles: ``,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PortableTextParserComponent {
+	paragraphs = input.required<BlockContent[]>();
+
+	appendClasses(paragraph: BlockContent): string {
+		const blocks = paragraph.children;
+		const includeSeparators = blocks.filter((block) => block.text.includes('***')).length > 0;
+
+		let classes = '';
+
+		if (includeSeparators) {
+			classes = `text-center ${classes}`;
+		}
+
+		return classes;
+	}
+
+	findUrlFromMarks(markDefs: MarkDef[], currentMark: string): string {
+		return markDefs.find((mark) => mark._key === currentMark)?.href ?? '#';
+	}
+
+	splitLineBreaks(text: string): string[] {
+		return text.split('\n');
+	}
+}

--- a/src/app/components/portable-text-parser/portable-text-parser.component.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.ts
@@ -39,12 +39,13 @@ import { PortableTextMarksSerializerComponent } from '../portable-text-styles-ma
 export class PortableTextParserComponent {
 	paragraphs = input.required<BlockContent[]>();
 	type = input<'paragraph' | 'span'>('paragraph');
+	classes = input<string>('classes');
 
 	appendClasses(paragraph: BlockContent): string {
 		const blocks = paragraph.children;
 		const includeSeparators = blocks.filter((block) => block.text.includes('***')).length > 0;
 
-		let classes = '';
+		let classes = this.classes();
 
 		if (includeSeparators) {
 			classes = `text-center ${classes}`;

--- a/src/app/components/portable-text-parser/portable-text-parser.component.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.ts
@@ -2,11 +2,12 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BlockContent } from '@models/block-content.model';
 import { PortableTextMarksSerializerComponent } from '../portable-text-styles-marks-serializer/portable-text-marks-serializer.component';
+import { ParagraphTemplateDirective } from './paragraph-template.directive';
 
 @Component({
 	selector: 'cuentoneta-portable-text-parser',
 	standalone: true,
-	imports: [CommonModule, PortableTextMarksSerializerComponent],
+	imports: [CommonModule, PortableTextMarksSerializerComponent, ParagraphTemplateDirective],
 	template: `
 		@if (type() === 'paragraph') {
 			@for (paragraph of paragraphs(); track $index) {
@@ -22,7 +23,7 @@ import { PortableTextMarksSerializerComponent } from '../portable-text-styles-ma
 			}
 		}
 
-		<ng-template #serializer let-paragraph>
+		<ng-template #serializer cuentonetaParagraphTemplateGuard let-paragraph>
 			@for (block of paragraph.children; track $index) {
 				<cuentoneta-portable-text-marks-serializer
 					[text]="block.text"

--- a/src/app/components/portable-text-parser/portable-text-parser.component.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.ts
@@ -1,131 +1,24 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BlockContent, MarkDef } from '@models/block-content.model';
+import { PortableTextMarksSerializerComponent } from '../portable-text-styles-marks-serializer/portable-text-marks-serializer.component';
 
 @Component({
 	selector: 'cuentoneta-portable-text-parser',
 	standalone: true,
-	imports: [CommonModule],
+	imports: [CommonModule, PortableTextMarksSerializerComponent],
 	template: `
 		@for (paragraph of paragraphs(); track $index) {
 			<p [ngClass]="appendClasses(paragraph)" class="source-serif-pro-body-xl mb-8 leading-8">
 				@for (block of paragraph.children; track $index) {
-					<ng-container
-						*ngTemplateOutlet="
-							blockTextStyleMarksParser;
-							context: { contextItem: { text: block.text, marks: block.marks ?? [], markDefs: paragraph.markDefs } }
-						"
-					></ng-container>
+					<cuentoneta-portable-text-marks-serializer
+						[text]="block.text"
+						[marks]="block.marks ?? []"
+						[markDefs]="paragraph.markDefs ?? []"
+					></cuentoneta-portable-text-marks-serializer>
 				}
 			</p>
 		}
-
-		<ng-template #applyBold let-block="contextItem">
-			<b
-				><ng-container
-					*ngTemplateOutlet="
-						blockTextStyleMarksParser;
-						context: { contextItem: { text: block.text, marks: block.marks, markDefs: block.markDefs } }
-					"
-				></ng-container
-			></b>
-		</ng-template>
-
-		<ng-template #applyItalics let-block="contextItem">
-			<i
-				><ng-container
-					*ngTemplateOutlet="
-						blockTextStyleMarksParser;
-						context: { contextItem: { text: block.text, marks: block.marks, markDefs: block.markDefs } }
-					"
-				></ng-container
-			></i>
-		</ng-template>
-
-		<ng-template #blockTextStyleMarksParser let-block="contextItem">
-			<!-- Caso base: no se aplica ningún estilo y se interpola la cadena de texto -->
-			@if (block.marks.length === 0) {
-				<!-- Chequeo de saltos de línea -->
-				@for (text of splitLineBreaks(block.text); let index = $index; track index) {
-					{{ text }}
-					@if (index !== splitLineBreaks(block.text).length - 1) {
-						<br />
-					}
-				}
-			} @else if (block.marks[0] === 'strong') {
-				<!-- Comienza a recorrer el arreglo de marks aplicando negrita -->
-				<ng-container
-					*ngTemplateOutlet="
-						applyBold;
-						context: {
-							contextItem: {
-								text: block.text,
-								currentMark: block.marks[0],
-								marks: block.marks.slice(1),
-								markDefs: block.markDefs
-							}
-						}
-					"
-				>
-				</ng-container>
-			} @else if (block.marks[0] === 'em') {
-				<!-- Comienza a recorrer el arreglo de marks aplicando itálicas -->
-				<ng-container
-					*ngTemplateOutlet="
-						applyItalics;
-						context: {
-							contextItem: {
-								text: block.text,
-								currentMark: block.marks[0],
-								marks: block.marks.slice(1),
-								markDefs: block.markDefs
-							}
-						}
-					"
-				></ng-container>
-			} @else if (block.marks[0]) {
-				<!-- Comienza a recorrer el arreglo de marks aplicando markDefs -->
-				@for (markDef of block.markDefs; track $index) {
-					@if (markDef._key === block.marks[0]) {
-						@switch (markDef._type) {
-							@case ('link') {
-								<ng-container
-									*ngTemplateOutlet="
-										applyUrl;
-										context: {
-											contextItem: {
-												text: block.text,
-												currentMark: block.marks[0],
-												marks: block.marks.slice(1),
-												markDefs: block.markDefs
-											}
-										}
-									"
-								></ng-container>
-							}
-						}
-					}
-				}
-			}
-		</ng-template>
-
-		<ng-template #applyUrl let-block="contextItem">
-			<a class="underline" [href]="findUrlFromMarks(block.markDefs, block.currentMark)"
-				><ng-container
-					*ngTemplateOutlet="
-						blockTextStyleMarksParser;
-						context: {
-							contextItem: {
-								text: block.text,
-								currentMark: block.marks[0],
-								marks: block.marks,
-								markDefs: block.markDefs
-							}
-						}
-					"
-				></ng-container
-			></a>
-		</ng-template>
 	`,
 	styles: ``,
 	changeDetection: ChangeDetectionStrategy.OnPush,
@@ -144,13 +37,5 @@ export class PortableTextParserComponent {
 		}
 
 		return classes;
-	}
-
-	findUrlFromMarks(markDefs: MarkDef[], currentMark: string): string {
-		return markDefs.find((mark) => mark._key === currentMark)?.href ?? '#';
-	}
-
-	splitLineBreaks(text: string): string[] {
-		return text.split('\n');
 	}
 }

--- a/src/app/components/portable-text-styles-marks-serializer/portable-text-marks-serializer.component.spec.ts
+++ b/src/app/components/portable-text-styles-marks-serializer/portable-text-marks-serializer.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PortableTextMarksSerializerComponent } from './portable-text-marks-serializer.component';
+
+describe('PortableTextMarksSerializerComponent', () => {
+	let component: PortableTextMarksSerializerComponent;
+	let fixture: ComponentFixture<PortableTextMarksSerializerComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [PortableTextMarksSerializerComponent],
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(PortableTextMarksSerializerComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/components/portable-text-styles-marks-serializer/portable-text-marks-serializer.component.ts
+++ b/src/app/components/portable-text-styles-marks-serializer/portable-text-marks-serializer.component.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MarkDef } from '@models/block-content.model';
 
@@ -51,7 +51,7 @@ import { MarkDef } from '@models/block-content.model';
 				}
 			}
 		}`,
-	styles: ``,
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PortableTextMarksSerializerComponent {
 	text = input.required({

--- a/src/app/components/portable-text-styles-marks-serializer/portable-text-marks-serializer.component.ts
+++ b/src/app/components/portable-text-styles-marks-serializer/portable-text-marks-serializer.component.ts
@@ -1,0 +1,66 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MarkDef } from '@models/block-content.model';
+
+@Component({
+	selector: 'cuentoneta-portable-text-marks-serializer',
+	standalone: true,
+	imports: [CommonModule],
+	template: ` <!-- Caso base: no se aplica ningún estilo y se interpola la cadena de texto -->
+		@if (marks().length === 0) {
+			<!-- Chequeo de saltos de línea -->
+			@for (portion of text(); let index = $index; track index) {
+				{{ portion }}
+				@if (index !== text().length - 1) {
+					<br />
+				}
+			}
+		} @else if (marks()[0] === 'strong') {
+			<!-- Comienza a recorrer el arreglo de marks aplicando negrita -->
+			<b>
+				<cuentoneta-portable-text-marks-serializer
+					[text]="text()"
+					[marks]="marks().slice(1)"
+					[markDefs]="markDefs()"
+				></cuentoneta-portable-text-marks-serializer>
+			</b>
+		} @else if (marks()[0] === 'em') {
+			<!-- Comienza a recorrer el arreglo de marks aplicando itálicas -->
+			<i>
+				<cuentoneta-portable-text-marks-serializer
+					[text]="text()"
+					[marks]="marks().slice(1)"
+					[markDefs]="markDefs()"
+				></cuentoneta-portable-text-marks-serializer>
+			</i>
+		} @else if (marks()[0]) {
+			<!-- Comienza a recorrer el arreglo de marks aplicando markDefs -->
+			@for (markDef of markDefs(); track $index) {
+				@if (markDef._key === marks()[0]) {
+					@switch (markDef._type) {
+						@case ('link') {
+							<a [href]="findUrlFromMarks(markDefs(), marks()[0])">
+								<cuentoneta-portable-text-marks-serializer
+									[text]="text()"
+									[marks]="marks().slice(1)"
+									[markDefs]="markDefs()"
+								></cuentoneta-portable-text-marks-serializer>
+							</a>
+						}
+					}
+				}
+			}
+		}`,
+	styles: ``,
+})
+export class PortableTextMarksSerializerComponent {
+	text = input.required({
+		transform: (span: string | string[]): string[] => (typeof span === 'string' ? span.split('\n') : span),
+	});
+	marks = input<string[]>([]);
+	markDefs = input<MarkDef[]>([]);
+
+	findUrlFromMarks(markDefs: MarkDef[], currentMark: string): string {
+		return markDefs.find((mark) => mark._key === currentMark)?.href ?? '#';
+	}
+}

--- a/src/app/components/space-recording-widget/space-recording-widget.stories.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.stories.ts
@@ -15,8 +15,8 @@ export default {
 
 const media: Media = {
 	title: 'En Algún Lugar de Tlön: Encuentro #1',
-	url: 'https://twitter.com/ladrondesabado/status/1736920785162240151',
 	type: 'spaceRecording',
+	icon: '',
 	data: {
 		id: '1736920785162240151',
 		createdAt: 'Tue Dec 19 01:26:00 +0000 2023',

--- a/src/app/components/story-card/story-card.component.html
+++ b/src/app/components/story-card/story-card.component.html
@@ -9,10 +9,11 @@
 			</header>
 			<section [lang]="story.language">
 				<h1 class="mb-1 text-ellipsis overflow-hidden whitespace-nowrap inter-body-xl-bold">{{ story.title }}</h1>
-				<p
-					[innerHTML]="previewText"
-					class="hidden sm:source-serif-pro-body-base sm:text-ellipsis sm:relative sm:text-justify sm:min-h-18 sm:line-clamp-3"
-				></p>
+                <cuentoneta-portable-text-parser
+                        class="hidden sm:source-serif-pro-body-base sm:text-ellipsis sm:relative sm:text-justify sm:min-h-18 sm:line-clamp-3"
+                        [type]="'span'"
+                        [paragraphs]="story.paragraphs"
+                ></cuentoneta-portable-text-parser>
 			</section>
 			<time class="font-semibold text-gray-600 inter-body-xs-semibold">
 				{{ story.approximateReadingTime }} minutos de lectura

--- a/src/app/components/story-card/story-card.component.stories.ts
+++ b/src/app/components/story-card/story-card.component.stories.ts
@@ -13,7 +13,7 @@ registerLocaleData(localeEs);
 
 // Modelos
 import { Publication } from '@models/storylist.model';
-import { Story } from '@models/story.model';
+import { Story, StoryCard } from '@models/story.model';
 
 export default {
 	title: 'StoryCardComponent',
@@ -26,7 +26,7 @@ export default {
 	],
 } as Meta<StoryCardComponent>;
 
-const publication: Publication<Story> = {
+const publication: Publication<StoryCard> = {
 	publishingOrder: 60,
 	published: true,
 	publishingDate: '2022-03-01',

--- a/src/app/components/story-card/story-card.component.stories.ts
+++ b/src/app/components/story-card/story-card.component.stories.ts
@@ -48,18 +48,80 @@ const publication: Publication<StoryCard> = {
 		media: [],
 		summary: [
 			{
-				classes: '',
-				text: '"Máscaras" está incluido en el volumen "Bar del Infierno", publicado en 2005. La acción de la obra se sucede en un bar del cual no es posible salir, dado que en el universo del libro el afuera no existe. En este escenario, El Narrador de Historias, protagonista principal de esta narración enmarcada, procede a contar una variedad de relatos ubicados en distintos lugares y distintas épocas.',
+				_key: '7eddf102184a',
+				markDefs: [],
+				children: [
+					{
+						_type: 'span',
+						marks: ['strong', 'em'],
+						text: 'Máscaras',
+						_key: 'f043f548f8c4',
+					},
+					{
+						_type: 'span',
+						marks: [],
+						text: ' está incluido en el volumen ',
+						_key: '7b11663f0e03',
+					},
+					{
+						text: 'Bar del Infierno',
+						_key: '3ddad9aa76c3',
+						_type: 'span',
+						marks: ['em'],
+					},
+					{
+						_type: 'span',
+						marks: [],
+						text: ', publicado en 2005. La acción de la obra se sucede en un bar del cual no es posible salir, dado que en el universo del libro el afuera no existe. En este escenario, El Narrador de Historias, protagonista principal de esta narración enmarcada, procede a contar una variedad de relatos ubicados en distintos lugares y distintas épocas.',
+						_key: 'afc1b9c43d8c',
+					},
+				],
+				_type: 'block',
+				style: 'normal',
 			},
 		],
 		paragraphs: [
 			{
-				classes: '',
-				text: 'Según cuentan algunos, el corso de la avenida La Plata, en Santos Lugares, era utilizado frecuentemente por ángeles y demonios cuando tenían que cumplir alguna misión terrestre. Solía decirse también que entre todas las máscaras del corso, una era el diablo. Los hechiceros de Lourdes y Villa Lynch aprovechaban aquellas jornadas para suscribir convenios de toda clase con los poderes de las tinieblas. Tras las caretas espeluznantes se ocultaba el verdadero horror de las caras del mal.',
+				style: 'normal',
+				_key: '01d31f77e38e',
+				markDefs: [],
+				children: [
+					{
+						text: 'Según cuentan algunos, el corso de la avenida La Plata, en Santos Lugares, era utilizado frecuentemente por ángeles y demonios cuando tenían que cumplir alguna misión terrestre. Solía decirse también que entre todas las máscaras del corso, una era el diablo. Los hechiceros de Lourdes y Villa Lynch aprovechaban aquellas jornadas para suscribir convenios de toda clase con los poderes de las tinieblas. Tras las caretas espeluznantes se ocultaba el verdadero horror de las caras del mal.',
+						_key: '47950aa594a0',
+						_type: 'span',
+						marks: [],
+					},
+				],
+				_type: 'block',
 			},
 			{
-				classes: '',
-				text: 'Los hombres sensibles de Flores solían pasearse por allí tratando de reconocer el sello de las legiones, o bien gritando frases ingeniosas en el oído de las muchachas. Cada vez que sospechaban el carácter sobrenatural de algún enmascarado, comenzaban a acosarlo tratando de provocar alguna reacción reveladora.',
+				_key: '4f7a3a195535',
+				markDefs: [],
+				children: [
+					{
+						_type: 'span',
+						marks: [],
+						text: 'Los hombres sensibles de Flores solían pasearse por allí tratando de reconocer el sello de las legiones, o bien gritando frases ingeniosas en el oído de las muchachas. Cada vez que sospechaban el carácter sobrenatural de algún enmascarado, comenzaban a acosarlo tratando de provocar alguna reacción reveladora.',
+						_key: '2510774b3b10',
+					},
+				],
+				_type: 'block',
+				style: 'normal',
+			},
+			{
+				markDefs: [],
+				children: [
+					{
+						_type: 'span',
+						marks: [],
+						text: 'Nunca tuvieron suerte. Las mascaritas eran muy diestras en la ocultación de investiduras infernales o eran, lisa y llanamente, sifoneros o ferroviarios disfrazados de Mandinga.',
+						_key: 'e863deeabe34',
+					},
+				],
+				_type: 'block',
+				style: 'normal',
+				_key: '90005bcd4cee',
 			},
 		],
 		prologues: [],

--- a/src/app/components/story-card/story-card.component.ts
+++ b/src/app/components/story-card/story-card.component.ts
@@ -8,6 +8,7 @@ import { StoryCardSkeletonComponent } from '../story-card-skeleton/story-card-sk
 import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
 import { CommonModule, DatePipe, NgIf, NgOptimizedImage } from '@angular/common';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component'
 
 @Component({
 	selector: 'cuentoneta-story-card',
@@ -20,6 +21,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 		NgOptimizedImage,
 		StoryCardSkeletonComponent,
 		StoryEditionDateLabelComponent,
+		PortableTextParserComponent,
 	],
 	providers: [DatePipe],
 	changeDetection: ChangeDetectionStrategy.OnPush,
@@ -33,7 +35,6 @@ export class StoryCardComponent implements OnInit {
 	@Input() editionIndex: number = 0;
 
 	editionLabel: string = '';
-	previewText: string = '';
 
 	private datePipe = inject(DatePipe);
 
@@ -43,7 +44,5 @@ export class StoryCardComponent implements OnInit {
 			this.editionSuffix ? ' | ' + this.editionSuffix : ''
 		}`;
 		this.comingNextLabel = this.displayDate ? `${this.comingNextLabel} ${dateFormat}` : this.comingNextLabel;
-
-		this.previewText = this.publication?.story.paragraphs.map((paragraph) => paragraph.text).join(' ') ?? '';
 	}
 }

--- a/src/app/components/story-card/story-card.component.ts
+++ b/src/app/components/story-card/story-card.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, Input, OnInit } from '@angular/core';
 
 // Modelos
-import { Story } from '@models/story.model';
+import { StoryCard } from '@models/story.model';
 import { Publication } from '@models/storylist.model';
 
 import { StoryCardSkeletonComponent } from '../story-card-skeleton/story-card-skeleton.component';
@@ -29,7 +29,7 @@ export class StoryCardComponent implements OnInit {
 	@Input() editionSuffix: string | undefined;
 	@Input() comingNextLabel: string = '';
 	@Input() displayDate: boolean = false;
-	@Input() publication: Publication<Story> | undefined;
+	@Input() publication: Publication<StoryCard> | undefined;
 	@Input() editionIndex: number = 0;
 
 	editionLabel: string = '';

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Publication, Storylist } from '@models/storylist.model';
-import { Story } from '@models/story.model';
+import { Story, StoryCard } from '@models/story.model';
 import { APP_ROUTE_TREE } from '../../app.routes';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
@@ -14,7 +14,7 @@ import { NgIf, NgFor, CommonModule } from '@angular/common';
 	imports: [CommonModule, NgxSkeletonLoaderModule, NgIf, NgFor, RouterLink, StoryEditionDateLabelComponent],
 })
 export class StoryNavigationBarComponent implements OnChanges {
-	@Input() displayedPublications: Publication<Story>[] = [];
+	@Input() displayedPublications: Publication<StoryCard>[] = [];
 	@Input() selectedStorySlug: string = '';
 	@Input() storylist: Storylist | undefined;
 
@@ -35,7 +35,7 @@ export class StoryNavigationBarComponent implements OnChanges {
 	 * caso de que la story actualmente en vista sea una de las primeras o de las últimas.
 	 * @author Ramiro Olivencia <ramiro@olivencia.com.ar>
 	 */
-	sliceDisplayedPublications(publications: Publication<Story>[]): void {
+	sliceDisplayedPublications(publications: Publication<StoryCard>[]): void {
 		if (!this.storylist) {
 			return;
 		}
@@ -67,7 +67,7 @@ export class StoryNavigationBarComponent implements OnChanges {
 	}
 
 	// ToDo: Separar card de cada cuento de la lista en su propio componente, para evitar usar un método en el template
-	getEditionLabel(publication: Publication<Story>, editionIndex: number = 0): string {
+	getEditionLabel(publication: Publication<StoryCard>, editionIndex: number = 0): string {
 		if (!this.storylist) {
 			return '';
 		}

--- a/src/app/models/author.model.ts
+++ b/src/app/models/author.model.ts
@@ -1,5 +1,4 @@
 import { BlockContent } from '@models/block-content.model';
-import { Paragraph } from '@models/story.model';
 import { Resource } from '@models/resource.model';
 
 interface AuthorBase {
@@ -11,7 +10,7 @@ interface AuthorBase {
 }
 
 export interface Author extends AuthorBase {
-	biography?: Paragraph[];
+	biography?: BlockContent[];
 }
 
 export interface AuthorDTO extends AuthorBase {

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -32,11 +32,6 @@ export interface StoryDTO extends StoryBase {
 	media: Media[];
 }
 
-export interface Paragraph {
-	classes: string;
-	text: string;
-}
-
 export interface StoryCard extends Story {
 	author: Omit<Author, 'biography'>;
 }

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -19,7 +19,7 @@ export interface StoryBase {
 export interface Story extends StoryBase {
 	author: Author;
 	prologues: Prologue[];
-	summary: Paragraph[];
+	summary: BlockContent[];
 	paragraphs: BlockContent[];
 	media: MediaTypes[];
 }

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -37,10 +37,6 @@ export interface Paragraph {
 	text: string;
 }
 
-export interface StoryCard extends StoryBase {
+export interface StoryCard extends Story {
 	author: Omit<Author, 'biography'>;
-	prologues: Prologue[];
-	summary: Paragraph[];
-	paragraphs: Paragraph[];
-	media: MediaTypes[];
 }

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -13,13 +13,14 @@ export interface StoryBase {
 	badLanguage?: boolean;
 	language: string;
 	resources?: Resource[]
+	paragraphs: unknown
 }
 
 export interface Story extends StoryBase {
 	author: Author;
 	prologues: Prologue[];
 	summary: Paragraph[];
-	paragraphs: Paragraph[];
+	paragraphs: BlockContent[];
 	media: MediaTypes[];
 }
 
@@ -36,6 +37,10 @@ export interface Paragraph {
 	text: string;
 }
 
-export interface StoryCard extends Story {
+export interface StoryCard extends StoryBase {
 	author: Omit<Author, 'biography'>;
+	prologues: Prologue[];
+	summary: Paragraph[];
+	paragraphs: Paragraph[];
+	media: MediaTypes[];
 }

--- a/src/app/models/storylist.model.ts
+++ b/src/app/models/storylist.model.ts
@@ -1,4 +1,4 @@
-import { Story, StoryBase, StoryDTO } from './story.model';
+import { Story, StoryBase, StoryCard, StoryDTO } from './story.model';
 import { SanityImageSource } from '@sanity/image-url/lib/types/types';
 import { Tag } from '@models/tag.model';
 
@@ -28,7 +28,7 @@ interface StorylistBase {
 export type StorylistCard = Omit<StorylistBase, 'images' | 'previewImages' | 'gridConfig' | 'previewGridConfig'>
 
 export interface Storylist extends StorylistBase {
-  publications: Publication<Story>[];
+  publications: Publication<StoryCard>[];
 }
 
 export interface StorylistDTO extends StorylistBase {

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -1,7 +1,7 @@
 <aside class="hidden md:block">
 	@defer {
 		<cuentoneta-story-navigation-bar
-		[selectedStorySlug]="story?.slug ?? ''"
+			[selectedStorySlug]="story?.slug ?? ''"
 			[storylist]="storylist"
 		></cuentoneta-story-navigation-bar>
 	}
@@ -88,12 +88,10 @@
 
 		@if (!!story && !fetchContentDirective.isLoading) {
 			<section [lang]="story.language">
-				@for (paragraph of story.paragraphs; track $index) {
-					<p
-						[innerHTML]="paragraph.text"
-						[ngClass]="['source-serif-pro-body-xl', paragraph.classes, 'mb-8', 'leading-8']"
-					></p>
-				}
+				<cuentoneta-portable-text-parser
+					[ngClass]="['source-serif-pro-body-xl', 'mb-8', 'leading-8']"
+					[paragraphs]="story.paragraphs"
+				></cuentoneta-portable-text-parser>
 			</section>
 		} @else {
 			@for (skeleton of dummyList; track $index) {

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -89,7 +89,7 @@
 		@if (!!story && !fetchContentDirective.isLoading) {
 			<section [lang]="story.language">
 				<cuentoneta-portable-text-parser
-					class="source-serif-pro-body-xl mb-8 leading-8"
+                    [classes]="'source-serif-pro-body-xl mb-8 leading-8'"
 					[paragraphs]="story.paragraphs"
 				></cuentoneta-portable-text-parser>
 			</section>

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -89,7 +89,7 @@
 		@if (!!story && !fetchContentDirective.isLoading) {
 			<section [lang]="story.language">
 				<cuentoneta-portable-text-parser
-					[ngClass]="['source-serif-pro-body-xl', 'mb-8', 'leading-8']"
+					class="source-serif-pro-body-xl mb-8 leading-8"
 					[paragraphs]="story.paragraphs"
 				></cuentoneta-portable-text-parser>
 			</section>

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -31,6 +31,7 @@ import { BioSummaryCardComponent } from '../../components/bio-summary-card/bio-s
 import { ShareContentComponent } from '../../components/share-content/share-content.component';
 import { EpigraphComponent } from '../../components/epigraph/epigraph.component';
 import { MediaResourceComponent } from '../../components/media-resource/media-resource.component'
+import { PortableTextParserComponent } from '../../components/portable-text-parser/portable-text-parser.component'
 
 @Component({
 	selector: 'cuentoneta-story',
@@ -50,6 +51,7 @@ import { MediaResourceComponent } from '../../components/media-resource/media-re
 		EpigraphComponent,
 		YouTubePlayer,
 		MediaResourceComponent,
+		PortableTextParserComponent,
 	],
 	hostDirectives: [FetchContentDirective, MetaTagsDirective],
 })

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -7,8 +7,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { environment } from '../environments/environment';
 
 // Models
-import { Paragraph, Story, StoryCard, StoryDTO } from '@models/story.model';
-import { Block, BlockContent, MarkDef } from '@models/block-content.model';
+import { Story, StoryCard, StoryDTO } from '@models/story.model';
 import { AudioRecording, Media, MediaTypes, SpaceRecording } from '@models/media.model';
 
 @Injectable({ providedIn: 'root' })
@@ -31,7 +30,7 @@ export class StoryService {
 			},
 			prologues: story.prologues ?? [],
 			paragraphs: story?.paragraphs ?? [],
-			summary: story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
+			summary: story?.summary ?? [],
 			media: story.media?.map((x) => this.mediaTypesAdapter(x)) ?? [],
 		};
 	}
@@ -41,11 +40,11 @@ export class StoryService {
 			...story,
 			prologues: story.prologues ?? [],
 			paragraphs: story?.paragraphs ?? [],
-			summary: story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
+			summary: story?.summary ?? [],
 			author: {
 				...story.author,
 				imageUrl: this.parseAvatarImageUrl(story.author.imageUrl),
-				biography: story.author.biography?.map((x) => this.parseParagraph(x)) ?? [],
+				biography: story.author.biography ?? [],
 			},
 			media: story.media?.map((x) => this.mediaTypesAdapter(x)) ?? [],
 		};
@@ -53,91 +52,6 @@ export class StoryService {
 
 	private parseAvatarImageUrl(imageUrl: string | undefined): string {
 		return imageUrl ?? 'assets/img/default-avatar.jpg';
-	}
-
-	private parseParagraph(blockContent: BlockContent): Paragraph {
-		let paragraph = '';
-		let classes: string[] = [];
-
-		blockContent.markDefs;
-
-		blockContent.children.forEach((block: Block) => {
-			let part = block.text;
-
-			part = this.parseBlockTextStyleMarks(block, part);
-			part = this.parseBlockTextMarkDefs(part, block.marks ?? [], blockContent.markDefs ?? []);
-
-			// Transformación de salto de línea en texto dentro del mismo párrafo
-			part = part.replaceAll('\n', '<br/>');
-
-			// Asignación de clases para modificar estilos del texto
-			// TODO: Utilizar mark particular en BlockContent para centrar cualquier tipo de texto a futuro
-			if (block.text?.includes('***')) {
-				classes = classes.concat(['text-center']);
-			}
-
-			paragraph = paragraph.concat(part);
-		});
-		return { classes: classes.join(' '), text: paragraph };
-	}
-
-	/**
-	 * Método encargado de procesar los estilos estáticos de texto soportados por Sanity
-	 * Genera tags HTML para los estilos de texto en negrita e itálica
-	 * // TODO: Soportar los restantes estilos de texto del tipo BlockContent en Sanity
-	 * @param block
-	 * @param part
-	 * @private
-	 */
-	private parseBlockTextStyleMarks(block: Block, part: string = ''): string {
-		const marks = block.marks ?? [];
-
-		if (block.marks?.length === 0) return part;
-
-		marks.forEach((mark) => {
-			switch (mark) {
-				case 'em':
-					part = this.addItalics(part);
-					break;
-				case 'strong':
-					part = this.addBold(part);
-					break;
-				default:
-					break;
-			}
-		});
-
-		return part;
-	}
-
-	private parseBlockTextMarkDefs(text: string, marks: string[], markDefs: MarkDef[]): string {
-		if (markDefs.length === 0 || marks.length === 0) return text;
-
-		markDefs.forEach((markDef) => {
-			if (marks.includes(markDef._key)) {
-				switch (markDef._type) {
-					case 'link':
-						text = this.addUrlLink(text, markDef.href);
-						break;
-					default:
-						break;
-				}
-			}
-		});
-
-		return text;
-	}
-
-	private addItalics(text: string): string {
-		return `<i>${text}</i>`;
-	}
-
-	private addBold(text: string): string {
-		return `<b>${text}</b>`;
-	}
-
-	private addUrlLink(text: string, url: string): string {
-		return `<a href="${url}">${text}</a>`;
 	}
 
 	/**

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -30,7 +30,7 @@ export class StoryService {
 				imageUrl: this.parseAvatarImageUrl(story.author.imageUrl),
 			},
 			prologues: story.prologues ?? [],
-			paragraphs: story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
+			paragraphs: story?.paragraphs ?? [],
 			summary: story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
 			media: story.media?.map((x) => this.mediaTypesAdapter(x)) ?? [],
 		};

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -40,7 +40,7 @@ export class StoryService {
 		return {
 			...story,
 			prologues: story.prologues ?? [],
-			paragraphs: story?.paragraphs?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
+			paragraphs: story?.paragraphs ?? [],
 			summary: story?.summary?.map((x: BlockContent) => this.parseParagraph(x)) ?? [],
 			author: {
 				...story.author,


### PR DESCRIPTION
# Resumen
* Crea nuevo componente `PortableTextParserComponent`, orientado a procesar texto en formato Portable Text y serializarlo a HTML.
* Elimina uso de interface `Paragraph`, reemplazando los métodos de parsing otrora en `StoryService` por el procesamiento del texto de tipo `BlockContent` en el nuevo componente.
* Implementado componente `PortableTextParserComponent` en reemplazo de todos los usos de `innerHTML` en los componentes orientados a mostrar contenido almacenado en Sanity en formato Portable Text (`StoryComponent`, `StoryCardComponent` y `BioSummaryCardComponent`).

## Otros cambios
* Repara stories de Storybook afectadas por últimos cambios.