### PR TITLE
[HF] - Corrige tipo de dato usado para propiedad summary en query y mapping

### DIFF
--- a/src/api/sanity/types.ts
+++ b/src/api/sanity/types.ts
@@ -553,24 +553,7 @@ export type StoryBySlugQueryResult = {
 	}>;
 	categories: null;
 	body: BlockContent;
-	review: {
-		children: Array<{
-			marks?: Array<string>;
-			text: string;
-			_type: 'span';
-			_key: string;
-		}>;
-		style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'normal';
-		listItem?: 'bullet';
-		markDefs?: Array<{
-			href: string;
-			_type: 'link';
-			_key: string;
-		}>;
-		level?: number;
-		_type: 'block';
-		_key: string;
-	};
+	review: BlockContent;
 	originalPublication: string;
 	approximateReadingTime: number;
 	mediaSources: Array<

--- a/src/api/story/story.service.ts
+++ b/src/api/story/story.service.ts
@@ -50,7 +50,7 @@ export async function fetchStoryBySlug(slug: string): Promise<Story> {
 		author: mapAuthor(author, properties.language),
 		resources: mapResources(properties.resources),
 		paragraphs: body as TextBlockContent[],
-		summary: [review],
+		summary: review as TextBlockContent[],
 		epigraphs: epigraphs as Epigraph[],
 	});
 }


### PR DESCRIPTION
# Resumen
Este PR resuelve un problema con la visualización del texto del campo `summary` en el template del componente `BioSummaryCardComponent`. El problema estaba causado por una definición de tipos y un mappeo erróneos de la propiedad en el backend.