### PR TITLE
Hide Empty Labels in `NavigableStoryTeaserComponent`

### DIFF
--- a/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
+++ b/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { StoryTeaser } from '@models/story.model';
 import { AppRoutes } from '../../app.routes';
@@ -29,6 +29,7 @@ import { RouterLink } from '@angular/router';
 					}"
 					class="bg-gray-50 px-7 py-5"
 				>
+					<!-- Render date label only if originalPublication exists -->
 					@if (story().originalPublication) {
 						<cuentoneta-story-edition-date-label [label]="story().originalPublication" />
 					}
@@ -46,8 +47,8 @@ import { RouterLink } from '@angular/router';
 	`,
 })
 export class NavigableStoryTeaserComponent {
-	story = input.required<StoryTeaser>();
-	selected = input<boolean>();
-	authorSlug = input.required<string>();
+	@Input() story!: StoryTeaser;
+	@Input() selected!: boolean;
+	@Input() authorSlug!: string;
 	protected readonly appRoutes = AppRoutes;
 }


### PR DESCRIPTION

Fixes #971 
The goal of this PR is to prevent the display of empty labels in the `NavigableStoryTeaserComponent`. As per the feedback, we will conditionally render the **CuentonetaStoryEditionDateLabel** based on the` story().originalPublication` value. This avoids code duplication and ensures the component only displays relevant information.