### PR TITLE
[#232] Elimina los colores hardcoded del proyecto

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { APP_ID, APP_INITIALIZER, ApplicationConfig } from '@angular/core';
+import { APP_ID, APP_INITIALIZER, ApplicationConfig, LOCALE_ID } from '@angular/core';
 import {
 	provideRouter,
 	withEnabledBlockingInitialNavigation,
@@ -6,22 +6,26 @@ import {
 	withViewTransitions,
 } from '@angular/router';
 import { appRoutes } from './app.routes';
-import { ContentService } from './providers/content.service';
-import { StoryService } from './providers/story.service';
+
 import { provideHttpClient, withFetch } from '@angular/common/http';
 import { provideClientHydration } from '@angular/platform-browser';
-
-// Localización
-import { LOCALE_ID } from '@angular/core';
 import localeEs from '@angular/common/locales/es-419';
 import { registerLocaleData } from '@angular/common';
+
+// Providers
+import { ThemeService } from './providers/theme.service';
+
 registerLocaleData(localeEs);
 
 export const appConfig: ApplicationConfig = {
 	providers: [
-		ContentService,
-		StoryService,
 		{ provide: APP_ID, useValue: 'serverApp' },
+		{
+			provide: APP_INITIALIZER,
+			useFactory: (themeService: ThemeService) => () => themeService.addThemeColorTag(),
+			deps: [ThemeService],
+			multi: true,
+		},
 		{ provide: LOCALE_ID, useValue: 'es-419' },
 		provideClientHydration(),
 		provideRouter(

--- a/src/app/components/share-content/share-content.component.html
+++ b/src/app/components/share-content/share-content.component.html
@@ -20,7 +20,7 @@
 					'height.px': 48,
 					'width.px': 48,
 					'margin.px': 0,
-					'background-color': '#D4D4D8'
+					'background-color': skeletonColor
 				}"
 				count="1"
 				appearance="circle"

--- a/src/app/components/share-content/share-content.component.ts
+++ b/src/app/components/share-content/share-content.component.ts
@@ -1,31 +1,33 @@
-import { Component, Input } from '@angular/core';
+import { Component, inject, Input } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { environment } from '../../environments/environment';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+import { ThemeService } from '../../providers/theme.service';
 
 @Component({
 	selector: 'cuentoneta-share-content',
 	standalone: true,
 	imports: [CommonModule, NgOptimizedImage, NgxSkeletonLoaderModule],
+	providers: [ThemeService],
 	templateUrl: './share-content.component.html',
 	styles: `
-    section {
-      button {
-        &:not(:last-child) {
-          @apply mr-6;
-        }
-      }
+		section {
+			button {
+				&:not(:last-child) {
+					@apply mr-6;
+				}
+			}
 
-      ngx-skeleton-loader {
-        div {
-          @apply m-0;
-        }
-        &:not(:last-child) {
-          @apply mr-6;
-        }
-      }
-    }
-  `,
+			ngx-skeleton-loader {
+				div {
+					@apply m-0;
+				}
+				&:not(:last-child) {
+					@apply mr-6;
+				}
+			}
+		}
+	`,
 })
 export class ShareContentComponent {
 	@Input() route: string = '';
@@ -48,6 +50,9 @@ export class ShareContentComponent {
 		//   url: 'copy',
 		// },
 	];
+
+	private themeService = inject(ThemeService);
+	skeletonColor = this.themeService.pickColor('zinc', 300);
 
 	onShareToPlatformClicked(event: MouseEvent | KeyboardEvent, platform: SharingPlatform) {
 		const urlParams = Object.keys(this.params)

--- a/src/app/components/story-card-skeleton/story-card-skeleton.component.html
+++ b/src/app/components/story-card-skeleton/story-card-skeleton.component.html
@@ -21,7 +21,7 @@
 	<ngx-skeleton-loader
 		[animation]="animation"
 		[theme]="{
-			'background-color': '#D4D4D8',
+			'background-color': skeletonColor,
 			height: '20px',
 			'margin-bottom': '8px',
 			'margin-top': '4px',
@@ -58,7 +58,7 @@
 	<ngx-skeleton-loader
 		[animation]="animation"
 		[theme]="{
-			'background-color': '#D4D4D8',
+			'background-color': skeletonColor,
 			height: '40px',
 			'margin-bottom': '2px',
 			'margin-top': '2px',

--- a/src/app/components/story-card-skeleton/story-card-skeleton.component.ts
+++ b/src/app/components/story-card-skeleton/story-card-skeleton.component.ts
@@ -1,7 +1,8 @@
-import { Component, Input } from '@angular/core';
+import { Component, inject, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
+import { ThemeService } from '../../providers/theme.service';
 
 @Component({
 	selector: 'cuentoneta-story-card-skeleton',
@@ -9,14 +10,17 @@ import { StoryEditionDateLabelComponent } from '../story-edition-date-label/stor
 	imports: [CommonModule, NgxSkeletonLoaderModule, StoryEditionDateLabelComponent],
 	templateUrl: './story-card-skeleton.component.html',
 	styles: `
-    :host {
-      @apply flex flex-col gap-2 md:gap-4;
-    }
-  `,
+		:host {
+			@apply flex flex-col gap-2 md:gap-4;
+		}
+	`,
 })
 export class StoryCardSkeletonComponent {
 	@Input() animation: 'progress' | 'progress-dark' | 'pulse' | 'false' | false = false;
 	@Input() displayDate: boolean = false;
 	@Input() editionLabel: string = '';
 	@Input() comingNextLabel: string = 'Próximamente';
+
+	private themeService = inject(ThemeService);
+	skeletonColor = this.themeService.pickColor('zinc', 300);
 }

--- a/src/app/components/storylist-card-component/storylist-card.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.ts
@@ -1,5 +1,5 @@
 // Angular Core
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 
 // Router
@@ -14,6 +14,7 @@ import { StorylistCard } from '@models/storylist.model';
 
 // Componentes
 import { BadgeComponent } from '../badge/badge.component';
+import { ThemeService } from '../../providers/theme.service';
 
 @Component({
 	selector: 'cuentoneta-storylist-card',
@@ -100,7 +101,7 @@ import { BadgeComponent } from '../badge/badge.component';
 				<footer class="flex justify-end rounded-b-lg px-5 pb-5 pt-4">
 					<ngx-skeleton-loader
 						[theme]="{
-							'background-color': '#D4D4D8',
+							'background-color': skeletonColor,
 							height: '22px',
 							'margin-bottom': 0,
 							width: '80px'
@@ -110,7 +111,7 @@ import { BadgeComponent } from '../badge/badge.component';
 					></ngx-skeleton-loader>
 					<ngx-skeleton-loader
 						[theme]="{
-							'background-color': '#D4D4D8',
+							'background-color': skeletonColor,
 							height: '22px',
 							'margin-left': '16px',
 							'margin-bottom': 0,
@@ -133,4 +134,7 @@ export class StorylistCardComponent {
 	@Input() storylist: StorylistCard | undefined;
 
 	protected readonly appRouteTree = APP_ROUTE_TREE;
+
+	private themeService = inject(ThemeService);
+	skeletonColor = this.themeService.pickColor('zinc', 300);
 }

--- a/src/app/components/storylist-card-component/storylist-card.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.ts
@@ -68,7 +68,7 @@ import { ThemeService } from '../../providers/theme.service';
 				<section class="flex flex-col gap-4 px-4 pt-5">
 					<ngx-skeleton-loader
 						[theme]="{
-							'background-color': '#D4D4D8',
+							'background-color': skeletonColor,
 							height: '40px',
 							'margin-bottom': 0,
 							width: '100%'

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.html
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.html
@@ -39,7 +39,7 @@
 						'margin-bottom.px': 20,
 						'height.px': 40,
 						width: '100%',
-						'background-color': '#D4D4D8'
+						'background-color': skeletonColor
 					}"
 					count="1"
 					appearance="line"
@@ -49,7 +49,7 @@
 						'margin-bottom.px': 10,
 						'height.px': 20,
 						width: '100%',
-						'background-color': '#D4D4D8'
+						'background-color': skeletonColor
 					}"
 					count="3"
 					appearance="line"
@@ -93,7 +93,7 @@
 				[theme]="{
 					height: '100%',
 					width: '100%',
-					'background-color': '#D4D4D8'
+					'background-color': skeletonColor
 				}"
 				class="xs:max-md:!col-span-1"
 				count="1"

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
@@ -1,5 +1,5 @@
 // Core
-import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 // Modules
@@ -11,6 +11,7 @@ import { GridItemPlacementConfig, Storylist } from '@models/storylist.model';
 import { APP_ROUTE_TREE } from '../../app.routes';
 import { StorylistGridSkeletonConfig } from '@models/content.model';
 import { PublicationCardComponent } from '../publication-card/publication-card.component';
+import { ThemeService } from '../../providers/theme.service';
 
 @Component({
 	selector: 'cuentoneta-storylist-card-deck',
@@ -32,6 +33,9 @@ export class StorylistCardDeckComponent implements OnInit, OnChanges {
 	imagesCardConfig: { [key: string]: CardDeckCSSGridConfig } = {};
 	storiesCardConfig: { [key: string]: CardDeckCSSGridConfig } = {};
 	readonly appRouteTree = APP_ROUTE_TREE;
+
+	private themeService = inject(ThemeService);
+	skeletonColor = this.themeService.pickColor('zinc', 300);
 
 	ngOnInit() {
 		this.dummyList = Array(this.number);

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -39,7 +39,7 @@
 					<ngx-skeleton-loader
 						[theme]="{
 							'height.px': 36,
-							'background-color': '#D4D4D8',
+							'background-color': skeletonColor,
 							width: '50%'
 						}"
 						count="1"
@@ -48,7 +48,7 @@
 					<ngx-skeleton-loader
 						[theme]="{
 							'height.px': 20,
-							'background-color': '#D4D4D8',
+							'background-color': skeletonColor,
 							width: '25%'
 						}"
 						count="1"
@@ -57,7 +57,7 @@
 					<ngx-skeleton-loader
 						[theme]="{
 							'height.px': 16,
-							'background-color': '#D4D4D8',
+							'background-color': skeletonColor,
 							width: '20%'
 						}"
 						count="1"

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -32,6 +32,7 @@ import { ShareContentComponent } from '../../components/share-content/share-cont
 import { EpigraphComponent } from '../../components/epigraph/epigraph.component';
 import { MediaResourceComponent } from '../../components/media-resource/media-resource.component';
 import { PortableTextParserComponent } from '../../components/portable-text-parser/portable-text-parser.component';
+import { ThemeService } from '../../providers/theme.service';
 
 @Component({
 	selector: 'cuentoneta-story',
@@ -83,6 +84,9 @@ export class StoryComponent {
 	dummyList = Array(10);
 	shareContentParams: { [key: string]: string } = {};
 	shareMessage: string = '';
+
+	private themeService = inject(ThemeService);
+	skeletonColor = this.themeService.pickColor('zinc', 300);
 
 	constructor() {
 		const platformId = inject(PLATFORM_ID);

--- a/src/app/providers/theme.service.spec.ts
+++ b/src/app/providers/theme.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ThemeService } from './theme.service';
+
+describe('ThemeService', () => {
+	let service: ThemeService;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({});
+		service = TestBed.inject(ThemeService);
+	});
+
+	it('should be created', () => {
+		expect(service).toBeTruthy();
+	});
+});

--- a/src/app/providers/theme.service.ts
+++ b/src/app/providers/theme.service.ts
@@ -1,13 +1,17 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
 
 // Tailwind
 import colors from 'tailwindcss/colors';
 import { DefaultColors } from 'tailwindcss/types/generated/colors';
+import { Meta } from '@angular/platform-browser';
 
 @Injectable({
 	providedIn: 'root',
 })
 export class ThemeService {
+	private meta = inject(Meta);
+	private platform = inject(PLATFORM_ID);
+
 	pickColor(color: keyof DefaultColors, scale: number = 50) {
 		if (!colors[color]) {
 			throw new Error(`Color ${color} not found in Tailwind CSS config!`);
@@ -20,5 +24,9 @@ export class ThemeService {
 
 		// @ts-expect-error - En este punto tanto el color como la escala han sido validados
 		return colors[color][scale.toString()].toUpperCase();
+	}
+
+	addThemeColorTag() {
+		this.meta.addTag({ name: 'theme-color', content: 'hsl(21, 57%, 44%)' });
 	}
 }

--- a/src/app/providers/theme.service.ts
+++ b/src/app/providers/theme.service.ts
@@ -1,32 +1,36 @@
 import { inject, Injectable, PLATFORM_ID } from '@angular/core';
 
 // Tailwind
-import colors from 'tailwindcss/colors';
+import * as defaultColors from 'tailwindcss/colors';
 import { DefaultColors } from 'tailwindcss/types/generated/colors';
 import { Meta } from '@angular/platform-browser';
+import { isPlatformBrowser } from '@angular/common';
+import { extendedColors } from '../../../theme.config';
 
 @Injectable({
 	providedIn: 'root',
 })
 export class ThemeService {
 	private meta = inject(Meta);
-	private platform = inject(PLATFORM_ID);
+	private platformId = inject(PLATFORM_ID);
 
 	pickColor(color: keyof DefaultColors, scale: number = 50) {
-		if (!colors[color]) {
+		if (!defaultColors[color]) {
 			throw new Error(`Color ${color} not found in Tailwind CSS config!`);
 		}
 
 		// @ts-expect-error - Este guard chequea la existencia de la escala en el color
-		if (!colors[color][scale.toString()]) {
+		if (!defaultColors[color][scale.toString()]) {
 			throw new Error(`Scale ${scale} not found in color ${color}!`);
 		}
 
 		// @ts-expect-error - En este punto tanto el color como la escala han sido validados
-		return colors[color][scale.toString()].toUpperCase();
+		return defaultColors[color][scale.toString()].toUpperCase();
 	}
 
 	addThemeColorTag() {
-		this.meta.addTag({ name: 'theme-color', content: 'hsl(21, 57%, 44%)' });
+		if (isPlatformBrowser(this.platformId)) {
+			this.meta.addTag({ name: 'theme-color', content: extendedColors['primary-500'] });
+		}
 	}
 }

--- a/src/app/providers/theme.service.ts
+++ b/src/app/providers/theme.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+
+// Tailwind
+import colors from 'tailwindcss/colors';
+import { DefaultColors } from 'tailwindcss/types/generated/colors';
+
+@Injectable({
+	providedIn: 'root',
+})
+export class ThemeService {
+	pickColor(color: keyof DefaultColors, scale: number = 50) {
+		return colors[color][200];
+	}
+}

--- a/src/app/providers/theme.service.ts
+++ b/src/app/providers/theme.service.ts
@@ -9,6 +9,16 @@ import { DefaultColors } from 'tailwindcss/types/generated/colors';
 })
 export class ThemeService {
 	pickColor(color: keyof DefaultColors, scale: number = 50) {
-		return colors[color][200];
+		if (!colors[color]) {
+			throw new Error(`Color ${color} not found in Tailwind CSS config!`);
+		}
+
+		// @ts-expect-error - Este guard chequea la existencia de la escala en el color
+		if (!colors[color][scale.toString()]) {
+			throw new Error(`Scale ${scale} not found in color ${color}!`);
+		}
+
+		// @ts-expect-error - En este punto tanto el color como la escala han sido validados
+		return colors[color][scale.toString()].toUpperCase();
 	}
 }

--- a/src/index.html
+++ b/src/index.html
@@ -5,9 +5,6 @@
 		<title>La Cuentoneta</title>
 		<meta name="format-detection" content="telephone=no" />
 		<meta name="msapplication-tap-highlight" content="no" />
-
-		<!-- TODO: #232: Corregir el theme-color como parte del trabajo de este issue. Asignar $primary-100 -->
-		<meta name="theme-color" content="hsl(218, 90%, 59%)" />
 		<meta name="author" content="Ramiro Olivencia" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,32 +1,12 @@
 import { createGlobPatternsForDependencies } from '@nx/angular/tailwind';
 import { join } from 'path';
 import { Config } from 'tailwindcss/types/config';
+import { extendedColors } from './theme.config';
 
 export default {
 	content: [join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'), ...createGlobPatternsForDependencies(__dirname)],
 	theme: {
-		colors: {
-			white: '#fff',
-			black: '#000',
-			'primary-100': 'hsl(9, 70%, 96%)',
-			'primary-200': 'hsl(11, 78%, 93%)',
-			'primary-300': 'hsl(24, 45%, 76%)',
-			'primary-400': 'hsl(25, 45%, 62%)',
-			'primary-500': 'hsl(21, 57%, 44%)',
-			'gray-50': 'hsl(0, 0%, 98%)',
-			'gray-100': 'hsl(240, 5%, 96%)',
-			'gray-200': 'hsl(240, 6%, 90%)',
-			'gray-300': 'hsl(240, 5%, 84%)',
-			'gray-400': 'hsl(240, 5%, 65%)',
-			'gray-500': 'hsl(240, 4%, 46%)',
-			'gray-600': 'hsl(240, 5%, 34%)',
-			'gray-700': 'hsl(240, 5%, 26%)',
-			'gray-800': 'hsl(240, 5%, 20%)',
-			'gray-900': 'hsl(240, 5%, 14%)',
-			'interactive-500': 'hsl(212, 70%, 45%)',
-			'interactive-600': 'hsl(212, 70%, 35%)',
-			'zinc-300': '#d4d4d8', // Utilizado formato hexadecimal por limitaciones de ngx-skeleton-loader
-		},
+		colors: extendedColors,
 		content: {
 			blank: '""',
 		},

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,8 +1,8 @@
-const { createGlobPatternsForDependencies } = require('@nx/angular/tailwind');
-const { join } = require('path');
+import { createGlobPatternsForDependencies } from '@nx/angular/tailwind';
+import { join } from 'path';
+import { Config } from 'tailwindcss/types/config';
 
-/** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
 	content: [join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'), ...createGlobPatternsForDependencies(__dirname)],
 	theme: {
 		colors: {
@@ -25,6 +25,7 @@ module.exports = {
 			'gray-900': 'hsl(240, 5%, 14%)',
 			'interactive-500': 'hsl(212, 70%, 45%)',
 			'interactive-600': 'hsl(212, 70%, 35%)',
+			'zinc-300': '#d4d4d8', // Utilizado formato hexadecimal por limitaciones de ngx-skeleton-loader
 		},
 		content: {
 			blank: '""',
@@ -60,12 +61,12 @@ module.exports = {
 				'5/4': '120%',
 			},
 			lineHeight: {
-				0: 0,
+				0: '0',
 			},
 			gridTemplateRows: {
 				'3-auto': 'repeat(3, auto)',
 			},
 		},
 	},
-	plugins: [{ cssnano: {} }],
-};
+	plugins: [],
+} satisfies Config;

--- a/theme.config.ts
+++ b/theme.config.ts
@@ -1,0 +1,22 @@
+export const extendedColors = {
+	white: '#fff',
+	black: '#000',
+	'primary-100': 'hsl(9, 70%, 96%)',
+	'primary-200': 'hsl(11, 78%, 93%)',
+	'primary-300': 'hsl(24, 45%, 76%)',
+	'primary-400': 'hsl(25, 45%, 62%)',
+	'primary-500': 'hsl(21, 57%, 44%)',
+	'gray-50': 'hsl(0, 0%, 98%)',
+	'gray-100': 'hsl(240, 5%, 96%)',
+	'gray-200': 'hsl(240, 6%, 90%)',
+	'gray-300': 'hsl(240, 5%, 84%)',
+	'gray-400': 'hsl(240, 5%, 65%)',
+	'gray-500': 'hsl(240, 4%, 46%)',
+	'gray-600': 'hsl(240, 5%, 34%)',
+	'gray-700': 'hsl(240, 5%, 26%)',
+	'gray-800': 'hsl(240, 5%, 20%)',
+	'gray-900': 'hsl(240, 5%, 14%)',
+	'interactive-500': 'hsl(212, 70%, 45%)',
+	'interactive-600': 'hsl(212, 70%, 35%)',
+	'zinc-300': '#d4d4d8', // Utilizado formato hexadecimal por limitaciones de ngx-skeleton-loader
+};


### PR DESCRIPTION
# Resumen
* Se remueven todas las definiciones de colores _hardcoded_ del proyecto, desarrollando nueva infraestructura para obtener colores definidos en la configuración de Tailwind.
* Implementado el uso de `ThemeService` a lo largo del proyecto para inyectar programáticamente los colores requeridos.