### PR TITLE
[#950] - Reimplementación de unit tests para StoryCardComponent

### DIFF
--- a/src/app/components/story-card/story-card.component.spec.ts
+++ b/src/app/components/story-card/story-card.component.spec.ts
@@ -1,9 +1,9 @@
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 import { StoryCardComponent } from './story-card.component';
 import { storyPreviewMock } from '../../mocks/story.mock';
 import { DefaultUrlSerializer, UrlTree } from '@angular/router';
 
-fdescribe('StoryCardComponent', () => {
+describe('StoryCardComponent', () => {
 	let urlTree: UrlTree;
 
 	beforeEach(() => {
@@ -19,5 +19,15 @@ fdescribe('StoryCardComponent', () => {
 			},
 		});
 		expect(container).toBeTruthy();
+	});
+	it('should display the mock story title', async () => {
+		await render(StoryCardComponent, {
+			componentInputs: {
+				story: storyPreviewMock,
+				navigationRoute: urlTree,
+			},
+		});
+		const resourceElement = screen.getByText(storyPreviewMock.title);
+		expect(resourceElement).toBeInTheDocument();
 	});
 });

--- a/src/app/components/story-card/story-card.component.spec.ts
+++ b/src/app/components/story-card/story-card.component.spec.ts
@@ -30,4 +30,14 @@ describe('StoryCardComponent', () => {
 		const resourceElement = screen.getByText(storyPreviewMock.title);
 		expect(resourceElement).toBeInTheDocument();
 	});
+	it('should display the approximate reading time', async () => {
+		await render(StoryCardComponent, {
+			componentInputs: {
+				story: storyPreviewMock,
+				navigationRoute: urlTree,
+			},
+		});
+		const readingTimeElement = screen.getByText(`${storyPreviewMock.approximateReadingTime} minutos de lectura`);
+		expect(readingTimeElement).toBeInTheDocument();
+	});
 });

--- a/src/app/components/story-card/story-card.component.spec.ts
+++ b/src/app/components/story-card/story-card.component.spec.ts
@@ -1,21 +1,23 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { render } from '@testing-library/angular';
 import { StoryCardComponent } from './story-card.component';
+import { storyPreviewMock } from '../../mocks/story.mock';
+import { DefaultUrlSerializer, UrlTree } from '@angular/router';
 
-xdescribe('StoryCardComponent', () => {
-	let component: StoryCardComponent;
-	let fixture: ComponentFixture<StoryCardComponent>;
+fdescribe('StoryCardComponent', () => {
+	let urlTree: UrlTree;
 
-	beforeEach(async () => {
-		await TestBed.configureTestingModule({
-			imports: [StoryCardComponent],
-		}).compileComponents();
-
-		fixture = TestBed.createComponent(StoryCardComponent);
-		component = fixture.componentInstance;
-		fixture.detectChanges();
+	beforeEach(() => {
+		const urlSerializer = new DefaultUrlSerializer();
+		urlTree = urlSerializer.parse('/story/el-espejo-del-tiempo?navigation=author&navigationSlug=francois-onoff');
 	});
 
-	it('should create', () => {
-		expect(component).toBeTruthy();
+	it('should render the component', async () => {
+		const { container } = await render(StoryCardComponent, {
+			componentInputs: {
+				story: storyPreviewMock,
+				navigationRoute: urlTree,
+			},
+		});
+		expect(container).toBeTruthy();
 	});
 });


### PR DESCRIPTION
### Tareas
 

- [x]  Migrar la implementación del archivo story-card.component.spec.ts de `TestBed` a Angular Testing Library.
- [x]  Agregar un objeto mock de tipo StoryPreview para pasar como propiedad al objeto `componentInputs` de la función render de Angular Testing Library. Buscar la constante mockStoryPreview disponible en story.mocks.ts para ello.
- [x] Usar `toBeInTheDocument` en lugar de toBeTruthy. 
- [x] Testear que `approximateReadingTime` aparezca en el documento.
- [x] Cambiar la definición de la función `xdescribe` en describe antes de crear la pull request vinculada a este issue.
