### PR TITLE
[#1022] -  Implementar schema `contentCampaign` en Sanity

### DIFF
--- a/cms/schemas/contentCampaign.ts
+++ b/cms/schemas/contentCampaign.ts
@@ -1,0 +1,162 @@
+import { defineField, defineType } from 'sanity';
+import { CalendarIcon } from '@sanity/icons';
+import { localizedRequire } from '../utils/validations';
+
+const imageResourcePattern = /^image-([a-f\d]+)-(\d+x\d+)-(\w+)$/;
+
+const decodeAssetId = (id) => {
+	const [, assetId, dimensions, format] = imageResourcePattern.exec(id);
+	const [width, height] = dimensions.split('x').map((v) => parseInt(v, 10));
+
+	return {
+		assetId,
+		dimensions: { width, height },
+		format,
+	};
+};
+
+const campaignCharLimitValidation = (blocks, context) => {
+	const limits = {
+		xs: {
+			title: 32,
+			subtitle: 36,
+		},
+		md: {
+			title: 36,
+			subtitle: 40,
+		},
+	};
+
+	if (!blocks || blocks.length === 0) return true;
+
+	const totalCharacters = blocks
+		.filter((block) => block._type === 'block')
+		.reduce((acc, block) => acc + block.children.reduce((sum, child) => sum + (child.text || '').length, 0), 0);
+
+	const property = context.path[context.path.length - 1];
+	const viewport = context.path[context.path.length - 2];
+	const maxChars = limits[viewport][property];
+
+	if (totalCharacters > maxChars) {
+		return `La longitud máxima es de ${maxChars} caracteres. Longitud actual: ${totalCharacters}`;
+	}
+
+	return true;
+};
+
+const campaignImageSizeValidation = (image, context) => {
+	const viewportSizes = {
+		xs: {
+			width: 540,
+			height: 220,
+		},
+		md: {
+			width: 960,
+			height: 280,
+		},
+	};
+
+	const viewport = context.path[context.path.length - 2];
+	const viewportSize = viewportSizes[viewport];
+
+	if (!image || !viewportSize) return true;
+	const { dimensions } = decodeAssetId(image.asset._ref);
+	return (
+		(dimensions.width === viewportSize.width && dimensions.height === viewportSize.height) ||
+		`La imagen debe tener un tamaño estricto de ${viewportSize.width} x ${viewportSize.height} px. El tamaño de la imagen actual es de ${dimensions.width} x ${dimensions.height} px`
+	);
+};
+
+export default defineType({
+	name: 'contentCampaign',
+	title: 'Campaña de Contenido',
+	type: 'document',
+	icon: CalendarIcon,
+	fields: [
+		defineField({
+			name: 'title',
+			title: 'Título',
+			type: 'string',
+			validation: (Rule) => Rule.custom(localizedRequire),
+		}),
+		defineField({
+			name: 'slug',
+			title: 'Slug',
+			type: 'slug',
+			options: {
+				source: 'title',
+				maxLength: 96,
+			},
+			validation: (Rule) => Rule.custom(localizedRequire),
+		}),
+		defineField({
+			name: 'description',
+			title: 'Descripción',
+			type: 'blockContent',
+			validation: (Rule) => Rule.custom(localizedRequire),
+		}),
+		defineField({
+			name: 'url',
+			title: 'URL',
+			type: 'string',
+			validation: (Rule) => Rule.custom(localizedRequire),
+		}),
+		defineField({
+			name: 'contents',
+			title: 'Contenidos',
+			type: 'object',
+			fields: [
+				defineField({
+					name: 'xs',
+					title: 'Viewport mobile (xs, sm)',
+					type: 'object',
+					fields: [
+						defineField({
+							name: 'title',
+							title: 'Título',
+							type: 'blockContent',
+							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignCharLimitValidation)],
+						}),
+						defineField({
+							name: 'subtitle',
+							title: 'Subtítulo',
+							type: 'blockContent',
+							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignCharLimitValidation)],
+						}),
+						defineField({
+							name: 'image',
+							title: 'Imagen (520px x 220px de tamaño)',
+							type: 'image',
+							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignImageSizeValidation)],
+						}),
+					],
+				}),
+				defineField({
+					name: 'md',
+					title: 'Viewport tablet horizontal y desktop (md y superior)',
+					type: 'object',
+					fields: [
+						defineField({
+							name: 'title',
+							title: 'Título',
+							type: 'blockContent',
+							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignCharLimitValidation)],
+						}),
+						defineField({
+							name: 'subtitle',
+							title: 'Subtítulo',
+							type: 'blockContent',
+							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignCharLimitValidation)],
+						}),
+						defineField({
+							name: 'image',
+							title: 'Imagen (960px x 280px de tamaño)',
+							type: 'image',
+							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignImageSizeValidation)],
+						}),
+					],
+				}),
+			],
+		}),
+	],
+});

--- a/cms/schemas/landingPage.ts
+++ b/cms/schemas/landingPage.ts
@@ -43,6 +43,19 @@ export default defineType({
 			validation: (Rule) => Rule.required(),
 		}),
 		defineField({
+			name: 'campaigns',
+			title: 'Campañas',
+			type: 'array',
+			of: [
+				defineArrayMember({
+					name: 'campaign',
+					title: 'Campaña',
+					type: 'reference',
+					to: [{ type: 'contentCampaign' }],
+				}),
+			],
+		}),
+		defineField({
 			name: 'cards',
 			title: 'Storylists con Tarjetas',
 			type: 'array',

--- a/cms/schemas/schema.ts
+++ b/cms/schemas/schema.ts
@@ -11,6 +11,7 @@ import storylist from './storylist';
 import tag from './tag';
 import { resourceType, resource } from './resourceType';
 import publication from './publication';
+import contentCampaign from './contentCampaign';
 
 export default [
 	// Tipos de propiedades
@@ -19,6 +20,7 @@ export default [
 	resource,
 	// Tipos de documentos
 	landingPage,
+	contentCampaign,
 	storylist,
 	story,
 	author,

--- a/cms/utils/validations.ts
+++ b/cms/utils/validations.ts
@@ -1,0 +1,4 @@
+export const localizedRequire = (value) => {
+	if (!value) return 'Este campo es requerido';
+	return true;
+};


### PR DESCRIPTION
## Resumen
- Se implementa el schema `contentCampaign` en Sanity, declarando propiedades análogas al modelo de dominio `ContentCampaign`.
- Se agrega la propiedad `campaigns` en el schema `landingPage`, la cual aloja un arreglo de referencias a objetos de schema de tipo `contentCampaign`.

## Otros cambios
- Se agrega validación genérica `localizedRequire` con mensaje de error en español, la cual debe de usarse en reemplazo de la validación genérica `required`.