### PR TITLE
[#1040] - Implementar componente `ContentCampaignCarouselComponent`

### DIFF
--- a/cms/schemas/contentCampaign.ts
+++ b/cms/schemas/contentCampaign.ts
@@ -6,7 +6,7 @@ import { localizedRequire } from '../utils/validations';
 import {
 	ContentCampaignViewport,
 	ContentCampaignViewportKeys,
-	imageViewportSizes,
+	viewportElementSizes,
 } from '../../src/app/models/content-campaign.model';
 
 const imageResourcePattern = /^image-([a-f\d]+)-(\d+x\d+)-(\w+)$/;
@@ -31,7 +31,7 @@ const campaignCharLimitValidation = (blocks, context) => {
 
 	const property = context.path[context.path.length - 1];
 	const viewport = context.path[context.path.length - 2];
-	const maxChars = imageViewportSizes[viewport][property];
+	const maxChars = viewportElementSizes[viewport][property];
 
 	if (totalCharacters > maxChars) {
 		return `La longitud máxima es de ${maxChars} caracteres. Longitud actual: ${totalCharacters}`;
@@ -42,7 +42,7 @@ const campaignCharLimitValidation = (blocks, context) => {
 
 const campaignImageSizeValidation = (image, context) => {
 	const viewport = context.path[context.path.length - 2];
-	const viewportSize = imageViewportSizes[viewport];
+	const viewportSize = viewportElementSizes[viewport];
 
 	if (!image || !viewportSize) return true;
 	const { dimensions } = decodeAssetId(image.asset._ref);
@@ -72,7 +72,7 @@ const generateContent = (viewport: ContentCampaignViewport) => {
 			}),
 			defineField({
 				name: 'image',
-				title: `Imagen (${imageViewportSizes[viewport].imageWidth}px x ${imageViewportSizes[viewport].imageHeight}px de tamaño)`,
+				title: `Imagen (${viewportElementSizes[viewport].imageWidth}px x ${viewportElementSizes[viewport].imageHeight}px de tamaño)`,
 				type: 'image',
 				validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignImageSizeValidation)],
 			}),

--- a/cms/schemas/contentCampaign.ts
+++ b/cms/schemas/contentCampaign.ts
@@ -2,6 +2,13 @@ import { defineField, defineType } from 'sanity';
 import { CalendarIcon } from '@sanity/icons';
 import { localizedRequire } from '../utils/validations';
 
+// Models
+import {
+	ContentCampaignViewport,
+	ContentCampaignViewportKeys,
+	imageViewportSizes,
+} from '../../src/app/models/content-campaign.model';
+
 const imageResourcePattern = /^image-([a-f\d]+)-(\d+x\d+)-(\w+)$/;
 
 const decodeAssetId = (id) => {
@@ -16,17 +23,6 @@ const decodeAssetId = (id) => {
 };
 
 const campaignCharLimitValidation = (blocks, context) => {
-	const limits = {
-		xs: {
-			title: 32,
-			subtitle: 36,
-		},
-		md: {
-			title: 40,
-			subtitle: 60,
-		},
-	};
-
 	if (!blocks || blocks.length === 0) return true;
 
 	const totalCharacters = blocks
@@ -35,7 +31,7 @@ const campaignCharLimitValidation = (blocks, context) => {
 
 	const property = context.path[context.path.length - 1];
 	const viewport = context.path[context.path.length - 2];
-	const maxChars = limits[viewport][property];
+	const maxChars = imageViewportSizes[viewport][property];
 
 	if (totalCharacters > maxChars) {
 		return `La longitud máxima es de ${maxChars} caracteres. Longitud actual: ${totalCharacters}`;
@@ -45,26 +41,43 @@ const campaignCharLimitValidation = (blocks, context) => {
 };
 
 const campaignImageSizeValidation = (image, context) => {
-	const viewportSizes = {
-		xs: {
-			width: 540,
-			height: 220,
-		},
-		md: {
-			width: 960,
-			height: 280,
-		},
-	};
-
 	const viewport = context.path[context.path.length - 2];
-	const viewportSize = viewportSizes[viewport];
+	const viewportSize = imageViewportSizes[viewport];
 
 	if (!image || !viewportSize) return true;
 	const { dimensions } = decodeAssetId(image.asset._ref);
 	return (
-		(dimensions.width === viewportSize.width && dimensions.height === viewportSize.height) ||
-		`La imagen debe tener un tamaño estricto de ${viewportSize.width} x ${viewportSize.height} px. El tamaño de la imagen actual es de ${dimensions.width} x ${dimensions.height} px`
+		(dimensions.width === viewportSize.imageWidth && dimensions.height === viewportSize.imageHeight) ||
+		`La imagen debe tener un tamaño estricto de ${viewportSize.imageWidth} x ${viewportSize.imageHeight} px. El tamaño de la imagen actual es de ${dimensions.width} x ${dimensions.height} px`
 	);
+};
+
+const generateContent = (viewport: ContentCampaignViewport) => {
+	return defineField({
+		name: viewport,
+		title: `Viewport ${viewport}`,
+		type: 'object',
+		fields: [
+			defineField({
+				name: 'title',
+				title: 'Título',
+				type: 'blockContent',
+				validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignCharLimitValidation)],
+			}),
+			defineField({
+				name: 'subtitle',
+				title: 'Subtítulo',
+				type: 'blockContent',
+				validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignCharLimitValidation)],
+			}),
+			defineField({
+				name: 'image',
+				title: `Imagen (${imageViewportSizes[viewport].imageWidth}px x ${imageViewportSizes[viewport].imageHeight}px de tamaño)`,
+				type: 'image',
+				validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignImageSizeValidation)],
+			}),
+		],
+	});
 };
 
 export default defineType({
@@ -105,58 +118,7 @@ export default defineType({
 			name: 'contents',
 			title: 'Contenidos',
 			type: 'object',
-			fields: [
-				defineField({
-					name: 'xs',
-					title: 'Viewport mobile (xs, sm)',
-					type: 'object',
-					fields: [
-						defineField({
-							name: 'title',
-							title: 'Título',
-							type: 'blockContent',
-							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignCharLimitValidation)],
-						}),
-						defineField({
-							name: 'subtitle',
-							title: 'Subtítulo',
-							type: 'blockContent',
-							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignCharLimitValidation)],
-						}),
-						defineField({
-							name: 'image',
-							title: 'Imagen (540px x 220px de tamaño)',
-							type: 'image',
-							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignImageSizeValidation)],
-						}),
-					],
-				}),
-				defineField({
-					name: 'md',
-					title: 'Viewport tablet horizontal y desktop (md y superior)',
-					type: 'object',
-					fields: [
-						defineField({
-							name: 'title',
-							title: 'Título',
-							type: 'blockContent',
-							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignCharLimitValidation)],
-						}),
-						defineField({
-							name: 'subtitle',
-							title: 'Subtítulo',
-							type: 'blockContent',
-							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignCharLimitValidation)],
-						}),
-						defineField({
-							name: 'image',
-							title: 'Imagen (960px x 280px de tamaño)',
-							type: 'image',
-							validation: (Rule) => [Rule.custom(localizedRequire), Rule.custom(campaignImageSizeValidation)],
-						}),
-					],
-				}),
-			],
+			fields: [...ContentCampaignViewportKeys.map((key) => generateContent(key))],
 		}),
 	],
 });

--- a/project.json
+++ b/project.json
@@ -22,7 +22,11 @@
 				"prerender": {
 					"discoverRoutes": true
 				},
-				"styles": ["./src/styles.scss"],
+				"styles": [
+					"node_modules/ngx-owl-carousel-o/lib/styles/prebuilt-themes/owl.carousel.min.css",
+					"node_modules/ngx-owl-carousel-o/lib/styles/prebuilt-themes/owl.theme.default.min.css",
+					"./src/styles.scss"
+				],
 				"scripts": []
 			},
 			"configurations": {

--- a/project.json
+++ b/project.json
@@ -22,11 +22,7 @@
 				"prerender": {
 					"discoverRoutes": true
 				},
-				"styles": [
-					"node_modules/ngx-owl-carousel-o/lib/styles/prebuilt-themes/owl.carousel.min.css",
-					"node_modules/ngx-owl-carousel-o/lib/styles/prebuilt-themes/owl.theme.default.min.css",
-					"./src/styles.scss"
-				],
+				"styles": ["./src/styles.scss"],
 				"scripts": []
 			},
 			"configurations": {

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -12,26 +12,23 @@ import imageUrlBuilder from '@sanity/image-url';
 
 // Modelos
 import { Author, AuthorTeaser } from '@models/author.model';
-import { BlockContent, LandingPageContentQueryResult, StorylistTeasersQueryResult } from '../sanity/types';
-import {
-	ContentCampaign,
-	ContentCampaignViewport,
-	ContentCampaignViewportKeys,
-	viewportElementSizes,
-} from '@models/content-campaign.model';
+import { ContentCampaign, viewportElementSizes } from '@models/content-campaign.model';
 import { LandingPageContent } from '@models/landing-page-content.model';
 import { Publication, Storylist, StorylistTeaser } from '@models/storylist.model';
 import { Resource } from '@models/resource.model';
 import { Story, StoryPreview, StoryTeaser } from '@models/story.model';
-import { TextBlockContent } from '@models/block-content.model';
 import { Tag } from '@models/tag.model';
+import { TextBlockContent } from '@models/block-content.model';
 
 // Tipos de Sanity
 import {
 	AuthorBySlugQueryResult,
+	BlockContent,
+	LandingPageContentQueryResult,
 	StoriesByAuthorSlugQueryResult,
 	StoryBySlugQueryResult,
 	StorylistQueryResult,
+	StorylistTeasersQueryResult,
 } from '../sanity/types';
 
 export function mapAuthor(rawAuthorData: NonNullable<AuthorBySlugQueryResult>, language: 'es' | 'en' = 'es'): Author {

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -17,7 +17,7 @@ import {
 	ContentCampaign,
 	ContentCampaignViewport,
 	ContentCampaignViewportKeys,
-	imageViewportSizes,
+	viewportElementSizes,
 } from '@models/content-campaign.model';
 import { LandingPageContent } from '@models/landing-page-content.model';
 import { Publication, Storylist, StorylistTeaser } from '@models/storylist.model';
@@ -231,15 +231,15 @@ export function mapContentCampaigns(campaigns: ContentCampaignsSubQuery): Conten
 					title: mapBlockContentToTextParagraphs(xs.title),
 					subtitle: mapBlockContentToTextParagraphs(xs.subtitle),
 					imageUrl: xs.image ? urlFor(xs.image) : '',
-					imageWidth: imageViewportSizes.xs.imageWidth,
-					imageHeight: imageViewportSizes.xs.imageHeight,
+					imageWidth: viewportElementSizes.xs.imageWidth,
+					imageHeight: viewportElementSizes.xs.imageHeight,
 				},
 				md: {
 					title: mapBlockContentToTextParagraphs(md.title),
 					subtitle: mapBlockContentToTextParagraphs(md.subtitle),
 					imageUrl: md.image ? urlFor(md.image) : '',
-					imageWidth: imageViewportSizes.md.imageWidth,
-					imageHeight: imageViewportSizes.md.imageHeight,
+					imageWidth: viewportElementSizes.md.imageWidth,
+					imageHeight: viewportElementSizes.md.imageHeight,
 				},
 			},
 		};

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -13,7 +13,12 @@ import imageUrlBuilder from '@sanity/image-url';
 // Modelos
 import { Author, AuthorTeaser } from '@models/author.model';
 import { BlockContent, LandingPageContentQueryResult, StorylistTeasersQueryResult } from '../sanity/types';
-import { ContentCampaign } from '@models/content-campaign.model';
+import {
+	ContentCampaign,
+	ContentCampaignViewport,
+	ContentCampaignViewportKeys,
+	imageViewportSizes,
+} from '@models/content-campaign.model';
 import { LandingPageContent } from '@models/landing-page-content.model';
 import { Publication, Storylist, StorylistTeaser } from '@models/storylist.model';
 import { Resource } from '@models/resource.model';
@@ -211,8 +216,7 @@ export function mapLandingPageContent(result: NonNullable<LandingPageContentQuer
 type ContentCampaignsSubQuery = NonNullable<LandingPageContentQueryResult>['campaigns'];
 export function mapContentCampaigns(campaigns: ContentCampaignsSubQuery): ContentCampaign[] {
 	return campaigns.map((campaign) => {
-		const xs = campaign.contents.xs;
-		const md = campaign.contents.md;
+		const { xs, md } = campaign.contents;
 
 		if (!xs || !md) {
 			throw new Error('Campaign content not found');
@@ -227,11 +231,15 @@ export function mapContentCampaigns(campaigns: ContentCampaignsSubQuery): Conten
 					title: mapBlockContentToTextParagraphs(xs.title),
 					subtitle: mapBlockContentToTextParagraphs(xs.subtitle),
 					imageUrl: xs.image ? urlFor(xs.image) : '',
+					imageWidth: imageViewportSizes.xs.imageWidth,
+					imageHeight: imageViewportSizes.xs.imageHeight,
 				},
 				md: {
 					title: mapBlockContentToTextParagraphs(md.title),
 					subtitle: mapBlockContentToTextParagraphs(md.subtitle),
 					imageUrl: md.image ? urlFor(md.image) : '',
+					imageWidth: imageViewportSizes.md.imageWidth,
+					imageHeight: imageViewportSizes.md.imageHeight,
 				},
 			},
 		};

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -14,6 +14,7 @@ import { DatePipe, registerLocaleData } from '@angular/common';
 
 // Providers
 import { ThemeService } from './providers/theme.service';
+import { provideAnimations } from '@angular/platform-browser/animations';
 
 registerLocaleData(localeEs);
 
@@ -29,6 +30,7 @@ export const appConfig: ApplicationConfig = {
 		},
 		{ provide: LOCALE_ID, useValue: 'es-419' },
 		provideClientHydration(),
+		provideAnimations(),
 		provideRouter(
 			appRoutes,
 			withEnabledBlockingInitialNavigation(),

--- a/src/app/components/content-campaign-carousel/content-campaign-carousel.component.spec.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel.component.spec.ts
@@ -1,0 +1,12 @@
+import { ContentCampaignCarouselComponent } from './content-campaign-carousel.component';
+import { render } from '@testing-library/angular';
+import { contentCampaignMock } from '../../mocks/content-campaign.mock';
+
+describe('ContentCampaignCarouselComponent', () => {
+	it('should render the component', async () => {
+		const { container } = await render(ContentCampaignCarouselComponent, {
+			inputs: { slides: contentCampaignMock },
+		});
+		expect(container).toBeInTheDocument();
+	});
+});

--- a/src/app/components/content-campaign-carousel/content-campaign-carousel.component.stories.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel.component.stories.ts
@@ -1,0 +1,41 @@
+import { Meta, moduleMetadata } from '@storybook/angular';
+import { ContentCampaignCarouselComponent } from './content-campaign-carousel.component';
+import { ContentService } from '../../providers/content.service';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { CarouselModule } from 'ngx-owl-carousel-o';
+import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
+import { contentCampaignMock } from '../../mocks/content-campaign.mock';
+import { RouterTestingModule } from '@angular/router/testing';
+
+export default {
+	title: 'ContentCampaignCarouselComponent',
+	component: ContentCampaignCarouselComponent,
+	decorators: [
+		moduleMetadata({
+			imports: [
+				CommonModule,
+				CarouselModule,
+				NgOptimizedImage,
+				RouterTestingModule,
+				PortableTextParserComponent,
+				NoopAnimationsModule,
+			],
+			providers: [ContentService],
+		}),
+	],
+} as Meta<ContentCampaignCarouselComponent>;
+
+export const Primary = {
+	render: (args: ContentCampaignCarouselComponent) => ({
+		props: args,
+		template: `
+	  <div class="block">
+		<cuentoneta-content-campaign-carousel [slides]="slides"/>
+		</div>
+		`,
+	}),
+	args: {
+		slides: contentCampaignMock,
+	},
+};

--- a/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
@@ -1,5 +1,5 @@
 // Core
-import { Component, computed, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 

--- a/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
@@ -1,0 +1,93 @@
+// Core
+import { Component, computed, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
+
+// 3rd party modules
+import { CarouselModule, OwlOptions } from 'ngx-owl-carousel-o';
+
+// Models
+import { ContentCampaign, ContentCampaignViewport, ContentCampaignViewportKeys } from '@models/content-campaign.model';
+
+// Components
+import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
+
+@Component({
+	selector: 'cuentoneta-content-campaign-carousel',
+	standalone: true,
+	imports: [CommonModule, CarouselModule, NgOptimizedImage, RouterLink, PortableTextParserComponent],
+
+	template: `
+		<section class="block">
+			<!-- TODO: Eliminar valor harcoded de 960px una vez actualizado el ancho máximo de pantalla -->
+			<owl-carousel-o [options]="options" class="mx-auto block max-w-[960px]">
+				@for (slide of slides(); track slide.slug) {
+					<ng-template carouselSlide>
+						<div class="slide mr-3">
+							@for (viewport of viewports; track $index) {
+								<a [routerLink]="slide.url" [ngClass]="viewportSpecificClasses[viewport]">
+									<header class="mb-3">
+										<h3 class="text-lg font-bold tracking-normal">
+											<cuentoneta-portable-text-parser
+												[paragraphs]="slide.contents[viewport].title"
+											></cuentoneta-portable-text-parser>
+										</h3>
+										<h4 class="h4 subtitle text-gray-600">
+											<cuentoneta-portable-text-parser
+												[paragraphs]="slide.contents[viewport].subtitle"
+											></cuentoneta-portable-text-parser>
+										</h4>
+									</header>
+									<img
+										[ngSrc]="slide.contents[viewport].imageUrl"
+										[width]="slide.contents[viewport].imageWidth"
+										[height]="slide.contents[viewport].imageHeight"
+										[alt]="'Imagen de la campaña de contenido ' + slide.title"
+										[ngClass]="
+											'max-w-[' +
+											slide.contents[viewport].imageWidth +
+											'px] max-h-[' +
+											slide.contents[viewport].imageHeight +
+											'px] rounded-2xl'
+										"
+										class="rounded-2xl"
+										priority
+									/>
+								</a>
+							}
+						</div>
+					</ng-template>
+				}
+			</owl-carousel-o>
+		</section>
+	`,
+})
+export class ContentCampaignCarouselComponent {
+	slides = input<ContentCampaign[]>([]);
+
+	// Lista de viewports soportados por el componente.
+	readonly viewports: ContentCampaignViewport[] = ContentCampaignViewportKeys;
+
+	// Asigna las clases específicas de visibilidad para cada uno de los viewports soportados.
+	readonly viewportSpecificClasses: { [key in ContentCampaignViewport]: string } = {
+		xs: 'md:hidden',
+		md: 'max-md:hidden',
+	};
+
+	// Opciones de configuración del carrusel de campañas de contenido.
+	readonly options: OwlOptions = Object.assign({
+		autoplay: true,
+		autoplaySpeed: 1200,
+		autoplayMouseleaveTimeout: 5000,
+		loop: true,
+		mouseDrag: false,
+		dots: true,
+		navSpeed: 500,
+		responsive: {
+			0: {
+				items: 1,
+			},
+		},
+		nav: false,
+	});
+}

--- a/src/app/mocks/content-campaign.mock.ts
+++ b/src/app/mocks/content-campaign.mock.ts
@@ -1,0 +1,2 @@
+import { ContentCampaign } from '@models/content-campaign.model';
+export const contentCampaignMock: ContentCampaign[] = [];

--- a/src/app/models/content-campaign.model.ts
+++ b/src/app/models/content-campaign.model.ts
@@ -1,11 +1,39 @@
 import { TextBlockContent } from '@models/block-content.model';
 
-type Viewport = 'xs' | 'md';
+/**
+ * Tipo que representa los diferentes viewports soportados por la aplicación para las campañas de contenido, a fin de
+ * proveer una experiencia responsive y adaptable para su visualización.
+ */
+export type ContentCampaignViewport = 'xs' | 'md';
 
+/**
+ * Constante que indica, para los viewports soportados, las longitudes máximas asignables a los títulos y subtítulos
+ * de las campañas de contenido y las dimensiones de las imágenes asociadas a cada una de ellas.
+ */
+export const imageViewportSizes = Object.freeze({
+	xs: {
+		title: 32,
+		subtitle: 36,
+		imageWidth: 540,
+		imageHeight: 220,
+	},
+	md: {
+		title: 40,
+		subtitle: 60,
+		imageWidth: 960,
+		imageHeight: 280,
+	},
+});
+
+/**
+ * Interface que define al objeto de dominio que representa una campaña de contenido en la plataforma.
+ */
 export interface ContentCampaign {
 	title: string;
 	slug: string;
 	description: TextBlockContent[];
 	url: string;
-	contents: { [key in Viewport]: { title: TextBlockContent[]; subtitle: TextBlockContent[]; imageUrl: string } };
+	contents: {
+		[key in ContentCampaignViewport]: { title: TextBlockContent[]; subtitle: TextBlockContent[]; imageUrl: string };
+	};
 }

--- a/src/app/models/content-campaign.model.ts
+++ b/src/app/models/content-campaign.model.ts
@@ -11,7 +11,7 @@ export type ContentCampaignViewport = (typeof ContentCampaignViewportKeys)[numbe
  * Constante que indica, para los viewports soportados, las longitudes máximas asignables a los títulos y subtítulos
  * de las campañas de contenido y las dimensiones de las imágenes asociadas a cada una de ellas.
  */
-export const imageViewportSizes = Object.freeze({
+export const viewportElementSizes = Object.freeze({
 	xs: {
 		title: 32,
 		subtitle: 36,

--- a/src/app/models/content-campaign.model.ts
+++ b/src/app/models/content-campaign.model.ts
@@ -4,7 +4,8 @@ import { TextBlockContent } from '@models/block-content.model';
  * Tipo que representa los diferentes viewports soportados por la aplicación para las campañas de contenido, a fin de
  * proveer una experiencia responsive y adaptable para su visualización.
  */
-export type ContentCampaignViewport = 'xs' | 'md';
+export const ContentCampaignViewportKeys = ['xs', 'md'];
+export type ContentCampaignViewport = (typeof ContentCampaignViewportKeys)[number];
 
 /**
  * Constante que indica, para los viewports soportados, las longitudes máximas asignables a los títulos y subtítulos
@@ -34,6 +35,12 @@ export interface ContentCampaign {
 	description: TextBlockContent[];
 	url: string;
 	contents: {
-		[key in ContentCampaignViewport]: { title: TextBlockContent[]; subtitle: TextBlockContent[]; imageUrl: string };
+		[key in ContentCampaignViewport]: {
+			title: TextBlockContent[];
+			subtitle: TextBlockContent[];
+			imageUrl: string;
+			imageWidth: number;
+			imageHeight: number;
+		};
 	};
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,6 +6,10 @@
 @use 'assets/scss/transitions' as *;
 @use 'src/app/directives/tooltip.directive.scss' as *;
 
+// Imports de estilos de Ngx Owl Carousel
+@import 'ngx-owl-carousel-o/lib/styles/scss/owl.carousel';
+@import 'ngx-owl-carousel-o/lib/styles/scss/owl.theme.default';
+
 // Imports de Tailwind
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## Resumen

## Modelos de dominio
- Se agregan las propiedades `imageWidth` e `imageHeight` para los contenidos de los distintos viewports de las instancias de `ContentCampaign`.
- Se define la constante `viewportElementSizes` para centrar en un único origen los valores relevantes a las longitudes de cadenas de texto de títulos y subtítulos y los tamaños de imagen de las slides del carousel en cada viewport soportado.

## Sanity schemas
- Se redefine el schema haciendo uso de la constante `viewportElementSizes`, a fin de evitar repetir código para cada viewport soportado.

## Backend
- Modifica función `mapContentCampaigns` para agregar los tamaños de imagen de las slides en cada viewport soportado, tomando los tamaños desde `viewportElementSizes`.

## Frontend
- Se agregan estilos de `ngx-owl-carousel-o` en `styles.scss`
- Agrega componente `ContentCampaignCarouselComponent`, el cual posee soporte de la dependencia `ngx-owl-carousel-o` para visualizar el carousel.
- Agregada story de Storybook para visualizar el componente abstraído de su implementación en la plataforma.

## Screenshots
![image](https://github.com/user-attachments/assets/9226edc8-6fe4-421d-b1b1-795ac27b81b9)
![image](https://github.com/user-attachments/assets/94c178af-eb78-4aa4-99e6-2e9b86c501f8)
