### PR TITLE
[#867] Reemplaza inputs basados en signals en `TooltipDirective` por writable signals

### DIFF
--- a/src/app/components/badge/badge.component.ts
+++ b/src/app/components/badge/badge.component.ts
@@ -31,7 +31,7 @@ export class BadgeComponent implements OnInit {
 	private tooltipDirective = inject(TooltipDirective);
 
 	ngOnInit() {
-		this.tooltipDirective.text = this.tag.description;
-		this.tooltipDirective.position = 'top';
+		this.tooltipDirective.text.set(this.tag.description);
+		this.tooltipDirective.position.set('top');
 	}
 }

--- a/src/app/components/resource/resource.component.ts
+++ b/src/app/components/resource/resource.component.ts
@@ -39,7 +39,7 @@ export class ResourceComponent implements OnInit {
 	private tooltipDirective = inject(TooltipDirective);
 
 	ngOnInit() {
-		this.tooltipDirective.text = this.resource.title;
-		this.tooltipDirective.position = 'bottom';
+		this.tooltipDirective.text.set(this.resource.title);
+		this.tooltipDirective.position.set('bottom');
 	}
 }

--- a/src/app/directives/tooltip.directive.ts
+++ b/src/app/directives/tooltip.directive.ts
@@ -1,14 +1,16 @@
-import { Directive, ElementRef, HostListener, input, OnDestroy } from '@angular/core';
+import { Directive, ElementRef, HostListener, input, OnDestroy, signal } from '@angular/core';
 import { computePosition, flip, shift, arrow, offset } from '@floating-ui/dom';
+
+type TooltipPosition = 'top' | 'right' | 'bottom' | 'left';
 
 @Directive({
 	selector: '[cuentonetaTooltip]',
 	standalone: true,
 })
 export class TooltipDirective implements OnDestroy {
-	text = input.required<string>(); // Texto para el Tooltip
-	position = input.required<'top' | 'right' | 'bottom' | 'left'>(); // Posición del tooltip
-	offset = input(6); // Offset del tooltip respecto al elemento
+	text = signal<string>(''); // Texto para el Tooltip
+	position = signal<TooltipPosition>('top'); // Posición del tooltip
+	offset = signal<number>(6); // Offset del tooltip respecto al elemento
 
 	private myPopup: HTMLElement | null = null;
 


### PR DESCRIPTION
# Resumen
- Reemplaza `InputSignals` por `WritableSignals` en `tooltip.directive.ts`.
- Modifica `BadgeComponent` y `ResourceComponent` para hacer uso de la nueva API de TooltipDirective.