### PR TITLE
[#755] Agregar endpoint para obtener lista de story previews de un autor particular

### DIFF
--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -234,6 +234,11 @@ export default {
 			title: 'Reseña',
 			type: 'blockContent',
 		},
+		{
+			name: 'originalPublication',
+			title: 'Publicación original',
+			type: 'string',
+		},
 	],
 	initialValue: {
 		language: 'es',

--- a/src/api/_queries/story.query.ts
+++ b/src/api/_queries/story.query.ts
@@ -1,0 +1,24 @@
+export const storyPreviewCommonFields: string = `
+    'slug': slug.current,
+    title,
+    language,
+    badLanguage,
+    categories,
+    body[0...3],
+    approximateReadingTime,
+    mediaSources,
+`;
+
+export const storyCommonFields: string = `
+    'slug': slug.current,
+    title, 
+    language,
+    badLanguage,
+    epigraphs,
+    categories, 
+    body, 
+    review, 
+    originalPublication,
+    approximateReadingTime,
+    mediaSources,
+`;

--- a/src/api/_queries/storylist.query.ts
+++ b/src/api/_queries/storylist.query.ts
@@ -1,4 +1,5 @@
 import { authorForStoryCard } from './author.query';
+import { storyPreviewCommonFields } from './story.query';
 
 const tags = `
     'tags': tags[] -> {
@@ -40,16 +41,7 @@ const gridConfig = (config: 'previewGridConfig' | 'gridConfig') => `
             'publishingDate': publication.publishingDate,
             'published': publication.published,
             'story': publication.story->{
-                _id,
-                'slug': slug.current,
-                title,
-                badLanguage,
-                categories,
-                body[0...3],
-                review,
-                approximateReadingTime,
-                language,
-                mediaSources,
+                ${storyPreviewCommonFields}
             	${authorForStoryCard}
             }
         }

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -22,9 +22,9 @@ export function mapAuthor(rawAuthorData: any, language?: string): AuthorDTO {
 			flag: urlFor(rawAuthorData.nationality?.flag)?.url(),
 		},
 		resources: mapResources(rawAuthorData.resources),
-		imageUrl: rawAuthorData.image ? urlFor(rawAuthorData.image).url() : undefined,
+		imageUrl: rawAuthorData.image ? urlFor(rawAuthorData.image).url() : '',
 		name: rawAuthorData.name,
-		biography: rawAuthorData.biography,
+		biography: rawAuthorData.biography ? rawAuthorData.biography[language || baseLanguage!.id] : undefined,
 	};
 }
 
@@ -36,7 +36,7 @@ export function mapAuthorForStory(rawAuthorData: any, language?: string): Author
 			flag: urlFor(rawAuthorData.nationality?.flag)?.url(),
 		},
 		resources: mapResources(rawAuthorData.resources),
-		imageUrl: rawAuthorData.image ? urlFor(rawAuthorData.image).url() : undefined,
+		imageUrl: rawAuthorData.image ? urlFor(rawAuthorData.image).url() : '',
 		name: rawAuthorData.name,
 		biography: rawAuthorData.biography ? rawAuthorData.biography[language || baseLanguage!.id] : undefined,
 	};

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,7 +1,7 @@
 import authorController from './author/author.controller';
 import contentController from './content.controller';
 import ogController from './og.controller';
-import storyController from './story.controller';
+import storyController from './story/story.controller';
 import storylistController from './storylist.controller';
 
 export default [

--- a/src/api/story.service.ts
+++ b/src/api/story.service.ts
@@ -12,27 +12,21 @@ import { mapMediaSources } from './_utils/media-sources.functions';
 // Subqueries
 import { authorForStory } from './_queries/author.query';
 import { resourcesSubQuery } from './_queries/resources.query';
+import { storyCommonFields, storyPreviewCommonFields } from './_queries/story.query';
 
 export async function fetchByAuthorSlug(slug: string): Promise<StoryDTO[]> {
 	const query = groq`*[_type == 'story' && author->slug.current == '${slug}']
 						  {
-							  'slug': slug.current,
-							  title, 
-							  language,
-							  badLanguage,
-							  categories, 
-							  body[0...2], 
-							  approximateReadingTime,
-							  mediaSources,
-							  ${resourcesSubQuery},
-						  }`;
+							${storyPreviewCommonFields}
+							${resourcesSubQuery},
+						  } | order(title asc)`;
 
 	const result = await client.fetch(query, {});
 	const stories = [];
 
 	// Toma las publicaciones que fueron traídas en la consulta a Sanity y las mapea a una colección de publicaciones
 	for (const story of result) {
-		const { body, review, author, mediaSources, ...properties } = story;
+		const { body, review, mediaSources, ...properties } = story;
 
 		stories.push({
 			...properties,
@@ -49,18 +43,9 @@ export async function fetchByAuthorSlug(slug: string): Promise<StoryDTO[]> {
 export async function fetchForRead(slug: string): Promise<StoryDTO> {
 	const query = groq`*[_type == 'story' && slug.current == '${slug}']
                           {
-                              'slug': slug.current,
-                              title, 
-                              language,
-                              badLanguage,
-                              epigraphs,
-                              categories, 
-                              body, 
-                              review, 
-                              approximateReadingTime,
-                              mediaSources,
-                              ${resourcesSubQuery},
-							  ${authorForStory}
+							${storyCommonFields},
+                            ${resourcesSubQuery},
+							${authorForStory}
                           }[0]`;
 	const story = await client.fetch(query, {});
 

--- a/src/api/story/interfaces.ts
+++ b/src/api/story/interfaces.ts
@@ -1,0 +1,5 @@
+export interface StoryByAuthorSlugArgs {
+	slug: string;
+	limit: number;
+	offset: number;
+}

--- a/src/api/story/story.controller.ts
+++ b/src/api/story/story.controller.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import * as storyService from './story.service';
+import { StoryByAuthorSlugArgs } from './interfaces';
 
 const router = express.Router();
 
@@ -19,8 +20,14 @@ function storyBySlug(req: express.Request, res: express.Response, next: express.
 
 function storiesByAuthorSlug(req: express.Request, res: express.Response, next: express.NextFunction) {
 	const { slug } = req.params;
+	const { limit, offset } = req.query;
+	const args: StoryByAuthorSlugArgs = {
+		slug: slug as string,
+		limit: parseInt((limit ?? '0') as string),
+		offset: parseInt((offset ?? '0') as string),
+	};
 	storyService
-		.fetchByAuthorSlug(slug as string)
+		.fetchByAuthorSlug(args)
 		.then((result) => res.json(result))
 		.catch((err) => next(err));
 }

--- a/src/api/story/story.service.ts
+++ b/src/api/story/story.service.ts
@@ -1,21 +1,25 @@
 // Conexión a Sanity
-import { client } from './_helpers/sanity-connector';
+import { client } from '../_helpers/sanity-connector';
 import groq from 'groq';
 
 // Utilidades
-import { mapAuthorForStory, mapResources } from './_utils/functions';
+import { mapAuthorForStory, mapResources } from '../_utils/functions';
 
 // Modelos
 import { StoryDTO } from '@models/story.model';
-import { mapMediaSources } from './_utils/media-sources.functions';
+import { mapMediaSources } from '../_utils/media-sources.functions';
 
 // Subqueries
-import { authorForStory } from './_queries/author.query';
-import { resourcesSubQuery } from './_queries/resources.query';
-import { storyCommonFields, storyPreviewCommonFields } from './_queries/story.query';
+import { authorForStory } from '../_queries/author.query';
+import { resourcesSubQuery } from '../_queries/resources.query';
+import { storyCommonFields, storyPreviewCommonFields } from '../_queries/story.query';
 
-export async function fetchByAuthorSlug(slug: string): Promise<StoryDTO[]> {
-	const query = groq`*[_type == 'story' && author->slug.current == '${slug}']
+// Interfaces
+import { StoryByAuthorSlugArgs } from './interfaces';
+
+export async function fetchByAuthorSlug(args: StoryByAuthorSlugArgs): Promise<StoryDTO[]> {
+	const slice = `${args.offset * args.limit}...${(args.offset + 1) * args.limit - 1}`;
+	const query = groq`*[_type == 'story' && author->slug.current == '${args.slug}'][${slice}]
 						  {
 							${storyPreviewCommonFields}
 							${resourcesSubQuery},

--- a/src/api/story/story.service.ts
+++ b/src/api/story/story.service.ts
@@ -18,7 +18,7 @@ import { storyCommonFields, storyPreviewCommonFields } from '../_queries/story.q
 import { StoryByAuthorSlugArgs } from './interfaces';
 
 export async function fetchByAuthorSlug(args: StoryByAuthorSlugArgs): Promise<StoryDTO[]> {
-	const slice = `${args.offset * args.limit}...${(args.offset + 1) * args.limit - 1}`;
+	const slice = `${args.offset * args.limit}...${(args.offset + 1) * args.limit}`;
 	const query = groq`*[_type == 'story' && author->slug.current == '${args.slug}'][${slice}]
 						  {
 							${storyPreviewCommonFields}


### PR DESCRIPTION
# Resumen
* Agrega atributo `originalPublication`. al schema `story`.
* Agrega abstracciones `storyPreviewCommonFields` y `storyCommonFields` para consultas de stories y storylists.
* Remueve usos de `undefined` en función `mapAuthor()`.
* Reubica `story.service.ts` y `story.controller.ts` a nuevo directorio.
* Implementa controller y service para endpoint `api/story/author`
* Agrega `interfaces.ts` con nuevo signature para función `fetchByAuthorSlug()`.