### PR TITLE
[#724] Crear componente de visualización de íconos de recursos multimedia

### DIFF
--- a/src/app/components/media-resource-tags/media-resource-tags.component.spec.ts
+++ b/src/app/components/media-resource-tags/media-resource-tags.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MediaResourceTagsComponent } from './media-resource-tags.component';
+
+describe('MediaResourceTagsComponent', () => {
+	let component: MediaResourceTagsComponent;
+	let fixture: ComponentFixture<MediaResourceTagsComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [MediaResourceTagsComponent],
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(MediaResourceTagsComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/components/media-resource-tags/media-resource-tags.component.ts
+++ b/src/app/components/media-resource-tags/media-resource-tags.component.ts
@@ -1,0 +1,32 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Media } from '@models/media.model';
+
+@Component({
+	selector: 'cuentoneta-media-resource-tags',
+	standalone: true,
+	imports: [CommonModule],
+	template: ` @for (mediaResource of resources(); track $index) {
+		@switch (mediaResource.type) {
+			@case ('audioRecording') {
+				<div [title]="'Contiene material en formato audio'" class="h-6 w-6">
+					<img [alt]="'Contiene audio'" src="assets/svg/waveform.svg" />
+				</div>
+			}
+			@case ('spaceRecording') {
+				<div [title]="'Contiene material en formato Spaces de X'" class="h-6 w-6">
+					<img [alt]="'Contiene link a Spaces'" src="assets/svg/twitter.svg" />
+				</div>
+			}
+			@case ('youTubeVideo') {
+				<div [title]="'Contiene material en formato video de YouTube'" class="h-6 w-6">
+					<img [alt]="'Contiene video de YouTube'" class="video" src="assets/svg/video.svg" />
+				</div>
+			}
+		}
+	}`,
+	styles: ``,
+})
+export class MediaResourceTagsComponent {
+	resources = input<Media[]>([]);
+}

--- a/src/app/components/media-resource-tags/media-resource-tags.component.ts
+++ b/src/app/components/media-resource-tags/media-resource-tags.component.ts
@@ -9,18 +9,18 @@ import { Media } from '@models/media.model';
 	template: ` @for (mediaResource of resources(); track $index) {
 		@switch (mediaResource.type) {
 			@case ('audioRecording') {
-				<div [title]="'Contiene material en formato audio'" class="h-6 w-6">
-					<img [alt]="'Contiene audio'" src="assets/svg/waveform.svg" />
+				<div [title]="'Contiene narraciones en audio'" class="h-6 w-6">
+					<img [alt]="'Contiene narraciones en audio'" src="assets/svg/waveform.svg" />
 				</div>
 			}
 			@case ('spaceRecording') {
-				<div [title]="'Contiene material en formato Spaces de X'" class="h-6 w-6">
-					<img [alt]="'Contiene link a Spaces'" src="assets/svg/twitter.svg" />
+				<div [title]="'Contiene grabaciones de Spaces de X'" class="h-6 w-6">
+					<img [alt]="'Contiene grabaciones de Spaces de X'" src="assets/svg/twitter.svg" />
 				</div>
 			}
 			@case ('youTubeVideo') {
-				<div [title]="'Contiene material en formato video de YouTube'" class="h-6 w-6">
-					<img [alt]="'Contiene video de YouTube'" class="video" src="assets/svg/video.svg" />
+				<div [title]="'Contiene videos de YouTube'" class="h-6 w-6">
+					<img [alt]="'Contiene videos de YouTube'" class="video" src="assets/svg/video.svg" />
 				</div>
 			}
 		}

--- a/src/app/components/media-resource-tags/media-resource-tags.component.ts
+++ b/src/app/components/media-resource-tags/media-resource-tags.component.ts
@@ -25,7 +25,6 @@ import { Media } from '@models/media.model';
 			}
 		}
 	}`,
-	styles: ``,
 })
 export class MediaResourceTagsComponent {
 	resources = input<Media[]>([]);

--- a/src/app/components/publication-card/publication-card.component.html
+++ b/src/app/components/publication-card/publication-card.component.html
@@ -44,25 +44,7 @@
 						}
 					</div>
 				</div>
-				@for (mediaResource of story.media; track $index) {
-					@switch (mediaResource.type) {
-						@case ('audioRecording') {
-							<div [title]="'Contiene material en formato audio'" class="h-6 w-6">
-								<img [alt]="'Contiene audio'" src="assets/svg/waveform.svg" />
-							</div>
-						}
-						@case ('spaceRecording') {
-							<div [title]="'Contiene material en formato Spaces de X'" class="h-6 w-6">
-								<img [alt]="'Contiene link a Spaces'" src="assets/svg/twitter.svg" />
-							</div>
-						}
-						@case ('youTubeVideo') {
-							<div [title]="'Contiene material audiovisual'" class="h-6 w-6">
-								<img [alt]="'Contiene video'" class="video" src="assets/svg/video.svg" />
-							</div>
-						}
-					}
-				}
+				<cuentoneta-media-resource-tags [resources]="story.media" />
 			</footer>
 		}
 	} @else {

--- a/src/app/components/publication-card/publication-card.component.ts
+++ b/src/app/components/publication-card/publication-card.component.ts
@@ -9,6 +9,7 @@ import { StoryEditionDateLabelComponent } from '../story-edition-date-label/stor
 import { CommonModule, DatePipe, NgIf, NgOptimizedImage } from '@angular/common';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
+import { MediaResourceTagsComponent } from '../media-resource-tags/media-resource-tags.component';
 
 @Component({
 	selector: 'cuentoneta-publication-card',
@@ -22,6 +23,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 		StoryCardSkeletonComponent,
 		StoryEditionDateLabelComponent,
 		PortableTextParserComponent,
+		MediaResourceTagsComponent,
 	],
 	providers: [DatePipe],
 	changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.html
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.html
@@ -35,25 +35,7 @@
 							<h5 class="inter-body-sm-regular">
 								{{ publication.story.author.name }}
 							</h5>
-							@for (mediaResource of publication.story.media; track $index) {
-								@switch (mediaResource.type) {
-									@case ('audioRecording') {
-										<div [title]="'Contiene material en formato audio'" class="h-6 w-6">
-											<img [alt]="'Contiene audio'" src="assets/svg/waveform.svg" />
-										</div>
-									}
-									@case ('spaceRecording') {
-										<div [title]="'Contiene material en formato Spaces de X'" class="h-6 w-6">
-											<img [alt]="'Contiene link a Spaces'" src="assets/svg/twitter.svg" />
-										</div>
-									}
-									@case ('youTubeVideo') {
-										<div [title]="'Contiene material audiovisual'" class="h-6 w-6">
-											<img [alt]="'Contiene video'" class="video" src="assets/svg/video.svg" />
-										</div>
-									}
-								}
-							}
+							<cuentoneta-media-resource-tags [resources]="publication.story.media" />
 						</div>
 					} @else {
 						<ngx-skeleton-loader count="2" appearance="line" animation="false"></ngx-skeleton-loader>

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -6,12 +6,21 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
 import { RouterLink } from '@angular/router';
 import { NgIf, NgFor, CommonModule } from '@angular/common';
+import { MediaResourceTagsComponent } from '../media-resource-tags/media-resource-tags.component';
 
 @Component({
 	selector: 'cuentoneta-story-navigation-bar',
 	templateUrl: './story-navigation-bar.component.html',
 	standalone: true,
-	imports: [CommonModule, NgxSkeletonLoaderModule, NgIf, NgFor, RouterLink, StoryEditionDateLabelComponent],
+	imports: [
+		CommonModule,
+		NgxSkeletonLoaderModule,
+		NgIf,
+		NgFor,
+		RouterLink,
+		StoryEditionDateLabelComponent,
+		MediaResourceTagsComponent,
+	],
 })
 export class StoryNavigationBarComponent implements OnChanges {
 	@Input() displayedPublications: Publication<StoryCard>[] = [];


### PR DESCRIPTION
# Resumen
- Agregado nuevo componente `MediaResourceTagsComponent`, el cual lista los íconos a visualizar correspondientes a los distintos recursos multimedia adjuntos a una story.
- Agregados usos del componente en reemplazo de los usos de `@switch` duplicados.