### PR TITLE
[#924] - Reimplementación de unit tests para `PortableTextMarksSerializerComponent`

### DIFF
--- a/src/app/components/portable-text-styles-marks-serializer/portable-text-marks-serializer.component.spec.ts
+++ b/src/app/components/portable-text-styles-marks-serializer/portable-text-marks-serializer.component.spec.ts
@@ -1,21 +1,24 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { render, screen } from '@testing-library/angular';
 import { PortableTextMarksSerializerComponent } from './portable-text-marks-serializer.component';
+import { portableTextMarksSerializerMock } from 'src/app/mocks/portable-text-marks-serializer.mock';
 
-xdescribe('PortableTextMarksSerializerComponent', () => {
-	let component: PortableTextMarksSerializerComponent;
-	let fixture: ComponentFixture<PortableTextMarksSerializerComponent>;
+fdescribe('PortableTextMarksSerializerComponent', () => {
+	const setup = async () =>
+		await render(PortableTextMarksSerializerComponent, {
+			inputs: {
+				text: [portableTextMarksSerializerMock],
+			},
+		});
 
-	beforeEach(async () => {
-		await TestBed.configureTestingModule({
-			imports: [PortableTextMarksSerializerComponent],
-		}).compileComponents();
+	it('should render the component', async () => {
+		const { container } = await setup();
 
-		fixture = TestBed.createComponent(PortableTextMarksSerializerComponent);
-		component = fixture.componentInstance;
-		fixture.detectChanges();
+		expect(container).toBeInTheDocument();
 	});
 
-	it('should create', () => {
-		expect(component).toBeTruthy();
+	it('should diply the text', async () => {
+		await setup();
+
+		expect(screen.getByText(portableTextMarksSerializerMock)).toBeInTheDocument();
 	});
 });

--- a/src/app/mocks/portable-text-marks-serializer.mock.ts
+++ b/src/app/mocks/portable-text-marks-serializer.mock.ts
@@ -1,0 +1,1 @@
+export const portableTextMarksSerializerMock: string = 'Pluma de la semana';


### PR DESCRIPTION
Tareas
 

- [x] Migrar la implementación del archivo `portable-text-marks-serializer.component.spec.ts` de TestBed a Angular Testing Library.
- [x]  Crear un mock de tipo string para pasar como propiedad al objeto componentInputs de la función render de Angular Testing Library.
- [x]  Usar toBeInTheDocument en lugar de toBeTruthy.
- [x]  Cambiar la definición de la función xdescribe en describe antes de crear la pull request vinculada a este issue.