### PR TITLE
[#946] -  Reimplementación de unit tests para BioSummaryCardComponent

### DIFF
--- a/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
@@ -5,6 +5,9 @@ import { storyMock } from 'src/app/mocks/story.mock';
 const country = storyMock.author.nationality.country;
 const countryRegex = new RegExp(`\\b${country}\\b`, 'i');
 
+const name = storyMock.author.name;
+const nameRegex = new RegExp(`\\b${name}\\b`, 'iu');
+
 describe('BioSummaryCardComponent', () => {
 	it('should render the component', async () => {
 		const { container } = await render(BioSummaryCardComponent, {
@@ -36,5 +39,26 @@ describe('BioSummaryCardComponent', () => {
 		});
 
 		expect(countryImage).toBeInTheDocument();
+	});
+
+	it('should display the author name', async () => {
+		await render(BioSummaryCardComponent, {
+			inputs: {
+				story: storyMock,
+			},
+		});
+		const authorTeaser = screen.getByRole('link', { name: nameRegex });
+		expect(authorTeaser).toBeInTheDocument();
+	});
+
+	it('should display the country', async () => {
+		await render(BioSummaryCardComponent, {
+			inputs: {
+				story: storyMock,
+			},
+		});
+		const authorTeaser = screen.getByRole('link', { name: nameRegex });
+
+		expect(authorTeaser).toHaveTextContent(country);
 	});
 });

--- a/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
@@ -1,50 +1,23 @@
-// import { render } from '@testing-library/angular';
-//
-// import { BioSummaryCardComponent } from './bio-summary-card.component';
-// import { Author } from 'src/app/models/author.model';
-// import { Story } from '@models/story.model';
+import { render, screen } from '@testing-library/angular';
+import { BioSummaryCardComponent } from './bio-summary-card.component';
+import { storyMock } from 'src/app/mocks/story.mock';
 
-// const mockAuthor: Author = {
-// 	id: '0',
-// 	name: 'Estudios Gativideo',
-// 	imageUrl: 'https://gativideo.com/image.png',
-// 	nationality: {
-// 		country: 'Argentina',
-// 		flag: 'AR',
-// 	},
-// };
-//
-// const mockStory: Story = {
-// 	id: 0,
-// 	title: 'El Marajá de San Telmo',
-// 	slug: 'el-maraja-de-san-telmo',
-// 	approximateReadingTime: 5,
-// 	author: mockAuthor,
-// 	language: 'es',
-// 	badLanguage: false,
-// 	epigraphs: [],
-// 	media: [],
-// 	summary: [
-// 		{ classes: '', text: 'Arranca con "Fanfare for the Common Man" y la próxima canción es "Silhouette" de Kenny G.' },
-// 	],
-// 	paragraphs: [
-// 		{
-// 			classes: '',
-// 			text: 'El presente Video-Cassette se vende para uso personal o doméstico exclusivamente, todos los demás derechos quedan reservados',
-// 		},
-// 		{
-// 			classes: '',
-// 			text: 'Cualquier divulgación total o parcial de la obra, sea a través de copias, edición, adición, exhibición, difusión y/o emisión de difusión queda expresamente prohibida.',
-// 		},
-// 	],
-// };
+describe('BioSummaryCardComponent', () => {
+	it('should render the component', async () => {
+		const { container } = await render(BioSummaryCardComponent, {
+			inputs: { story: storyMock },
+		});
 
-xdescribe('BioSummaryCardComponent', () => {
-	it('should create', async () => {
-		// const component = await render(BioSummaryCardComponent, {
-		// 	componentProperties: { story: mockStory },
-		// });
-		//
-		// expect(component).toBeTruthy();
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should display the Biography', async () => {
+		await render(BioSummaryCardComponent, {
+			inputs: {
+				story: storyMock,
+			},
+		});
+
+		expect(screen.getByText('(Chateauroux, 1948 - París, 1994) fue un escritor', { exact: false })).toBeInTheDocument();
 	});
 });

--- a/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
@@ -2,6 +2,9 @@ import { render, screen } from '@testing-library/angular';
 import { BioSummaryCardComponent } from './bio-summary-card.component';
 import { storyMock } from 'src/app/mocks/story.mock';
 
+const country = storyMock.author.nationality.country;
+const countryRegex = new RegExp(`\\b${country}\\b`, 'i');
+
 describe('BioSummaryCardComponent', () => {
 	it('should render the component', async () => {
 		const { container } = await render(BioSummaryCardComponent, {
@@ -19,5 +22,19 @@ describe('BioSummaryCardComponent', () => {
 		});
 
 		expect(screen.getByText('(Chateauroux, 1948 - París, 1994) fue un escritor', { exact: false })).toBeInTheDocument();
+	});
+
+	it('should display the country image text', async () => {
+		await render(BioSummaryCardComponent, {
+			inputs: {
+				story: storyMock,
+			},
+		});
+
+		const countryImage = screen.getByRole('img', {
+			name: countryRegex,
+		});
+
+		expect(countryImage).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
 - [x] Usar `toBeInTheDocument` en lugar de `toBeTruthy`.
 - [x] Cambiar la definición de la función `xdescribe` en `describe` antes de crear la pull request vinculada a este issue.
 - [x] Testear que el country y el name aparezcan en el documento.

