### PR TITLE
[#760] - Abstraer en un componente los ítems navegables de StoryNavigationBar

### DIFF
--- a/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.spec.ts
+++ b/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NavigablePublicationTeaserComponent } from './navigable-publication-teaser.component';
+
+describe('NavigablePublicationTeaserComponent', () => {
+	let component: NavigablePublicationTeaserComponent;
+	let fixture: ComponentFixture<NavigablePublicationTeaserComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [NavigablePublicationTeaserComponent],
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(NavigablePublicationTeaserComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
+++ b/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
@@ -31,7 +31,7 @@ import { RouterLink } from '@angular/router';
 				class="bg-gray-50 px-7 py-5"
 			>
 				<cuentoneta-story-edition-date-label
-					[label]="publication().published ? getEditionLabel(publication()) : storylist().comingNextLabel"
+					[label]="publication().published ? publication().editionLabel : storylist().comingNextLabel"
 				/>
 				@if (publication().published) {
 					<h4 class="inter-body-sm-bold mb-2">{{ publication().story.title }}</h4>
@@ -53,15 +53,4 @@ export class NavigablePublicationTeaserComponent {
 	selected = input<boolean>();
 	storylist = input.required<Storylist>();
 	protected readonly appRouteTree = APP_ROUTE_TREE;
-
-	// ToDo: Separar card de cada cuento de la lista en su propio componente, para evitar usar un método en el template
-	getEditionLabel(publication: Publication<StoryCard>): string {
-		if (!this.storylist) {
-			return '';
-		}
-
-		return `${this.storylist()?.editionPrefix} ${this.publication().publishingOrder} ${
-			this.storylist()?.displayDates ? ' - ' + publication.publishingDate : ''
-		}`;
-	}
 }

--- a/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
+++ b/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
@@ -1,0 +1,67 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { APP_ROUTE_TREE } from '../../app.routes';
+import { MediaResourceTagsComponent } from '../media-resource-tags/media-resource-tags.component';
+import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
+import { StoryCard } from '@models/story.model';
+import { Publication, Storylist } from '@models/storylist.model';
+import { RouterLink } from '@angular/router';
+
+@Component({
+	selector: 'cuentoneta-navigable-publication-teaser',
+	standalone: true,
+	imports: [
+		CommonModule,
+		MediaResourceTagsComponent,
+		NgxSkeletonLoaderModule,
+		StoryEditionDateLabelComponent,
+		RouterLink,
+	],
+	template: `
+		<a
+			[routerLink]="
+				publication().published ? ['/' + appRouteTree['STORY'], publication().story.slug, storylist().slug] : null
+			"
+		>
+			<article
+				[ngClass]="{
+					'border-l-4 border-solid border-primary-400 bg-primary-100': selected()
+				}"
+				class="bg-gray-50 px-7 py-5"
+			>
+				<cuentoneta-story-edition-date-label
+					[label]="publication().published ? getEditionLabel(publication()) : storylist().comingNextLabel"
+				/>
+				@if (publication().published) {
+					<h4 class="inter-body-sm-bold mb-2">{{ publication().story.title }}</h4>
+					<div class="flex items-center justify-between">
+						<h5 class="inter-body-sm-regular">
+							{{ publication().story.author.name }}
+						</h5>
+						<cuentoneta-media-resource-tags [resources]="publication().story.media" />
+					</div>
+				} @else {
+					<ngx-skeleton-loader count="2" appearance="line" animation="false"></ngx-skeleton-loader>
+				}
+			</article>
+		</a>
+	`,
+})
+export class NavigablePublicationTeaserComponent {
+	publication = input.required<Publication<StoryCard>>();
+	selected = input<boolean>();
+	storylist = input.required<Storylist>();
+	protected readonly appRouteTree = APP_ROUTE_TREE;
+
+	// ToDo: Separar card de cada cuento de la lista en su propio componente, para evitar usar un método en el template
+	getEditionLabel(publication: Publication<StoryCard>): string {
+		if (!this.storylist) {
+			return '';
+		}
+
+		return `${this.storylist()?.editionPrefix} ${this.publication().publishingOrder} ${
+			this.storylist()?.displayDates ? ' - ' + publication.publishingDate : ''
+		}`;
+	}
+}

--- a/src/app/components/publication-card/publication-card.component.html
+++ b/src/app/components/publication-card/publication-card.component.html
@@ -5,7 +5,7 @@
 	@if (!!publication && publication.published) {
 		@if (publication.story; as story) {
 			<header [lang]="story.language" class="card-header">
-				<cuentoneta-story-edition-date-label [label]="editionLabel" />
+				<cuentoneta-story-edition-date-label [label]="publication.editionLabel" />
 			</header>
 			<section [lang]="story.language">
 				<h1 class="inter-body-xl-bold mb-1 overflow-hidden text-ellipsis whitespace-nowrap">{{ story.title }}</h1>
@@ -55,7 +55,7 @@
 			<cuentoneta-story-card-skeleton
 				[animation]="false"
 				[displayDate]="false"
-				[editionLabel]="editionLabel"
+				[editionLabel]="publication.editionLabel"
 				[comingNextLabel]="comingNextLabel"
 			/>
 		}

--- a/src/app/components/publication-card/publication-card.component.ts
+++ b/src/app/components/publication-card/publication-card.component.ts
@@ -29,22 +29,15 @@ import { MediaResourceTagsComponent } from '../media-resource-tags/media-resourc
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PublicationCardComponent implements OnInit {
-	@Input() editionPrefix: string | undefined;
-	@Input() editionSuffix: string | undefined;
 	@Input() comingNextLabel: string = '';
 	@Input() displayDate: boolean = false;
 	@Input() publication: Publication<StoryCard> | undefined;
-	@Input() editionIndex: number = 0;
-
-	editionLabel: string = '';
 
 	private datePipe = inject(DatePipe);
 
 	ngOnInit() {
 		const dateFormat = this.datePipe.transform(this.publication?.publishingDate, `dd 'de' MMMM, YYYY`);
-		this.editionLabel = `${this.editionPrefix} ${this.editionIndex} ${this.displayDate ? ' - ' + dateFormat : ''}${
-			this.editionSuffix ? ' | ' + this.editionSuffix : ''
-		}`;
+
 		this.comingNextLabel = this.displayDate ? `${this.comingNextLabel} ${dateFormat}` : this.comingNextLabel;
 	}
 }

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.html
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.html
@@ -11,37 +11,11 @@
 
 	@if (!!storylist) {
 		@for (publication of displayedPublications; track $index) {
-			<a
-				[routerLink]="
-					publication.published ? ['/' + appRouteTree['STORY'], publication.story.slug, storylist.slug] : null
-				"
-			>
-				<article
-					[ngClass]="{
-						'border-l-4 border-solid border-primary-400 bg-primary-100': selectedStorySlug === publication.story.slug
-					}"
-					class="bg-gray-50 px-7 py-5"
-				>
-					<cuentoneta-story-edition-date-label
-						[label]="
-							publication.published
-								? getEditionLabel(publication, publication.publishingOrder)
-								: storylist.comingNextLabel
-						"
-					/>
-					@if (publication.published) {
-						<h4 class="inter-body-sm-bold mb-2">{{ publication.story.title }}</h4>
-						<div class="flex items-center justify-between">
-							<h5 class="inter-body-sm-regular">
-								{{ publication.story.author.name }}
-							</h5>
-							<cuentoneta-media-resource-tags [resources]="publication.story.media" />
-						</div>
-					} @else {
-						<ngx-skeleton-loader count="2" appearance="line" animation="false"></ngx-skeleton-loader>
-					}
-				</article>
-			</a>
+			<cuentoneta-navigable-publication-teaser
+				[publication]="publication"
+				[selected]="selectedStorySlug === publication.story.slug"
+				[storylist]="storylist"
+			/>
 		}
 	} @else {
 		@for (skeleton of dummyList; track $index) {

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -1,12 +1,13 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Publication, Storylist } from '@models/storylist.model';
-import { Story, StoryCard } from '@models/story.model';
+import { StoryCard } from '@models/story.model';
 import { APP_ROUTE_TREE } from '../../app.routes';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
 import { RouterLink } from '@angular/router';
 import { NgIf, NgFor, CommonModule } from '@angular/common';
 import { MediaResourceTagsComponent } from '../media-resource-tags/media-resource-tags.component';
+import { NavigablePublicationTeaserComponent } from '../navigable-publication-teaser/navigable-publication-teaser.component';
 
 @Component({
 	selector: 'cuentoneta-story-navigation-bar',
@@ -20,6 +21,7 @@ import { MediaResourceTagsComponent } from '../media-resource-tags/media-resourc
 		RouterLink,
 		StoryEditionDateLabelComponent,
 		MediaResourceTagsComponent,
+		NavigablePublicationTeaserComponent,
 	],
 })
 export class StoryNavigationBarComponent implements OnChanges {
@@ -73,16 +75,5 @@ export class StoryNavigationBarComponent implements OnChanges {
 			upperIndex === publications.length ? publications.length - numberOfDisplayedPublications : lowerIndex,
 			lowerIndex === 0 ? numberOfDisplayedPublications : upperIndex,
 		);
-	}
-
-	// ToDo: Separar card de cada cuento de la lista en su propio componente, para evitar usar un método en el template
-	getEditionLabel(publication: Publication<StoryCard>, editionIndex: number = 0): string {
-		if (!this.storylist) {
-			return '';
-		}
-
-		return `${this.storylist?.editionPrefix} ${editionIndex} ${
-			this.storylist?.displayDates ? ' - ' + publication.publishingDate : ''
-		}`;
 	}
 }

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.html
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.html
@@ -116,13 +116,7 @@
 				"
 				class="xs:max-md:!col-span-1"
 			>
-				<cuentoneta-publication-card
-					[displayDate]="storylist.displayDates"
-					[editionPrefix]="storylist.editionPrefix"
-					[publication]="publication"
-					[editionIndex]="publication.publishingOrder"
-					[comingNextLabel]="storylist.comingNextLabel"
-				/>
+				<cuentoneta-publication-card [publication]="publication" [comingNextLabel]="storylist.comingNextLabel" />
 			</a>
 		}
 	}

--- a/src/app/models/landing-page-content.model.ts
+++ b/src/app/models/landing-page-content.model.ts
@@ -1,0 +1,4 @@
+export interface LandingPageContent<T> {
+	cards: T[];
+	previews: T[];
+}

--- a/src/app/models/storylist.model.ts
+++ b/src/app/models/storylist.model.ts
@@ -37,6 +37,7 @@ export interface StorylistDTO extends StorylistBase {
 
 export interface Publication<T extends StoryBase> {
 	publishingOrder: number;
+	editionLabel: string;
 	published: boolean;
 	publishingDate?: string;
 	story: T;

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -4,11 +4,12 @@ import { map, Observable } from 'rxjs';
 
 // Interfaces
 import { StorylistCardDeck, StorylistDeckConfig } from '@models/content.model';
-import { Storylist } from '@models/storylist.model';
+import { Storylist, StorylistDTO } from '@models/storylist.model';
 
 // Providers
 import { environment } from '../environments/environment';
 import { HttpClient } from '@angular/common/http';
+import { StorylistService } from './storylist.service';
 
 interface LandingPageContent {
 	cards: StorylistDeckConfig[];
@@ -23,13 +24,19 @@ export class ContentService {
 
 	// Services
 	private http = inject(HttpClient);
+	private storylistService = inject(StorylistService);
 
 	get contentConfig(): LandingPageContent {
 		return environment.contentConfig as LandingPageContent;
 	}
 
 	public getLandingPageContent(): Observable<{ cards: Storylist[]; previews: Storylist[] }> {
-		return this.http.get<{ cards: Storylist[]; previews: Storylist[] }>(`${this.prefix}/landing-page`);
+		return this.http.get<{ cards: StorylistDTO[]; previews: StorylistDTO[] }>(`${this.prefix}/landing-page`).pipe(
+			map((content) => ({
+				cards: content.cards.map((cards) => this.storylistService.mapStorylist(cards)),
+				previews: content.previews.map((preview) => this.storylistService.mapStorylist(preview)),
+			})),
+		);
 	}
 
 	// ToDo: Obtener listas de navs desde API

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -4,17 +4,13 @@ import { map, Observable } from 'rxjs';
 
 // Interfaces
 import { StorylistCardDeck, StorylistDeckConfig } from '@models/content.model';
-import { Storylist, StorylistDTO } from '@models/storylist.model';
+import { LandingPageContent } from '@models/landing-page-content.model';
 
+import { Storylist, StorylistDTO } from '@models/storylist.model';
 // Providers
 import { environment } from '../environments/environment';
 import { HttpClient } from '@angular/common/http';
 import { StorylistService } from './storylist.service';
-
-interface LandingPageContent {
-	cards: StorylistDeckConfig[];
-	previews: StorylistDeckConfig[];
-}
 
 @Injectable({
 	providedIn: 'root',
@@ -26,12 +22,12 @@ export class ContentService {
 	private http = inject(HttpClient);
 	private storylistService = inject(StorylistService);
 
-	get contentConfig(): LandingPageContent {
-		return environment.contentConfig as LandingPageContent;
+	get contentConfig(): LandingPageContent<StorylistDeckConfig> {
+		return environment.contentConfig as LandingPageContent<StorylistDeckConfig>;
 	}
 
-	public getLandingPageContent(): Observable<{ cards: Storylist[]; previews: Storylist[] }> {
-		return this.http.get<{ cards: StorylistDTO[]; previews: StorylistDTO[] }>(`${this.prefix}/landing-page`).pipe(
+	public getLandingPageContent(): Observable<LandingPageContent<Storylist>> {
+		return this.http.get<LandingPageContent<StorylistDTO>>(`${this.prefix}/landing-page`).pipe(
 			map((content) => ({
 				cards: content.cards.map((cards) => this.storylistService.mapStorylist(cards)),
 				previews: content.previews.map((preview) => this.storylistService.mapStorylist(preview)),
@@ -54,7 +50,7 @@ export class ContentService {
 	 * contienen la configuración y la correspondiente información para renderizar
 	 * los decks de previews y cards de cada storylist.
 	 */
-	public fetchStorylistDecks(): Observable<{ previews: StorylistCardDeck[]; cards: StorylistCardDeck[] }> {
+	public fetchStorylistDecks(): Observable<LandingPageContent<StorylistCardDeck>> {
 		const previewConfigs = this.contentConfig.previews;
 		const cardConfigs = this.contentConfig.cards;
 		const landingConfig$ = this.getLandingPageContent();


### PR DESCRIPTION
# Resumen
- Abstrae ítems de navegación de `StoryNavigationBar` a nuevo componente `NavigablePublicationTeaser`.
- Agrega propiedad `editionLabel` a interface `Publication`.
- Agrega métodos para mappear propiedad editionLabel.
- Abstrae interface `LandingPageContent` a nuevo archivo, agregándole genéricos.
- Agrega uso de campo editionLabel para publication cards y publication teasers.
