### PR TITLE
[#919] - Migra tests de `AudioRecordingWidgetComponent ` a Angular Testing Library

### DIFF
--- a/src/app/components/audio-recording-widget/audio-recording-widget.component.spec.ts
+++ b/src/app/components/audio-recording-widget/audio-recording-widget.component.spec.ts
@@ -1,21 +1,35 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+// Testing library
+import { render, screen } from '@testing-library/angular';
+
+// Component
 import { AudioRecordingWidgetComponent } from './audio-recording-widget.component';
 
-xdescribe('AudioRecordingWidgetComponent', () => {
-	let component: AudioRecordingWidgetComponent;
-	let fixture: ComponentFixture<AudioRecordingWidgetComponent>;
+// Mocks
+import { audioRecordingMock } from '../../mocks/audio-recording.mock';
 
-	beforeEach(async () => {
-		await TestBed.configureTestingModule({
-			imports: [AudioRecordingWidgetComponent],
-		}).compileComponents();
+fdescribe('AudioRecordingWidgetComponent', () => {
+	it('should render the component', async () => {
+		const { container } = await render(AudioRecordingWidgetComponent, {
+			inputs: { media: audioRecordingMock },
+		});
 
-		fixture = TestBed.createComponent(AudioRecordingWidgetComponent);
-		component = fixture.componentInstance;
-		fixture.detectChanges();
+		expect(container).toBeInTheDocument();
 	});
 
-	it('should create', () => {
-		expect(component).toBeTruthy();
+	it('should render the audio player', async () => {
+		await render(AudioRecordingWidgetComponent, {
+			inputs: { media: audioRecordingMock },
+		});
+
+		const audioRecordingElement = screen.getByTestId('audio-recording') as HTMLElement & { currentSrc: string };
+		expect(audioRecordingElement.currentSrc === audioRecordingMock.data.url).toBeTruthy();
+	});
+
+	it('should display the audio recording title', async () => {
+		await render(AudioRecordingWidgetComponent, {
+			inputs: { media: audioRecordingMock },
+		});
+
+		expect(screen.getByText('Lectura del artículo sobre ajedrez en Wikipedia.')).toBeInTheDocument();
 	});
 });

--- a/src/app/components/audio-recording-widget/audio-recording-widget.component.ts
+++ b/src/app/components/audio-recording-widget/audio-recording-widget.component.ts
@@ -7,10 +7,10 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	selector: 'cuentoneta-audio-recording-widget',
 	standalone: true,
 	imports: [CommonModule, PortableTextParserComponent],
-	template: ` <audio [src]="media().data.url" controls class="mb-2 block w-full"></audio>
-		<label class="inter-body-xs-medium text-primary-500"
-			><cuentoneta-portable-text-parser [paragraphs]="media().description" />
-		</label>`,
+	template: `
+		<audio [src]="media().data.url" controls class="mb-2 block w-full"></audio>
+		<cuentoneta-portable-text-parser [paragraphs]="media().description" class="inter-body-xs-medium text-primary-500" />
+	`,
 	styles: ``,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/app/components/audio-recording-widget/audio-recording-widget.component.ts
+++ b/src/app/components/audio-recording-widget/audio-recording-widget.component.ts
@@ -1,6 +1,10 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+
+// Models
 import { AudioRecording } from '@models/media.model';
+
+// Components
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 
 @Component({
@@ -8,10 +12,9 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	standalone: true,
 	imports: [CommonModule, PortableTextParserComponent],
 	template: `
-		<audio [src]="media().data.url" controls class="mb-2 block w-full"></audio>
+		<audio [src]="media().data.url" data-testid="audio-recording" controls class="mb-2 block w-full"></audio>
 		<cuentoneta-portable-text-parser [paragraphs]="media().description" class="inter-body-xs-medium text-primary-500" />
 	`,
-	styles: ``,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AudioRecordingWidgetComponent {

--- a/src/app/mocks/audio-recording.mock.ts
+++ b/src/app/mocks/audio-recording.mock.ts
@@ -9,22 +9,10 @@ export const audioRecordingMock: AudioRecording = {
 			markDefs: [],
 			children: [
 				{
-					text: 'Lectura del artículo sobre ',
+					text: 'Lectura del artículo sobre ajedrez en Wikipedia.',
 					_key: '9c6409086fe0',
 					_type: 'span',
 					marks: [],
-				},
-				{
-					_type: 'span',
-					marks: ['em'],
-					text: 'ajedrez',
-					_key: '26de23832101',
-				},
-				{
-					_type: 'span',
-					marks: [],
-					text: 'en Wikipedia.',
-					_key: '5816b3cc116b',
 				},
 			],
 			_type: 'block',

--- a/src/app/mocks/audio-recording.mock.ts
+++ b/src/app/mocks/audio-recording.mock.ts
@@ -1,0 +1,37 @@
+import { AudioRecording } from '@models/media.model';
+
+export const audioRecordingMock: AudioRecording = {
+	title: 'Lectura de artículo en formato .ogg',
+	type: 'audioRecording',
+	description: [
+		{
+			_key: '93a3b8bbeb86',
+			markDefs: [],
+			children: [
+				{
+					text: 'Lectura del artículo sobre ',
+					_key: '9c6409086fe0',
+					_type: 'span',
+					marks: [],
+				},
+				{
+					_type: 'span',
+					marks: ['em'],
+					text: 'ajedrez',
+					_key: '26de23832101',
+				},
+				{
+					_type: 'span',
+					marks: [],
+					text: 'en Wikipedia.',
+					_key: '5816b3cc116b',
+				},
+			],
+			_type: 'block',
+			style: 'normal',
+		},
+	],
+	data: {
+		url: 'https://es.wikipedia.org/wiki/Archivo:Es-Ajedrez-article-part1.ogg',
+	},
+};


### PR DESCRIPTION
## Resumen
- Agrega mock para objeto del tipo `AudioRecording`.
- Migra tests para `AudioRecordingWidgetComponent` desde TestBed a Angular Testing Library.
- Agrega tests relevantes al componente. Se hace uso de `getByTestId`, con el atributo `data-testid` para resolver la ausencia de `roles` asignables a tags de tipo `audio`. Ver caso de [audio](https://www.w3.org/TR/html-aria/#el-audio) en el sitio del WCAG.