### PR TITLE
[#922] -  Reimplementación de unit tests para  BadgeComponent

### DIFF
--- a/src/app/components/badge/badge.component.spec.ts
+++ b/src/app/components/badge/badge.component.spec.ts
@@ -1,28 +1,27 @@
-// import { ComponentFixture, TestBed } from '@angular/core/testing';
-// import { BadgeComponent } from './badge.component';
+import { render, screen } from '@testing-library/angular';
+import { BadgeComponent } from './badge.component';
+import { tagMock } from '../../mocks/tag.mocks';
 
-xdescribe('BadgeComponent', () => {
-	// let component: BadgeComponent;
-	// let fixture: ComponentFixture<BadgeComponent>;
+describe('BadgeComponent', () => {
+	it('should render the component', async () => {
+		const { container } = await render(BadgeComponent, {
+			inputs: {
+				tag: tagMock,
+				showIcon: true,
+			},
+		});
+		expect(container).toBeTruthy();
+	});
 
-	// beforeEach(async () => {
-	// 	await TestBed.configureTestingModule({
-	// 		imports: [BadgeComponent],
-	// 	}).compileComponents();
-	//
-	// 	fixture = TestBed.createComponent(BadgeComponent);
-	// 	component = fixture.componentInstance;
-	// 	component.tag = {
-	// 		title: 'test',
-	// 		description: 'test',
-	// 		icon: { svg: 'test.svg', provider: 'md', name: 'test' },
-	// 		slug: 'test',
-	// 	};
-	// 	component.showIcon = true;
-	// 	fixture.detectChanges();
-	// });
-
-	it('should create', () => {
-		// expect(component).toBeTruthy();
+	it('should display the mock badge title', async () => {
+		await render(BadgeComponent, {
+			inputs: {
+				tag: tagMock,
+				showIcon: true,
+			},
+		});
+		const resourceElement = screen.getByText(tagMock.title);
+		expect(resourceElement).toBeInTheDocument();
 	});
 });
+

--- a/src/app/mocks/tag.mocks.ts
+++ b/src/app/mocks/tag.mocks.ts
@@ -1,0 +1,28 @@
+import { Tag } from '@models/tag.model';
+
+export const tagMock: Tag = {
+	title: 'Colaborativa',
+	slug: 'colaborativa',
+	shortDescription: 'Lista de textos generada colaborativamente por la comunidad.',
+	description: [
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: '558175c4191c',
+			markDefs: [],
+			children: [
+				{
+					text: 'Lista de textos generada colaborativamente por la comunidad.',
+					_key: '423250ef7cf30',
+					_type: 'span',
+					marks: [],
+				},
+			],
+		},
+	],
+	icon: {
+		provider: 'mdi',
+		name: 'people',
+		svg: `<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style="width: 1.5em; height: 1em;"><path fill="none" d="M0 0h24v24H0z"></path><path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"></path></svg>`,
+	},
+};


### PR DESCRIPTION
- [x] Migrar la implementación del archivo badge.component.spec.ts de TestBed a Angular Testing Library.
- [x]  Agregar un objeto mock de tipo Tag y un objeto de tipo boolean para pasar como propiedad al objeto componentInputs de la función render de Angular Testing Library.
- [x]  Usar toBeInTheDocument en lugar de toBeTruthy.
- [x]  Testear que el title aparezca en el documento..
- [x]  Cambiar la definición de la función xdescribe en describe antes de crear la pull request vinculada a este issue.

El uso de `componentInputs` ha sido deprecado en favor de `inputs` para asignar las propiedades de los componentes en Angular Testing Library. 

Más información sobre la deprecación de `componentInputs` se puede encontrar en la documentación oficial:  [ componentInputs deprecado](https://testing-library.com/docs/angular-testing-library/api/#componentinputs-deprecated).