### PR TITLE
[#928] -  Reimplementación de unit tests para `EpigraphComponent`

### DIFF
--- a/src/app/components/epigraph/epigraph.component.spec.ts
+++ b/src/app/components/epigraph/epigraph.component.spec.ts
@@ -1,21 +1,22 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { render, screen } from '@testing-library/angular';
 import { EpigraphComponent } from './epigraph.component';
+import { epigraphMock } from 'src/app/mocks/epigraph-mock';
 
-xdescribe('EpigraphComponent', () => {
-	let component: EpigraphComponent;
-	let fixture: ComponentFixture<EpigraphComponent>;
+describe('EpigraphComponent', () => {
+	const setup = async () =>
+		await render(EpigraphComponent, {
+			inputs: { epigraph: epigraphMock },
+		});
 
-	beforeEach(async () => {
-		await TestBed.configureTestingModule({
-			imports: [EpigraphComponent],
-		}).compileComponents();
+	it('should render the component', async () => {
+		const { container } = await setup();
 
-		fixture = TestBed.createComponent(EpigraphComponent);
-		component = fixture.componentInstance;
-		fixture.detectChanges();
+		expect(container).toBeInTheDocument();
 	});
 
-	it('should create', () => {
-		expect(component).toBeTruthy();
+	it('should display text reference', async () => {
+		await setup();
+
+		expect(screen.getByText('El libro de las maravillas de antaño y de hace poco')).toBeInTheDocument();
 	});
 });

--- a/src/app/mocks/epigraph-mock.ts
+++ b/src/app/mocks/epigraph-mock.ts
@@ -1,0 +1,36 @@
+import { Epigraph } from '@models/story.model';
+
+export const epigraphMock: Epigraph = {
+	text: [
+		{
+			children: [
+				{
+					_type: 'span',
+					marks: [],
+					text: 'El pasado es un espejo roto; cada fragmento refleja una verdad diferente.',
+					_key: '3cfcb08396f00',
+				},
+			],
+			_type: 'block',
+			style: 'normal',
+			_key: '8412a637a907',
+			markDefs: [],
+		},
+	],
+	reference: [
+		{
+			children: [
+				{
+					_type: 'span',
+					marks: [],
+					text: 'El libro de las maravillas de antaño y de hace poco',
+					_key: '3cfcb08396f00',
+				},
+			],
+			_type: 'block',
+			style: 'normal',
+			_key: 'c965514932',
+			markDefs: [],
+		},
+	],
+};


### PR DESCRIPTION
- [x]  Migrar la implementación del archivo epigraph.component.spec.ts de TestBed a Angular Testing Library.
- [x]  Agregar un objeto mock de tipo Epigraph para pasar como propiedad al objeto componentInputs de la función render de Angular Testing Library.
- [x]  Usar toBeInTheDocument en lugar de toBeTruthy.
- [x]  Testear que el reference aparezca en el documento.
- [x]  Cambiar la definición de la función xdescribe en describe antes de crear la pull request vinculada a este issue.