### PR TITLE
[#811] - Corregir warnings del archivo `storylist-card-deck.component.ts`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
 				"@typescript-eslint/no-inferrable-types": 0,
 				"@typescript-eslint/no-extra-semi": "error",
 				"@typescript-eslint/no-unused-vars": "error",
+				"@typescript-eslint/no-non-null-assertion": "error",
 				"no-extra-semi": "off"
 			}
 		},

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
 				],
 				"@typescript-eslint/no-inferrable-types": 0,
 				"@typescript-eslint/no-extra-semi": "error",
+				"@typescript-eslint/no-unused-vars": "error",
 				"no-extra-semi": "off"
 			}
 		},

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
@@ -54,13 +54,16 @@ export class StorylistCardDeckComponent implements OnChanges {
 		}
 		const parsedConfigs = cardsPlacement
 			.filter((card) => !!card.imageSlug)
-			.map((card) => ({
-				slug: card.imageSlug,
-				...this.generateCardConfig(card.imageSlug!),
-			}));
+			.map((card) => {
+				return {
+					slug: card.imageSlug,
+					...this.generateCardConfig(card.imageSlug as string),
+				};
+			});
+
 		for (const config of parsedConfigs) {
 			const { slug, ...other } = config;
-			this.imagesCardConfig[slug!] = other;
+			this.imagesCardConfig[slug as string] = other;
 		}
 	}
 
@@ -73,13 +76,16 @@ export class StorylistCardDeckComponent implements OnChanges {
 
 		const parsedConfigs = cardsPlacement
 			.filter((card) => !!card.slug)
-			.map((card) => ({
-				slug: card.slug,
-				...this.generateCardConfig(card.slug!),
-			}));
+			.map((card) => {
+				return {
+					slug: card.imageSlug,
+					...this.generateCardConfig(card.slug as string),
+				};
+			});
+
 		for (const config of parsedConfigs) {
 			const { slug, ...other } = config;
-			this.storiesCardConfig[slug!] = other;
+			this.storiesCardConfig[slug as string] = other;
 		}
 	}
 

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
@@ -47,7 +47,7 @@ export class StorylistCardDeckComponent implements OnChanges {
 	}
 
 	private generateImagesCardConfig() {
-		const cardsPlacement: GridItemPlacementConfig[] | undefined = this.storylist!.gridConfig?.cardsPlacement;
+		const cardsPlacement: GridItemPlacementConfig[] | undefined = this.storylist?.gridConfig?.cardsPlacement;
 
 		if (!cardsPlacement) {
 			return;

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
@@ -1,5 +1,5 @@
 // Core
-import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 
 // Modules


### PR DESCRIPTION
# Resumen
- Remoción de todos los usos de operadores de non-null assertion (!) en el archivo `storylist-card-deck.component.ts`
- Eliminado import en desuso.

## Otros cambios
- Establece nivel de rigurosidad de las reglas `@typescript-eslint/no-non-null-assertion` y `@typescript-eslint/no-unused-vars` en "error" en la configuración de ESLint.