### PR TITLE
[#690] - Simplificar representación en formato card para stories

### DIFF
--- a/cms/schemas/author.ts
+++ b/cms/schemas/author.ts
@@ -13,6 +13,7 @@ export default {
 			name: 'name',
 			title: 'Nombre',
 			type: 'string',
+			validation: (Rule) => Rule.required(),
 		},
 		{
 			name: 'slug',
@@ -37,12 +38,14 @@ export default {
 			options: {
 				hotspot: true,
 			},
+			validation: (Rule) => Rule.required(),
 		},
 		{
 			name: 'nationality',
 			title: 'Nacionalidad',
 			type: 'reference',
 			to: { type: 'nationality' },
+			validation: (Rule) => Rule.required(),
 		},
 		{
 			name: 'biography',

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -13,6 +13,7 @@ import { baseLanguage } from '../../../cms/utils/localization';
 import { AuthorDTO } from '@models/author.model';
 import { mapMediaSources } from './media-sources.functions';
 import { StorylistDTO } from '@models/storylist.model';
+import { Story, StoryPreview } from '@models/story.model';
 
 export function mapAuthor(rawAuthorData: any, language?: string): AuthorDTO {
 	return {
@@ -75,13 +76,13 @@ export async function mapStorylist(result: any): Promise<StorylistDTO> {
 		const { review, body, author, mediaSources, ...story } = publication.story;
 		publications.push({
 			...publication,
-			story: {
+			story: mapStoryPreviewContent({
 				...story,
 				media: mediaSources ? await mapMediaSources(mediaSources) : undefined,
 				summary: review,
 				paragraphs: body,
 				author: mapAuthorForStory(author),
-			},
+			}),
 		});
 	}
 
@@ -97,4 +98,34 @@ export async function mapStorylist(result: any): Promise<StorylistDTO> {
 					})),
 		publications: publications,
 	};
+}
+
+export function mapStoryContent(story: Story): Story {
+	return {
+		...story,
+		epigraphs: story.epigraphs ?? [],
+		paragraphs: story?.paragraphs ?? [],
+		summary: story?.summary ?? [],
+		author: {
+			...story.author,
+			biography: story.author.biography ?? [],
+		},
+		media: story.media ?? [],
+	};
+}
+
+export function mapStoryPreviewContent(story: StoryPreview): StoryPreview {
+	const card = {
+		...story,
+		paragraphs: story?.paragraphs ?? [],
+		media: story.media ?? [],
+		originalPublication: story.originalPublication ?? '',
+	};
+
+	if (story.author) {
+		card.author = {
+			...story.author,
+		};
+	}
+	return card;
 }

--- a/src/api/story/story.service.ts
+++ b/src/api/story/story.service.ts
@@ -6,7 +6,7 @@ import groq from 'groq';
 import { mapAuthorForStory, mapResources } from '../_utils/functions';
 
 // Modelos
-import { Story, StoryPreview } from '@models/story.model';
+import { Story, StoryBase } from '@models/story.model';
 import { mapMediaSources } from '../_utils/media-sources.functions';
 
 // Subqueries
@@ -17,7 +17,7 @@ import { storyCommonFields, storyPreviewCommonFields } from '../_queries/story.q
 // Interfaces
 import { StoryByAuthorSlugArgs } from './interfaces';
 
-export async function fetchByAuthorSlug(args: StoryByAuthorSlugArgs): Promise<StoryPreview[]> {
+export async function fetchByAuthorSlug(args: StoryByAuthorSlugArgs): Promise<StoryBase[]> {
 	const slice = `${args.offset * args.limit}...${(args.offset + 1) * args.limit}`;
 	const query = groq`*[_type == 'story' && author->slug.current == '${args.slug}'][${slice}]
 						  {

--- a/src/api/story/story.service.ts
+++ b/src/api/story/story.service.ts
@@ -6,7 +6,7 @@ import groq from 'groq';
 import { mapAuthorForStory, mapResources } from '../_utils/functions';
 
 // Modelos
-import { StoryDTO } from '@models/story.model';
+import { Story, StoryPreview } from '@models/story.model';
 import { mapMediaSources } from '../_utils/media-sources.functions';
 
 // Subqueries
@@ -17,7 +17,7 @@ import { storyCommonFields, storyPreviewCommonFields } from '../_queries/story.q
 // Interfaces
 import { StoryByAuthorSlugArgs } from './interfaces';
 
-export async function fetchByAuthorSlug(args: StoryByAuthorSlugArgs): Promise<StoryDTO[]> {
+export async function fetchByAuthorSlug(args: StoryByAuthorSlugArgs): Promise<StoryPreview[]> {
 	const slice = `${args.offset * args.limit}...${(args.offset + 1) * args.limit}`;
 	const query = groq`*[_type == 'story' && author->slug.current == '${args.slug}'][${slice}]
 						  {
@@ -44,7 +44,7 @@ export async function fetchByAuthorSlug(args: StoryByAuthorSlugArgs): Promise<St
 	return stories;
 }
 
-export async function fetchForRead(slug: string): Promise<StoryDTO> {
+export async function fetchForRead(slug: string): Promise<Story> {
 	const query = groq`*[_type == 'story' && slug.current == '${slug}']
                           {
 							${storyCommonFields},

--- a/src/api/story/story.service.ts
+++ b/src/api/story/story.service.ts
@@ -3,7 +3,7 @@ import { client } from '../_helpers/sanity-connector';
 import groq from 'groq';
 
 // Utilidades
-import { mapAuthorForStory, mapResources } from '../_utils/functions';
+import { mapAuthorForStory, mapResources, mapStoryContent } from '../_utils/functions';
 
 // Modelos
 import { Story, StoryBase } from '@models/story.model';
@@ -55,12 +55,12 @@ export async function fetchForRead(slug: string): Promise<Story> {
 
 	const { body, review, author, mediaSources, ...properties } = story;
 
-	return {
+	return mapStoryContent({
 		...properties,
 		media: await mapMediaSources(mediaSources),
 		author: mapAuthorForStory(author, properties.language),
 		resources: mapResources(properties.resources),
 		paragraphs: body,
 		summary: review,
-	};
+	});
 }

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
@@ -8,7 +8,7 @@ import { CommonModule } from '@angular/common';
 import { AppRoutes } from '../../app.routes';
 
 // Models
-import { StoryPreview } from '@models/story.model';
+import { StoryBase, StoryPreview } from '@models/story.model';
 
 // Providers
 import { StoryService } from '../../providers/story.service';
@@ -37,7 +37,7 @@ import { NavigableStoryTeaserComponent } from '../navigable-story-teaser/navigab
 	`,
 })
 export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
-	stories: StoryPreview[] = [];
+	stories: StoryBase[] = [];
 	authorSlug: string = '';
 
 	readonly appRoutes = AppRoutes;
@@ -52,7 +52,7 @@ export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
 				takeUntilDestroyed(),
 				switchMap(({ navigationSlug }) => {
 					this.authorSlug = navigationSlug;
-					return this.fetchContentDirective.fetchContent$<StoryPreview[]>(storyService.getByAuthorSlug(navigationSlug));
+					return this.fetchContentDirective.fetchContent$<StoryBase[]>(storyService.getByAuthorSlug(navigationSlug));
 				}),
 			)
 			.subscribe((stories) => {

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
@@ -8,7 +8,7 @@ import { CommonModule } from '@angular/common';
 import { AppRoutes } from '../../app.routes';
 
 // Models
-import { StoryCard } from '@models/story.model';
+import { StoryPreview } from '@models/story.model';
 
 // Providers
 import { StoryService } from '../../providers/story.service';
@@ -37,7 +37,7 @@ import { NavigableStoryTeaserComponent } from '../navigable-story-teaser/navigab
 	`,
 })
 export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
-	stories: StoryCard[] = [];
+	stories: StoryPreview[] = [];
 	authorSlug: string = '';
 
 	readonly appRoutes = AppRoutes;
@@ -52,7 +52,7 @@ export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
 				takeUntilDestroyed(),
 				switchMap(({ navigationSlug }) => {
 					this.authorSlug = navigationSlug;
-					return this.fetchContentDirective.fetchContent$<StoryCard[]>(storyService.getByAuthorSlug(navigationSlug));
+					return this.fetchContentDirective.fetchContent$<StoryPreview[]>(storyService.getByAuthorSlug(navigationSlug));
 				}),
 			)
 			.subscribe((stories) => {

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
@@ -8,7 +8,7 @@ import { CommonModule } from '@angular/common';
 import { AppRoutes } from '../../app.routes';
 
 // Models
-import { StoryBase, StoryPreview } from '@models/story.model';
+import { StoryBase } from '@models/story.model';
 
 // Providers
 import { StoryService } from '../../providers/story.service';

--- a/src/app/components/epigraph/epigraph.component.ts
+++ b/src/app/components/epigraph/epigraph.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component, effect, Input, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Epigraph } from '@models/epigraph.model';
+import { Epigraph } from '@models/story.model';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 
 @Component({

--- a/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
+++ b/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
@@ -4,7 +4,7 @@ import { AppRoutes } from '../../app.routes';
 import { MediaResourceTagsComponent } from '../media-resource-tags/media-resource-tags.component';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
-import { StoryCard } from '@models/story.model';
+import { StoryPreview } from '@models/story.model';
 import { Publication, Storylist } from '@models/storylist.model';
 import { RouterLink } from '@angular/router';
 
@@ -48,7 +48,7 @@ import { RouterLink } from '@angular/router';
 	`,
 })
 export class NavigablePublicationTeaserComponent {
-	publication = input.required<Publication<StoryCard>>();
+	publication = input.required<Publication<StoryPreview>>();
 	selected = input<boolean>();
 	storylist = input.required<Storylist>();
 	protected readonly appRoutes = AppRoutes;

--- a/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
+++ b/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
@@ -1,6 +1,6 @@
 import { Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { StoryPreview } from '@models/story.model';
+import { StoryBase, StoryPreview } from '@models/story.model';
 import { AppRoutes } from '../../app.routes';
 import { MediaResourceTagsComponent } from '../media-resource-tags/media-resource-tags.component';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
@@ -44,7 +44,7 @@ import { RouterLink } from '@angular/router';
 	`,
 })
 export class NavigableStoryTeaserComponent {
-	story = input.required<StoryPreview>();
+	story = input.required<StoryBase>();
 	selected = input<boolean>();
 	authorSlug = input.required<string>();
 	protected readonly appRoutes = AppRoutes;

--- a/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
+++ b/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
@@ -1,6 +1,6 @@
 import { Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { StoryCard } from '@models/story.model';
+import { StoryPreview } from '@models/story.model';
 import { AppRoutes } from '../../app.routes';
 import { MediaResourceTagsComponent } from '../media-resource-tags/media-resource-tags.component';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
@@ -44,7 +44,7 @@ import { RouterLink } from '@angular/router';
 	`,
 })
 export class NavigableStoryTeaserComponent {
-	story = input.required<StoryCard>();
+	story = input.required<StoryPreview>();
 	selected = input<boolean>();
 	authorSlug = input.required<string>();
 	protected readonly appRoutes = AppRoutes;

--- a/src/app/components/publication-card/publication-card.component.stories.ts
+++ b/src/app/components/publication-card/publication-card.component.stories.ts
@@ -13,7 +13,7 @@ registerLocaleData(localeEs);
 
 // Modelos
 import { Publication } from '@models/storylist.model';
-import { StoryCard } from '@models/story.model';
+import { StoryPreview } from '@models/story.model';
 
 export default {
 	title: 'PublicationCardComponent',
@@ -26,7 +26,7 @@ export default {
 	],
 } as Meta<PublicationCardComponent>;
 
-const publication: Publication<StoryCard> = {
+const publication: Publication<StoryPreview> = {
 	comingNextLabel: '',
 	publishingOrder: 60,
 	published: true,

--- a/src/app/components/publication-card/publication-card.component.ts
+++ b/src/app/components/publication-card/publication-card.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 // Modelos
-import { StoryCard } from '@models/story.model';
+import { StoryPreview } from '@models/story.model';
 import { Publication } from '@models/storylist.model';
 
 // Componentes
@@ -39,6 +39,6 @@ import { UrlTree } from '@angular/router';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PublicationCardComponent {
-	publication = input.required<Publication<StoryCard>>();
+	publication = input.required<Publication<StoryPreview>>();
 	navigationRoute = input.required<UrlTree>();
 }

--- a/src/app/components/story-card-content/story-card-content.component.ts
+++ b/src/app/components/story-card-content/story-card-content.component.ts
@@ -1,4 +1,4 @@
-import { Component, effect, input } from '@angular/core';
+import { Component, computed, effect, input } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
@@ -71,7 +71,7 @@ import { AppRoutes } from '../../app.routes';
 					>
 						<img
 							[alt]="'Retrato de ' + story().author.name"
-							[ngSrc]="story().author.imageUrl + '?h=40&w=40'"
+							[ngSrc]="authorImageUrl()"
 							class="mr-3 h-10 w-10 rounded"
 							width="40"
 							height="40"
@@ -82,7 +82,7 @@ import { AppRoutes } from '../../app.routes';
 								<div class="flex items-center">
 									<img
 										[alt]="'Bandera de ' + nationality.country"
-										[ngSrc]="nationality.flag + '?w=20&h=15'"
+										[ngSrc]="nationality.flag"
 										class="h-[15px] w-[20px] rounded"
 										width="20"
 										height="15"
@@ -104,6 +104,8 @@ export class StoryCardContentComponent {
 	story = input.required<StoryPreview>();
 	headerText = input<string>();
 	navigationLink = input<UrlTree>();
+
+	authorImageUrl = computed(() => this.story().author.imageUrl ?? 'assets/img/default-avatar.jpg');
 
 	protected readonly appRoutes = AppRoutes;
 }

--- a/src/app/components/story-card-content/story-card-content.component.ts
+++ b/src/app/components/story-card-content/story-card-content.component.ts
@@ -2,7 +2,7 @@ import { Component, effect, input } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
-import { StoryCard } from '@models/story.model';
+import { StoryPreview } from '@models/story.model';
 import { RouterLink, UrlTree } from '@angular/router';
 import { AppRoutes } from '../../app.routes';
 
@@ -101,7 +101,7 @@ import { AppRoutes } from '../../app.routes';
 	`,
 })
 export class StoryCardContentComponent {
-	story = input.required<StoryCard>();
+	story = input.required<StoryPreview>();
 	headerText = input<string>();
 	navigationLink = input<UrlTree>();
 

--- a/src/app/components/story-card-content/story-card-content.stories.ts
+++ b/src/app/components/story-card-content/story-card-content.stories.ts
@@ -8,7 +8,7 @@ import localeEs from '@angular/common/locales/es-419';
 registerLocaleData(localeEs);
 
 // Modelos
-import { StoryCard } from '@models/story.model';
+import { StoryPreview } from '@models/story.model';
 import { StoryCardContentComponent } from './story-card-content.component';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 import { provideRouter, RouterLink } from '@angular/router';
@@ -31,7 +31,7 @@ export default {
 	],
 } as Meta<StoryCardContentComponent>;
 
-const story: StoryCard = {
+const story: StoryPreview = {
 	originalPublication: 'Bar del Infierno (2005)',
 	language: 'Español',
 	approximateReadingTime: 4,

--- a/src/app/components/story-card/story-card.component.ts
+++ b/src/app/components/story-card/story-card.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, inject, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { StoryCard } from '@models/story.model';
+import { StoryPreview } from '@models/story.model';
 import { StoryCardContentComponent } from '../story-card-content/story-card-content.component';
 import { StoryCardSkeletonComponent } from '../story-card-skeleton/story-card-skeleton.component';
 import { Router, UrlTree } from '@angular/router';
@@ -18,7 +18,7 @@ import { AppRoutes } from '../../app.routes';
 	styles: ``,
 })
 export class StoryCardComponent {
-	story = input.required<StoryCard>();
+	story = input.required<StoryPreview>();
 	headerText = computed(() => this.story().originalPublication ?? '');
 	navigationRoute = input<UrlTree>();
 	computedRoute = computed(() => {

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
@@ -12,7 +12,7 @@ import { StorylistService } from '../../providers/storylist.service';
 
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 // Models
-import { StoryCard } from '@models/story.model';
+import { StoryPreview } from '@models/story.model';
 import { Publication, Storylist } from '@models/storylist.model';
 
 // Routes
@@ -54,7 +54,7 @@ export type NavigationBarConfig = {
 export class StorylistNavigationFrameComponent extends NavigationFrameComponent {
 	readonly appRoutes = AppRoutes;
 
-	displayedPublications: Publication<StoryCard>[] = [];
+	displayedPublications: Publication<StoryPreview>[] = [];
 	dummyList: null[] = Array(9);
 	storylist: Storylist | undefined;
 
@@ -89,7 +89,7 @@ export class StorylistNavigationFrameComponent extends NavigationFrameComponent 
 	 * caso de que la story actualmente en vista sea una de las primeras o de las últimas.
 	 * @author Ramiro Olivencia <ramiro@olivencia.com.ar>
 	 */
-	sliceDisplayedPublications(publications: Publication<StoryCard>[]): void {
+	sliceDisplayedPublications(publications: Publication<StoryPreview>[]): void {
 		if (!this.storylist) {
 			return;
 		}

--- a/src/app/models/epigraph.model.ts
+++ b/src/app/models/epigraph.model.ts
@@ -1,6 +1,0 @@
-import { BlockContent } from '@models/block-content.model';
-
-export interface Epigraph {
-	text: BlockContent[];
-	reference: string;
-}

--- a/src/app/models/epigraph.model.ts
+++ b/src/app/models/epigraph.model.ts
@@ -4,8 +4,3 @@ export interface Epigraph {
 	text: BlockContent[];
 	reference: string;
 }
-
-export interface EpigraphDTO {
-	text: BlockContent[];
-	reference: string;
-}

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -28,6 +28,6 @@ export interface StoryDTO extends StoryBase {
 	summary?: BlockContent[];
 }
 
-export interface StoryCard extends StoryBase {
+export interface StoryPreview extends StoryBase {
 	author: Omit<Author, 'biography'>;
 }

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -1,8 +1,8 @@
-import { Author, AuthorDTO } from './author.model';
+import { Author } from './author.model';
 import { BlockContent } from '@models/block-content.model';
 import { Media } from '@models/media.model';
 import { Resource } from '@models/resource.model';
-import { Epigraph, EpigraphDTO } from '@models/epigraph.model';
+import { Epigraph } from '@models/epigraph.model';
 
 export interface StoryBase {
 	title: string;
@@ -20,12 +20,6 @@ export interface Story extends StoryBase {
 	author: Author;
 	epigraphs: Epigraph[];
 	summary: BlockContent[];
-}
-
-export interface StoryDTO extends StoryBase {
-	author: AuthorDTO;
-	epigraphs: EpigraphDTO[];
-	summary?: BlockContent[];
 }
 
 export interface StoryPreview extends StoryBase {

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -2,7 +2,6 @@ import { Author } from './author.model';
 import { BlockContent } from '@models/block-content.model';
 import { Media } from '@models/media.model';
 import { Resource } from '@models/resource.model';
-import { Epigraph } from '@models/epigraph.model';
 
 export interface StoryBase {
 	title: string;
@@ -14,6 +13,11 @@ export interface StoryBase {
 	paragraphs: BlockContent[];
 	media: Media[];
 	originalPublication: string;
+}
+
+export interface Epigraph {
+	text: BlockContent[];
+	reference: string;
 }
 
 export interface Story extends StoryBase {

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -9,7 +9,7 @@ export interface StoryBase {
 	approximateReadingTime: number;
 	badLanguage?: boolean;
 	language: string;
-	resources?: Resource[];
+	resources: Resource[];
 	paragraphs: BlockContent[];
 	media: Media[];
 	originalPublication: string;

--- a/src/app/models/storylist.model.ts
+++ b/src/app/models/storylist.model.ts
@@ -1,4 +1,4 @@
-import { StoryBase, StoryPreview, StoryDTO } from './story.model';
+import { StoryBase, StoryPreview } from './story.model';
 import { SanityImageSource } from '@sanity/image-url/lib/types/types';
 import { Tag } from '@models/tag.model';
 
@@ -32,7 +32,7 @@ export interface Storylist extends StorylistBase {
 }
 
 export interface StorylistDTO extends StorylistBase {
-	publications: Publication<StoryDTO>[];
+	publications: Publication<StoryPreview>[];
 }
 
 export interface Publication<T extends StoryBase> {

--- a/src/app/models/storylist.model.ts
+++ b/src/app/models/storylist.model.ts
@@ -1,4 +1,4 @@
-import { StoryBase, StoryCard, StoryDTO } from './story.model';
+import { StoryBase, StoryPreview, StoryDTO } from './story.model';
 import { SanityImageSource } from '@sanity/image-url/lib/types/types';
 import { Tag } from '@models/tag.model';
 
@@ -28,7 +28,7 @@ interface StorylistBase {
 export type StorylistCard = Omit<StorylistBase, 'images' | 'previewImages' | 'gridConfig' | 'previewGridConfig'>;
 
 export interface Storylist extends StorylistBase {
-	publications: Publication<StoryCard>[];
+	publications: Publication<StoryPreview>[];
 }
 
 export interface StorylistDTO extends StorylistBase {

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -7,7 +7,7 @@ import { StoryCardComponent } from '../../components/story-card/story-card.compo
 import { AuthorService } from '../../providers/author.service';
 import { PortableTextParserComponent } from '../../components/portable-text-parser/portable-text-parser.component';
 import { ResourceComponent } from '../../components/resource/resource.component';
-import { StoryCard } from '@models/story.model';
+import { StoryPreview } from '@models/story.model';
 import { AppRoutes } from '../../app.routes';
 import { Author } from '@models/author.model';
 
@@ -98,7 +98,7 @@ export class AuthorComponent {
 				navigationRoute: this.router.createUrlTree(['/', this.appRoutes.Story, story.slug], {
 					queryParams: { navigation: 'author', navigationSlug: slug },
 				}),
-			})) as (StoryCard & { navigationRoute: UrlTree })[];
+			})) as (StoryPreview & { navigationRoute: UrlTree })[];
 		}),
 	);
 

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -2,7 +2,7 @@ import { Component, inject } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { ActivatedRoute, Router, RouterLink, UrlTree } from '@angular/router';
 import { StoryService } from '../../providers/story.service';
-import { combineLatest, delay, map, of, switchMap, tap } from 'rxjs';
+import { combineLatest, map, of, switchMap, tap } from 'rxjs';
 import { StoryCardComponent } from '../../components/story-card/story-card.component';
 import { AuthorService } from '../../providers/author.service';
 import { PortableTextParserComponent } from '../../components/portable-text-parser/portable-text-parser.component';
@@ -16,7 +16,6 @@ import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 import { FetchContentDirective } from '../../directives/fetch-content.directive';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { StoryCardSkeletonComponent } from '../../components/story-card-skeleton/story-card-skeleton.component';
-import { ThemeService } from '../../providers/theme.service';
 import { RepeatPipe } from '../../pipes/repeat.pipe';
 import { AuthorSkeletonComponent } from './author-skeleton.component';
 

--- a/src/app/providers/author.service.ts
+++ b/src/app/providers/author.service.ts
@@ -1,6 +1,6 @@
 // Core
 import { inject, Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 // Environment

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -1,6 +1,6 @@
 // Core
 import { inject, Injectable } from '@angular/core';
-import { map, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { HttpClient, HttpParams } from '@angular/common/http';
 
 // Environment

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -7,7 +7,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { environment } from '../environments/environment';
 
 // Models
-import { Story, StoryPreview, StoryDTO } from '@models/story.model';
+import { Story, StoryPreview } from '@models/story.model';
 import { ApiUrl, Endpoints } from './endpoints';
 
 @Injectable({ providedIn: 'root' })
@@ -18,17 +18,17 @@ export class StoryService {
 	public getBySlug(slug: string): Observable<Story> {
 		const params = new HttpParams().set('slug', slug);
 
-		return this.http.get<StoryDTO>(`${this.url}/read`, { params }).pipe(map((story) => this.parseStoryContent(story)));
+		return this.http.get<Story>(`${this.url}/read`, { params }).pipe(map((story) => this.parseStoryContent(story)));
 	}
 
 	public getByAuthorSlug(slug: string, offset: number = 0, limit: number = 20): Observable<StoryPreview[]> {
 		const params = new HttpParams().set('offset', offset).append('limit', limit);
 		return this.http
-			.get<StoryDTO[]>(`${this.url}/author/${slug}`, { params })
+			.get<StoryPreview[]>(`${this.url}/author/${slug}`, { params })
 			.pipe(map((stories) => stories.map((story) => this.parseStoryCardContent(story))));
 	}
 
-	public parseStoryCardContent(story: StoryDTO): StoryPreview {
+	public parseStoryCardContent(story: StoryPreview): StoryPreview {
 		const card = {
 			...story,
 			paragraphs: story?.paragraphs ?? [],
@@ -45,7 +45,7 @@ export class StoryService {
 		return card;
 	}
 
-	private parseStoryContent(story: StoryDTO): Story {
+	private parseStoryContent(story: Story): Story {
 		return {
 			...story,
 			epigraphs: story.epigraphs ?? [],

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -39,7 +39,6 @@ export class StoryService {
 		if (story.author) {
 			card.author = {
 				...story.author,
-				imageUrl: this.parseAvatarImageUrl(story.author.imageUrl),
 			};
 		}
 		return card;
@@ -53,14 +52,9 @@ export class StoryService {
 			summary: story?.summary ?? [],
 			author: {
 				...story.author,
-				imageUrl: this.parseAvatarImageUrl(story.author.imageUrl),
 				biography: story.author.biography ?? [],
 			},
 			media: story.media ?? [],
 		};
-	}
-
-	private parseAvatarImageUrl(imageUrl: string | undefined): string {
-		return imageUrl ?? 'assets/img/default-avatar.jpg';
 	}
 }

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -7,7 +7,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { environment } from '../environments/environment';
 
 // Models
-import { Story, StoryCard, StoryDTO } from '@models/story.model';
+import { Story, StoryPreview, StoryDTO } from '@models/story.model';
 import { ApiUrl, Endpoints } from './endpoints';
 
 @Injectable({ providedIn: 'root' })
@@ -21,14 +21,14 @@ export class StoryService {
 		return this.http.get<StoryDTO>(`${this.url}/read`, { params }).pipe(map((story) => this.parseStoryContent(story)));
 	}
 
-	public getByAuthorSlug(slug: string, offset: number = 0, limit: number = 20): Observable<StoryCard[]> {
+	public getByAuthorSlug(slug: string, offset: number = 0, limit: number = 20): Observable<StoryPreview[]> {
 		const params = new HttpParams().set('offset', offset).append('limit', limit);
 		return this.http
 			.get<StoryDTO[]>(`${this.url}/author/${slug}`, { params })
 			.pipe(map((stories) => stories.map((story) => this.parseStoryCardContent(story))));
 	}
 
-	public parseStoryCardContent(story: StoryDTO): StoryCard {
+	public parseStoryCardContent(story: StoryDTO): StoryPreview {
 		const card = {
 			...story,
 			paragraphs: story?.paragraphs ?? [],

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -7,7 +7,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { environment } from '../environments/environment';
 
 // Models
-import { Story, StoryPreview } from '@models/story.model';
+import { Story, StoryBase, StoryPreview } from '@models/story.model';
 import { ApiUrl, Endpoints } from './endpoints';
 
 @Injectable({ providedIn: 'root' })
@@ -17,15 +17,12 @@ export class StoryService {
 
 	public getBySlug(slug: string): Observable<Story> {
 		const params = new HttpParams().set('slug', slug);
-
 		return this.http.get<Story>(`${this.url}/read`, { params }).pipe(map((story) => this.parseStoryContent(story)));
 	}
 
-	public getByAuthorSlug(slug: string, offset: number = 0, limit: number = 20): Observable<StoryPreview[]> {
+	public getByAuthorSlug(slug: string, offset: number = 0, limit: number = 20): Observable<StoryBase[]> {
 		const params = new HttpParams().set('offset', offset).append('limit', limit);
-		return this.http
-			.get<StoryPreview[]>(`${this.url}/author/${slug}`, { params })
-			.pipe(map((stories) => stories.map((story) => this.parseStoryCardContent(story))));
+		return this.http.get<StoryBase[]>(`${this.url}/author/${slug}`, { params });
 	}
 
 	public parseStoryCardContent(story: StoryPreview): StoryPreview {

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -7,7 +7,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { environment } from '../environments/environment';
 
 // Models
-import { Story, StoryBase, StoryPreview } from '@models/story.model';
+import { Story, StoryBase } from '@models/story.model';
 import { ApiUrl, Endpoints } from './endpoints';
 
 @Injectable({ providedIn: 'root' })
@@ -17,41 +17,11 @@ export class StoryService {
 
 	public getBySlug(slug: string): Observable<Story> {
 		const params = new HttpParams().set('slug', slug);
-		return this.http.get<Story>(`${this.url}/read`, { params }).pipe(map((story) => this.parseStoryContent(story)));
+		return this.http.get<Story>(`${this.url}/read`, { params });
 	}
 
 	public getByAuthorSlug(slug: string, offset: number = 0, limit: number = 20): Observable<StoryBase[]> {
 		const params = new HttpParams().set('offset', offset).append('limit', limit);
 		return this.http.get<StoryBase[]>(`${this.url}/author/${slug}`, { params });
-	}
-
-	public parseStoryCardContent(story: StoryPreview): StoryPreview {
-		const card = {
-			...story,
-			paragraphs: story?.paragraphs ?? [],
-			media: story.media ?? [],
-			originalPublication: story.originalPublication ?? '',
-		};
-
-		if (story.author) {
-			card.author = {
-				...story.author,
-			};
-		}
-		return card;
-	}
-
-	private parseStoryContent(story: Story): Story {
-		return {
-			...story,
-			epigraphs: story.epigraphs ?? [],
-			paragraphs: story?.paragraphs ?? [],
-			summary: story?.summary ?? [],
-			author: {
-				...story.author,
-				biography: story.author.biography ?? [],
-			},
-			media: story.media ?? [],
-		};
 	}
 }

--- a/src/app/providers/storylist.service.ts
+++ b/src/app/providers/storylist.service.ts
@@ -17,7 +17,6 @@ export class StorylistService {
 	// Providers
 	private datePipe = inject(DatePipe);
 	private http = inject(HttpClient);
-	private storyService = inject(StoryService);
 
 	public get(slug: string, amount: number = 5, ordering: 'asc' | 'desc' = 'asc'): Observable<Storylist> {
 		const params = new HttpParams().set('slug', slug).set('amount', amount).set('ordering', ordering);
@@ -31,7 +30,6 @@ export class StorylistService {
 				...publication,
 				editionLabel: this.mapEditionLabel(publication, storylist),
 				comingNextLabel: this.mapComingNextLabel(publication, storylist),
-				story: this.storyService.parseStoryCardContent(publication.story),
 			})) as Publication<StoryPreview>[],
 		};
 	}

--- a/src/app/providers/storylist.service.ts
+++ b/src/app/providers/storylist.service.ts
@@ -4,7 +4,6 @@ import { Publication, Storylist, StorylistDTO } from '@models/storylist.model';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { StoryPreview } from '@models/story.model';
 import { environment } from '../environments/environment';
-import { StoryService } from './story.service';
 import { ApiUrl, Endpoints } from './endpoints';
 import { DatePipe } from '@angular/common';
 

--- a/src/app/providers/storylist.service.ts
+++ b/src/app/providers/storylist.service.ts
@@ -2,7 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { map, Observable } from 'rxjs';
 import { Publication, Storylist, StorylistDTO } from '@models/storylist.model';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { StoryCard } from '@models/story.model';
+import { StoryPreview } from '@models/story.model';
 import { environment } from '../environments/environment';
 import { StoryService } from './story.service';
 import { ApiUrl, Endpoints } from './endpoints';
@@ -32,11 +32,11 @@ export class StorylistService {
 				editionLabel: this.mapEditionLabel(publication, storylist),
 				comingNextLabel: this.mapComingNextLabel(publication, storylist),
 				story: this.storyService.parseStoryCardContent(publication.story),
-			})) as Publication<StoryCard>[],
+			})) as Publication<StoryPreview>[],
 		};
 	}
 
-	private mapEditionLabel(publication: Publication<StoryCard>, storylist: Storylist): string {
+	private mapEditionLabel(publication: Publication<StoryPreview>, storylist: Storylist): string {
 		let result = `${storylist.editionPrefix} ${publication.publishingOrder}`;
 
 		if (storylist.displayDates) {
@@ -47,7 +47,7 @@ export class StorylistService {
 		return result;
 	}
 
-	private mapComingNextLabel(publication: Publication<StoryCard>, storylist: Storylist): string {
+	private mapComingNextLabel(publication: Publication<StoryPreview>, storylist: Storylist): string {
 		let result = `${storylist.comingNextLabel}`;
 
 		if (storylist.displayDates) {


### PR DESCRIPTION
# Resumen
- Renombra tipo `StoryCard` a `StoryPreview`.
- Asigna tipo `StoryBase` a requests que obtienen stories sin información de autores y a componentes que manipulan stories sin información de autores (`AuthorComponent`, `AuthorNavigationFrameComponent`, `NavigableStoryTeaserComponent`).
- Mueve funciones de mappeo para generación de objetos story previews y stories al backend en `functions.ts` desde los métodos de `StoryService`.

## Otros cambios
- Agrega restricciones para campos en schema `author`.
- Mueve modelo `Epigraph` al archivo `story.model.ts`.
- Elimina método `parseAvatarImageUrl` de asignación de avatar por default en `StoryService`, reemplazándolo en `StoryCardContent` por una propiedad computed.