### PR TITLE
[#707] - Refactor de navegación a Stories asociadas a Storylists

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { Routes } from '@angular/router';
 // Guards
 import { redirectQueryParamsBasedStoryUrlsGuard } from './guards/redirect-query-params-based-story-urls.guard';
 import { redirectQueryParamsBasedStorylistUrlsGuard } from './guards/redirect-query-params-based-storylist-urls.guard';
+import { redirectParamsForStorylistInStoryRouteGuard } from './guards/redirect-params-for-storylist-in-story-route.guard';
 
 export enum AppRoutes {
 	Home = 'home',
@@ -18,8 +19,13 @@ export const appRoutes: Routes = [
 		loadComponent: () => import('./pages/home/home.component').then((m) => m.HomeComponent),
 	},
 	{
+		path: `${AppRoutes.Story}/:slug`,
+		loadComponent: () => import('./pages/story/story.component').then((m) => m.StoryComponent),
+	},
+	{
 		path: `${AppRoutes.Story}/:slug/:list`,
 		loadComponent: () => import('./pages/story/story.component').then((m) => m.StoryComponent),
+		canActivate: [redirectParamsForStorylistInStoryRouteGuard],
 	},
 	{
 		path: `${AppRoutes.Story}`, // Ruta definida por cuestiones de retrocompatibilidad. Redirecciona de '/story' con queryParams a params

--- a/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
+++ b/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
@@ -20,9 +20,8 @@ import { RouterLink } from '@angular/router';
 	],
 	template: `
 		<a
-			[routerLink]="
-				publication().published ? ['/' + appRoutes.Story, publication().story.slug, storylist().slug] : null
-			"
+			[routerLink]="publication().published ? ['/', appRoutes.Story, publication().story.slug] : null"
+			[queryParams]="{ navigation: 'storylist', slug: storylist().slug }"
 		>
 			<article
 				[ngClass]="{

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.html
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.html
@@ -1,42 +1,26 @@
 <section class="grid grid-cols-1 gap-y-0.5 rounded-xl bg-gray-200 shadow-lg">
-	<header [attr.aria-busy]="!storylist" [lang]="storylist?.language" class="bg-gray-50 px-7 py-5">
-		@if (!!storylist && storylist.title) {
-			<a [routerLink]="'/' + appRoutes.StoryList + '/' + storylist.slug">
-				<h3 class="h3 hover:text-interactive-500">{{ storylist.title }}</h3>
+	<header [attr.aria-busy]="isLoading" class="bg-gray-50 px-7 py-5">
+		@if (config.headerTitle) {
+			<a [routerLink]="config.navigationRoute.toString()">
+				<h3 class="h3 hover:text-interactive-500">{{ config.headerTitle }}</h3>
 			</a>
 		} @else {
 			<ng-container *ngTemplateOutlet="titleSkeleton"></ng-container>
 		}
 	</header>
 
-	@if (!!storylist) {
-		@for (publication of displayedPublications; track $index) {
-			<cuentoneta-navigable-publication-teaser
-				[publication]="publication"
-				[selected]="selectedStorySlug === publication.story.slug"
-				[storylist]="storylist"
-			/>
-		}
-	} @else {
-		@for (skeleton of dummyList; track $index) {
-			<article [attr.aria-busy]="true" class="bg-gray-50 px-7 py-5">
-				<ngx-skeleton-loader count="2" appearance="line"></ngx-skeleton-loader>
-			</article>
-		}
-	}
+	<ng-content></ng-content>
 
-	<!-- ToDo: #288 - Generar abstracción para evitar repetir lógica presente en el header (ver líneas 2 - 9)-->
-	@if (!!storylist && storylist.publications.length >= 10) {
-		<footer class="bg-gray-50 px-7 py-5">
-			@if (storylist) {
-				<a [routerLink]="'/' + appRoutes.StoryList + '/' + storylist.slug">
-					<h3 class="h3 inter-body-xl-bold hover:text-interactive-500">Ver más...</h3>
-				</a>
-			} @else {
-				<ng-container *ngTemplateOutlet="titleSkeleton"></ng-container>
-			}
-		</footer>
-	}
+	<footer class="bg-gray-50 px-7 py-5">
+		@if (!isLoading && config.showFooter) {
+			<a [routerLink]="config.navigationRoute.toString()">
+				<h3 class="h3 inter-body-xl-bold hover:text-interactive-500">Ver más...</h3>
+			</a>
+		}
+		@if (isLoading) {
+			<ng-container *ngTemplateOutlet="titleSkeleton"></ng-container>
+		}
+	</footer>
 </section>
 
 <ng-template #titleSkeleton>

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -1,79 +1,36 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { Publication, Storylist } from '@models/storylist.model';
-import { StoryCard } from '@models/story.model';
-import { AppRoutes } from '../../app.routes';
+import { AfterViewInit, Component, ContentChildren, QueryList } from '@angular/core';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
-import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
 import { RouterLink } from '@angular/router';
-import { NgIf, NgFor, CommonModule } from '@angular/common';
-import { MediaResourceTagsComponent } from '../media-resource-tags/media-resource-tags.component';
-import { NavigablePublicationTeaserComponent } from '../navigable-publication-teaser/navigable-publication-teaser.component';
+import { CommonModule } from '@angular/common';
+import {
+	NavigationBarConfig,
+	StorylistNavigationFrameComponent,
+} from '../storylist-navigation-frame/storylist-navigation-frame.component';
+import { combineLatest } from 'rxjs';
 
 @Component({
 	selector: 'cuentoneta-story-navigation-bar',
 	templateUrl: './story-navigation-bar.component.html',
 	standalone: true,
-	imports: [
-		CommonModule,
-		NgxSkeletonLoaderModule,
-		NgIf,
-		NgFor,
-		RouterLink,
-		StoryEditionDateLabelComponent,
-		MediaResourceTagsComponent,
-		NavigablePublicationTeaserComponent,
-	],
+	imports: [CommonModule, NgxSkeletonLoaderModule, RouterLink],
 })
-export class StoryNavigationBarComponent implements OnChanges {
-	@Input() displayedPublications: Publication<StoryCard>[] = [];
-	@Input() selectedStorySlug: string = '';
-	@Input() storylist: Storylist | undefined;
+export class StoryNavigationBarComponent implements AfterViewInit {
+	@ContentChildren(StorylistNavigationFrameComponent) frames: QueryList<StorylistNavigationFrameComponent> | undefined;
 
-	readonly appRoutes = AppRoutes;
-	dummyList: null[] = Array(10);
+	isLoading = false;
+	config: NavigationBarConfig = {
+		headerTitle: '',
+		footerTitle: '',
+		navigationRoute: '',
+		showFooter: false,
+	};
 
-	ngOnChanges(changes: SimpleChanges) {
-		const storylist: Storylist = changes['storylist'].currentValue;
-		if (!!storylist) {
-			this.sliceDisplayedPublications(storylist.publications);
-		}
-	}
-
-	/**
-	 * Este método se encarga de mostrar la lista de publicaciones de la navbar en base a la story actualmente en vista.
-	 * Si la storylist tiene más de 10 publicaciones, se muestran las 10 publicaciones más cercanas a la story actualmente
-	 * en vista tomando las 5 publicaciones anteriores y las 5 siguientes en el caso por defecto y ajustando los límites en
-	 * caso de que la story actualmente en vista sea una de las primeras o de las últimas.
-	 * @author Ramiro Olivencia <ramiro@olivencia.com.ar>
-	 */
-	sliceDisplayedPublications(publications: Publication<StoryCard>[]): void {
-		if (!this.storylist) {
-			return;
-		}
-
-		const numberOfDisplayedPublications = 10;
-
-		if (publications.length <= numberOfDisplayedPublications) {
-			this.displayedPublications = publications;
-			return;
-		}
-
-		const selectedStoryIndex = publications.findIndex(
-			(publication) => publication.story.slug === this.selectedStorySlug,
-		);
-
-		const lowerIndex =
-			selectedStoryIndex - numberOfDisplayedPublications / 2 < 0
-				? 0
-				: selectedStoryIndex - numberOfDisplayedPublications / 2;
-		const upperIndex =
-			selectedStoryIndex + numberOfDisplayedPublications / 2 > publications.length
-				? publications.length
-				: selectedStoryIndex + numberOfDisplayedPublications / 2;
-
-		this.displayedPublications = this.storylist.publications.slice(
-			upperIndex === publications.length ? publications.length - numberOfDisplayedPublications : lowerIndex,
-			lowerIndex === 0 ? numberOfDisplayedPublications : upperIndex,
-		);
+	ngAfterViewInit() {
+		this.frames?.forEach((frame) => {
+			combineLatest([frame.isLoading, frame.loaded]).subscribe(([loading, config]) => {
+				this.isLoading = loading;
+				this.config = config;
+			});
+		});
 	}
 }

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.html
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.html
@@ -109,9 +109,8 @@
 			<a
 				[ngStyle]="storiesCardConfig[publication.story.slug]"
 				[class.disabled]="!publication || !publication.published"
-				[routerLink]="
-					!!publication && publication.published ? ['/', appRoutes.Story, publication.story.slug, storylist.slug] : null
-				"
+				[routerLink]="!!publication && publication.published ? ['/', appRoutes.Story, publication.story.slug] : null"
+				[queryParams]="{ navigation: 'storylist', slug: storylist.slug }"
 				class="xs:max-md:!col-span-1"
 			>
 				<cuentoneta-publication-card [publication]="publication" [comingNextLabel]="storylist.comingNextLabel" />

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.spec.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StorylistNavigationFrameComponent } from './storylist-navigation-frame.component';
+
+describe('StorylistNavigationFrameComponent', () => {
+	let component: StorylistNavigationFrameComponent;
+	let fixture: ComponentFixture<StorylistNavigationFrameComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [StorylistNavigationFrameComponent],
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(StorylistNavigationFrameComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
@@ -74,28 +74,26 @@ export class StorylistNavigationFrameComponent {
 		const storylistService = inject(StorylistService);
 		const macroTaskWrapperService = inject(MacroTaskWrapperService);
 
-		const paramsObservable$ = activatedRoute.params;
-
-		const queryParamsObservable$ = this.fetchContentDirective.fetchContentWithSourceParams$(
-			activatedRoute.queryParams,
-			switchMap(({ navigation, slug }) => storylistService.get(slug, 9)),
-		);
-
-		const fetchObservable$ = combineLatest([paramsObservable$, queryParamsObservable$]).pipe(
-			tap(() => this.isLoading.emit(true)),
-			takeUntilDestroyed(),
-		);
+		const fetchObservable$ = this.fetchContentDirective
+			.fetchContentWithSourceParams$(
+				activatedRoute.queryParams,
+				switchMap(({ slug }) => storylistService.get(slug, 9)),
+			)
+			.pipe(
+				tap(() => this.isLoading.emit(true)),
+				takeUntilDestroyed(),
+			);
 
 		const content$ = isPlatformBrowser(platformId)
 			? fetchObservable$
-			: macroTaskWrapperService.wrapMacroTaskObservable<[Params, Storylist]>(
+			: macroTaskWrapperService.wrapMacroTaskObservable<Storylist>(
 					'StorylistNavigationFrameComponent.fetchData',
 					fetchObservable$,
 					null,
 					'first-emit',
 				);
 
-		content$.subscribe(([_, storylist]) => {
+		content$.subscribe((storylist) => {
 			this.storylist = storylist;
 			this.sliceDisplayedPublications(storylist.publications);
 			this.loaded.emit({

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
@@ -1,0 +1,148 @@
+import { Component, EventEmitter, inject, Input, Output, PLATFORM_ID } from '@angular/core';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { combineLatest, switchMap, tap } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Params, Router, UrlTree } from '@angular/router';
+
+// Directives
+import { FetchContentDirective } from '../../directives/fetch-content.directive';
+
+// Componentes
+import { NavigablePublicationTeaserComponent } from '../navigable-publication-teaser/navigable-publication-teaser.component';
+
+// Providers
+import { StorylistService } from '../../providers/storylist.service';
+import { MacroTaskWrapperService } from '../../providers/macro-task-wrapper.service';
+
+import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+// Models
+import { Story, StoryCard } from '@models/story.model';
+import { Publication, Storylist } from '@models/storylist.model';
+
+// Routes
+import { AppRoutes } from '../../app.routes';
+
+export type NavigationBarConfig = {
+	headerTitle: string;
+	footerTitle: string;
+	navigationRoute: UrlTree | string;
+	showFooter: boolean;
+};
+
+@Component({
+	selector: 'cuentoneta-storylist-navigation-frame',
+	standalone: true,
+	imports: [CommonModule, NavigablePublicationTeaserComponent, NgxSkeletonLoaderModule],
+	template: ` @if (!!storylist) {
+			@for (publication of displayedPublications; track $index) {
+				<cuentoneta-navigable-publication-teaser
+					[publication]="publication"
+					[selected]="selectedStorySlug === publication.story.slug"
+					[storylist]="storylist"
+				/>
+			}
+		} @else {
+			@for (skeleton of dummyList; track $index) {
+				<article [attr.aria-busy]="true" class="bg-gray-50 px-7 py-5">
+					<ngx-skeleton-loader count="2" appearance="line"></ngx-skeleton-loader>
+				</article>
+			}
+		}`,
+	styles: `
+		:host {
+			@apply grid grid-cols-1 gap-y-0.5 rounded-xl bg-gray-200 shadow-lg;
+		}
+	`,
+})
+export class StorylistNavigationFrameComponent {
+	@Input() selectedStorySlug: string = '';
+
+	@Output() isLoading = new EventEmitter<boolean>();
+	@Output() loaded = new EventEmitter<NavigationBarConfig>();
+
+	readonly appRoutes = AppRoutes;
+
+	displayedPublications: Publication<StoryCard>[] = [];
+	dummyList: null[] = Array(9);
+	fetchContentDirective = inject(FetchContentDirective<[Story, Storylist]>);
+	storylist: Storylist | undefined;
+
+	constructor() {
+		const router = inject(Router);
+		const platformId = inject(PLATFORM_ID);
+		const activatedRoute = inject(ActivatedRoute);
+		const storylistService = inject(StorylistService);
+		const macroTaskWrapperService = inject(MacroTaskWrapperService);
+
+		const paramsObservable$ = activatedRoute.params;
+
+		const queryParamsObservable$ = this.fetchContentDirective.fetchContentWithSourceParams$(
+			activatedRoute.queryParams,
+			switchMap(({ navigation, slug }) => storylistService.get(slug, 9)),
+		);
+
+		const fetchObservable$ = combineLatest([paramsObservable$, queryParamsObservable$]).pipe(
+			tap(() => this.isLoading.emit(true)),
+			takeUntilDestroyed(),
+		);
+
+		const content$ = isPlatformBrowser(platformId)
+			? fetchObservable$
+			: macroTaskWrapperService.wrapMacroTaskObservable<[Params, Storylist]>(
+					'StorylistNavigationFrameComponent.fetchData',
+					fetchObservable$,
+					null,
+					'first-emit',
+				);
+
+		content$.subscribe(([_, storylist]) => {
+			this.storylist = storylist;
+			this.sliceDisplayedPublications(storylist.publications);
+			this.loaded.emit({
+				headerTitle: storylist.title,
+				footerTitle: 'Ver más...',
+				navigationRoute: router.createUrlTree([this.appRoutes.StoryList, storylist.slug]),
+				showFooter: true,
+			});
+			this.isLoading.emit(false);
+		});
+	}
+
+	/**
+	 * Este método se encarga de mostrar la lista de publicaciones de la navbar en base a la story actualmente en vista.
+	 * Si la storylist tiene más de 10 publicaciones, se muestran las 10 publicaciones más cercanas a la story actualmente
+	 * en vista tomando las 5 publicaciones anteriores y las 5 siguientes en el caso por defecto y ajustando los límites en
+	 * caso de que la story actualmente en vista sea una de las primeras o de las últimas.
+	 * @author Ramiro Olivencia <ramiro@olivencia.com.ar>
+	 */
+	sliceDisplayedPublications(publications: Publication<StoryCard>[]): void {
+		if (!this.storylist) {
+			return;
+		}
+
+		const numberOfDisplayedPublications = 9;
+
+		if (publications.length <= numberOfDisplayedPublications) {
+			this.displayedPublications = publications;
+			return;
+		}
+
+		const selectedStoryIndex = publications.findIndex(
+			(publication) => publication.story.slug === this.selectedStorySlug,
+		);
+
+		const lowerIndex =
+			selectedStoryIndex - numberOfDisplayedPublications / 2 < 0
+				? 0
+				: selectedStoryIndex - Math.floor(numberOfDisplayedPublications / 2);
+		const upperIndex =
+			selectedStoryIndex + numberOfDisplayedPublications / 2 > publications.length
+				? publications.length
+				: Math.ceil(selectedStoryIndex + numberOfDisplayedPublications / 2);
+
+		this.displayedPublications = this.storylist.publications.slice(
+			upperIndex === publications.length ? publications.length - numberOfDisplayedPublications : lowerIndex,
+			lowerIndex === 0 ? numberOfDisplayedPublications : upperIndex,
+		);
+	}
+}

--- a/src/app/guards/redirect-params-for-storylist-in-story-route.guard.ts
+++ b/src/app/guards/redirect-params-for-storylist-in-story-route.guard.ts
@@ -1,9 +1,15 @@
-import type { ActivatedRouteSnapshot, UrlTree } from '@angular/router';
-import { createUrlTreeFromSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, Router, UrlTree } from '@angular/router';
+import { inject } from '@angular/core';
+import { AppRoutes } from '../app.routes';
 
 export const redirectParamsForStorylistInStoryRouteGuard = (activatedRoute: ActivatedRouteSnapshot): UrlTree => {
-	return createUrlTreeFromSnapshot(activatedRoute, [activatedRoute.queryParams['slug']], {
-		navigation: 'storylist',
-		slug: activatedRoute.queryParams['list'],
+	const router = inject(Router);
+	const appRoutes = AppRoutes;
+
+	return router.createUrlTree([appRoutes.Story, activatedRoute.params['slug']], {
+		queryParams: {
+			navigation: 'storylist',
+			slug: activatedRoute.params['list'],
+		},
 	});
 };

--- a/src/app/guards/redirect-params-for-storylist-in-story-route.guard.ts
+++ b/src/app/guards/redirect-params-for-storylist-in-story-route.guard.ts
@@ -1,0 +1,9 @@
+import type { ActivatedRouteSnapshot, UrlTree } from '@angular/router';
+import { createUrlTreeFromSnapshot } from '@angular/router';
+
+export const redirectParamsForStorylistInStoryRouteGuard = (activatedRoute: ActivatedRouteSnapshot): UrlTree => {
+	return createUrlTreeFromSnapshot(activatedRoute, [activatedRoute.queryParams['slug']], {
+		navigation: 'storylist',
+		slug: activatedRoute.queryParams['list'],
+	});
+};

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -1,9 +1,10 @@
 <aside class="hidden md:block">
 	@defer {
-		<cuentoneta-story-navigation-bar
-			[selectedStorySlug]="story?.slug ?? ''"
-			[storylist]="storylist"
-		></cuentoneta-story-navigation-bar>
+		<cuentoneta-story-navigation-bar>
+			<cuentoneta-storylist-navigation-frame
+				[selectedStorySlug]="story?.slug ?? ''"
+			></cuentoneta-storylist-navigation-frame>
+		</cuentoneta-story-navigation-bar>
 	}
 </aside>
 


### PR DESCRIPTION
# Resumen
- Agrega guard para retrocompatibilidad de definiciones previas de ruta `/story`.
- Reorganiza y desacopla código de componente `StoryNavigationBarComponent`, introduciendo una nueva estructura utilizando proyección del componente `StorylistFrameNavigationComponent` mediante ng-content.
- Actualiza definiciones de `routerLink` referidas a `/story` para acondicionarlas a nueva estructura de rutas.
- Desacopla tratamiento de request a `api/story`, ahora la única en `StoryComponent`, y request a `api/storylist` ahora en `StorylistFrameNavigationComponent`.