### PR TITLE
 [#888] - Agregar regla @typescript-eslint/no-explicit-any a configuración de ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,42 +3,44 @@
 	"ignorePatterns": ["!**/*"],
 	"plugins": ["@nx"],
 	"overrides": [
-		{
-			"files": ["*.ts"],
-			"extends": [
-				"plugin:@nx/typescript",
-				"plugin:@nx/angular",
-				"plugin:@angular-eslint/template/process-inline-templates"
-			],
-			"rules": {
-				"@angular-eslint/directive-selector": [
-					"error",
-					{
-						"type": "attribute",
-						"prefix": "cuentoneta",
-						"style": "camelCase"
-					}
-				],
-				"@angular-eslint/component-selector": [
-					"error",
-					{
-						"type": "element",
-						"prefix": "cuentoneta",
-						"style": "kebab-case"
-					}
-				],
-				"@typescript-eslint/no-inferrable-types": 0,
-				"@typescript-eslint/no-extra-semi": "error",
-				"@typescript-eslint/no-unused-vars": "error",
-				"@typescript-eslint/no-non-null-assertion": "error",
-				"no-extra-semi": "off"
+	  {
+		"files": ["*.ts"],
+		"extends": [
+		  "plugin:@nx/typescript",
+		  "plugin:@nx/angular",
+		  "plugin:@angular-eslint/template/process-inline-templates"
+		],
+		"rules": {
+		  "@angular-eslint/directive-selector": [
+			"error",
+			{
+			  "type": "attribute",
+			  "prefix": "cuentoneta",
+			  "style": "camelCase"
 			}
-		},
-		{
-			"files": ["*.html"],
-			"extends": ["plugin:@nx/angular-template"],
-			"rules": {}
+		  ],
+		  "@angular-eslint/component-selector": [
+			"error",
+			{
+			  "type": "element",
+			  "prefix": "cuentoneta",
+			  "style": "kebab-case"
+			}
+		  ],
+		  "@typescript-eslint/no-inferrable-types": 0,
+		  "@typescript-eslint/no-extra-semi": "error",
+		  "@typescript-eslint/no-unused-vars": "error",
+		  "@typescript-eslint/no-non-null-assertion": "error",
+		  "@typescript-eslint/no-explicit-any": "error",
+		  "no-extra-semi": "off"
 		}
+	  },
+	  {
+		"files": ["*.html"],
+		"extends": ["plugin:@nx/angular-template"],
+		"rules": {}
+	  }
 	],
 	"extends": ["plugin:storybook/recommended"]
-}
+  }
+  

--- a/e2e/.eslintrc.json
+++ b/e2e/.eslintrc.json
@@ -7,6 +7,7 @@
 			"extends": ["plugin:@nx/typescript"],
 			"rules": {
 				"@typescript-eslint/no-extra-semi": "error",
+				"@typescript-eslint/no-explicit-any": "error",  
 				"no-extra-semi": "off"
 			}
 		},
@@ -15,12 +16,15 @@
 			"extends": ["plugin:@nx/javascript"],
 			"rules": {
 				"@typescript-eslint/no-extra-semi": "error",
+				"@typescript-eslint/no-explicit-any": "error",  
 				"no-extra-semi": "off"
 			}
 		},
 		{
 			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-			"rules": {}
+			"rules": {
+				"@typescript-eslint/no-explicit-any": "error"  
+			}
 		},
 		{
 			"files": ["src/plugins/index.js"],

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.html
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.html
@@ -1,36 +1,39 @@
-<article [attr.aria-busy]="!storylist" class="stories-card-container grid grid-cols-1 gap-y-5 md:grid-cols-12 md:gap-8">
+<article
+	[attr.aria-busy]="!storylist()"
+	class="stories-card-container grid grid-cols-1 gap-y-5 md:grid-cols-12 md:gap-8"
+>
 	<ng-container *ngTemplateOutlet="storylistTemplate"> </ng-container>
 </article>
 
 <ng-template #storylistTemplate>
 	<!-- Renderizado de título y descripción -->
-	@if (displayTitle) {
-		@if (!!storylist) {
+	@if (displayTitle()) {
+		@if (!!storylist()) {
 			<div
-				[lang]="storylist.language"
+				[lang]="storylist()?.language"
 				[ngStyle]="{
-					order: storylist.gridConfig?.titlePlacement?.order,
-					'grid-column-start': storylist.gridConfig?.titlePlacement?.startCol,
-					'grid-column-end': storylist.gridConfig?.titlePlacement?.endCol
+					order: storylist()?.gridConfig?.titlePlacement?.order,
+					'grid-column-start': storylist()?.gridConfig?.titlePlacement?.startCol,
+					'grid-column-end': storylist()?.gridConfig?.titlePlacement?.endCol
 				}"
 				class="xs:max-md:!col-span-1 xs:max-sm:!order-1"
 			>
 				<h1 class="h1 mb-5">
 					<a
-						[ngClass]="{ 'hover:text-interactive-500': canNavigateToStorylist }"
-						[routerLink]="canNavigateToStorylist ? '/' + appRoutes.StoryList + '/' + storylist.slug : null"
+						[ngClass]="{ 'hover:text-interactive-500': canNavigateToStorylist() }"
+						[routerLink]="canNavigateToStorylist() ? '/' + appRoutes.StoryList + '/' + storylist()?.slug : null"
 						class="disabled:pointer-events-none disabled:cursor-default"
-						>{{ storylist.title }}</a
+						>{{ storylist()?.title }}</a
 					>
 				</h1>
-				<h3 class="h3 subtitle text-gray-600">{{ storylist.description }}</h3>
+				<h3 class="h3 subtitle text-gray-600">{{ storylist()?.description }}</h3>
 			</div>
 		} @else {
 			<div
 				[ngStyle]="{
-					order: skeletonConfig?.titlePlacement?.order,
-					'grid-column-start': skeletonConfig?.titlePlacement?.startCol,
-					'grid-column-end': skeletonConfig?.titlePlacement?.endCol
+					order: skeletonConfig()?.titlePlacement?.order,
+					'grid-column-start': skeletonConfig()?.titlePlacement?.startCol,
+					'grid-column-end': skeletonConfig()?.titlePlacement?.endCol
 				}"
 				class="xs:max-md:col-span-1 xs:max-sm:!order-1"
 			>
@@ -59,8 +62,8 @@
 	}
 
 	<!-- Renderizado de imágenes alusivas -->
-	@if (!!storylist?.images) {
-		@for (image of storylist?.images; track $index) {
+	@if (!!storylist()?.images) {
+		@for (image of storylist()?.images; track $index) {
 			<div [ngStyle]="imagesCardConfig[image.slug]" class="xs:max-md:!col-span-1">
 				<img [src]="image.url" class="rounded-lg" alt="" />
 			</div>
@@ -68,11 +71,12 @@
 	}
 
 	<!-- Renderizado de tarjetas de stories -->
-	<ng-container *ngTemplateOutlet="storylist?.publications ? publicationsTemplate : skeletonsTemplate"> </ng-container>
+	<ng-container *ngTemplateOutlet="storylist()?.publications ? publicationsTemplate : skeletonsTemplate">
+	</ng-container>
 </ng-template>
 
 <ng-template #skeletonsTemplate>
-	@for (skeleton of skeletonConfig?.cardsPlacement; track $index) {
+	@for (skeleton of skeletonConfig()?.cardsPlacement; track $index) {
 		@if (!!skeleton.slug) {
 			<cuentoneta-story-card-skeleton
 				[ngStyle]="{
@@ -104,8 +108,8 @@
 </ng-template>
 
 <ng-template #publicationsTemplate>
-	@if (!!storylist) {
-		@for (publication of storylist.publications; track $index) {
+	@if (!!storylist()) {
+		@for (publication of storylist()?.publications; track $index) {
 			<div
 				[ngStyle]="storiesCardConfig[publication.story.slug]"
 				[class.disabled]="!publication || !publication.published"
@@ -119,7 +123,7 @@
 							router.createUrlTree(['/', this.appRoutes.Story, publication.story.slug], {
 								queryParams: {
 									navigation: 'storylist',
-									navigationSlug: storylist.slug
+									navigationSlug: storylist()?.slug
 								}
 							})
 						"

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
@@ -1,5 +1,5 @@
 // Core
-import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnChanges, SimpleChanges } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 
 // Modules
@@ -22,13 +22,13 @@ import { StoryCardSkeletonComponent } from '../story-card-skeleton/story-card-sk
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StorylistCardDeckComponent implements OnChanges {
-	@Input() number: number = 6;
-	@Input() storylist: Storylist | undefined;
-	@Input() isLoading: boolean = false; // Utilizado para mostrar/ocultar skeletons
-	@Input() canNavigateToStorylist: boolean = false;
-	@Input() displayTitle: boolean = true;
-	@Input() displayFeaturedImage: boolean = false;
-	@Input() skeletonConfig: StorylistGridSkeletonConfig | undefined;
+	number = input<number>(6);
+	storylist = input<Storylist>();
+	isLoading = input<boolean>(false); // Utilizado para mostrar/ocultar skeletons
+	canNavigateToStorylist = input<boolean>(false);
+	displayTitle = input<boolean>(true);
+	displayFeaturedImage = input<boolean>(true);
+	skeletonConfig = input<StorylistGridSkeletonConfig>();
 
 	public router = inject(Router);
 
@@ -47,7 +47,7 @@ export class StorylistCardDeckComponent implements OnChanges {
 	}
 
 	private generateImagesCardConfig() {
-		const cardsPlacement: GridItemPlacementConfig[] | undefined = this.storylist?.gridConfig?.cardsPlacement;
+		const cardsPlacement: GridItemPlacementConfig[] | undefined = this.storylist()?.gridConfig?.cardsPlacement;
 
 		if (!cardsPlacement) {
 			return;
@@ -68,7 +68,7 @@ export class StorylistCardDeckComponent implements OnChanges {
 	}
 
 	private generateStoriesCardConfig() {
-		const cardsPlacement: GridItemPlacementConfig[] | undefined = this.storylist?.gridConfig?.cardsPlacement;
+		const cardsPlacement: GridItemPlacementConfig[] | undefined = this.storylist()?.gridConfig?.cardsPlacement;
 
 		if (!cardsPlacement) {
 			return;
@@ -90,7 +90,7 @@ export class StorylistCardDeckComponent implements OnChanges {
 	}
 
 	private generateCardConfig(slug: string): CardDeckCSSGridConfig {
-		const storyCardConfig = this.storylist?.gridConfig?.cardsPlacement?.find((card) =>
+		const storyCardConfig = this.storylist()?.gridConfig?.cardsPlacement?.find((card) =>
 			[card.slug, card.imageSlug].includes(slug),
 		);
 		return {


### PR DESCRIPTION
Fixes #888

This Pull Request addresses the issue of enforcing the use of the @typescript-eslint/no-explicit-any rule in our ESLint configurations. The rule was added to improve code quality by disallowing the use of the `any` type in TypeScript, which can lead to less type safety and potential bugs.

Changes Made:
- Root Configuration (.eslintrc.json at the root):
  - Added the rule @typescript-eslint/no-explicit-any with "error" severity.
- E2E Configuration (.eslintrc.json in the e2e directory):
  - Added the rule @typescript-eslint/no-explicit-any with "error" severity.
