### PR TITLE
[#708] Generar endpoint para obtener storylists del home en una única request

### DIFF
--- a/src/api/_queries/storylist.query.ts
+++ b/src/api/_queries/storylist.query.ts
@@ -54,7 +54,8 @@ export const storylistPreviewQuery = `
                     }
 `;
 
-export const storylistQuery = `{ 
+export const storylistQuery = `
+{ 
                         _id,
                         'slug': slug.current,
                         title,
@@ -103,4 +104,5 @@ export const storylistQuery = `{
                           	}
                         },
                         'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
+                }
 `;

--- a/src/api/_queries/storylist.query.ts
+++ b/src/api/_queries/storylist.query.ts
@@ -1,6 +1,6 @@
 import { authorForStoryCard } from './author.query';
 
-const storylistTagsQuery = `
+const tags = `
     'tags': tags[] -> {
         title, 
         'slug': slug.current, 
@@ -9,7 +9,20 @@ const storylistTagsQuery = `
     }
 `;
 
-const gridConfigQuery = (config: 'previewGridConfig' | 'gridConfig') => `
+const commonFields = `
+    _id,
+    'slug': slug.current,
+    title,
+    description,
+    language,
+    displayDates,
+    editionPrefix,
+    comingNextLabel,
+    featuredImage,
+    ${tags}
+`;
+
+const gridConfig = (config: 'previewGridConfig' | 'gridConfig') => `
 'gridConfig': { 
     'gridTemplateColumns': ${config}.gridTemplateColumns,
     'titlePlacement': ${config}.titlePlacement,
@@ -47,50 +60,23 @@ const gridConfigQuery = (config: 'previewGridConfig' | 'gridConfig') => `
 
 export const storylistCardQuery = `
 { 
-    _id,
-    'slug': slug.current,
-    title,
-    description,
-    language,
-    displayDates,
-    editionPrefix,
-    comingNextLabel,
-    ${storylistTagsQuery},
-    featuredImage,
+    ${commonFields},
     'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
 }
 `;
 
 export const storylistPreviewQuery = `
 { 
-    _id,
-    'slug': slug.current,
-    title,
-    description,
-    language,
-    displayDates,
-    editionPrefix,
-    comingNextLabel,
-    ${storylistTagsQuery},
-    featuredImage,
-    ${gridConfigQuery('previewGridConfig')},
+    ${commonFields},
+    ${gridConfig('previewGridConfig')},
     'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
     }
 `;
 
 export const storylistQuery = `
 { 
-    _id,
-    'slug': slug.current,
-    title,
-    description,
-    language,
-    displayDates,
-    editionPrefix,
-    comingNextLabel,
-    featuredImage,
-    ${storylistTagsQuery},
-    ${gridConfigQuery('gridConfig')},
+    ${commonFields},
+    ${gridConfig('gridConfig')},
     'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
 }
 `;

--- a/src/api/_queries/storylist.query.ts
+++ b/src/api/_queries/storylist.query.ts
@@ -1,0 +1,106 @@
+import { authorForStoryCard } from './author.query';
+
+export const storylistPreviewQuery = `
+{ 
+                        _id,
+                        'slug': slug.current,
+                        title,
+                        description,
+                        language,
+                        displayDates,
+                        editionPrefix,
+                        comingNextLabel,
+                        'tags': tags[] -> {
+                            title, 
+                            'slug': slug.current, 
+                            description, 
+                            'icon': {'name': icon.name, 'provider': icon.provider, 'svg': icon.svg}
+                        },
+                        featuredImage,
+                        'gridConfig': { 
+                            'gridTemplateColumns': previewGridConfig.gridTemplateColumns,
+                            'titlePlacement': previewGridConfig.titlePlacement,
+                            'cardsPlacement': previewGridConfig.cardsPlacement[]
+                                {
+                                    'order': order,
+                                    'slug': publication.story->slug.current,
+                                    'startCol': startCol,
+                                    'image': image,
+                                    'imageSlug': imageSlug.current,
+                                    'endCol': endCol,
+                                    'startRow': startRow,
+                                    'endRow': endRow,
+                                    'publication': {
+                                        'publishingOrder': publication.publishingOrder,
+                                        'publishingDate': publication.publishingDate,
+                                        'published': publication.published,
+                                        'story': publication.story->{
+                                            _id,
+                                            'slug': slug.current,
+                                            title,
+                                            badLanguage,
+                                            categories,
+                                            body[0...3],
+                                            review,
+                                            approximateReadingTime,
+                                            language,
+                                            mediaSources,
+                                        	${authorForStoryCard}
+                                        }
+                                    }
+                                }
+                        },
+                        'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
+                    }
+`;
+
+export const storylistQuery = `{ 
+                        _id,
+                        'slug': slug.current,
+                        title,
+                        description,
+                        language,
+                        displayDates,
+                        editionPrefix,
+                        comingNextLabel,
+                        featuredImage,
+                        'tags': tags[] -> {
+                            title, 
+                            'slug': slug.current, 
+                            description, 
+                            'icon': {'name': icon.name, 'provider': icon.provider, 'svg': icon.svg}
+                        },
+                        'gridConfig': {
+                            'gridTemplateColumns': gridConfig.gridTemplateColumns,
+                            'titlePlacement': gridConfig.titlePlacement,
+                            'cardsPlacement': gridConfig.cardsPlacement[]
+                            {
+                                'order': order,
+                                'slug': publication.story->slug.current,
+                                'startCol': startCol,
+                                'image': image,
+                                'imageSlug': imageSlug.current,
+                                'endCol': endCol,
+                                'startRow': startRow,
+                                'endRow': endRow,
+                                'publication': {
+                                     'publishingOrder': publication.publishingOrder,
+                                     'publishingDate': publication.publishingDate,
+                                     'published': publication.published,
+                                     'story': publication.story->{
+                                        _id,
+                                        'slug': slug.current,
+                                        title,
+                                        categories,
+                                        body[0...3],
+                                        review,
+                                        approximateReadingTime,
+                                        language,
+                                        mediaSources,
+                                        ${authorForStoryCard}
+                                    }
+                                }
+                          	}
+                        },
+                        'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
+`;

--- a/src/api/_queries/storylist.query.ts
+++ b/src/api/_queries/storylist.query.ts
@@ -1,108 +1,96 @@
 import { authorForStoryCard } from './author.query';
 
+const storylistTagsQuery = `
+    'tags': tags[] -> {
+        title, 
+        'slug': slug.current, 
+        description, 
+        'icon': {'name': icon.name, 'provider': icon.provider, 'svg': icon.svg}
+    }
+`;
+
+const gridConfigQuery = (config: 'previewGridConfig' | 'gridConfig') => `
+'gridConfig': { 
+    'gridTemplateColumns': ${config}.gridTemplateColumns,
+    'titlePlacement': ${config}.titlePlacement,
+    'cardsPlacement': ${config}.cardsPlacement[]
+    {
+        'order': order,
+        'slug': publication.story->slug.current,
+        'startCol': startCol,
+        'image': image,
+        'imageSlug': imageSlug.current,
+        'endCol': endCol,
+        'startRow': startRow,
+        'endRow': endRow,
+        'publication': {
+            'publishingOrder': publication.publishingOrder,
+            'publishingDate': publication.publishingDate,
+            'published': publication.published,
+            'story': publication.story->{
+                _id,
+                'slug': slug.current,
+                title,
+                badLanguage,
+                categories,
+                body[0...3],
+                review,
+                approximateReadingTime,
+                language,
+                mediaSources,
+            	${authorForStoryCard}
+            }
+        }
+    }
+}
+`;
+
+export const storylistCardQuery = `
+{ 
+    _id,
+    'slug': slug.current,
+    title,
+    description,
+    language,
+    displayDates,
+    editionPrefix,
+    comingNextLabel,
+    ${storylistTagsQuery},
+    featuredImage,
+    'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
+}
+`;
+
 export const storylistPreviewQuery = `
 { 
-                        _id,
-                        'slug': slug.current,
-                        title,
-                        description,
-                        language,
-                        displayDates,
-                        editionPrefix,
-                        comingNextLabel,
-                        'tags': tags[] -> {
-                            title, 
-                            'slug': slug.current, 
-                            description, 
-                            'icon': {'name': icon.name, 'provider': icon.provider, 'svg': icon.svg}
-                        },
-                        featuredImage,
-                        'gridConfig': { 
-                            'gridTemplateColumns': previewGridConfig.gridTemplateColumns,
-                            'titlePlacement': previewGridConfig.titlePlacement,
-                            'cardsPlacement': previewGridConfig.cardsPlacement[]
-                                {
-                                    'order': order,
-                                    'slug': publication.story->slug.current,
-                                    'startCol': startCol,
-                                    'image': image,
-                                    'imageSlug': imageSlug.current,
-                                    'endCol': endCol,
-                                    'startRow': startRow,
-                                    'endRow': endRow,
-                                    'publication': {
-                                        'publishingOrder': publication.publishingOrder,
-                                        'publishingDate': publication.publishingDate,
-                                        'published': publication.published,
-                                        'story': publication.story->{
-                                            _id,
-                                            'slug': slug.current,
-                                            title,
-                                            badLanguage,
-                                            categories,
-                                            body[0...3],
-                                            review,
-                                            approximateReadingTime,
-                                            language,
-                                            mediaSources,
-                                        	${authorForStoryCard}
-                                        }
-                                    }
-                                }
-                        },
-                        'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
-                    }
+    _id,
+    'slug': slug.current,
+    title,
+    description,
+    language,
+    displayDates,
+    editionPrefix,
+    comingNextLabel,
+    ${storylistTagsQuery},
+    featuredImage,
+    ${gridConfigQuery('previewGridConfig')},
+    'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
+    }
 `;
 
 export const storylistQuery = `
 { 
-                        _id,
-                        'slug': slug.current,
-                        title,
-                        description,
-                        language,
-                        displayDates,
-                        editionPrefix,
-                        comingNextLabel,
-                        featuredImage,
-                        'tags': tags[] -> {
-                            title, 
-                            'slug': slug.current, 
-                            description, 
-                            'icon': {'name': icon.name, 'provider': icon.provider, 'svg': icon.svg}
-                        },
-                        'gridConfig': {
-                            'gridTemplateColumns': gridConfig.gridTemplateColumns,
-                            'titlePlacement': gridConfig.titlePlacement,
-                            'cardsPlacement': gridConfig.cardsPlacement[]
-                            {
-                                'order': order,
-                                'slug': publication.story->slug.current,
-                                'startCol': startCol,
-                                'image': image,
-                                'imageSlug': imageSlug.current,
-                                'endCol': endCol,
-                                'startRow': startRow,
-                                'endRow': endRow,
-                                'publication': {
-                                     'publishingOrder': publication.publishingOrder,
-                                     'publishingDate': publication.publishingDate,
-                                     'published': publication.published,
-                                     'story': publication.story->{
-                                        _id,
-                                        'slug': slug.current,
-                                        title,
-                                        categories,
-                                        body[0...3],
-                                        review,
-                                        approximateReadingTime,
-                                        language,
-                                        mediaSources,
-                                        ${authorForStoryCard}
-                                    }
-                                }
-                          	}
-                        },
-                        'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
-                }
+    _id,
+    'slug': slug.current,
+    title,
+    description,
+    language,
+    displayDates,
+    editionPrefix,
+    comingNextLabel,
+    featuredImage,
+    ${storylistTagsQuery},
+    ${gridConfigQuery('gridConfig')},
+    'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
+}
 `;

--- a/src/api/_queries/storylist.query.ts
+++ b/src/api/_queries/storylist.query.ts
@@ -10,7 +10,6 @@ const tags = `
 `;
 
 const commonFields = `
-    _id,
     'slug': slug.current,
     title,
     description,

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -11,6 +11,7 @@ import { baseLanguage } from '../../../cms/utils/localization';
 
 // Modelos
 import { AuthorDTO } from '@models/author.model';
+import { mapMediaSources } from './media-sources.functions';
 
 export function mapAuthor(rawAuthorData: any, language?: string): AuthorDTO {
 	return {
@@ -57,4 +58,81 @@ export function mapResources(resources: any[]) {
 			},
 		})) ?? []
 	);
+}
+
+export async function mapStorylist(result: any) {
+	const storylistImages = result.gridConfig.cardsPlacement?.filter((config: any) => !!config.imageSlug) ?? [];
+
+	const rawPublications = result.gridConfig.cardsPlacement
+		.filter((cardPlacement: any) => !!cardPlacement.publication && !!cardPlacement.publication.story)
+		.map((cardPlacement: any) => cardPlacement.publication);
+	const publications = [];
+
+	// Toma las publicaciones que fueron traídas en la consulta a Sanity y las mapea a una colección de publicaciones
+	for (const publication of rawPublications) {
+		const { review, body, author, mediaSources, ...story } = publication.story;
+		publications.push({
+			...publication,
+			story: {
+				...story,
+				media: mediaSources ? await mapMediaSources(mediaSources) : undefined,
+				summary: review,
+				paragraphs: body,
+				author: mapAuthorForStory(author),
+			},
+		});
+	}
+
+	const storylist = {
+		...result,
+		featuredImage: !result.featuredImage ? undefined : urlFor(result.featuredImage).url(),
+		images:
+			storylistImages.length === 0
+				? []
+				: storylistImages.map((card: any) => ({
+						slug: card.imageSlug,
+						url: urlFor(card.image).url(),
+					})),
+		publications: publications,
+	};
+}
+
+export function mapStorylistPreview(result: any) {
+	const previewImages = result.gridConfig?.cardsPlacement?.filter((config: any) => !!config.imageSlug) ?? [];
+	return {
+		...result,
+		// Elimina elementos publication traídos en la consulta a Sanity del objeto grid config
+		gridConfig: {
+			...result.gridConfig,
+			cardsPlacement: result.gridConfig.cardsPlacement?.map((placement: any) => {
+				const { publication, image, ...other } = placement;
+				return other;
+			}),
+		},
+		featuredImage: !result.featuredImage ? undefined : urlFor(result.featuredImage).url(),
+		images:
+			previewImages.length === 0
+				? []
+				: previewImages.map((card: any) => ({
+						slug: card.imageSlug,
+						url: urlFor(card.image).url(),
+					})),
+
+		// Toma las publicaciones que fueron traídas en la consulta a Sanity y las mapea a una colección de publicaciones
+		publications: result.gridConfig.cardsPlacement
+			.filter((cardPlacement: any) => !!cardPlacement.publication && !!cardPlacement.publication.story)
+			.map((cardPlacement: any) => cardPlacement.publication)
+			.map((publication: any) => {
+				const { review, body, author, ...story } = publication.story;
+				return {
+					...publication,
+					story: {
+						...story,
+						summary: review,
+						paragraphs: body,
+						author: mapAuthorForStory(author),
+					},
+				};
+			}),
+	};
 }

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -12,6 +12,7 @@ import { baseLanguage } from '../../../cms/utils/localization';
 // Modelos
 import { AuthorDTO } from '@models/author.model';
 import { mapMediaSources } from './media-sources.functions';
+import { StorylistDTO } from '@models/storylist.model';
 
 export function mapAuthor(rawAuthorData: any, language?: string): AuthorDTO {
 	return {
@@ -60,10 +61,11 @@ export function mapResources(resources: any[]) {
 	);
 }
 
-export async function mapStorylist(result: any) {
-	const storylistImages = result.gridConfig.cardsPlacement?.filter((config: any) => !!config.imageSlug) ?? [];
+export async function mapStorylist(result: any): Promise<StorylistDTO> {
+	const cardsPlacement = result.gridConfig?.cardsPlacement ?? [];
+	const storylistImages = cardsPlacement.filter((config: any) => !!config.imageSlug) ?? [];
 
-	const rawPublications = result.gridConfig.cardsPlacement
+	const rawPublications = cardsPlacement
 		.filter((cardPlacement: any) => !!cardPlacement.publication && !!cardPlacement.publication.story)
 		.map((cardPlacement: any) => cardPlacement.publication);
 	const publications = [];
@@ -94,45 +96,5 @@ export async function mapStorylist(result: any) {
 						url: urlFor(card.image).url(),
 					})),
 		publications: publications,
-	};
-}
-
-export function mapStorylistPreview(result: any) {
-	const previewImages = result.gridConfig?.cardsPlacement?.filter((config: any) => !!config.imageSlug) ?? [];
-	return {
-		...result,
-		// Elimina elementos publication traídos en la consulta a Sanity del objeto grid config
-		gridConfig: {
-			...result.gridConfig,
-			cardsPlacement: result.gridConfig.cardsPlacement?.map((placement: any) => {
-				const { publication, image, ...other } = placement;
-				return other;
-			}),
-		},
-		featuredImage: !result.featuredImage ? undefined : urlFor(result.featuredImage).url(),
-		images:
-			previewImages.length === 0
-				? []
-				: previewImages.map((card: any) => ({
-						slug: card.imageSlug,
-						url: urlFor(card.image).url(),
-					})),
-
-		// Toma las publicaciones que fueron traídas en la consulta a Sanity y las mapea a una colección de publicaciones
-		publications: result.gridConfig.cardsPlacement
-			.filter((cardPlacement: any) => !!cardPlacement.publication && !!cardPlacement.publication.story)
-			.map((cardPlacement: any) => cardPlacement.publication)
-			.map((publication: any) => {
-				const { review, body, author, ...story } = publication.story;
-				return {
-					...publication,
-					story: {
-						...story,
-						summary: review,
-						paragraphs: body,
-						author: mapAuthorForStory(author),
-					},
-				};
-			}),
 	};
 }

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -83,7 +83,7 @@ export async function mapStorylist(result: any) {
 		});
 	}
 
-	const storylist = {
+	return {
 		...result,
 		featuredImage: !result.featuredImage ? undefined : urlFor(result.featuredImage).url(),
 		images:

--- a/src/api/content.controller.ts
+++ b/src/api/content.controller.ts
@@ -7,8 +7,8 @@ router.get('/landing-page', getLandingPageContent);
 
 export default router;
 
-function getLandingPageContent(req: express.Request, res: express.Response, next: express.NextFunction) {
-	fetchLandingPageContent(req, res)
+function getLandingPageContent(_: express.Request, res: express.Response, next: express.NextFunction) {
+	fetchLandingPageContent()
 		.then((result) => res.json(result))
 		.catch((err) => next(err));
 }

--- a/src/api/content.service.ts
+++ b/src/api/content.service.ts
@@ -1,17 +1,17 @@
+// Sanity Client
 import { client } from './_helpers/sanity-connector';
-import express from 'express';
 
-export async function fetchLandingPageContent(req: express.Request, res: express.Response) {
+// Queries
+import { storylistPreviewQuery } from './_queries/storylist.query';
+
+export async function fetchLandingPageContent() {
 	const query = `*[_type == 'landingPage'] {
-            'previews': previews[]->,
-            'cards': cards[]->
+            'previews': previews[]-> ${storylistPreviewQuery},
+            'cards': cards[]-> ${storylistPreviewQuery}
         }[0]`;
 
 	const result = await client.fetch(query, {});
 
-	if (!result) {
-		res.json(null);
-	}
-
-	return res.json(result);
+	// TODO: Generar tipos correctos de respuestas
+	return { previews: result.previews, cards: result.cards };
 }

--- a/src/api/content.service.ts
+++ b/src/api/content.service.ts
@@ -2,16 +2,26 @@
 import { client } from './_helpers/sanity-connector';
 
 // Queries
-import { storylistPreviewQuery } from './_queries/storylist.query';
+import { storylistCardQuery, storylistPreviewQuery } from './_queries/storylist.query';
+import { mapStorylist } from './_utils/functions';
 
 export async function fetchLandingPageContent() {
 	const query = `*[_type == 'landingPage'] {
             'previews': previews[]-> ${storylistPreviewQuery},
-            'cards': cards[]-> ${storylistPreviewQuery}
+            'cards': cards[]-> ${storylistCardQuery}
         }[0]`;
 
 	const result = await client.fetch(query, {});
+	const cards = [];
+	const previews = [];
 
-	// TODO: Generar tipos correctos de respuestas
-	return { previews: result.previews, cards: result.cards };
+	for (const preview of result.previews) {
+		previews.push(await mapStorylist(preview));
+	}
+
+	for (const card of result.cards) {
+		cards.push(await mapStorylist(card));
+	}
+
+	return { previews, cards };
 }

--- a/src/api/storylist.controller.ts
+++ b/src/api/storylist.controller.ts
@@ -10,13 +10,16 @@ router.get('/preview', getPreview);
 export default router;
 
 function get(req: express.Request, res: express.Response, next: express.NextFunction) {
-	fetchStorylist(req, res)
+	const { slug, amount, ordering = 'asc' } = req.query;
+	const limit = parseInt(amount as string) - 1;
+	fetchStorylist({ slug: slug as string, amount: amount as string, limit, ordering: ordering as string })
 		.then((result) => res.json(result))
 		.catch((err) => next(err));
 }
 
 function getPreview(req: express.Request, res: express.Response, next: express.NextFunction) {
-	fetchPreview(req, res)
+	const { slug } = req.query;
+	fetchPreview(slug as string)
 		.then((result) => res.json(result))
 		.catch((err) => next(err));
 }

--- a/src/api/storylist.service.ts
+++ b/src/api/storylist.service.ts
@@ -1,211 +1,43 @@
-import express from 'express';
+// Connector
 import { client } from './_helpers/sanity-connector';
-import { mapAuthorForStory, urlFor } from './_utils/functions';
-import { mapMediaSources } from './_utils/media-sources.functions';
-import { authorForStoryCard } from './_queries/author.query';
 
-async function fetchPreview(req: express.Request, res: express.Response) {
-	const { slug } = req.query;
+// Functions
+import { mapStorylist, mapStorylistPreview } from './_utils/functions';
 
-	const query = `*[_type == 'storylist' && slug.current == '${slug}'][0]
-                    { 
-                        _id,
-                        'slug': slug.current,
-                        title,
-                        description,
-                        language,
-                        displayDates,
-                        editionPrefix,
-                        comingNextLabel,
-                        'tags': tags[] -> {
-                            title, 
-                            'slug': slug.current, 
-                            description, 
-                            'icon': {'name': icon.name, 'provider': icon.provider, 'svg': icon.svg}
-                        },
-                        featuredImage,
-                        'gridConfig': { 
-                            'gridTemplateColumns': previewGridConfig.gridTemplateColumns,
-                            'titlePlacement': previewGridConfig.titlePlacement,
-                            'cardsPlacement': previewGridConfig.cardsPlacement[]
-                                {
-                                    'order': order,
-                                    'slug': publication.story->slug.current,
-                                    'startCol': startCol,
-                                    'image': image,
-                                    'imageSlug': imageSlug.current,
-                                    'endCol': endCol,
-                                    'startRow': startRow,
-                                    'endRow': endRow,
-                                    'publication': {
-                                        'publishingOrder': publication.publishingOrder,
-                                        'publishingDate': publication.publishingDate,
-                                        'published': publication.published,
-                                        'story': publication.story->{
-                                            _id,
-                                            'slug': slug.current,
-                                            title,
-                                            badLanguage,
-                                            categories,
-                                            body[0...3],
-                                            review,
-                                            approximateReadingTime,
-                                            language,
-                                            mediaSources,
-                                        	${authorForStoryCard}
-                                        }
-                                    }
-                                }
-                        },
-                        'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
-                    }`;
+// Queries
+import { storylistPreviewQuery, storylistQuery } from './_queries/storylist.query';
 
+async function fetchPreview(slug: string) {
+	console.log(slug);
+
+	const query = `*[_type == 'storylist' && slug.current == '${slug}'][0]${storylistPreviewQuery}`;
 	const result = await client.fetch(query, {});
 
 	if (!result) {
-		res.json(null);
+		throw new Error('Storylist not found');
 	}
 
-	const previewImages = result.gridConfig.cardsPlacement?.filter((config: any) => !!config.imageSlug) ?? [];
-
-	const storylist = {
-		...result,
-		// Elimina elementos publication traídos en la consulta a Sanity del objeto grid config
-		gridConfig: {
-			...result.gridConfig,
-			cardsPlacement: result.gridConfig.cardsPlacement.map((placement: any) => {
-				const { publication, image, ...other } = placement;
-				return other;
-			}),
-		},
-		featuredImage: !result.featuredImage ? undefined : urlFor(result.featuredImage).url(),
-		images:
-			previewImages.length === 0
-				? []
-				: previewImages.map((card: any) => ({
-						slug: card.imageSlug,
-						url: urlFor(card.image).url(),
-					})),
-
-		// Toma las publicaciones que fueron traídas en la consulta a Sanity y las mapea a una colección de publicaciones
-		publications: result.gridConfig.cardsPlacement
-			.filter((cardPlacement: any) => !!cardPlacement.publication && !!cardPlacement.publication.story)
-			.map((cardPlacement: any) => cardPlacement.publication)
-			.map((publication: any) => {
-				const { review, body, author, ...story } = publication.story;
-				return {
-					...publication,
-					story: {
-						...story,
-						summary: review,
-						paragraphs: body,
-						author: mapAuthorForStory(author),
-					},
-				};
-			}),
-	};
-
-	res.json(storylist);
+	return mapStorylistPreview(result);
 }
-async function fetchStorylist(req: any, res: any) {
-	const { slug, amount, ordering = 'asc' } = req.query;
-	const limit = parseInt(amount as string) - 1;
-
-	const query = `*[_type == 'storylist' && slug.current == '${slug}'][0]
-                    { 
-                        _id,
-                        'slug': slug.current,
-                        title,
-                        description,
-                        language,
-                        displayDates,
-                        editionPrefix,
-                        comingNextLabel,
-                        featuredImage,
-                        'tags': tags[] -> {
-                            title, 
-                            'slug': slug.current, 
-                            description, 
-                            'icon': {'name': icon.name, 'provider': icon.provider, 'svg': icon.svg}
-                        },
-                        'gridConfig': {
-                            'gridTemplateColumns': gridConfig.gridTemplateColumns,
-                            'titlePlacement': gridConfig.titlePlacement,
-                            'cardsPlacement': gridConfig.cardsPlacement[]
-                            {
-                                'order': order,
-                                'slug': publication.story->slug.current,
-                                'startCol': startCol,
-                                'image': image,
-                                'imageSlug': imageSlug.current,
-                                'endCol': endCol,
-                                'startRow': startRow,
-                                'endRow': endRow,
-                                'publication': {
-                                     'publishingOrder': publication.publishingOrder,
-                                     'publishingDate': publication.publishingDate,
-                                     'published': publication.published,
-                                     'story': publication.story->{
-                                        _id,
-                                        'slug': slug.current,
-                                        title,
-                                        categories,
-                                        body[0...3],
-                                        review,
-                                        approximateReadingTime,
-                                        language,
-                                        mediaSources,
-                                        ${authorForStoryCard}
-                                    }
-                                }
-                          	}
-                        },
-                        'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
-                    }`;
-
+async function fetchStorylist({
+	slug,
+	amount,
+	limit,
+	ordering,
+}: {
+	slug: string;
+	amount: string;
+	limit: number;
+	ordering: string;
+}) {
+	const query = `*[_type == 'storylist' && slug.current == '${slug}'][0]${storylistQuery}`;
 	const result = await client.fetch(query, {});
 
 	if (!result) {
-		res.json(null);
-		return;
+		throw new Error('Storylist not found');
 	}
 
-	const storylistImages = result.gridConfig.cardsPlacement?.filter((config: any) => !!config.imageSlug) ?? [];
-
-	const rawPublications = result.gridConfig.cardsPlacement
-		.filter((cardPlacement: any) => !!cardPlacement.publication && !!cardPlacement.publication.story)
-		.map((cardPlacement: any) => cardPlacement.publication);
-	const publications = [];
-
-	// Toma las publicaciones que fueron traídas en la consulta a Sanity y las mapea a una colección de publicaciones
-	for (const publication of rawPublications) {
-		const { review, body, author, mediaSources, ...story } = publication.story;
-		publications.push({
-			...publication,
-			story: {
-				...story,
-				media: mediaSources ? await mapMediaSources(mediaSources) : undefined,
-				summary: review,
-				paragraphs: body,
-				author: mapAuthorForStory(author),
-			},
-		});
-	}
-
-	const storylist = {
-		...result,
-		featuredImage: !result.featuredImage ? undefined : urlFor(result.featuredImage).url(),
-		images:
-			storylistImages.length === 0
-				? []
-				: storylistImages.map((card: any) => ({
-						slug: card.imageSlug,
-						url: urlFor(card.image).url(),
-					})),
-		publications: publications,
-	};
-
-	res.json(storylist);
+	return mapStorylist(result);
 }
 
 export { fetchPreview, fetchStorylist };

--- a/src/api/storylist.service.ts
+++ b/src/api/storylist.service.ts
@@ -2,7 +2,7 @@
 import { client } from './_helpers/sanity-connector';
 
 // Functions
-import { mapStorylist, mapStorylistPreview } from './_utils/functions';
+import { mapStorylist } from './_utils/functions';
 
 // Queries
 import { storylistPreviewQuery, storylistQuery } from './_queries/storylist.query';
@@ -17,7 +17,7 @@ async function fetchPreview(slug: string) {
 		throw new Error('Storylist not found');
 	}
 
-	return mapStorylistPreview(result);
+	return mapStorylist(result);
 }
 async function fetchStorylist({
 	slug,

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -22,12 +22,6 @@ export const appConfig: ApplicationConfig = {
 		ContentService,
 		StoryService,
 		{ provide: APP_ID, useValue: 'serverApp' },
-		{
-			provide: APP_INITIALIZER,
-			useFactory: (contentService: ContentService) => () => contentService.fetchContentConfig(),
-			deps: [ContentService],
-			multi: true,
-		},
 		{ provide: LOCALE_ID, useValue: 'es-419' },
 		provideClientHydration(),
 		provideRouter(

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -57,9 +57,11 @@ export class HomeComponent {
 
 	private loadStorylistDecks() {
 		this.fetchContentDirective
-			.fetchContent$<[StorylistCardDeck[], StorylistCardDeck[]]>(this.contentService.fetchStorylistDecks())
+			.fetchContent$<{ previews: StorylistCardDeck[]; cards: StorylistCardDeck[] }>(
+				this.contentService.fetchStorylistDecks(),
+			)
 			.pipe(takeUntilDestroyed())
-			.subscribe(([previews, cards]) => {
+			.subscribe(({ previews, cards }) => {
 				this.previews = previews;
 				this.cards = cards;
 			});

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -20,7 +20,7 @@ interface LandingPageContent {
 })
 export class ContentService {
 	private readonly prefix = `${environment.apiUrl}api/content`;
-	private _contentConfig: LandingPageContent = { cards: [], previews: [] };
+	private _contentConfig = environment.contentConfig as LandingPageContent;
 
 	// Services
 	private http = inject(HttpClient);
@@ -31,14 +31,6 @@ export class ContentService {
 
 	public getLandingPageContent(): Observable<{ cards: Storylist[]; previews: Storylist[] }> {
 		return this.http.get<{ cards: Storylist[]; previews: Storylist[] }>(`${this.prefix}/landing-page`);
-	}
-
-	public fetchContentConfig(): Observable<LandingPageContent> {
-		return of(environment.contentConfig as LandingPageContent).pipe(
-			tap((contentConfig) => {
-				this._contentConfig = contentConfig;
-			}),
-		);
 	}
 
 	// ToDo: Obtener listas de navs desde API

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -1,6 +1,6 @@
 // Core
 import { inject, Injectable } from '@angular/core';
-import { map, Observable, of, tap } from 'rxjs';
+import { map, Observable } from 'rxjs';
 
 // Interfaces
 import { StorylistCardDeck, StorylistDeckConfig } from '@models/content.model';

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -51,8 +51,7 @@ export class ContentService {
 	}
 
 	/**
-	 * En base a la configuración de contenido disponible, hace fetch de la lista de
-	 * storylists referenciada en los objetos de configuración, para luego generar
+	 * Hace fetch de la configuración de landing page desde el origen de datos y genera
 	 * una tupla de arrays de objetos compuestos de tipo StorylistCardDeck, los cuales
 	 * contienen la configuración y la correspondiente información para renderizar
 	 * los decks de previews y cards de cada storylist.

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -1,6 +1,6 @@
 // Core
 import { inject, Injectable } from '@angular/core';
-import { map, Observable, of, switchMap, tap } from 'rxjs';
+import { map, Observable, of, tap } from 'rxjs';
 
 // Interfaces
 import { StorylistCardDeck, StorylistDeckConfig } from '@models/content.model';

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -20,13 +20,12 @@ interface LandingPageContent {
 })
 export class ContentService {
 	private readonly prefix = `${environment.apiUrl}api/content`;
-	private _contentConfig = environment.contentConfig as LandingPageContent;
 
 	// Services
 	private http = inject(HttpClient);
 
 	get contentConfig(): LandingPageContent {
-		return this._contentConfig;
+		return environment.contentConfig as LandingPageContent;
 	}
 
 	public getLandingPageContent(): Observable<{ cards: Storylist[]; previews: Storylist[] }> {


### PR DESCRIPTION
# Resumen
* Agrega nuevo archivo para almacenar y abstraer queries relacionadas con storylists.
* Relocaliza función `mapStorylist` a `functions.ts`, eliminando además la función redundante `mapStorylistPreview`.
* Implementa endpoint `/content/landing-page`
* Transforma lógica de `ContentService` en frontend para trabajar con una única request hacia el endpoint `/content/landing-page`.

## Otros cambios
* Mueve tratamiento de params desde `storylist.service.ts` hacia `storylist.controller.ts`, separando correctamente el manejo de la request HTTP de la lógica de negocios implementada por el servicio.
* Elimina uso de token `APP_INITIALIZER` para asignar configuración de contenido previo a inicializar la aplicación.
