### PR TITLE
[#1049] - Agrega componente para skeleton de carrusel de contenido

### DIFF
--- a/src/app/components/content-campaign-carousel/content-campaign-carousel-skeleton.component.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel-skeleton.component.ts
@@ -1,0 +1,82 @@
+// Core
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+// 3rd party modules
+import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+
+// Services
+import { ThemeService } from '../../providers/theme.service';
+
+@Component({
+	selector: 'cuentoneta-content-campaign-carousel-skeleton',
+	standalone: true,
+	imports: [CommonModule, NgxSkeletonLoaderModule],
+	template: ` <div class="mx-auto max-w-[960px]">
+		<div class="slider">
+			<header class="mb-3">
+				<ngx-skeleton-loader
+					[theme]="{
+						'margin-top.px': 5,
+						'margin-bottom.px': 5,
+						'width.px': 192,
+						'height.px': 18,
+						'background-color': skeletonTextColor
+					}"
+					count="1"
+					appearance="line"
+					class="grid"
+				></ngx-skeleton-loader>
+
+				<ngx-skeleton-loader
+					[theme]="{
+						'margin-top.px': 4,
+						'margin-bottom.px': 4,
+						'width.px': 304,
+						'height.px': 16,
+						'background-color': skeletonTextColor
+					}"
+					count="1"
+					appearance="line"
+					class="grid"
+				></ngx-skeleton-loader>
+			</header>
+			<ngx-skeleton-loader
+				[theme]="{
+					'justify-self': 'center',
+					'border-radius.px': '16',
+					'margin-bottom.px': 0,
+					height: '100%',
+					width: '100%',
+					'background-color': skeletonBackgroundColor
+				}"
+				count="1"
+				appearance="line"
+				class="grid aspect-[540/220] w-full object-cover md:aspect-[960/280]"
+			></ngx-skeleton-loader>
+		</div>
+		<div class="footer mt-[10px] h-[27px]">
+			<ngx-skeleton-loader
+				[theme]="{
+					'justify-self': 'center',
+					'border-radius.px': '16',
+					'margin-top.px': 5,
+					'margin-bottom.px': 5,
+					'width.px': 48,
+					'height.px': 10,
+					'background-color': skeletonTextColor
+				}"
+				count="1"
+				appearance="line"
+				class="grid"
+			></ngx-skeleton-loader>
+		</div>
+	</div>`,
+	styles: ``,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ContentCampaignCarouselSkeletonComponent {
+	private themeService = inject(ThemeService);
+	skeletonBackgroundColor = this.themeService.pickColor('zinc', 200);
+	skeletonTextColor = this.themeService.pickColor('zinc', 300);
+}

--- a/src/app/components/content-campaign-carousel/content-campaign-carousel.component.stories.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel.component.stories.ts
@@ -7,6 +7,7 @@ import { CarouselModule } from 'ngx-owl-carousel-o';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 import { contentCampaignMock } from '../../mocks/content-campaign.mock';
 import { RouterTestingModule } from '@angular/router/testing';
+import { ContentCampaignCarouselSkeletonComponent } from './content-campaign-carousel-skeleton.component';
 
 export default {
 	title: 'ContentCampaignCarouselComponent',
@@ -20,6 +21,7 @@ export default {
 				RouterTestingModule,
 				PortableTextParserComponent,
 				NoopAnimationsModule,
+				ContentCampaignCarouselSkeletonComponent,
 			],
 			providers: [ContentService],
 		}),
@@ -32,6 +34,7 @@ export const Primary = {
 		template: `
 	  <div class="block">
 		<cuentoneta-content-campaign-carousel [slides]="slides"/>
+		<cuentoneta-content-campaign-carousel-skeleton/>
 		</div>
 		`,
 	}),

--- a/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
@@ -23,7 +23,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 			<owl-carousel-o [options]="options" class="mx-auto block max-w-[960px]">
 				@for (slide of slides(); track slide.slug) {
 					<ng-template carouselSlide>
-						<div class="slide mr-3">
+						<div class="slide">
 							@for (viewport of viewports; track $index) {
 								<a [routerLink]="slide.url" [ngClass]="viewportSpecificClasses[viewport]">
 									<header class="mb-3">
@@ -83,6 +83,7 @@ export class ContentCampaignCarouselComponent {
 		mouseDrag: false,
 		dots: true,
 		navSpeed: 500,
+		margin: 12,
 		responsive: {
 			0: {
 				items: 1,

--- a/src/app/components/storylist-card-component/storylist-card-skeleton.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card-skeleton.component.ts
@@ -1,0 +1,85 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+import { ThemeService } from '../../providers/theme.service';
+
+@Component({
+	selector: 'cuentoneta-storylist-card-skeleton',
+	standalone: true,
+	imports: [CommonModule, NgxSkeletonLoaderModule],
+	template: `
+		<ngx-skeleton-loader
+			[animation]="'progress-dark'"
+			[theme]="{
+				'border-radius': '0',
+				'border-top-left-radius': '8px',
+				'border-top-right-radius': '8px',
+				height: '240px',
+				'margin-bottom': 0,
+				width: '100%'
+			}"
+			count="1"
+			appearance="line"
+		></ngx-skeleton-loader>
+		<section class="flex flex-col gap-4 px-4 pt-5">
+			<ngx-skeleton-loader
+				[theme]="{
+					'background-color': skeletonColor,
+					height: '40px',
+					'margin-bottom': 0,
+					width: '100%'
+				}"
+				count="1"
+				appearance="line"
+			></ngx-skeleton-loader>
+			<div>
+				<ngx-skeleton-loader
+					[theme]="{
+						height: '16px',
+						'margin-bottom': '8px',
+						width: '100%'
+					}"
+					count="2"
+					appearance="line"
+				></ngx-skeleton-loader>
+				<ngx-skeleton-loader
+					[theme]="{
+						height: '16px',
+						'margin-bottom': '8px',
+						width: '80%'
+					}"
+					count="1"
+					appearance="line"
+				></ngx-skeleton-loader>
+			</div>
+			<hr class="text-gray-300" />
+		</section>
+		<footer class="flex justify-end rounded-b-lg px-5 pb-5 pt-4">
+			<ngx-skeleton-loader
+				[theme]="{
+					'background-color': skeletonColor,
+					height: '22px',
+					'margin-bottom': 0,
+					width: '80px'
+				}"
+				count="1"
+				appearance="line"
+			></ngx-skeleton-loader>
+			<ngx-skeleton-loader
+				[theme]="{
+					'background-color': skeletonColor,
+					height: '22px',
+					'margin-left': '16px',
+					'margin-bottom': 0,
+					width: '80px'
+				}"
+				count="1"
+				appearance="line"
+			></ngx-skeleton-loader>
+		</footer>
+	`,
+})
+export class StorylistCardSkeletonComponent {
+	private themeService = inject(ThemeService);
+	skeletonColor = this.themeService.pickColor('zinc', 300);
+}

--- a/src/app/components/storylist-card-component/storylist-card.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.ts
@@ -1,5 +1,5 @@
 // Core
-import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 
 // Router
@@ -15,9 +15,6 @@ import { StorylistTeaser } from '@models/storylist.model';
 // Components
 import { BadgeComponent } from '../badge/badge.component';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
-
-// Providers
-import { ThemeService } from '../../providers/theme.service';
 
 @Component({
 	selector: 'cuentoneta-storylist-card',
@@ -63,76 +60,6 @@ import { ThemeService } from '../../providers/theme.service';
 						}
 					}
 				</footer>
-			} @else {
-				<ngx-skeleton-loader
-					[animation]="'progress-dark'"
-					[theme]="{
-						'border-radius': '0',
-						'border-top-left-radius': '8px',
-						'border-top-right-radius': '8px',
-						height: '240px',
-						'margin-bottom': 0,
-						width: '100%'
-					}"
-					count="1"
-					appearance="line"
-				></ngx-skeleton-loader>
-				<section class="flex flex-col gap-4 px-4 pt-5">
-					<ngx-skeleton-loader
-						[theme]="{
-							'background-color': skeletonColor,
-							height: '40px',
-							'margin-bottom': 0,
-							width: '100%'
-						}"
-						count="1"
-						appearance="line"
-					></ngx-skeleton-loader>
-					<div>
-						<ngx-skeleton-loader
-							[theme]="{
-								height: '16px',
-								'margin-bottom': '8px',
-								width: '100%'
-							}"
-							count="2"
-							appearance="line"
-						></ngx-skeleton-loader>
-						<ngx-skeleton-loader
-							[theme]="{
-								height: '16px',
-								'margin-bottom': '8px',
-								width: '80%'
-							}"
-							count="1"
-							appearance="line"
-						></ngx-skeleton-loader>
-					</div>
-					<hr class="text-gray-300" />
-				</section>
-				<footer class="flex justify-end rounded-b-lg px-5 pb-5 pt-4">
-					<ngx-skeleton-loader
-						[theme]="{
-							'background-color': skeletonColor,
-							height: '22px',
-							'margin-bottom': 0,
-							width: '80px'
-						}"
-						count="1"
-						appearance="line"
-					></ngx-skeleton-loader>
-					<ngx-skeleton-loader
-						[theme]="{
-							'background-color': skeletonColor,
-							height: '22px',
-							'margin-left': '16px',
-							'margin-bottom': 0,
-							width: '80px'
-						}"
-						count="1"
-						appearance="line"
-					></ngx-skeleton-loader>
-				</footer>
 			}
 		</article>
 	`,
@@ -144,9 +71,5 @@ import { ThemeService } from '../../providers/theme.service';
 })
 export class StorylistCardComponent {
 	storylist = input<StorylistTeaser>();
-
 	protected readonly appRoutes = AppRoutes;
-
-	private themeService = inject(ThemeService);
-	skeletonColor = this.themeService.pickColor('zinc', 300);
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,11 +1,7 @@
 <main>
-	@if (campaigns.length > 0) {
-		@defer {
-			<cuentoneta-content-campaign-carousel [slides]="campaigns"> </cuentoneta-content-campaign-carousel>
-		} @placeholder (minimum 500ms) {
-			<cuentoneta-content-campaign-carousel-skeleton />
-		}
-	} @else {
+	@defer (when campaigns.length > 0) {
+		<cuentoneta-content-campaign-carousel [slides]="campaigns" />
+	} @placeholder (minimum 500ms) {
 		<cuentoneta-content-campaign-carousel-skeleton />
 	}
 

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -16,10 +16,15 @@
 		</h3>
 	</div>
 
-	<!-- TODO: Reintroducir render de skeletons para cards de storylists -->
 	<section class="grid grid-cols-1 justify-items-center gap-8 lg:grid-cols-2">
-		@for (storylist of cards; track storylist.slug) {
-			<cuentoneta-storylist-card [storylist]="storylist" class="card w-full"> </cuentoneta-storylist-card>
+		@defer (when cards.length > 0) {
+			@for (storylist of cards; track storylist.slug) {
+				<cuentoneta-storylist-card [storylist]="storylist" class="card w-full"> </cuentoneta-storylist-card>
+			}
+		} @placeholder (minimum 500ms) {
+			@for (_ of [].constructor(6); track $index) {
+				<cuentoneta-storylist-card-skeleton class="card w-full" />
+			}
 		}
 	</section>
 </main>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,20 +1,12 @@
 <main>
-	@defer (on viewport) {
-		@if (campaigns.length > 0) {
+	@if (campaigns.length > 0) {
+		@defer {
 			<cuentoneta-content-campaign-carousel [slides]="campaigns"> </cuentoneta-content-campaign-carousel>
+		} @placeholder (minimum 500ms) {
+			<cuentoneta-content-campaign-carousel-skeleton />
 		}
-	} @placeholder {
-		<!-- TODO: Emprolijar skeletons en issues futuros relacionados al carousel -->
-		<ngx-skeleton-loader
-			[theme]="{
-				'width.px': 960,
-				'height.px': 240,
-				'background-color': skeletonColor,
-				width: '100%'
-			}"
-			count="1"
-			appearance="line"
-		></ngx-skeleton-loader>
+	} @else {
+		<cuentoneta-content-campaign-carousel-skeleton />
 	}
 
 	<div class="mb-4 flex content-between items-center">

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -19,6 +19,7 @@ import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 import { ContentCampaignCarouselComponent } from '../../components/content-campaign-carousel/content-campaign-carousel.component';
 import { StorylistCardComponent } from '../../components/storylist-card-component/storylist-card.component';
 import { ContentCampaignCarouselSkeletonComponent } from '../../components/content-campaign-carousel/content-campaign-carousel-skeleton.component';
+import { StorylistCardSkeletonComponent } from '../../components/storylist-card-component/storylist-card-skeleton.component';
 
 @Component({
 	selector: 'cuentoneta-home',
@@ -29,6 +30,7 @@ import { ContentCampaignCarouselSkeletonComponent } from '../../components/conte
 		ContentCampaignCarouselComponent,
 		StorylistCardComponent,
 		ContentCampaignCarouselSkeletonComponent,
+		StorylistCardSkeletonComponent,
 	],
 	hostDirectives: [FetchContentDirective, MetaTagsDirective],
 })

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -3,12 +3,8 @@ import { Component, inject, PLATFORM_ID } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 
-// 3rd party modules
-import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
-
 // Services
 import { ContentService } from '../../providers/content.service';
-import { ThemeService } from '../../providers/theme.service';
 
 // Models
 import { ContentCampaign } from '@models/content-campaign.model';
@@ -22,18 +18,23 @@ import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 // Componentes
 import { ContentCampaignCarouselComponent } from '../../components/content-campaign-carousel/content-campaign-carousel.component';
 import { StorylistCardComponent } from '../../components/storylist-card-component/storylist-card.component';
+import { ContentCampaignCarouselSkeletonComponent } from '../../components/content-campaign-carousel/content-campaign-carousel-skeleton.component';
 
 @Component({
 	selector: 'cuentoneta-home',
 	templateUrl: './home.component.html',
 	standalone: true,
-	imports: [CommonModule, ContentCampaignCarouselComponent, NgxSkeletonLoaderModule, StorylistCardComponent],
+	imports: [
+		CommonModule,
+		ContentCampaignCarouselComponent,
+		StorylistCardComponent,
+		ContentCampaignCarouselSkeletonComponent,
+	],
 	hostDirectives: [FetchContentDirective, MetaTagsDirective],
 })
 export class HomeComponent {
 	// Services
 	private contentService = inject(ContentService);
-	private themeService = inject(ThemeService);
 
 	// Directives
 	private fetchContentDirective = inject(FetchContentDirective);
@@ -41,7 +42,6 @@ export class HomeComponent {
 
 	cards: StorylistTeaser[] = [];
 	campaigns: ContentCampaign[] = [];
-	skeletonColor = this.themeService.pickColor('zinc', 300);
 
 	constructor() {
 		// Asignación inicial para dibujar skeletons


### PR DESCRIPTION
## Resumen
- Agregado de componente `ContentCampaignCarouselSkeletonComponent` para visualizar skeleton del carrusel de campañas de contenido, incluyendo modificación de stories de Storybook para `ContentCampaignCarouselComponent` para visualizar el estado de carga con skeleton.

## Otros cambios
- Cambios en uso de spacing para `ContentCampaignCarouselSkeletonComponent`, pasando el margin a utilizar como propiedad de la instancia de `NgxOwlCarouselComponent`.
- Agregado componente `StorylistCardSkeletonComponent` para separación de responsabilidades en la visualización del estado de carga de `StorylistCardComponent`
- Agregado uso de `@defer` con la cláusula `when` para simplificar condiciones de visualización de skeleton o instancias cargadas de componentes.

## Screenshots
### Versión desktop
![image](https://github.com/user-attachments/assets/73bac004-ec93-4a34-9d48-91e230e2c397)
### Versión mobile
![image](https://github.com/user-attachments/assets/adbed1bf-2e4f-49a0-ac2a-8aaffb3dbbc3)