### PR TITLE
[#552] Agregar soporte para epígrafes multilínea

### DIFF
--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -177,39 +177,14 @@ export default {
 					type: 'object',
 					fields: [
 						{
-							name: 'epigraphText',
+							name: 'text',
 							title: 'Texto del epígrafe',
 							type: 'blockContent',
 						},
 						{
-							name: 'epigraphAuthor',
+							name: 'reference',
 							title: 'Referencia del epígrafe',
 							description: 'Referencia del origen del epígrafe',
-							type: 'string',
-						},
-					],
-				},
-			],
-		},
-		{
-			name: 'forewords',
-			title: 'Prólogo(s)',
-			type: 'array',
-			of: [
-				{
-					name: 'foreword',
-					title: 'Prólogo',
-					type: 'object',
-					fields: [
-						{
-							name: 'fwText',
-							title: 'Texto del prólogo',
-							type: 'string',
-						},
-						{
-							name: 'fwAuthor',
-							title: 'Referencia del prólogo',
-							description: 'Referencia del origen del prólogo',
 							type: 'string',
 						},
 					],

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -11,7 +11,6 @@ import { baseLanguage } from '../../../cms/utils/localization';
 
 // Modelos
 import { AuthorDTO } from '@models/author.model';
-import { PrologueDTO } from '@models/prologue.model';
 import { getTweetData } from './twitter-api';
 import {
 	AudioRecording,

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -49,15 +49,6 @@ export function mapAuthorForStory(rawAuthorData: any, language?: string): Author
 	};
 }
 
-export function mapPrologues(rawProloguesData: any): PrologueDTO[] {
-	return rawProloguesData
-		? rawProloguesData.map((x: { fwAuthor: any; fwText: any }) => ({
-				reference: x.fwAuthor,
-				text: x.fwText,
-			}))
-		: [];
-}
-
 export function urlFor(source: SanityImageSource): ImageUrlBuilder {
 	return imageUrlBuilder(client).image(source);
 }

--- a/src/api/story.service.ts
+++ b/src/api/story.service.ts
@@ -3,7 +3,7 @@ import { client } from './_helpers/sanity-connector';
 import groq from 'groq';
 
 // Utilidades
-import { mapAuthorForStory, mapMediaSources, mapPrologues, mapResources } from './_utils/functions';
+import { mapAuthorForStory, mapMediaSources, mapResources } from './_utils/functions';
 
 // Modelos
 import { StoryDTO } from '@models/story.model';
@@ -20,7 +20,6 @@ export async function fetchByAuthorSlug(slug: string): Promise<StoryDTO[]> {
 							  language,
 							  videoUrl,
 							  badLanguage,
-							  forewords, 
 							  categories, 
 							  body[0...2], 
 							  approximateReadingTime,
@@ -33,12 +32,11 @@ export async function fetchByAuthorSlug(slug: string): Promise<StoryDTO[]> {
 
 	// Toma las publicaciones que fueron traídas en la consulta a Sanity y las mapea a una colección de publicaciones
 	for (const story of result) {
-		const { body, review, author, forewords, mediaSources, ...properties } = story;
+		const { body, review, author, mediaSources, ...properties } = story;
 
 		stories.push({
 			...properties,
 			media: await mapMediaSources(mediaSources),
-			prologues: mapPrologues(forewords),
 			resources: mapResources(properties.resources),
 			paragraphs: body,
 			summary: review,
@@ -56,11 +54,10 @@ export async function fetchForRead(slug: string): Promise<StoryDTO> {
                               language,
                               videoUrl,
                               badLanguage,
-                              forewords, 
+                              epigraphs,
                               categories, 
                               body, 
                               review, 
-                              forewords, 
                               approximateReadingTime,
                               mediaSources,
                               ${resourcesSubQuery},
@@ -68,13 +65,12 @@ export async function fetchForRead(slug: string): Promise<StoryDTO> {
                           }[0]`;
 	const story = await client.fetch(query, {});
 
-	const { body, review, author, forewords, mediaSources, ...properties } = story;
+	const { body, review, author, mediaSources, ...properties } = story;
 
 	return {
 		...properties,
 		media: await mapMediaSources(mediaSources),
 		author: mapAuthorForStory(author, properties.language),
-		prologues: mapPrologues(forewords),
 		resources: mapResources(properties.resources),
 		paragraphs: body,
 		summary: review,

--- a/src/api/storylist.service.ts
+++ b/src/api/storylist.service.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { client } from './_helpers/sanity-connector';
-import { mapAuthorForStory, mapMediaSources, mapPrologues, urlFor } from './_utils/functions';
+import { mapAuthorForStory, mapMediaSources, urlFor } from './_utils/functions';
 
 // Subqueries
 import { authorForStoryCard } from './_queries/author.query';
@@ -48,11 +48,9 @@ async function fetchPreview(req: express.Request, res: express.Response) {
                                             title,
                                             videoUrl,
                                             badLanguage,
-                                            forewords,
                                             categories,
                                             body[0...3],
                                             review,
-                                            forewords,
                                             approximateReadingTime,
                                             videoUrl,
                                             language,
@@ -97,7 +95,7 @@ async function fetchPreview(req: express.Request, res: express.Response) {
 			.filter((cardPlacement: any) => !!cardPlacement.publication && !!cardPlacement.publication.story)
 			.map((cardPlacement: any) => cardPlacement.publication)
 			.map((publication: any) => {
-				const { review, body, forewords, author, ...story } = publication.story;
+				const { review, body, author, ...story } = publication.story;
 				return {
 					...publication,
 					story: {
@@ -105,7 +103,6 @@ async function fetchPreview(req: express.Request, res: express.Response) {
 						summary: review,
 						paragraphs: body,
 						author: mapAuthorForStory(author),
-						prologues: mapPrologues(forewords),
 					},
 				};
 			}),
@@ -155,11 +152,9 @@ async function fetchStorylist(req: any, res: any) {
                                         _id,
                                         'slug': slug.current,
                                         title,
-                                        forewords,
                                         categories,
                                         body[0...3],
                                         review,
-                                        forewords,
                                         approximateReadingTime,
                                         videoUrl,
                                         language,
@@ -188,7 +183,7 @@ async function fetchStorylist(req: any, res: any) {
 
 	// Toma las publicaciones que fueron traídas en la consulta a Sanity y las mapea a una colección de publicaciones
 	for (const publication of rawPublications) {
-		const { review, body, forewords, author, mediaSources, ...story } = publication.story;
+		const { review, body, author, mediaSources, ...story } = publication.story;
 		publications.push({
 			...publication,
 			story: {
@@ -197,7 +192,6 @@ async function fetchStorylist(req: any, res: any) {
 				summary: review,
 				paragraphs: body,
 				author: mapAuthorForStory(author),
-				prologues: mapPrologues(forewords),
 			},
 		});
 	}

--- a/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
@@ -23,7 +23,7 @@ const mockStory: Story = {
     language: 'es',
     videoUrl: 'https://gativideo.com/video.mp4',
     badLanguage: false,
-    prologues: [],
+    epigraphs: [],
     media: [],
     summary: [{classes: '', text: 'Arranca con "Fanfare for the Common Man" y la próxima canción es "Silhouette" de Kenny G.',}],
     paragraphs: [

--- a/src/app/components/bio-summary-card/bio-summary-card.component.stories.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.stories.ts
@@ -144,7 +144,7 @@ export const Primary = {
 					},
 				],
 			},
-			prologues: [],
+			epigraphs: [],
 			paragraphs: [],
 			summary: [
 				{

--- a/src/app/components/epigraph/epigraph.component.ts
+++ b/src/app/components/epigraph/epigraph.component.ts
@@ -1,18 +1,22 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, Input, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Prologue } from '@models/prologue.model';
+import { Epigraph } from '@models/epigraph.model';
+import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 
 @Component({
 	selector: 'cuentoneta-story-epigraph',
 	standalone: true,
-	imports: [CommonModule],
+	imports: [CommonModule, PortableTextParserComponent],
 	template: `
-		<div class="border-l-3 border-solid border-primary-500 mr-4"></div>
-		<div class="flex flex-wrap flex-col items-end justify-end flex-1 source-serif-pro-body-lg text-gray-700">
-			<p class="self-baseline">{{ prologue.text }}&nbsp;</p>
+		<div class="mr-4 border-l-3 border-solid border-primary-500"></div>
+		<div class="source-serif-pro-body-lg flex flex-1 flex-col flex-wrap items-end justify-end text-gray-700">
+			<cuentoneta-portable-text-parser
+				[classes]="'self-baseline'"
+				[paragraphs]="epigraph().text"
+			></cuentoneta-portable-text-parser>
 			<div class="text-end">
-				@if (prologue.reference) {
-					<em>{{ prologue.reference }}</em>
+				@if (epigraph().reference) {
+					<em>{{ epigraph().reference }}</em>
 				}
 			</div>
 		</div>
@@ -25,5 +29,5 @@ import { Prologue } from '@models/prologue.model';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EpigraphComponent {
-	@Input({ required: true }) prologue!: Prologue;
+	epigraph = input.required<Epigraph>();
 }

--- a/src/app/components/story-card/story-card.component.stories.ts
+++ b/src/app/components/story-card/story-card.component.stories.ts
@@ -124,7 +124,7 @@ const publication: Publication<StoryCard> = {
 				_key: '90005bcd4cee',
 			},
 		],
-		prologues: [],
+		epigraphs: [],
 	},
 };
 

--- a/src/app/components/storylist-card-deck/story-list-card-deck.component.stories.ts
+++ b/src/app/components/storylist-card-deck/story-list-card-deck.component.stories.ts
@@ -32,7 +32,7 @@ const fullyLoadedStorylist = {
             'https://cdn.sanity.io/images/s4dbqkc5/production/c91d9010f27d5078ef787cb231395042b66db2cd-400x400.jpg',
           name: 'Alejandro Dolina',
         },
-        prologues: [],
+        epigraphs: [],
       },
     },
     {
@@ -59,7 +59,7 @@ const fullyLoadedStorylist = {
             'https://cdn.sanity.io/images/s4dbqkc5/production/a40ec40510c92f6553bc1da10d7bc9bffc859b35-340x340.jpg',
           name: 'Kjell Askildsen',
         },
-        prologues: [],
+        epigraphs: [],
       },
     },
     {
@@ -86,7 +86,7 @@ const fullyLoadedStorylist = {
             'https://cdn.sanity.io/images/s4dbqkc5/production/b2670eebece01f8f8636f16f0cbdfc5f1da02bc3-300x287.jpg',
           name: 'Nikolai Gógol',
         },
-        prologues: [],
+        epigraphs: [],
       },
     },
     {
@@ -113,7 +113,7 @@ const fullyLoadedStorylist = {
             'https://cdn.sanity.io/images/s4dbqkc5/production/354a4a60eebcf20984cd6ff07576b7a32deed162-340x313.jpg',
           name: 'Émile Zola',
         },
-        prologues: [],
+        epigraphs: [],
       },
     },
     {
@@ -140,7 +140,7 @@ const fullyLoadedStorylist = {
             'https://cdn.sanity.io/images/s4dbqkc5/production/0af12a6a33d2c7e0b7f47e2eb7f157bcc0178eea-340x322.jpg',
           name: 'Luigi Pirandello',
         },
-        prologues: [],
+        epigraphs: [],
       },
     },
   ],
@@ -177,7 +177,7 @@ const upcomingStoriesStorylist = {
             'https://cdn.sanity.io/images/s4dbqkc5/production/c91d9010f27d5078ef787cb231395042b66db2cd-400x400.jpg',
           name: 'Alejandro Dolina',
         },
-        prologues: [],
+        epigraphs: [],
       },
     },
     {
@@ -205,7 +205,7 @@ const upcomingStoriesStorylist = {
             'https://cdn.sanity.io/images/s4dbqkc5/production/a40ec40510c92f6553bc1da10d7bc9bffc859b35-340x340.jpg',
           name: 'Kjell Askildsen',
         },
-        prologues: [],
+        epigraphs: [],
       },
     },
     {
@@ -232,7 +232,7 @@ const upcomingStoriesStorylist = {
             'https://cdn.sanity.io/images/s4dbqkc5/production/b2670eebece01f8f8636f16f0cbdfc5f1da02bc3-300x287.jpg',
           name: 'Nikolai Gógol',
         },
-        prologues: [],
+        epigraphs: [],
       },
     },
     {
@@ -259,7 +259,7 @@ const upcomingStoriesStorylist = {
             'https://cdn.sanity.io/images/s4dbqkc5/production/354a4a60eebcf20984cd6ff07576b7a32deed162-340x313.jpg',
           name: 'Émile Zola',
         },
-        prologues: [],
+        epigraphs: [],
       },
     },
     {
@@ -286,7 +286,7 @@ const upcomingStoriesStorylist = {
             'https://cdn.sanity.io/images/s4dbqkc5/production/0af12a6a33d2c7e0b7f47e2eb7f157bcc0178eea-340x322.jpg',
           name: 'Luigi Pirandello',
         },
-        prologues: [],
+        epigraphs: [],
       },
     },
   ],

--- a/src/app/models/epigraph.model.ts
+++ b/src/app/models/epigraph.model.ts
@@ -1,0 +1,11 @@
+import { BlockContent } from '@models/block-content.model'
+
+export interface Epigraph {
+    text: BlockContent[];
+    reference: string;
+}
+
+export interface EpigraphDTO {
+    text: BlockContent[];
+    reference: string;
+}

--- a/src/app/models/prologue.model.ts
+++ b/src/app/models/prologue.model.ts
@@ -1,9 +1,0 @@
-export interface Prologue {
-    text: string;
-    reference: string;
-}
-
-export interface PrologueDTO {
-    text: string;
-    reference: string;
-}

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -1,8 +1,8 @@
 import { Author, AuthorDTO } from './author.model';
-import { Prologue, PrologueDTO } from './prologue.model';
 import { BlockContent } from '@models/block-content.model';
-import { Media, MediaTypes } from '@models/media.model'
-import { Resource } from '@models/resource.model'
+import { Media, MediaTypes } from '@models/media.model';
+import { Resource } from '@models/resource.model';
+import { Epigraph, EpigraphDTO } from '@models/epigraph.model';
 
 export interface StoryBase {
 	id: number;
@@ -12,13 +12,13 @@ export interface StoryBase {
 	videoUrl?: string;
 	badLanguage?: boolean;
 	language: string;
-	resources?: Resource[]
-	paragraphs: unknown
+	resources?: Resource[];
+	paragraphs: unknown;
 }
 
 export interface Story extends StoryBase {
 	author: Author;
-	prologues: Prologue[];
+	epigraphs: Epigraph[];
 	summary: BlockContent[];
 	paragraphs: BlockContent[];
 	media: MediaTypes[];
@@ -26,12 +26,14 @@ export interface Story extends StoryBase {
 
 export interface StoryDTO extends StoryBase {
 	author: AuthorDTO;
-	prologues: PrologueDTO[];
+	epigraphs: EpigraphDTO[];
 	summary?: BlockContent[];
 	paragraphs: BlockContent[];
 	media: Media[];
 }
 
-export interface StoryCard extends Story {
+export interface StoryCard extends StoryBase {
 	author: Omit<Author, 'biography'>;
+	paragraphs: BlockContent[];
+	media: MediaTypes[];
 }

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -7,9 +7,9 @@
 	}
 </aside>
 <main>
-	<article class="bg-gray-50 p-5 md:p-15 md:rounded-xl md:shadow-lg">
-		<header class="flex flex-col-reverse sm:block mb-6 sm:mb-10">
-			<aside class="sm:float-right mt-6 sm:ml-12 sm:mb-12 sm:mt-0">
+	<article class="bg-gray-50 p-5 md:rounded-xl md:p-15 md:shadow-lg">
+		<header class="mb-6 flex flex-col-reverse sm:mb-10 sm:block">
+			<aside class="mt-6 sm:float-right sm:mb-12 sm:ml-12 sm:mt-0">
 				@defer {
 					<cuentoneta-share-content
 						[isLoading]="fetchContentDirective.isLoading"
@@ -28,7 +28,7 @@
 					</time>
 
 					@if (!!story.badLanguage) {
-						<p class="inter-body-base-semibold flex items-center mt-2 text-primary-500">* Contiene lenguaje adulto</p>
+						<p class="inter-body-base-semibold mt-2 flex items-center text-primary-500">* Contiene lenguaje adulto</p>
 					}
 				} @else {
 					<ngx-skeleton-loader
@@ -75,11 +75,11 @@
 				}
 			}
 
-			@if (!!story.prologues && story.prologues.length > 0) {
-				<section class="flex flex-col gap-10 mb-10">
-					@for (prologue of story.prologues; track $index) {
+			@if (!!story.epigraphs && story.epigraphs.length > 0) {
+				<section class="mb-10 flex flex-col gap-10">
+					@for (epigraph of story.epigraphs; track $index) {
 						@defer {
-							<cuentoneta-story-epigraph [prologue]="prologue"></cuentoneta-story-epigraph>
+							<cuentoneta-story-epigraph [epigraph]="epigraph"></cuentoneta-story-epigraph>
 						}
 					}
 				</section>
@@ -89,7 +89,7 @@
 		@if (!!story && !fetchContentDirective.isLoading) {
 			<section [lang]="story.language">
 				<cuentoneta-portable-text-parser
-                    [classes]="'source-serif-pro-body-xl mb-8 leading-8'"
+					[classes]="'source-serif-pro-body-xl mb-8 leading-8'"
 					[paragraphs]="story.paragraphs"
 				></cuentoneta-portable-text-parser>
 			</section>

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -28,9 +28,7 @@ export class StoryService {
 				...story.author,
 				imageUrl: this.parseAvatarImageUrl(story.author.imageUrl),
 			},
-			prologues: story.prologues ?? [],
 			paragraphs: story?.paragraphs ?? [],
-			summary: story?.summary ?? [],
 			media: story.media?.map((x) => this.mediaTypesAdapter(x)) ?? [],
 		};
 	}
@@ -38,7 +36,7 @@ export class StoryService {
 	private parseStoryContent(story: StoryDTO): Story {
 		return {
 			...story,
-			prologues: story.prologues ?? [],
+			epigraphs: story.epigraphs ?? [],
 			paragraphs: story?.paragraphs ?? [],
 			summary: story?.summary ?? [],
 			author: {


### PR DESCRIPTION
# Resumen
* Reemplaza uso de campo `forewords` en Sanity por `epigraphs`: un tipo de objeto que contiene texto en formato Portable Text para soportar epígrafes de texto enriquecido y multilínea.
* Adapta backend, frontend y modelos de dominio de la aplicación a estos cambios.