### PR TITLE
[#802]`- Migrar schema `tag` definido en `cms/schemas/tag.ts`

### DIFF
--- a/cms/schemas/tag.ts
+++ b/cms/schemas/tag.ts
@@ -1,7 +1,8 @@
 import { TagIcon } from '@sanity/icons';
 import { preview } from 'sanity-plugin-icon-picker';
+import { defineField, defineType } from 'sanity';
 
-export default {
+export default defineType({
 	name: 'tag',
 	title: 'Etiquetas',
 	type: 'document',
@@ -22,13 +23,13 @@ export default {
 		},
 	},
 	fields: [
-		{
+		defineField({
 			name: 'title',
 			title: 'Título',
 			type: 'string',
 			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({
 			name: 'slug',
 			title: 'Slug',
 			type: 'slug',
@@ -37,20 +38,15 @@ export default {
 				maxLength: 96,
 			},
 			validation: (Rule) => Rule.required(),
-		},
-		{
-			name: 'description',
-			title: 'Descripción',
-			type: 'string',
-			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({ name: 'description', title: 'Descripción', type: 'string', validation: (Rule) => Rule.required() }),
+		defineField({
 			name: 'icon',
 			title: 'Icono',
 			type: 'iconPicker',
 			options: {
 				storeSvg: true,
 			},
-		},
+		}),
 	],
-};
+});

--- a/cms/schemas/tag.ts
+++ b/cms/schemas/tag.ts
@@ -11,14 +11,13 @@ export default defineType({
 		select: {
 			title: 'title',
 			description: 'description',
-			provider: 'icon.provider',
-			name: 'icon.name',
+			icon: 'icon',
 		},
 		prepare(selection) {
 			return {
 				title: selection.title,
 				subtitle: selection.description,
-				media: preview(selection),
+				media: preview(selection.icon),
 			};
 		},
 	},


### PR DESCRIPTION
# Resumen
- Se hace uso de `defineType` y `defineConfig` para definir el schema `tag`.
- Se corrige definición de preview y función prepare, en base a nueva información de tipado surgida con la redefinición del schema.