### PR TITLE
[#279] - Agrega opción de prerender para rutas fijas

### DIFF
--- a/project.json
+++ b/project.json
@@ -17,6 +17,9 @@
 				"inlineStyleLanguage": "scss",
 				"assets": ["./src/favicon.ico", "./src/assets"],
 				"server": "./src/main.server.ts",
+				"prerender": {
+					"discoverRoutes": true
+				},
 				"styles": ["./src/styles.scss"],
 				"scripts": []
 			},


### PR DESCRIPTION
# Resumen
Agrega prerender para rutas `about`, `dmca`, `home`, `story` y `storylist`, mediante el autodescubrimiento de rutas.