### PR TITLE
[#702] Agregar campo slug a schema author y sus modelos relacionados

### DIFF
--- a/cms/schemas/author.ts
+++ b/cms/schemas/author.ts
@@ -15,6 +15,16 @@ export default {
 			type: 'string',
 		},
 		{
+			name: 'slug',
+			title: 'Slug',
+			type: 'slug',
+			options: {
+				source: 'name',
+				maxLength: 96,
+			},
+			validation: (Rule) => Rule.required(),
+		},
+		{
 			name: 'image',
 			title: 'Foto',
 			type: 'image',

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "pretty-quick": "^3.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "slugify": "^1.6.6",
     "storybook": "7.0.8",
     "tailwindcss": "^3.4.1",
     "ts-jest": "29.1.0",
@@ -108,4 +109,3 @@
     "webpack": "^5.64.0"
   }
 }
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ dependencies:
     version: 17.2.2(@angular/common@17.3.3)(@angular/core@17.3.3)(rxjs@7.5.7)
   '@nx/angular':
     specifier: 18.2.3
-    version: 18.2.3(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.2.3)(@angular-devkit/schematics@17.2.3)(@schematics/angular@17.2.3)(@swc/core@1.3.85)(@types/node@18.16.9)(esbuild@0.19.11)(eslint@8.57.0)(html-webpack-plugin@5.5.0)(nx@18.2.3)(rxjs@7.5.7)(typescript@5.4.4)
+    version: 18.2.3(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.3.3)(@angular-devkit/schematics@17.3.3)(@schematics/angular@17.3.3)(@swc/core@1.3.85)(@types/node@18.16.9)(esbuild@0.19.11)(eslint@8.57.0)(html-webpack-plugin@5.5.0)(nx@18.2.3)(rxjs@7.5.7)(typescript@5.4.4)
   '@sanity/client':
     specifier: ^3.4.1
     version: 3.4.1
@@ -89,6 +89,9 @@ dependencies:
   satori-html:
     specifier: ^0.3.2
     version: 0.3.2
+  slugify:
+    specifier: ^1.6.6
+    version: 1.6.6
   tslib:
     specifier: ^2.3.0
     version: 2.5.0
@@ -147,7 +150,7 @@ devDependencies:
     version: 1.3.0(@types/node@18.16.9)(less@4.2.0)(postcss@8.4.36)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.1)(typescript@5.4.4)(webpack@5.76.3)
   '@storybook/angular':
     specifier: 7.5.3
-    version: 7.5.3(@angular-devkit/architect@0.1702.3)(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.2.3)(@angular/cli@17.3.3)(@angular/common@17.3.3)(@angular/compiler-cli@17.3.3)(@angular/compiler@17.3.3)(@angular/core@17.3.3)(@angular/forms@17.3.3)(@angular/platform-browser-dynamic@17.3.3)(@angular/platform-browser@17.3.3)(@babel/core@7.23.9)(@swc/core@1.3.85)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(rxjs@7.5.7)(typescript@5.4.4)(zone.js@0.14.3)
+    version: 7.5.3(@angular-devkit/architect@0.1703.3)(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.3.3)(@angular/cli@17.3.3)(@angular/common@17.3.3)(@angular/compiler-cli@17.3.3)(@angular/compiler@17.3.3)(@angular/core@17.3.3)(@angular/forms@17.3.3)(@angular/platform-browser-dynamic@17.3.3)(@angular/platform-browser@17.3.3)(@babel/core@7.24.0)(@swc/core@1.3.85)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(rxjs@7.5.7)(typescript@5.4.4)(zone.js@0.14.3)
   '@storybook/core-server':
     specifier: 7.5.3
     version: 7.5.3
@@ -207,7 +210,7 @@ devDependencies:
     version: 29.5.0
   jest-preset-angular:
     specifier: 14.0.3
-    version: 14.0.3(@angular-devkit/build-angular@17.3.3)(@angular/compiler-cli@17.3.3)(@angular/core@17.3.3)(@angular/platform-browser-dynamic@17.3.3)(@babel/core@7.23.9)(jest@29.5.0)(typescript@5.4.4)
+    version: 14.0.3(@angular-devkit/build-angular@17.3.3)(@angular/compiler-cli@17.3.3)(@angular/core@17.3.3)(@angular/platform-browser-dynamic@17.3.3)(@babel/core@7.24.0)(jest@29.5.0)(typescript@5.4.4)
   lint-staged:
     specifier: ^13.2.3
     version: 13.2.3
@@ -243,7 +246,7 @@ devDependencies:
     version: 3.4.1(ts-node@10.9.1)
   ts-jest:
     specifier: 29.1.0
-    version: 29.1.0(@babel/core@7.23.9)(esbuild@0.19.11)(jest@29.5.0)(typescript@5.4.4)
+    version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.11)(jest@29.5.0)(typescript@5.4.4)
   ts-node:
     specifier: 10.9.1
     version: 10.9.1(@swc/core@1.3.85)(@types/node@18.16.9)(typescript@5.4.4)
@@ -280,16 +283,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
-
-  /@angular-devkit/architect@0.1702.3:
-    resolution: {integrity: sha512-4jeBgtBIZxAeJyiwSdbRE4+rWu34j0UMCKia8s7473rKj0Tn4+dXlHmA/kuFYIp6K/9pE/hBoeUFxLNA/DZuRQ==}
-    engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
-    dependencies:
-      '@angular-devkit/core': 17.2.3
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - chokidar
-    dev: true
 
   /@angular-devkit/architect@0.1703.3:
     resolution: {integrity: sha512-BKbdigCjmspqxOxSIQuWgPZzpyuKqZoTBDh0jDeLcAmvPsuxCgIWbsExI4OQ0CyusnQ+XT0IT39q8B9rvF56cg==}
@@ -446,22 +439,6 @@ packages:
     transitivePeerDependencies:
       - chokidar
 
-  /@angular-devkit/core@17.2.3:
-    resolution: {integrity: sha512-A7WWl1/VsZw6utFFPBib1wSbAB5OeBgAgQmVpVe9wW8u9UZa6CLc7b3InWtRRyBXTo9Sa5GNZDFfwlXhy3iW3w==}
-    engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
-    peerDependencies:
-      chokidar: ^3.5.2
-    peerDependenciesMeta:
-      chokidar:
-        optional: true
-    dependencies:
-      ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
-      jsonc-parser: 3.2.1
-      picomatch: 4.0.1
-      rxjs: 7.8.1
-      source-map: 0.7.4
-
   /@angular-devkit/core@17.3.3:
     resolution: {integrity: sha512-J22Sh3M7rj8Ar3iEs20ko5wgC3DE7vWfYZNdimt2IJiS4J7BEX8R3Awf+TRt+6AN3NFm3/xe1Sz4yvDh3FvNFg==}
     engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -478,19 +455,6 @@ packages:
       rxjs: 7.8.1
       source-map: 0.7.4
 
-  /@angular-devkit/schematics@17.2.3:
-    resolution: {integrity: sha512-JZCzHHheotv+iJ4p6qLc3pEi2M8NO12Slo6uiCg2T9B01glAcJB7DA1nwqjwD1cElf24Pt0C+HI0r+Lng48IsQ==}
-    engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
-    dependencies:
-      '@angular-devkit/core': 17.2.3
-      jsonc-parser: 3.2.1
-      magic-string: 0.30.7
-      ora: 5.4.1
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - chokidar
-    dev: false
-
   /@angular-devkit/schematics@17.3.3:
     resolution: {integrity: sha512-SABqTtj2im4PJhQjNaAsSypbNkpZFW8YozJ3P748tlh5a9XoHpgiqXv5JhRbyKElLDAyk5i9fe2++JmSudPG/Q==}
     engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -502,7 +466,6 @@ packages:
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
-    dev: true
 
   /@angular-eslint/bundled-angular-compiler@17.3.0:
     resolution: {integrity: sha512-ejfNzRuBeHUV8m2fkgs+M809rj5STuCuQo4fdfc6ccQpzXDI6Ha7BKpTznWfg5g529q/wrkoGSGgFxU9Yc2/dQ==}
@@ -3677,6 +3640,20 @@ packages:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.9)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.9)
 
+  /@babel/plugin-transform-object-rest-spread@7.23.4(@babel/core@7.24.0):
+    resolution: {integrity: sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.23.5
+      '@babel/core': 7.24.0
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.24.0)
+    dev: true
+
   /@babel/plugin-transform-object-rest-spread@7.24.1(@babel/core@7.24.0):
     resolution: {integrity: sha512-XjD5f0YqOtebto4HGISLNfiNMTTs6tbkFf2TOqJlYKYmbo+mN9Dnpl4SRoofiziuOWMIyq3sZEUqLo3hLITFEA==}
     engines: {node: '>=6.9.0'}
@@ -4688,6 +4665,97 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/preset-env@7.23.9(@babel/core@7.24.0):
+    resolution: {integrity: sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.23.5
+      '@babel/core': 7.24.0
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.23.5
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.23.7(@babel/core@7.24.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.0)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.0)
+      '@babel/plugin-syntax-import-assertions': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-syntax-import-attributes': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.0)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.0)
+      '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-async-generator-functions': 7.23.9(@babel/core@7.24.0)
+      '@babel/plugin-transform-async-to-generator': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-class-properties': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-class-static-block': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-classes': 7.23.8(@babel/core@7.24.0)
+      '@babel/plugin-transform-computed-properties': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-destructuring': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-dotall-regex': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-duplicate-keys': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-dynamic-import': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-export-namespace-from': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-for-of': 7.23.6(@babel/core@7.24.0)
+      '@babel/plugin-transform-function-name': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-json-strings': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-literals': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-member-expression-literals': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-modules-amd': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-modules-systemjs': 7.23.9(@babel/core@7.24.0)
+      '@babel/plugin-transform-modules-umd': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.24.0)
+      '@babel/plugin-transform-new-target': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-numeric-separator': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-object-rest-spread': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-object-super': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-private-methods': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-private-property-in-object': 7.23.4(@babel/core@7.24.0)
+      '@babel/plugin-transform-property-literals': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-regenerator': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-reserved-words': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-shorthand-properties': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-spread': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-sticky-regex': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-template-literals': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-typeof-symbol': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-unicode-escapes': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-unicode-property-regex': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-unicode-regex': 7.23.3(@babel/core@7.24.0)
+      '@babel/plugin-transform-unicode-sets-regex': 7.23.3(@babel/core@7.24.0)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.0)
+      babel-plugin-polyfill-corejs2: 0.4.8(@babel/core@7.24.0)
+      babel-plugin-polyfill-corejs3: 0.9.0(@babel/core@7.24.0)
+      babel-plugin-polyfill-regenerator: 0.5.5(@babel/core@7.24.0)
+      core-js-compat: 3.33.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@babel/preset-env@7.24.0(@babel/core@7.24.0):
     resolution: {integrity: sha512-ZxPEzV9IgvGn73iK0E6VB9/95Nd7aMFpbE0l8KQFDG70cOV9IxRP7Y2FUPmlK0v6ImlLqYX50iuZ3ZTVhOF2lA==}
@@ -6317,10 +6385,10 @@ packages:
       - supports-color
     dev: true
 
-  /@nrwl/angular@18.2.3(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.2.3)(@angular-devkit/schematics@17.2.3)(@schematics/angular@17.2.3)(@swc/core@1.3.85)(@types/node@18.16.9)(esbuild@0.19.11)(eslint@8.57.0)(html-webpack-plugin@5.5.0)(nx@18.2.3)(rxjs@7.5.7)(typescript@5.4.4):
+  /@nrwl/angular@18.2.3(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.3.3)(@angular-devkit/schematics@17.3.3)(@schematics/angular@17.3.3)(@swc/core@1.3.85)(@types/node@18.16.9)(esbuild@0.19.11)(eslint@8.57.0)(html-webpack-plugin@5.5.0)(nx@18.2.3)(rxjs@7.5.7)(typescript@5.4.4):
     resolution: {integrity: sha512-F0RtvSIH/Qs0ju7VcdfBpDeBZvwio2g4KdNpRog9ZBlgJjEmRWu7aA733A2xng96IkJkIrO0DiJaFbNdm8Yelw==}
     dependencies:
-      '@nx/angular': 18.2.3(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.2.3)(@angular-devkit/schematics@17.2.3)(@schematics/angular@17.2.3)(@swc/core@1.3.85)(@types/node@18.16.9)(esbuild@0.19.11)(eslint@8.57.0)(html-webpack-plugin@5.5.0)(nx@18.2.3)(rxjs@7.5.7)(typescript@5.4.4)
+      '@nx/angular': 18.2.3(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.3.3)(@angular-devkit/schematics@17.3.3)(@schematics/angular@17.3.3)(@swc/core@1.3.85)(@types/node@18.16.9)(esbuild@0.19.11)(eslint@8.57.0)(html-webpack-plugin@5.5.0)(nx@18.2.3)(rxjs@7.5.7)(typescript@5.4.4)
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@angular-devkit/build-angular'
@@ -6536,7 +6604,7 @@ packages:
       - '@swc/core'
       - debug
 
-  /@nx/angular@18.2.3(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.2.3)(@angular-devkit/schematics@17.2.3)(@schematics/angular@17.2.3)(@swc/core@1.3.85)(@types/node@18.16.9)(esbuild@0.19.11)(eslint@8.57.0)(html-webpack-plugin@5.5.0)(nx@18.2.3)(rxjs@7.5.7)(typescript@5.4.4):
+  /@nx/angular@18.2.3(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.3.3)(@angular-devkit/schematics@17.3.3)(@schematics/angular@17.3.3)(@swc/core@1.3.85)(@types/node@18.16.9)(esbuild@0.19.11)(eslint@8.57.0)(html-webpack-plugin@5.5.0)(nx@18.2.3)(rxjs@7.5.7)(typescript@5.4.4):
     resolution: {integrity: sha512-oSp4cNlyCUd03SNoa+x5zjrnqBjxANInB0+vsGD5VlOewpfkVNWPb7TIRa+JyOFXWSWblF0LNEiLxWnxY+27gw==}
     peerDependencies:
       '@angular-devkit/build-angular': '>= 15.0.0 < 18.0.0'
@@ -6550,9 +6618,9 @@ packages:
         optional: true
     dependencies:
       '@angular-devkit/build-angular': 17.3.3(@angular/compiler-cli@17.3.3)(@angular/platform-server@17.3.3)(@swc/core@1.3.85)(@types/express@4.17.17)(@types/node@18.16.9)(browser-sync@3.0.2)(html-webpack-plugin@5.5.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0)(stylus@0.59.0)(tailwindcss@3.4.1)(typescript@5.4.4)
-      '@angular-devkit/core': 17.2.3
-      '@angular-devkit/schematics': 17.2.3
-      '@nrwl/angular': 18.2.3(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.2.3)(@angular-devkit/schematics@17.2.3)(@schematics/angular@17.2.3)(@swc/core@1.3.85)(@types/node@18.16.9)(esbuild@0.19.11)(eslint@8.57.0)(html-webpack-plugin@5.5.0)(nx@18.2.3)(rxjs@7.5.7)(typescript@5.4.4)
+      '@angular-devkit/core': 17.3.3
+      '@angular-devkit/schematics': 17.3.3
+      '@nrwl/angular': 18.2.3(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.3.3)(@angular-devkit/schematics@17.3.3)(@schematics/angular@17.3.3)(@swc/core@1.3.85)(@types/node@18.16.9)(esbuild@0.19.11)(eslint@8.57.0)(html-webpack-plugin@5.5.0)(nx@18.2.3)(rxjs@7.5.7)(typescript@5.4.4)
       '@nx/devkit': 18.2.3(nx@18.2.3)
       '@nx/eslint': 18.2.3(@swc/core@1.3.85)(@types/node@18.16.9)(nx@18.2.3)
       '@nx/js': 18.2.3(@swc/core@1.3.85)(@types/node@18.16.9)(nx@18.2.3)(typescript@5.4.4)
@@ -6560,7 +6628,7 @@ packages:
       '@nx/webpack': 18.2.3(@swc/core@1.3.85)(@types/node@18.16.9)(esbuild@0.19.11)(html-webpack-plugin@5.5.0)(nx@18.2.3)(typescript@5.4.4)
       '@nx/workspace': 18.2.3(@swc/core@1.3.85)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.4.4)
-      '@schematics/angular': 17.2.3
+      '@schematics/angular': 17.3.3
       '@typescript-eslint/type-utils': 7.6.0(eslint@8.57.0)(typescript@5.4.4)
       chalk: 4.1.2
       esbuild: 0.19.11
@@ -7702,17 +7770,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /@schematics/angular@17.2.3:
-    resolution: {integrity: sha512-rXsYmWC1a8uvGTC6RwICwg1GLLQlTw8jOSqHf6T2AFMzP4p1FV3/GFSGyPIMl9yPwn6JqbmfQy3Bvj0stQNM0Q==}
-    engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
-    dependencies:
-      '@angular-devkit/core': 17.2.3
-      '@angular-devkit/schematics': 17.2.3
-      jsonc-parser: 3.2.1
-    transitivePeerDependencies:
-      - chokidar
-    dev: false
-
   /@schematics/angular@17.3.3:
     resolution: {integrity: sha512-kNlyjIKTBhfi8Jab3MCkxNRbbpErbzdu0lZNSL8Nidmqs6Tk23Dc1bZe4t/gPNOCkCvQlwYa6X88SjC/ntyVng==}
     engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -7722,7 +7779,6 @@ packages:
       jsonc-parser: 3.2.1
     transitivePeerDependencies:
       - chokidar
-    dev: true
 
   /@shuding/opentype.js@1.4.0-beta.0:
     resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
@@ -8110,7 +8166,7 @@ packages:
       - '@types/react-dom'
     dev: true
 
-  /@storybook/angular@7.5.3(@angular-devkit/architect@0.1702.3)(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.2.3)(@angular/cli@17.3.3)(@angular/common@17.3.3)(@angular/compiler-cli@17.3.3)(@angular/compiler@17.3.3)(@angular/core@17.3.3)(@angular/forms@17.3.3)(@angular/platform-browser-dynamic@17.3.3)(@angular/platform-browser@17.3.3)(@babel/core@7.23.9)(@swc/core@1.3.85)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(rxjs@7.5.7)(typescript@5.4.4)(zone.js@0.14.3):
+  /@storybook/angular@7.5.3(@angular-devkit/architect@0.1703.3)(@angular-devkit/build-angular@17.3.3)(@angular-devkit/core@17.3.3)(@angular/cli@17.3.3)(@angular/common@17.3.3)(@angular/compiler-cli@17.3.3)(@angular/compiler@17.3.3)(@angular/core@17.3.3)(@angular/forms@17.3.3)(@angular/platform-browser-dynamic@17.3.3)(@angular/platform-browser@17.3.3)(@babel/core@7.24.0)(@swc/core@1.3.85)(esbuild@0.19.11)(react-dom@18.2.0)(react@18.2.0)(rxjs@7.5.7)(typescript@5.4.4)(zone.js@0.14.3):
     resolution: {integrity: sha512-wGyebTb7hhdrhEopouFIsBS8SM/5nlTwxilaYbs9Cg3elSmsJyI3uLCHEeGKYupnzokQzP3xElWjwT2VYyW0fQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -8135,9 +8191,9 @@ packages:
       '@angular/cli':
         optional: true
     dependencies:
-      '@angular-devkit/architect': 0.1702.3
+      '@angular-devkit/architect': 0.1703.3
       '@angular-devkit/build-angular': 17.3.3(@angular/compiler-cli@17.3.3)(@angular/platform-server@17.3.3)(@swc/core@1.3.85)(@types/express@4.17.17)(@types/node@18.16.9)(browser-sync@3.0.2)(html-webpack-plugin@5.5.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0)(stylus@0.59.0)(tailwindcss@3.4.1)(typescript@5.4.4)
-      '@angular-devkit/core': 17.2.3
+      '@angular-devkit/core': 17.3.3
       '@angular/cli': 17.3.3
       '@angular/common': 17.3.3(@angular/core@17.3.3)(rxjs@7.5.7)
       '@angular/compiler': 17.3.3(@angular/core@17.3.3)
@@ -8146,7 +8202,7 @@ packages:
       '@angular/forms': 17.3.3(@angular/common@17.3.3)(@angular/core@17.3.3)(@angular/platform-browser@17.3.3)(rxjs@7.5.7)
       '@angular/platform-browser': 17.3.3(@angular/animations@17.3.3)(@angular/common@17.3.3)(@angular/core@17.3.3)
       '@angular/platform-browser-dynamic': 17.3.3(@angular/common@17.3.3)(@angular/compiler@17.3.3)(@angular/core@17.3.3)(@angular/platform-browser@17.3.3)
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.0
       '@storybook/builder-webpack5': 7.5.3(esbuild@0.19.11)(typescript@5.4.4)
       '@storybook/cli': 7.5.3
       '@storybook/client-logger': 7.5.3
@@ -8393,7 +8449,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/core': 7.23.9
-      '@babel/preset-env': 7.23.9(@babel/core@7.23.9)
+      '@babel/preset-env': 7.23.9(@babel/core@7.24.0)
       '@ndelangen/get-tarball': 3.0.7
       '@storybook/codemod': 7.0.8
       '@storybook/core-common': 7.0.8
@@ -15047,7 +15103,7 @@ packages:
     dependencies:
       jest-resolve: 29.5.0
 
-  /jest-preset-angular@14.0.3(@angular-devkit/build-angular@17.3.3)(@angular/compiler-cli@17.3.3)(@angular/core@17.3.3)(@angular/platform-browser-dynamic@17.3.3)(@babel/core@7.23.9)(jest@29.5.0)(typescript@5.4.4):
+  /jest-preset-angular@14.0.3(@angular-devkit/build-angular@17.3.3)(@angular/compiler-cli@17.3.3)(@angular/core@17.3.3)(@angular/platform-browser-dynamic@17.3.3)(@babel/core@7.24.0)(jest@29.5.0)(typescript@5.4.4):
     resolution: {integrity: sha512-usgBL7x0rXMnMSx8iEFeOozj50W6fp+YAmQcQBUdAXhN+PAXRy4UXL6I/rfcAOU09rnnq7RKsLsmhpp/fFEuag==}
     engines: {node: ^14.15.0 || >=16.10.0}
     peerDependencies:
@@ -15068,7 +15124,7 @@ packages:
       jest-environment-jsdom: 29.5.0
       jest-util: 29.5.0
       pretty-format: 29.5.0
-      ts-jest: 29.1.0(@babel/core@7.23.9)(esbuild@0.19.11)(jest@29.5.0)(typescript@5.4.4)
+      ts-jest: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.11)(jest@29.5.0)(typescript@5.4.4)
       typescript: 5.4.4
     optionalDependencies:
       esbuild: 0.19.11
@@ -18731,6 +18787,11 @@ packages:
       is-fullwidth-code-point: 4.0.0
     dev: true
 
+  /slugify@1.6.6:
+    resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
+    engines: {node: '>=8.0.0'}
+    dev: false
+
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -19595,7 +19656,7 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  /ts-jest@29.1.0(@babel/core@7.23.9)(esbuild@0.19.11)(jest@29.5.0)(typescript@5.4.4):
+  /ts-jest@29.1.0(@babel/core@7.24.0)(esbuild@0.19.11)(jest@29.5.0)(typescript@5.4.4):
     resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -19616,7 +19677,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.0
       bs-logger: 0.2.6
       esbuild: 0.19.11
       fast-json-stable-stringify: 2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ dependencies:
   satori-html:
     specifier: ^0.3.2
     version: 0.3.2
-  slugify:
-    specifier: ^1.6.6
-    version: 1.6.6
   tslib:
     specifier: ^2.3.0
     version: 2.5.0
@@ -238,6 +235,9 @@ devDependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  slugify:
+    specifier: ^1.6.6
+    version: 1.6.6
   storybook:
     specifier: 7.0.8
     version: 7.0.8
@@ -18790,7 +18790,7 @@ packages:
   /slugify@1.6.6:
     resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
     engines: {node: '>=8.0.0'}
-    dev: false
+    dev: true
 
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}

--- a/scripts/add-slug-field-to-authors.ts
+++ b/scripts/add-slug-field-to-authors.ts
@@ -1,0 +1,61 @@
+/**
+ * Script utilizado para actualizar el campo approximateReadingTime de todos los documentos de tipo story,
+ * ajustando así el tiempo de lectura aproximado para cada historia de la plataforma
+ *
+ * */
+import { client } from '../src/api/_helpers/sanity-connector';
+import slugify from 'slugify';
+
+const fetchDocuments = () => client.fetch(`*[_type == 'author'] {_id, _rev, name}`);
+
+const buildPatches = (docs: any[]) => {
+	return docs.map((doc) => {
+		const newSlug = doc.name
+			? slugify(doc.name.toLowerCase(), {
+					replacement: '-',
+					lower: true,
+					strict: true,
+					trim: true,
+				})
+			: null;
+		return {
+			id: doc._id,
+			patch: {
+				set: {
+					slug: {
+						_type: 'slug',
+						current: newSlug,
+					},
+				},
+				ifRevisionID: doc._rev,
+			},
+		};
+	});
+};
+
+const createTransaction = (patches: any) =>
+	patches.reduce((tx: any, patch: any) => tx.patch(patch.id, patch.patch), client.transaction());
+
+const commitTransaction = (tx: any) => tx.commit();
+
+const migrateNextBatch = async (): Promise<any> => {
+	const documents = await fetchDocuments();
+	console.log(documents);
+	const patches = buildPatches(documents);
+	if (patches.length === 0) {
+		console.log('No more documents to migrate!');
+		return null;
+	}
+	console.log(
+		`Migrating batch:\n %s`,
+		patches.map((patch) => `${patch.id} => ${JSON.stringify(patch.patch)}`).join('\n'),
+	);
+	const transaction = createTransaction(patches);
+	await commitTransaction(transaction);
+	return null;
+};
+
+migrateNextBatch().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/scripts/add-slug-field-to-authors.ts
+++ b/scripts/add-slug-field-to-authors.ts
@@ -1,6 +1,6 @@
 /**
- * Script utilizado para actualizar el campo approximateReadingTime de todos los documentos de tipo story,
- * ajustando así el tiempo de lectura aproximado para cada historia de la plataforma
+ * Script utilizado para la generación programática de slugs de autores
+ * en base al campo name de los documentos de tipo author
  *
  * */
 import { client } from '../src/api/_helpers/sanity-connector';

--- a/src/api/_queries/author.query.ts
+++ b/src/api/_queries/author.query.ts
@@ -1,0 +1,5 @@
+import { resourcesSubQuery } from './resources.query';
+
+export const authorForStoryCard = "'author': author-> { name, slug, image, nationality-> }";
+
+export const authorForStory = `'author': author-> { name, slug, image, biography, nationality->, ${resourcesSubQuery}}`;

--- a/src/api/_queries/author.query.ts
+++ b/src/api/_queries/author.query.ts
@@ -1,5 +1,7 @@
 import { resourcesSubQuery } from './resources.query';
 
-export const authorForStoryCard = "'author': author-> { name, slug, image, nationality-> }";
+export const authorThumbnailFields = ['slug', 'name', 'image', 'nationality->'];
+export const authorDetailedFields = [...authorThumbnailFields, 'biography', resourcesSubQuery]
 
-export const authorForStory = `'author': author-> { name, slug, image, biography, nationality->, ${resourcesSubQuery}}`;
+export const authorForStoryCard = `'author': author-> { ${authorThumbnailFields.join(',')} }`;
+export const authorForStory = `'author': author-> { ${authorDetailedFields.join(',')} }`;

--- a/src/api/_queries/resources.query.ts
+++ b/src/api/_queries/resources.query.ts
@@ -1,0 +1,14 @@
+export const resourcesSubQuery: string = `                              	
+								resources[]{ 
+                              	title, 
+                              	url, 
+                              	resourceType->{ 
+                              		title, 
+                              		description, 
+                              		'icon': { 
+                              			'name': icon.name, 
+                              			'svg': icon.svg, 
+                              			'provider': icon.provider 
+                              			} 
+                              		} 
+                              	} `;

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -23,8 +23,7 @@ import {
 
 export function mapAuthorForStory(rawAuthorData: any, language?: string): AuthorDTO {
 	return {
-		id: rawAuthorData._id,
-		slug: rawAuthorData.slug,
+		slug: rawAuthorData.slug.current,
 		nationality: {
 			country: rawAuthorData.nationality?.country,
 			flag: urlFor(rawAuthorData.nationality?.flag)?.url(),

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -21,6 +21,20 @@ import {
 	SpaceRecordingSchemaObject,
 } from '@models/media.model';
 
+export function mapAuthor(rawAuthorData: any, language?: string): AuthorDTO {
+	return {
+		slug: rawAuthorData.slug.current,
+		nationality: {
+			country: rawAuthorData.nationality?.country,
+			flag: urlFor(rawAuthorData.nationality?.flag)?.url(),
+		},
+		resources: mapResources(rawAuthorData.resources),
+		imageUrl: rawAuthorData.image ? urlFor(rawAuthorData.image).url() : undefined,
+		name: rawAuthorData.name,
+		biography: rawAuthorData.biography,
+	};
+}
+
 export function mapAuthorForStory(rawAuthorData: any, language?: string): AuthorDTO {
 	return {
 		slug: rawAuthorData.slug.current,

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -18,13 +18,13 @@ import {
 	AudioRecordingSchemaObject,
 	Media,
 	MediaSchemaObject,
-	SpaceRecording,
 	SpaceRecordingSchemaObject,
 } from '@models/media.model';
 
-export function mapAuthor(rawAuthorData: any, language?: string): AuthorDTO {
+export function mapAuthorForStory(rawAuthorData: any, language?: string): AuthorDTO {
 	return {
 		id: rawAuthorData._id,
+		slug: rawAuthorData.slug,
 		nationality: {
 			country: rawAuthorData.nationality?.country,
 			flag: urlFor(rawAuthorData.nationality?.flag)?.url(),

--- a/src/api/author/author.controller.ts
+++ b/src/api/author/author.controller.ts
@@ -4,12 +4,12 @@ import * as authorService from './author.service';
 const router = express.Router();
 
 // Routes
-router.get('/', getBySlug);
+router.get('/:slug', getBySlug);
 
 export default router;
 
 function getBySlug(req: express.Request, res: express.Response, next: express.NextFunction) {
-	const { slug } = req.query;
+	const { slug } = req.params;
 
 	authorService
 		.getBySlug(slug as string)

--- a/src/api/author/author.controller.ts
+++ b/src/api/author/author.controller.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import * as authorService from './author.service';
+
+const router = express.Router();
+
+// Routes
+router.get('/', getBySlug);
+
+export default router;
+
+function getBySlug(req: express.Request, res: express.Response, next: express.NextFunction) {
+	const { slug } = req.query;
+
+	authorService
+		.getBySlug(slug as string)
+		.then((result) => res.json(result))
+		.catch((err) => next(err));
+}

--- a/src/api/author/author.service.ts
+++ b/src/api/author/author.service.ts
@@ -1,0 +1,19 @@
+// Sanity
+import { client } from '../_helpers/sanity-connector';
+
+// Subqueries
+import { resourcesSubQuery } from '../_queries/resources.query';
+
+// Funciones
+import { mapAuthor } from '../_utils/functions';
+
+// Interfaces
+import { AuthorDTO } from '@models/author.model';
+
+export async function getBySlug(slug: string): Promise<AuthorDTO> {
+	const filter = `*[_type == 'author' && slug.current == '${slug}'][0]`;
+	const fields = ['slug', 'name', 'image', 'nationality->', 'biography', resourcesSubQuery];
+	const query = filter + `{ ${fields.join(',')} }`;
+	const result = await client.fetch(query, {});
+	return mapAuthor(result);
+}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,9 +1,14 @@
+import authorController from './author/author.controller'
 import contentController from './content.controller';
 import ogController from './og.controller';
 import storyController from './story.controller';
 import storylistController from './storylist.controller';
 
 export default [
+  {
+    path: '/author',
+    controller: authorController,
+  },
   {
     path: '/content',
     controller: contentController,

--- a/src/api/story.controller.ts
+++ b/src/api/story.controller.ts
@@ -1,21 +1,26 @@
 import express from 'express';
-import { fetchForRead } from './story.service';
+import * as storyService from './story.service';
 
 const router = express.Router();
 
 // Routes
-router.get('/read', read);
+router.get('/read', storyBySlug);
+router.get('/author/:slug', storiesByAuthorSlug);
 
 export default router;
 
-function read(
-  req: express.Request,
-  res: express.Response,
-  next: express.NextFunction
-) {
+function storyBySlug(req: express.Request, res: express.Response, next: express.NextFunction) {
+	const { slug } = req.query;
+	storyService
+		.fetchForRead(slug as string)
+		.then((result) => res.json(result))
+		.catch((err) => next(err));
+}
 
-  const { slug } = req.query;
-  fetchForRead(slug as string)
-    .then((result) => res.json(result))
-    .catch((err) => next(err));
+function storiesByAuthorSlug(req: express.Request, res: express.Response, next: express.NextFunction) {
+	const { slug } = req.params;
+	storyService
+		.fetchByAuthorSlug(slug as string)
+		.then((result) => res.json(result))
+		.catch((err) => next(err));
 }

--- a/src/api/story.service.ts
+++ b/src/api/story.service.ts
@@ -3,7 +3,7 @@ import { client } from './_helpers/sanity-connector';
 import groq from 'groq';
 
 // Utilidades
-import { mapAuthor, mapMediaSources, mapPrologues, mapResources } from './_utils/functions';
+import { mapAuthorForStory, mapMediaSources, mapPrologues, mapResources } from './_utils/functions';
 
 // Modelos
 import { StoryDTO } from '@models/story.model';
@@ -53,7 +53,7 @@ async function fetchForRead(slug: string): Promise<StoryDTO> {
 		return {
 			...properties,
 			media: await mapMediaSources(mediaSources),
-			author: mapAuthor(author, properties.language),
+			author: mapAuthorForStory(author, properties.language),
 			prologues: mapPrologues(forewords),
 			resources: mapResources(properties.resources),
 			paragraphs: body,

--- a/src/api/story.service.ts
+++ b/src/api/story.service.ts
@@ -12,9 +12,44 @@ import { StoryDTO } from '@models/story.model';
 import { authorForStory } from './_queries/author.query';
 import { resourcesSubQuery } from './_queries/resources.query';
 
-async function fetchForRead(slug: string): Promise<StoryDTO> {
-	{
-		const query = groq`*[_type == 'story' && slug.current == '${slug}']
+export async function fetchByAuthorSlug(slug: string): Promise<StoryDTO[]> {
+	const query = groq`*[_type == 'story' && author->slug.current == '${slug}']
+						  {
+							  'slug': slug.current,
+							  title, 
+							  language,
+							  videoUrl,
+							  badLanguage,
+							  forewords, 
+							  categories, 
+							  body[0...2], 
+							  approximateReadingTime,
+							  mediaSources,
+							  ${resourcesSubQuery},
+						  }`;
+
+	const result = await client.fetch(query, {});
+	const stories = [];
+
+	// Toma las publicaciones que fueron traídas en la consulta a Sanity y las mapea a una colección de publicaciones
+	for (const story of result) {
+		const { body, review, author, forewords, mediaSources, ...properties } = story;
+
+		stories.push({
+			...properties,
+			media: await mapMediaSources(mediaSources),
+			prologues: mapPrologues(forewords),
+			resources: mapResources(properties.resources),
+			paragraphs: body,
+			summary: review,
+		});
+	}
+
+	return stories;
+}
+
+export async function fetchForRead(slug: string): Promise<StoryDTO> {
+	const query = groq`*[_type == 'story' && slug.current == '${slug}']
                           {
                               'slug': slug.current,
                               title, 
@@ -31,20 +66,17 @@ async function fetchForRead(slug: string): Promise<StoryDTO> {
                               ${resourcesSubQuery},
 							  ${authorForStory}
                           }[0]`;
-		const story = await client.fetch(query, {});
+	const story = await client.fetch(query, {});
 
-		const { body, review, author, forewords, mediaSources, ...properties } = story;
+	const { body, review, author, forewords, mediaSources, ...properties } = story;
 
-		return {
-			...properties,
-			media: await mapMediaSources(mediaSources),
-			author: mapAuthorForStory(author, properties.language),
-			prologues: mapPrologues(forewords),
-			resources: mapResources(properties.resources),
-			paragraphs: body,
-			summary: review,
-		};
-	}
+	return {
+		...properties,
+		media: await mapMediaSources(mediaSources),
+		author: mapAuthorForStory(author, properties.language),
+		prologues: mapPrologues(forewords),
+		resources: mapResources(properties.resources),
+		paragraphs: body,
+		summary: review,
+	};
 }
-
-export { fetchForRead };

--- a/src/api/story.service.ts
+++ b/src/api/story.service.ts
@@ -8,23 +8,12 @@ import { mapAuthorForStory, mapMediaSources, mapPrologues, mapResources } from '
 // Modelos
 import { StoryDTO } from '@models/story.model';
 
+// Subqueries
+import { authorForStory } from './_queries/author.query';
+import { resourcesSubQuery } from './_queries/resources.query';
+
 async function fetchForRead(slug: string): Promise<StoryDTO> {
 	{
-		const resourcesSubQuery: string = `                              	
-								resources[]{ 
-                              	title, 
-                              	url, 
-                              	resourceType->{ 
-                              		title, 
-                              		description, 
-                              		'icon': { 
-                              			'name': icon.name, 
-                              			'svg': icon.svg, 
-                              			'provider': icon.provider 
-                              			} 
-                              		} 
-                              	} `;
-
 		const query = groq`*[_type == 'story' && slug.current == '${slug}']
                           {
                               'slug': slug.current,
@@ -40,11 +29,7 @@ async function fetchForRead(slug: string): Promise<StoryDTO> {
                               approximateReadingTime,
                               mediaSources,
                               ${resourcesSubQuery},
-                              'author': author-> {
-                              	..., 
-                              	nationality->, 
-								${resourcesSubQuery}
-                              }
+							  ${authorForStory}
                           }[0]`;
 		const story = await client.fetch(query, {});
 

--- a/src/api/storylist.service.ts
+++ b/src/api/storylist.service.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { client } from './_helpers/sanity-connector';
-import { mapAuthor, mapMediaSources, mapPrologues, urlFor } from './_utils/functions';
+import { mapAuthorForStory, mapMediaSources, mapPrologues, urlFor } from './_utils/functions';
 
 async function fetchPreview(req: express.Request, res: express.Response) {
 	const { slug } = req.query;
@@ -101,7 +101,7 @@ async function fetchPreview(req: express.Request, res: express.Response) {
 						...story,
 						summary: review,
 						paragraphs: body,
-						author: mapAuthor(author),
+						author: mapAuthorForStory(author),
 						prologues: mapPrologues(forewords),
 					},
 				};
@@ -193,7 +193,7 @@ async function fetchStorylist(req: any, res: any) {
 				media: mediaSources ? await mapMediaSources(mediaSources) : undefined,
 				summary: review,
 				paragraphs: body,
-				author: mapAuthor(author),
+				author: mapAuthorForStory(author),
 				prologues: mapPrologues(forewords),
 			},
 		});

--- a/src/api/storylist.service.ts
+++ b/src/api/storylist.service.ts
@@ -151,7 +151,7 @@ async function fetchStorylist(req: any, res: any) {
                                      'publishingOrder': publication.publishingOrder,
                                      'publishingDate': publication.publishingDate,
                                      'published': publication.published,
-                                    'story': publication.story->{
+                                     'story': publication.story->{
                                         _id,
                                         'slug': slug.current,
                                         title,
@@ -167,7 +167,7 @@ async function fetchStorylist(req: any, res: any) {
                                         ${authorForStoryCard}
                                     }
                                 }
-                          }
+                          	}
                         },
                         'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
                     }`;

--- a/src/api/storylist.service.ts
+++ b/src/api/storylist.service.ts
@@ -2,6 +2,9 @@ import express from 'express';
 import { client } from './_helpers/sanity-connector';
 import { mapAuthorForStory, mapMediaSources, mapPrologues, urlFor } from './_utils/functions';
 
+// Subqueries
+import { authorForStoryCard } from './_queries/author.query';
+
 async function fetchPreview(req: express.Request, res: express.Response) {
 	const { slug } = req.query;
 
@@ -54,7 +57,7 @@ async function fetchPreview(req: express.Request, res: express.Response) {
                                             videoUrl,
                                             language,
                                             mediaSources,
-                                            'author': author-> { name, slug, image, nationality-> }
+                                        	${authorForStoryCard}
                                         }
                                     }
                                 }
@@ -161,7 +164,7 @@ async function fetchStorylist(req: any, res: any) {
                                         videoUrl,
                                         language,
                                         mediaSources,
-                                        'author': author-> { name, slug, image, nationality-> }
+                                        ${authorForStoryCard}
                                     }
                                 }
                           }

--- a/src/api/storylist.service.ts
+++ b/src/api/storylist.service.ts
@@ -54,7 +54,7 @@ async function fetchPreview(req: express.Request, res: express.Response) {
                                             videoUrl,
                                             language,
                                             mediaSources,
-                                            'author': author-> { name, image, nationality-> }
+                                            'author': author-> { name, slug, image, nationality-> }
                                         }
                                     }
                                 }
@@ -161,7 +161,7 @@ async function fetchStorylist(req: any, res: any) {
                                         videoUrl,
                                         language,
                                         mediaSources,
-                                        'author': author-> { name, image, nationality-> }
+                                        'author': author-> { name, slug, image, nationality-> }
                                     }
                                 }
                           }

--- a/src/app/models/author.model.ts
+++ b/src/app/models/author.model.ts
@@ -3,6 +3,7 @@ import { Resource } from '@models/resource.model';
 
 interface AuthorBase {
 	id: string;
+	slug: string;
 	name: string;
 	imageUrl?: string;
 	resources?: Resource[];

--- a/src/app/models/author.model.ts
+++ b/src/app/models/author.model.ts
@@ -2,7 +2,6 @@ import { BlockContent } from '@models/block-content.model';
 import { Resource } from '@models/resource.model';
 
 interface AuthorBase {
-	id: string;
 	slug: string;
 	name: string;
 	imageUrl?: string;


### PR DESCRIPTION
# Resumen

## Dominio y Datos
* Agrega campo `slug` al schema `author` y a la interface `AuthorBase`.
* Agrega la devDependency `slugify` para generación programática de slugs.
* Agrega script `add-slug-field-to-authors` para generar slugs de autores en base al campo `name`.

## Endpoints
* Agrega ruta `/author` para endpoints relacionados a información de autores.
* Agrega controller y service para manejo de lógica de negocios de entidad `author`.
* Agrega endpoint `/author` para entidades de tipo `story`, orientado a obtener la lista de stories de un autor determinado en base al slug del autor.

## Otros cambios
* Agrega archivos de subqueries para facilitar escritura de las consultas en formato GROQ hechas a Sanity.
* Agrega función `mapAuthor` para transformar datos crudos obtenidos desde Sanity a objetos con el signature de la interface `AuthorDTO`.
* Usa subqueries en `storylist.service.ts` y `story.service.ts`.