### PR TITLE
[#1006] - Eliminar trazas de la propiedad `previews` de la aplicación

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -979,50 +979,6 @@
 				},
 				"optional": false
 			},
-			"previews": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "array",
-					"of": {
-						"type": "object",
-						"attributes": {
-							"_ref": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string"
-								}
-							},
-							"_type": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string",
-									"value": "reference"
-								}
-							},
-							"_weak": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "boolean"
-								},
-								"optional": true
-							}
-						},
-						"dereferencesTo": "storylist",
-						"rest": {
-							"type": "object",
-							"attributes": {
-								"_key": {
-									"type": "objectAttribute",
-									"value": {
-										"type": "string"
-									}
-								}
-							}
-						}
-					}
-				},
-				"optional": true
-			},
 			"cards": {
 				"type": "objectAttribute",
 				"value": {

--- a/cms/schemas/landingPage.ts
+++ b/cms/schemas/landingPage.ts
@@ -43,19 +43,6 @@ export default defineType({
 			validation: (Rule) => Rule.required(),
 		}),
 		defineField({
-			name: 'previews',
-			title: 'Storylists con Vista Previa',
-			type: 'array',
-			of: [
-				defineArrayMember({
-					name: 'storylist',
-					title: 'Storylist',
-					type: 'reference',
-					to: [{ type: 'storylist' }],
-				}),
-			],
-		}),
-		defineField({
 			name: 'cards',
 			title: 'Storylists con Tarjetas',
 			type: 'array',

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -45,7 +45,6 @@ const environmentFileContent = `
     export const environment = {
        environment: "${environment}",
        contentConfig: { 
-           previews: [],
            cards: []
        },
        website: "${process.env['CUENTONETA_WEBSITE']}",

--- a/scripts/set-test-environment.ts
+++ b/scripts/set-test-environment.ts
@@ -23,7 +23,6 @@ const environmentFileContent = `
     export const environment = {
        environment: "${environment}",
        contentConfig: { 
-        previews: [],
         cards: []
        },
        website: "http://localhost:4000/",

--- a/src/api/content/content.service.ts
+++ b/src/api/content/content.service.ts
@@ -1,9 +1,9 @@
 // Queries
 import { fetchStorylistTeasers } from '../storylist/storylist.service';
+import { LandingPageContent } from '@models/landing-page-content.model';
 
-export async function fetchLandingPageContent() {
+export async function fetchLandingPageContent(): Promise<LandingPageContent> {
 	const cards = await fetchStorylistTeasers();
-	const previews: [] = [];
 
-	return { previews, cards };
+	return { cards };
 }

--- a/src/api/sanity/generated-schema-types.ts
+++ b/src/api/sanity/generated-schema-types.ts
@@ -117,13 +117,6 @@ export type LandingPage = {
 	config: string;
 	slug: Slug;
 	active: boolean;
-	previews?: Array<{
-		_ref: string;
-		_type: 'reference';
-		_weak?: boolean;
-		_key: string;
-		[internalGroqTypeReferenceTo]?: 'storylist';
-	}>;
 	cards?: Array<{
 		_ref: string;
 		_type: 'reference';

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,6 +1,4 @@
-import { Component, inject } from '@angular/core';
-import { Storylist } from '@models/storylist.model';
-import { ContentService } from '../../providers/content.service';
+import { Component } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { InternalLink } from '@models/link.model';
@@ -83,12 +81,7 @@ export class HeaderComponent {
 		{ label: 'Inicio', path: '/home' },
 		{ label: 'Nosotros', path: '/about' },
 	];
-	lists: Pick<Storylist, 'title' | 'slug'>[] = [];
 	displayMenu: boolean = false;
-	constructor() {
-		const contentService = inject(ContentService);
-		this.lists = contentService.getNavLists();
-	}
 
 	onMenuTogglerClicked() {
 		this.displayMenu = !this.displayMenu;

--- a/src/app/models/landing-page-content.model.ts
+++ b/src/app/models/landing-page-content.model.ts
@@ -1,6 +1,5 @@
-import { Storylist, StorylistTeaser } from '@models/storylist.model';
+import { StorylistTeaser } from '@models/storylist.model';
 
 export interface LandingPageContent {
 	cards: StorylistTeaser[];
-	previews: Storylist[];
 }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -11,7 +11,7 @@ import { AppRoutes } from '../../app.routes';
 import { ContentService } from '../../providers/content.service';
 
 // Models
-import { Storylist, StorylistTeaser } from '@models/storylist.model';
+import { StorylistTeaser } from '@models/storylist.model';
 
 // Directives
 import { FetchContentDirective } from '../../directives/fetch-content.directive';
@@ -64,7 +64,7 @@ export class HomeComponent {
 
 	private loadStorylistDecks() {
 		this.fetchContentDirective
-			.fetchContent$<{ previews: Storylist[]; cards: StorylistTeaser[] }>(this.contentService.fetchStorylistDecks())
+			.fetchContent$<{ cards: StorylistTeaser[] }>(this.contentService.getLandingPageContent())
 			.pipe(takeUntilDestroyed())
 			.subscribe(({ cards }) => {
 				this.cards = cards;

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -21,36 +21,9 @@ export class ContentService {
 
 	public getLandingPageContent(): Observable<LandingPageContent> {
 		return this.http.get<LandingPageContent>(`${this.prefix}/landing-page`).pipe(
-			map((content) => ({
-				cards: content.cards,
-				previews: content.cards,
+			map(({ cards }) => ({
+				cards: cards,
 			})),
-		);
-	}
-
-	// ToDo: Obtener listas de navs desde API
-	public getNavLists(): Pick<Storylist, 'slug' | 'title'>[] {
-		return [
-			{ slug: 'otono-2023', title: 'Cuentos de Otoño' },
-			{ slug: 'fec-english-sessions', title: 'FEC English Sessions' },
-			{ slug: 'verano-2022', title: 'La Cuentoneta 1.0' },
-		];
-	}
-
-	/**
-	 * Hace fetch de la configuración de landing page desde el origen de datos y genera
-	 * una tupla de arrays de objetos compuestos de tipo StorylistCardDeck, los cuales
-	 * contienen la configuración y la correspondiente información para renderizar
-	 * los decks de previews y cards de cada storylist.
-	 */
-	public fetchStorylistDecks(): Observable<LandingPageContent> {
-		return this.getLandingPageContent().pipe(
-			map(({ previews, cards }) => {
-				return {
-					previews: previews,
-					cards: cards,
-				};
-			}),
 		);
 	}
 }

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -5,7 +5,6 @@ import { map, Observable } from 'rxjs';
 // Interfaces
 import { LandingPageContent } from '@models/landing-page-content.model';
 
-import { Storylist } from '@models/storylist.model';
 // Providers
 import { environment } from '../environments/environment';
 import { HttpClient } from '@angular/common/http';


### PR DESCRIPTION
## Resumen
Elimina todas las instancias y usos de la propiedad `previews` en el backend, frontend y modelos de dominio de la aplicación.