### PR TITLE
[HOTFIX] - Resolver problemas de despliegue de versión 2.4.3

### DIFF
--- a/src/api/_queries/storylist.query.ts
+++ b/src/api/_queries/storylist.query.ts
@@ -96,7 +96,7 @@ export const storylistQuery = groq`*[_type == 'storylist' && slug.current == $sl
                 'publishingDate': publication.publishingDate,
                 'published': publication.published,
                 'editionPrefix': publication.editionPrefix,
-                'comingNextLabel': publication.comingNextLabel
+                'comingNextLabel': publication.comingNextLabel,
                 'story': publication.story->{
                     'slug': slug.current,
                     title,
@@ -113,5 +113,5 @@ export const storylistQuery = groq`*[_type == 'storylist' && slug.current == $sl
         }
     },
     'count': count(*[ _type == 'publication' && storylist._ref == ^._id ])
-}
+    }
 `;

--- a/src/api/content/content.service.ts
+++ b/src/api/content/content.service.ts
@@ -2,7 +2,7 @@
 import { client } from '../_helpers/sanity-connector';
 
 // Queries
-import { mapStorylist } from '../_utils/functions';
+import { mapStorylist, mapStorylistTeaser } from '../_utils/functions';
 import { fetchLandingPageContentQuery } from '../_queries/content.query';
 import { FetchLandingPageContentQueryResult } from '../sanity/types';
 
@@ -16,7 +16,7 @@ export async function fetchLandingPageContent() {
 	}
 
 	for (const card of result.cards) {
-		cards.push(await mapStorylist(card));
+		cards.push(await mapStorylistTeaser(card));
 	}
 
 	return { previews, cards };


### PR DESCRIPTION
# Resumen
- Agrega coma faltante en query de storylist.
- Agrega función para procesar storylists en formato card de forma diferenciada. Remueve procesamiento de imágenes.