### PR TITLE
[#800] - Tipar schema story definido en `cms/schemas/story.ts`

### DIFF
--- a/cms/schemas/resourceType.ts
+++ b/cms/schemas/resourceType.ts
@@ -1,8 +1,8 @@
 import { LinkIcon } from '@sanity/icons';
 import { preview } from 'sanity-plugin-icon-picker';
-import { defineType } from 'sanity';
+import { defineField, defineType } from 'sanity';
 
-export const resource = defineType({
+export const resource = defineField({
 	name: 'resource',
 	title: 'Recurso',
 	type: 'object',
@@ -19,22 +19,22 @@ export const resource = defineType({
 		},
 	},
 	fields: [
-		{
+		defineField({
 			name: 'title',
 			title: 'Título',
 			type: 'string',
-		},
-		{
+		}),
+		defineField({
 			name: 'url',
 			title: 'URL',
 			type: 'string',
-		},
-		{
+		}),
+		defineField({
 			name: 'resourceType',
 			title: 'Tipo de recurso',
 			type: 'reference',
 			to: { type: 'resourceType' },
-		},
+		}),
 	],
 });
 
@@ -60,13 +60,13 @@ export default defineType({
 		},
 	},
 	fields: [
-		{
+		defineField({
 			name: 'title',
 			title: 'Título',
 			type: 'string',
 			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({
 			name: 'slug',
 			title: 'Slug',
 			type: 'slug',
@@ -75,20 +75,20 @@ export default defineType({
 				maxLength: 96,
 			},
 			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({
 			name: 'description',
 			title: 'Descripción',
 			type: 'string',
 			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({
 			name: 'icon',
 			title: 'Icono',
 			type: 'iconPicker',
 			options: {
 				storeSvg: true,
 			},
-		},
+		}),
 	],
 });

--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -1,7 +1,7 @@
 import { supportedLanguages } from '../utils/localization';
 import { DocumentTextIcon, DocumentVideoIcon, PlayIcon, TwitterIcon } from '@sanity/icons';
 import { resource } from './resourceType';
-import { defineType } from 'sanity';
+import { defineField, defineType } from 'sanity';
 
 const audioRecording = {
 	name: 'audioRecording',
@@ -120,13 +120,13 @@ export default defineType({
 	type: 'document',
 	icon: DocumentTextIcon,
 	fields: [
-		{
+		defineField({
 			name: 'title',
 			title: 'Título',
 			type: 'string',
 			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({
 			name: 'slug',
 			title: 'Slug',
 			type: 'slug',
@@ -135,8 +135,8 @@ export default defineType({
 				maxLength: 96,
 			},
 			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({
 			name: 'language',
 			title: 'Idioma',
 			type: 'string',
@@ -147,32 +147,32 @@ export default defineType({
 				})),
 				layout: 'radio',
 			},
-		},
-		{
+		}),
+		defineField({
 			name: 'author',
 			title: 'Autor/a',
 			type: 'reference',
 			to: { type: 'author' },
 			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({
 			name: 'mediaSources',
 			title: 'Información de recursos multimedia asociados a la historia en otras plataformas web',
 			type: 'array',
 			of: [audioRecording, spaceRecording, youtubeVideo],
-		},
-		{
+		}),
+		defineField({
 			name: 'resources',
 			title: 'Recursos web asociados a la story y su contenido',
 			type: 'array',
 			of: [resource],
-		},
-		{
+		}),
+		defineField({
 			name: 'badLanguage',
 			title: '¿Contiene lenguaje adulto?',
 			type: 'boolean',
-		},
-		{
+		}),
+		defineField({
 			name: 'approximateReadingTime',
 			title: 'Tiempo de lectura aproximado',
 			type: 'computedNumber',
@@ -198,8 +198,8 @@ export default defineType({
 					return Math.ceil(wordCount / 200);
 				},
 			},
-		},
-		{
+		}),
+		defineField({
 			name: 'epigraphs',
 			title: 'Epígrafes',
 			type: 'array',
@@ -223,23 +223,23 @@ export default defineType({
 					],
 				},
 			],
-		},
-		{
+		}),
+		defineField({
 			name: 'body',
 			title: 'Cuerpo del cuento',
 			type: 'blockContent',
 			validation: (Rule) => Rule.required(),
-		},
-		{
+		}),
+		defineField({
 			name: 'review',
 			title: 'Reseña',
 			type: 'blockContent',
-		},
-		{
+		}),
+		defineField({
 			name: 'originalPublication',
 			title: 'Publicación original',
 			type: 'string',
-		},
+		}),
 	],
 	initialValue: {
 		language: 'es',

--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -1,6 +1,7 @@
 import { supportedLanguages } from '../utils/localization';
 import { DocumentTextIcon, DocumentVideoIcon, PlayIcon, TwitterIcon } from '@sanity/icons';
 import { resource } from './resourceType';
+import { defineType } from 'sanity';
 
 const audioRecording = {
 	name: 'audioRecording',
@@ -113,7 +114,7 @@ const youtubeVideo = {
 	],
 };
 
-export default {
+export default defineType({
 	name: 'story',
 	title: 'Cuento',
 	type: 'document',
@@ -257,4 +258,4 @@ export default {
 			};
 		},
 	},
-};
+});

--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -8,7 +8,7 @@ const audioRecording = defineField({
 	title: 'Grabación de audio con el relato del texto',
 	type: 'object',
 	icon: PlayIcon,
-	previews: {
+	preview: {
 		select: {
 			title: 'title',
 			url: 'spaceUrl',
@@ -40,7 +40,7 @@ const spaceRecording = defineField({
 	title: 'Grabación de Spaces de X',
 	type: 'object',
 	icon: TwitterIcon,
-	previews: {
+	preview: {
 		select: {
 			title: 'postId',
 			url: 'spaceUrl',
@@ -82,7 +82,7 @@ const youtubeVideo = defineField({
 	title: 'Video de YouTube',
 	type: 'object',
 	icon: DocumentVideoIcon,
-	previews: {
+	preview: {
 		select: {
 			title: 'title',
 			url: 'url',

--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -3,7 +3,7 @@ import { DocumentTextIcon, DocumentVideoIcon, PlayIcon, TwitterIcon } from '@san
 import { resource } from './resourceType';
 import { defineField, defineType } from 'sanity';
 
-const audioRecording = {
+const audioRecording = defineField({
 	name: 'audioRecording',
 	title: 'Grabación de audio con el relato del texto',
 	type: 'object',
@@ -33,9 +33,9 @@ const audioRecording = {
 			type: 'url',
 		},
 	],
-};
+});
 
-const spaceRecording = {
+const spaceRecording = defineField({
 	name: 'spaceRecording',
 	title: 'Grabación de Spaces de X',
 	type: 'object',
@@ -75,9 +75,9 @@ const spaceRecording = {
 			type: 'string',
 		},
 	],
-};
+});
 
-const youtubeVideo = {
+const youtubeVideo = defineField({
 	name: 'youTubeVideo',
 	title: 'Video de YouTube',
 	type: 'object',
@@ -112,7 +112,7 @@ const youtubeVideo = {
 			type: 'string',
 		},
 	],
-};
+});
 
 export default defineType({
 	name: 'story',


### PR DESCRIPTION
# Resumen
Se redefinió el schema `story` haciendo uso de las funciones `defineField`, `defineType` y `defineArrayMember` para fortalecer el tipado y autocompletado.