### PR TITLE
[#786] - Agregar metatags para perfil de autor

### DIFF
--- a/src/app/directives/meta-tags.directive.ts
+++ b/src/app/directives/meta-tags.directive.ts
@@ -11,8 +11,8 @@ export class MetaTagsDirective {
 	private platformId = inject(PLATFORM_ID);
 	private titleService = inject(Title);
 
-	setTitle(title: string) {
-		const platformTitle = isPlatformBrowser(this.platformId) ? `${title} | La Cuentoneta` : title;
+	setTitle(title: string, addPrefix: boolean = true) {
+		const platformTitle = isPlatformBrowser(this.platformId) && addPrefix ? `${title} | La Cuentoneta` : title;
 		this.titleService.setTitle(`${platformTitle}`);
 		this.metaTagService.updateTag({
 			name: 'twitter:title',
@@ -38,5 +38,14 @@ export class MetaTagsDirective {
 			property: 'og:description',
 			content: content,
 		});
+	}
+
+	setDefault() {
+		this.setTitle('La Cuentoneta', false);
+		this.setDefaultDescription();
+	}
+
+	setDefaultDescription() {
+		this.setDescription('Una iniciativa que busca fomentar y hacer accesible la lectura digital.');
 	}
 }

--- a/src/app/directives/meta-tags.directive.ts
+++ b/src/app/directives/meta-tags.directive.ts
@@ -1,5 +1,6 @@
-import { Directive, inject } from '@angular/core';
+import { Directive, inject, PLATFORM_ID } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
+import { isPlatformBrowser } from '@angular/common';
 
 @Directive({
 	selector: '[cuentonetaMetaTags]',
@@ -7,10 +8,12 @@ import { Meta, Title } from '@angular/platform-browser';
 })
 export class MetaTagsDirective {
 	private metaTagService = inject(Meta);
+	private platformId = inject(PLATFORM_ID);
 	private titleService = inject(Title);
 
 	setTitle(title: string) {
-		this.titleService.setTitle(`${title} | La Cuentoneta`);
+		const platformTitle = isPlatformBrowser(this.platformId) ? `${title} | La Cuentoneta` : title;
+		this.titleService.setTitle(`${platformTitle}`);
 		this.metaTagService.updateTag({
 			name: 'twitter:title',
 			content: title,

--- a/src/app/directives/meta-tags.directive.ts
+++ b/src/app/directives/meta-tags.directive.ts
@@ -10,7 +10,7 @@ export class MetaTagsDirective {
 	private titleService = inject(Title);
 
 	setTitle(title: string) {
-		this.titleService.setTitle(title);
+		this.titleService.setTitle(`${title} | La Cuentoneta`);
 		this.metaTagService.updateTag({
 			name: 'twitter:title',
 			content: title,

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -1,10 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 
 @Component({
 	selector: 'cuentoneta-about',
 	standalone: true,
 	imports: [CommonModule, NgOptimizedImage],
+	hostDirectives: [MetaTagsDirective],
 	templateUrl: './about.component.html',
 })
 export class AboutComponent {
@@ -97,4 +99,10 @@ export class AboutComponent {
 			username: '@7SilviaT',
 		},
 	];
+
+	private metaTagsDirective = inject(MetaTagsDirective);
+	constructor() {
+		this.metaTagsDirective.setTitle('Nosotros');
+		this.metaTagsDirective.setDefaultDescription();
+	}
 }

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -7,9 +7,10 @@ import { StoryCardComponent } from '../../components/story-card/story-card.compo
 import { AuthorService } from '../../providers/author.service';
 import { PortableTextParserComponent } from '../../components/portable-text-parser/portable-text-parser.component';
 import { ResourceComponent } from '../../components/resource/resource.component';
-import { Title } from '@angular/platform-browser';
 import { StoryCard } from '@models/story.model';
 import { AppRoutes } from '../../app.routes';
+import { Author } from '@models/author.model';
+import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 
 @Component({
 	selector: 'cuentoneta-author',
@@ -22,6 +23,7 @@ import { AppRoutes } from '../../app.routes';
 		ResourceComponent,
 		RouterLink,
 	],
+	hostDirectives: [MetaTagsDirective],
 	template: ` <main>
 		<article class="grid grid-cols-1 gap-8">
 			<section class="flex flex-col items-center gap-4">
@@ -62,13 +64,13 @@ export class AuthorComponent {
 	// Providers
 	private activatedRoute = inject(ActivatedRoute);
 	private authorService = inject(AuthorService);
+	private metaTagsDirective = inject(MetaTagsDirective);
 	private storyService = inject(StoryService);
 	private router = inject(Router);
-	private title = inject(Title);
 
 	author$ = this.activatedRoute.params.pipe(
 		switchMap(({ slug }) => this.authorService.getBySlug(slug)),
-		tap((author) => this.title.setTitle(`${author.name} - Autor en La Cuentoneta`)),
+		tap((author) => this.updateMetaTags(author)),
 	);
 
 	stories$ = combineLatest([this.activatedRoute.params, this.activatedRoute.queryParams]).pipe(
@@ -84,4 +86,9 @@ export class AuthorComponent {
 			})) as (StoryCard & { navigationRoute: UrlTree })[];
 		}),
 	);
+
+	private updateMetaTags(author: Author) {
+		this.metaTagsDirective.setTitle(`${author.name}`);
+		this.metaTagsDirective.setDescription(`Perfil y obras de ${author.name} para leer en La Cuentoneta.`);
+	}
 }

--- a/src/app/pages/dmca/dmca.component.ts
+++ b/src/app/pages/dmca/dmca.component.ts
@@ -1,10 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 
 @Component({
 	selector: 'cuentoneta-dmca',
 	standalone: true,
 	imports: [CommonModule],
+	hostDirectives: [MetaTagsDirective],
 	template: `
 		<main class="mx-5 bg-gray-50 p-5 shadow-lg md:mx-0 md:rounded-xl md:p-15 lg:mt-28">
 			<h1 class="h1 mb-5">Disclaimer for La Cuentoneta</h1>
@@ -109,4 +111,10 @@ import { CommonModule } from '@angular/common';
 		</main>
 	`,
 })
-export class DmcaComponent {}
+export class DmcaComponent {
+	private metaTagsDirective = inject(MetaTagsDirective);
+	constructor() {
+		this.metaTagsDirective.setTitle('DMCA');
+		this.metaTagsDirective.setDefaultDescription();
+	}
+}

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -16,6 +16,8 @@ import { PublicationCardComponent } from '../../components/publication-card/publ
 import { StorylistCardDeckComponent } from 'src/app/components/storylist-card-deck/storylist-card-deck.component';
 import { RouterModule } from '@angular/router';
 import { StorylistCardComponent } from '../../components/storylist-card-component/storylist-card.component';
+import { MetaTagsDirective } from '../../directives/meta-tags.directive';
+import { Meta } from '@angular/platform-browser';
 
 @Component({
 	selector: 'cuentoneta-home',
@@ -29,7 +31,7 @@ import { StorylistCardComponent } from '../../components/storylist-card-componen
 		RouterModule,
 		StorylistCardComponent,
 	],
-	hostDirectives: [FetchContentDirective],
+	hostDirectives: [FetchContentDirective, MetaTagsDirective],
 })
 export class HomeComponent {
 	readonly appRoutes = AppRoutes;
@@ -37,14 +39,18 @@ export class HomeComponent {
 	cards: StorylistCardDeck[] = [];
 	previews: StorylistCardDeck[] = [];
 
-	// Services
+	// Directives
 	public fetchContentDirective = inject(FetchContentDirective);
+	private metaTagsDirective = inject(MetaTagsDirective);
+
+	// Services
 	private contentService = inject(ContentService);
 
 	constructor() {
 		// Asignación inicial para dibujar skeletons
 		this.cards = this.contentService.contentConfig.cards;
 		this.previews = this.contentService.contentConfig.previews;
+		this.metaTagsDirective.setDefault();
 
 		const platformId = inject(PLATFORM_ID);
 		if (!isPlatformBrowser(platformId)) {

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -98,9 +98,9 @@ export class StoryComponent {
 			.subscribe((story) => {
 				this.story = story;
 
-				metaTagsDirective.setTitle(`${story.title}, de ${story.author.name} en La Cuentoneta`);
+				metaTagsDirective.setTitle(`${story.title} - ${story.author.name}`);
 				metaTagsDirective.setDescription(
-					`"${story.title}", de ${story.author.name} en La Cuentoneta: Una iniciativa que busca fomentar y hacer accesible la lectura digital.`,
+					`Una lectura en La Cuentoneta: Una iniciativa que busca fomentar y hacer accesible la lectura digital.`,
 				);
 				this.shareContentParams = { slug: story.slug };
 				this.shareMessage = `Leí "${story.title}" de ${story.author.name} en La Cuentoneta y te lo comparto. Sumate a leer este y otros cuentos en este link:`;

--- a/src/app/pages/storylist/storylist.component.ts
+++ b/src/app/pages/storylist/storylist.component.ts
@@ -57,9 +57,9 @@ export class StorylistComponent {
 			)
 			.subscribe((storylist) => {
 				this.storylist = storylist;
-				metaTagsDirective.setTitle(`"${storylist.title}" en La Cuentoneta`);
+				metaTagsDirective.setTitle(`${storylist.title}`);
 				metaTagsDirective.setDescription(
-					`Colección "${storylist.title}", una storylist en La Cuentoneta: Una iniciativa que busca fomentar y hacer accesible la lectura digital.`,
+					`Una storylist en La Cuentoneta: Una iniciativa que busca fomentar y hacer accesible la lectura digital.`,
 				);
 			});
 	}


### PR DESCRIPTION
# Resumen
- Agregados metatags de Title y Description al acceder a un perfil de autor.
- Correcciones menores en meta tags de los demás componentes navegables.
- Agregado de nueva lógica y métodos para defaults en `MetaTagsDirective`.