### PR TITLE
[#1026] - Incluir atributo `campaigns` en modelo de dominio `LandingPageContent`

### DIFF
--- a/src/app/models/landing-page-content.model.ts
+++ b/src/app/models/landing-page-content.model.ts
@@ -3,6 +3,5 @@ import { ContentCampaign } from '@models/content-campaign.model';
 
 export interface LandingPageContent {
 	cards: StorylistTeaser[];
-	// TODO: Transformar propiedad en obligatoria al actualizar método de request de frontend
-	campaigns?: ContentCampaign[];
+	campaigns: ContentCampaign[];
 }

--- a/src/app/providers/content.service.ts
+++ b/src/app/providers/content.service.ts
@@ -1,6 +1,5 @@
 // Core
 import { inject, Injectable } from '@angular/core';
-import { map, Observable } from 'rxjs';
 
 // Interfaces
 import { LandingPageContent } from '@models/landing-page-content.model';
@@ -18,11 +17,7 @@ export class ContentService {
 	// Services
 	private http = inject(HttpClient);
 
-	public getLandingPageContent(): Observable<LandingPageContent> {
-		return this.http.get<LandingPageContent>(`${this.prefix}/landing-page`).pipe(
-			map(({ cards }) => ({
-				cards: cards,
-			})),
-		);
+	public getLandingPageContent() {
+		return this.http.get<LandingPageContent>(`${this.prefix}/landing-page`);
 	}
 }


### PR DESCRIPTION
## Resumen
- Agregado el atributo `campaigns` en el modelo `LandingPageContent` como propiedad obligatoria.
- Actualizada la firma del método `getLandingPageContent` para soportar los cambios de `LandingPageContent`.