### PR TITLE
[#888] - Agregar regla `@typescript-eslint/no-explicit-any` a configuración de ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
 				"@typescript-eslint/no-extra-semi": "error",
 				"@typescript-eslint/no-unused-vars": "error",
 				"@typescript-eslint/no-non-null-assertion": "error",
+				"@typescript-eslint/no-explicit-any": "error",  // Added rule
 				"no-extra-semi": "off"
 			}
 		},

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,7 @@
 				"@typescript-eslint/no-extra-semi": "error",
 				"@typescript-eslint/no-unused-vars": "error",
 				"@typescript-eslint/no-non-null-assertion": "error",
-				"@typescript-eslint/no-explicit-any": "error",  // Added rule
+				"@typescript-eslint/no-explicit-any": "error",
 				"no-extra-semi": "off"
 			}
 		},

--- a/e2e/.eslintrc.json
+++ b/e2e/.eslintrc.json
@@ -8,7 +8,7 @@
 			"rules": {
 				"@typescript-eslint/no-extra-semi": "error",
 				"no-extra-semi": "off",
-				"@typescript-eslint/no-explicit-any": "error"  // Added rule
+				"@typescript-eslint/no-explicit-any": "error" 
 			}
 		},
 		{

--- a/e2e/.eslintrc.json
+++ b/e2e/.eslintrc.json
@@ -7,7 +7,8 @@
 			"extends": ["plugin:@nx/typescript"],
 			"rules": {
 				"@typescript-eslint/no-extra-semi": "error",
-				"no-extra-semi": "off"
+				"no-extra-semi": "off",
+				"@typescript-eslint/no-explicit-any": "error"  // Added rule
 			}
 		},
 		{


### PR DESCRIPTION
 ### Fixes #888 

## Description

This Pull Request addresses the issue of enforcing the use of the `@typescript-eslint/no-explicit-any` rule in our ESLint configurations. The rule was added to improve code quality by disallowing the use of the `any` type in TypeScript, which can lead to less type safety and potential bugs.

## Issue

### Issue Description

The issue was raised with the following description:
> "Agregar la regla @typescript-eslint/no-explicit-any con un valor de rigurosidad error en el archivo .eslintrc.json"

## Solution

### Changes Made

1. **Root Configuration (`.eslintrc.json` at the root)**
   - Added the rule `@typescript-eslint/no-explicit-any` with `"error"` severity to enforce type safety across the main project.

   ```json
   {
     "root": true,
     "ignorePatterns": ["!**/*"],
     "plugins": ["@nx"],
     "overrides": [
       {
         "files": ["*.ts"],
         "extends": [
           "plugin:@nx/typescript",
           "plugin:@nx/angular",
           "plugin:@angular-eslint/template/process-inline-templates"
         ],
         "rules": {
           "no-extra-semi": "off",
           "@typescript-eslint/no-explicit-any": "error" 
         }
       }
     ],
     "extends": ["plugin:storybook/recommended"]
   }

2. **E2E Configuration (.eslintrc.json in the e2e directory)**
-  Added the rule @typescript-eslint/no-explicit-any with "error" severity to ensure the rule is enforced for end-to-end tests.

```json
{
  "extends": ["plugin:cypress/recommended"],
  "ignorePatterns": ["!**/*"],
  "overrides": [
    {
      "files": ["*.ts", "*.tsx"],
      "extends": ["plugin:@nx/typescript"],
      "rules": {
        "@typescript-eslint/no-explicit-any": "error"
      }
    }
  ],
  "plugins": ["@nx"]
}
```

