### PR TITLE
[#801] - Tipar schema storylist definido en `cms/schemas/storylist.ts`

### DIFF
--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -1,5 +1,6 @@
 import { supportedLanguages } from '../utils/localization';
 import { DashboardIcon } from '@sanity/icons';
+import { defineType } from 'sanity';
 
 const gridItemFields = [
 	{
@@ -152,7 +153,7 @@ const gridConfigfields = [
 	},
 ];
 
-export default {
+export default defineType({
 	name: 'storylist',
 	title: 'Storylists',
 	type: 'document',
@@ -211,7 +212,7 @@ export default {
 			description:
 				'Prefijo usado para identificar qué representa cada historia en una Storylist (día, edición, historia, etc.)',
 			type: 'string',
-			default: 'Edición',
+			initialValue: 'Edición',
 		},
 		{
 			name: 'featuredImage',
@@ -265,4 +266,4 @@ export default {
 		comingNextLabel: 'Próximamente',
 		language: 'Español',
 	},
-};
+});

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -67,7 +67,7 @@ const gridConfigFields = [
 						endCol: 'endCol',
 					},
 					prepare(selection) {
-						const { order, publicationOrder, storyTitle, image, imageSlug, startCol, endCol } = selection;
+						const { order, publicationOrder, storyTitle, image, imageSlug, endCol } = selection;
 
 						// Preview para stories en grid
 						const title = `${image ? imageSlug : storyTitle}`;

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -1,52 +1,52 @@
 import { supportedLanguages } from '../utils/localization';
 import { DashboardIcon } from '@sanity/icons';
-import { defineType } from 'sanity';
+import { defineField, defineType } from 'sanity';
 
 const gridItemFields = [
-	{
+	defineField({
 		name: 'order',
 		title: 'Orden',
 		description: 'Orden utilizado internamente por CSS Grid para renderizar el elemento',
 		type: 'number',
 		validation: (Rule) => Rule.required(),
-	},
-	{
+	}),
+	defineField({
 		name: 'startCol',
 		title: 'Columna inicial en CSS Grid',
 		type: 'string',
-	},
-	{
+	}),
+	defineField({
 		name: 'endCol',
 		title: 'Columna final en CSS Grid',
 		type: 'string',
-	},
-	{
+	}),
+	defineField({
 		name: 'startRow',
 		title: 'Fila inicial en CSS Grid',
 		type: 'string',
-	},
-	{
+	}),
+	defineField({
 		name: 'endRow',
 		title: 'Fila final en CSS Grid',
 		type: 'string',
-	},
+	}),
 ];
 
 const gridConfigfields = [
-	{
+	defineField({
 		name: 'gridTemplateColumns',
 		title: 'Template de columnas en CSS Grid (grid-template-columns)',
 		type: 'string',
 		description: 'Ejemplo: "repeat(3, 1fr)", "repeat(12, 1fr), etc.',
 		initialValue: 'repeat(3, 1fr)',
-	},
-	{
+	}),
+	defineField({
 		name: 'titlePlacement',
 		title: 'Posición del título',
 		type: 'object',
 		fields: [...gridItemFields],
-	},
-	{
+	}),
+	defineField({
 		name: 'cardsPlacement',
 		description:
 			'Posiciones de las tarjetas y las imágenes alusivas de la storylist, con su orden de renderizado y extensión en columnas y filas dentro del layout de CSS Grid',
@@ -150,7 +150,7 @@ const gridConfigfields = [
 				},
 			},
 		],
-	},
+	}),
 ];
 
 export default defineType({
@@ -159,12 +159,12 @@ export default defineType({
 	type: 'document',
 	icon: DashboardIcon,
 	fields: [
-		{
+		defineField({
 			name: 'title',
 			title: 'Título',
 			type: 'string',
-		},
-		{
+		}),
+		defineField({
 			name: 'slug',
 			title: 'Slug',
 			type: 'slug',
@@ -173,13 +173,13 @@ export default defineType({
 				maxLength: 96,
 			},
 			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({
 			name: 'description',
 			title: 'Descripción',
 			type: 'text',
-		},
-		{
+		}),
+		defineField({
 			name: 'language',
 			title: 'Idioma',
 			type: 'string',
@@ -191,38 +191,38 @@ export default defineType({
 				layout: 'radio',
 			},
 			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({
 			name: 'displayDates',
 			title: 'Mostrar fechas',
 			type: 'boolean',
 			initialValue: false,
-		},
-		{
+		}),
+		defineField({
 			name: 'comingNextLabel',
 			title: 'Etiqueta de "Próximo"',
 			description:
 				'Etiqueta que se mostrará en una publicación programada dentro de una storylist pero que aún no ha sido publicada.',
 			type: 'string',
 			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({
 			name: 'editionPrefix',
 			title: 'Prefijo de edición',
 			description:
 				'Prefijo usado para identificar qué representa cada historia en una Storylist (día, edición, historia, etc.)',
 			type: 'string',
 			initialValue: 'Edición',
-		},
-		{
+		}),
+		defineField({
 			name: 'featuredImage',
 			title: 'Imagen destacada',
 			type: 'image',
 			options: {
 				hotspot: true,
 			},
-		},
-		{
+		}),
+		defineField({
 			name: 'tags',
 			title: 'Etiquetas',
 			type: 'array',
@@ -234,14 +234,14 @@ export default defineType({
 					to: [{ type: 'tag' }],
 				},
 			],
-		},
-		{
+		}),
+		defineField({
 			name: 'gridConfig',
 			title: 'Configuración de vista completa de Storylist en layout de CSS Grid',
 			type: 'object',
 			fields: [...gridConfigfields],
-		},
-		{
+		}),
+		defineField({
 			name: 'previewGridConfig',
 			title: 'Configuración de vista previa de Storylist en layout de CSS Grid',
 			type: 'object',
@@ -260,7 +260,7 @@ export default defineType({
 					},
 				},
 			],
-		},
+		}),
 	],
 	initialValue: {
 		comingNextLabel: 'Próximamente',

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -32,7 +32,7 @@ const gridItemFields = [
 	}),
 ];
 
-const gridConfigfields = [
+const gridConfigFields = [
 	defineField({
 		name: 'gridTemplateColumns',
 		title: 'Template de columnas en CSS Grid (grid-template-columns)',
@@ -239,14 +239,14 @@ export default defineType({
 			name: 'gridConfig',
 			title: 'Configuración de vista completa de Storylist en layout de CSS Grid',
 			type: 'object',
-			fields: [...gridConfigfields],
+			fields: [...gridConfigFields],
 		}),
 		defineField({
 			name: 'previewGridConfig',
 			title: 'Configuración de vista previa de Storylist en layout de CSS Grid',
 			type: 'object',
 			fields: [
-				...gridConfigfields,
+				...gridConfigFields,
 				{
 					name: 'ordering',
 					title: 'Orden de publicaciones',

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -86,7 +86,7 @@ const gridConfigFields = [
 						title: 'Publicación de Cuento/Texto/Historia dentro de la storylist',
 						type: 'object',
 						fields: [
-							{
+							defineField({
 								name: 'story',
 								title: 'Referencia a historia',
 								type: 'reference',
@@ -101,8 +101,8 @@ const gridConfigFields = [
 									},
 									disableNew: true,
 								},
-							},
-							{
+							}),
+							defineField({
 								name: 'published',
 								title: '¿Publicado?',
 								description:
@@ -110,19 +110,19 @@ const gridConfigFields = [
 								type: 'boolean',
 								validation: (Rule) => Rule.required(),
 								initialValue: false,
-							},
-							{
+							}),
+							defineField({
 								name: 'publishingOrder',
 								title: 'Orden de publicación',
 								description: 'Número ordinal de publicación dentro de la storylist para el cuento',
 								type: 'number',
-							},
-							{
+							}),
+							defineField({
 								name: 'publishingDate',
 								title: 'Fecha de publicación',
 								description: 'Fecha en la cual el cuento se publicó o publicará en la storylist',
 								type: 'date',
-							},
+							}),
 						],
 					}),
 					defineField({

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -1,6 +1,6 @@
 import { supportedLanguages } from '../utils/localization';
 import { DashboardIcon } from '@sanity/icons';
-import { defineField, defineType } from 'sanity';
+import { defineArrayMember, defineField, defineType } from 'sanity';
 
 const gridItemFields = [
 	defineField({
@@ -52,7 +52,7 @@ const gridConfigfields = [
 			'Posiciones de las tarjetas y las imágenes alusivas de la storylist, con su orden de renderizado y extensión en columnas y filas dentro del layout de CSS Grid',
 		type: 'array',
 		of: [
-			{
+			defineArrayMember({
 				name: 'deckPreviewConfigItem',
 				title: 'Configuración de preview de Storylist',
 				type: 'object',
@@ -148,7 +148,7 @@ const gridConfigfields = [
 					startCol: 'auto',
 					endCol: 'span 4',
 				},
-			},
+			}),
 		],
 	}),
 ];
@@ -227,12 +227,12 @@ export default defineType({
 			title: 'Etiquetas',
 			type: 'array',
 			of: [
-				{
+				defineArrayMember({
 					name: 'tag',
 					title: 'Etiqueta',
 					type: 'reference',
 					to: [{ type: 'tag' }],
-				},
+				}),
 			],
 		}),
 		defineField({

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -81,7 +81,7 @@ const gridConfigfields = [
 					},
 				},
 				fields: [
-					{
+					defineField({
 						name: 'publication',
 						title: 'Publicación de Cuento/Texto/Historia dentro de la storylist',
 						type: 'object',
@@ -124,16 +124,16 @@ const gridConfigfields = [
 								type: 'date',
 							},
 						],
-					},
-					{
+					}),
+					defineField({
 						name: 'image',
 						title: 'Imagen de grid',
 						type: 'image',
 						options: {
 							hotspot: true,
 						},
-					},
-					{
+					}),
+					defineField({
 						name: 'imageSlug',
 						title: 'Slug de imagen alusiva',
 						type: 'slug',
@@ -141,7 +141,7 @@ const gridConfigfields = [
 							source: 'title',
 							maxLength: 96,
 						},
-					},
+					}),
 					...gridItemFields,
 				],
 				initialValue: {


### PR DESCRIPTION
# Resumen
Se redefinió el schema `storylist` haciendo uso de las funciones `defineField`, `defineType` y `defineArrayMember` para fortalecer el tipado y autocompletado.