### PR TITLE
[#1000] - Añadido hook de pre-commit de stylelint

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@ echo "--- Formating Code ---"
 echo ""
 pnpm dlx pretty-quick --staged
 echo "--- Running Stylelint ---"
-pnpm dlx stylelint "**/*.{css,scss,sass}" --fix
+pnpm stylelint "**/*.{css,scss,sass}" --fix

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 echo "--- Formating Code ---"
 echo ""
-pnpm dlx pretty-quick --staged
+pnpm pretty-quick --staged
 echo "--- Running Stylelint ---"
 pnpm stylelint "**/*.{css,scss,sass}" --fix

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
 echo "--- Formating Code ---"
 echo ""
-npx pretty-quick --staged
+pnpm dlx pretty-quick --staged
+echo "--- Running Stylelint ---"
+pnpm dlx stylelint "**/*.{css,scss,sass}" --fix

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,6 @@
 {
 	"extends": ["stylelint-config-recommended", "stylelint-config-standard", "stylelint-config-standard-scss"],
+	"plugins": ["stylelint-scss"],
 	"rules": {
 		"at-rule-no-unknown": null,
 		"scss/at-rule-no-unknown": [
@@ -21,7 +22,9 @@
 			{
 				"ignorePseudoElements": ["ng-deep"]
 			}
-		]
+		],
+		"scss/double-slash-comment-empty-line-before": null,
+		"scss/no-global-function-names": null
 	},
 	"ignoreFiles": ["!**/*", "dist/**/*"]
 }


### PR DESCRIPTION
- Actualizado el archivo [.stylelintrc.json](https://github.com/cuentoneta/cuentoneta/blob/develop/.stylelintrc.json) con reglas adicionales.
- Reemplazado el comando npx por pnpm dlx para que sea consistente con el gestor de paquetes que utilizamos en el proyecto.
- Añadida la instrucción `pnpm dlx stylelint "**/*.{css,scss,sass}" --fix` al archivo [pre-commit](https://github.com/cuentoneta/cuentoneta/blob/develop/.husky/pre-commit) para solucionar los errores de estilo.
- Resuelve el _issue_ #1000.
