### PR TITLE
[#778] - Crear template para visualizar datos de perfil de autor y stories de su autoría

### DIFF
--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -1,11 +1,70 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { StoryService } from '../../providers/story.service';
+import { combineLatest, switchMap, tap } from 'rxjs';
+import { StoryCardComponent } from '../../components/story-card/story-card.component';
+import { AuthorService } from '../../providers/author.service';
+import { PortableTextParserComponent } from '../../components/portable-text-parser/portable-text-parser.component';
+import { ResourceComponent } from '../../components/resource/resource.component';
+import { Title } from '@angular/platform-browser';
 
 @Component({
 	selector: 'cuentoneta-author',
 	standalone: true,
-	imports: [CommonModule],
-	template: `<p>author works!</p>`,
-	styles: ``,
+	imports: [
+		CommonModule,
+		StoryCardComponent,
+		NgOptimizedImage,
+		PortableTextParserComponent,
+		ResourceComponent,
+		RouterLink,
+	],
+	template: ` <main>
+		<article class="grid grid-cols-1 gap-8">
+			<section class="flex flex-col items-center gap-4">
+				@if (author$ | async; as author) {
+					@if (author) {
+						<img [src]="author.imageUrl" class="h-[192px] rounded-xl" />
+						<div class="flex items-center gap-4">
+							<h1 class="h1">{{ author.name }}</h1>
+							<img [ngSrc]="author.nationality.flag" width="30" height="20" class="h-6 w-8" />
+						</div>
+						@if (author.resources && author.resources.length > 0) {
+							<div class="flex justify-start gap-4 sm:justify-end">
+								@for (resource of author.resources; track $index) {
+									<cuentoneta-resource [resource]="resource"></cuentoneta-resource>
+								}
+							</div>
+						}
+						<cuentoneta-portable-text-parser
+							[paragraphs]="author.biography!"
+							[classes]="'source-serif-pro-body-xl mb-8 leading-8'"
+						></cuentoneta-portable-text-parser>
+					}
+				}
+			</section>
+			<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 md:gap-8">
+				@if (stories$ | async; as stories) {
+					@for (story of stories; track $index) {
+						<cuentoneta-story-card [story]="story"></cuentoneta-story-card>
+					}
+				}
+			</section>
+		</article>
+	</main>`,
 })
-export class AuthorComponent {}
+export class AuthorComponent {
+	private activatedRoute = inject(ActivatedRoute);
+	private authorService = inject(AuthorService);
+	private storyService = inject(StoryService);
+	private title = inject(Title);
+
+	author$ = this.activatedRoute.params.pipe(
+		switchMap(({ slug }) => this.authorService.getBySlug(slug)),
+		tap((author) => this.title.setTitle(`${author.name} - Autor en La Cuentoneta`)),
+	);
+	stories$ = combineLatest([this.activatedRoute.params, this.activatedRoute.queryParams]).pipe(
+		switchMap(([{ slug }, { limit, offset }]) => this.storyService.getByAuthorSlug(slug, offset, limit)),
+	);
+}

--- a/src/app/providers/endpoints.ts
+++ b/src/app/providers/endpoints.ts
@@ -1,6 +1,6 @@
 export enum Endpoints {
 	Author = 'api/author',
-	Story = 'api/story/read',
+	Story = 'api/story',
 	StoryList = 'api/storylist',
 }
 

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -18,7 +18,7 @@ export class StoryService {
 	public getBySlug(slug: string): Observable<Story> {
 		const params = new HttpParams().set('slug', slug);
 
-		return this.http.get<StoryDTO>(this.url, { params }).pipe(map((story) => this.parseStoryContent(story)));
+		return this.http.get<StoryDTO>(`${this.url}/read`, { params }).pipe(map((story) => this.parseStoryContent(story)));
 	}
 
 	public getByAuthorSlug(slug: string, offset: number = 0, limit: number = 20): Observable<StoryCard[]> {


### PR DESCRIPTION
# Resumen
- Agrega template a `AuthorComponent` para visualizar perfil de usuario y stories de su autoría.
- Corrige definiciones de endpoints para obtener las stories de un autor en base a su slug.