### PR TITLE
[#1051] - Actualizar layout y estilos de StorylistCardComponent

### DIFF
--- a/project.json
+++ b/project.json
@@ -73,7 +73,8 @@
 				"configDir": "./.storybook",
 				"browserTarget": "cuentoneta:build",
 				"compodoc": false,
-				"styles": ["./src/styles.scss"]
+				"styles": ["./src/styles.scss"],
+				"assets": ["./src/favicon.ico", "./src/assets"]
 			},
 			"configurations": {
 				"ci": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,7 +10,7 @@ import { RouterModule } from '@angular/router';
 	selector: 'cuentoneta-root',
 	template: `
 		<cuentoneta-header />
-		<div class="mx-5 my-0 min-h-screen md:m-auto md:max-w-screen-lg">
+		<div class="mx-5 my-0 min-h-screen md:m-auto md:max-w-screen-md">
 			<router-outlet />
 		</div>
 		<cuentoneta-footer />

--- a/src/app/components/publication-card/publication-card.component.stories.ts
+++ b/src/app/components/publication-card/publication-card.component.stories.ts
@@ -14,13 +14,20 @@ registerLocaleData(localeEs);
 // Modelos
 import { Publication } from '@models/storylist.model';
 import { storyPreviewMock } from '../../mocks/story.mock';
+import { RouterTestingModule } from '@angular/router/testing';
 
 export default {
 	title: 'PublicationCardComponent',
 	component: PublicationCardComponent,
 	decorators: [
 		moduleMetadata({
-			imports: [NgOptimizedImage, NgxSkeletonLoaderModule, StoryCardSkeletonComponent, StoryEditionDateLabelComponent],
+			imports: [
+				NgOptimizedImage,
+				NgxSkeletonLoaderModule,
+				StoryCardSkeletonComponent,
+				StoryEditionDateLabelComponent,
+				RouterTestingModule,
+			],
 			providers: [DatePipe, { provide: LOCALE_ID, useValue: 'es-419' }],
 		}),
 	],
@@ -33,55 +40,20 @@ const publication: Publication = {
 	story: storyPreviewMock,
 };
 
-export const Historia = {
+export const Primary = {
 	render: (args: PublicationCardComponent) => ({
 		props: args,
 		template: `
       <div class="grid grid-cols-3 gap-4">
           <cuentoneta-publication-card
-              [editionPrefix]="editionPrefix" 
-              [editionSuffix]="editionSuffix" 
-              [displayDate]="displayDate" 
-              [editionIndex]="editionIndex" 
-              [publication]="publication1">
-          </cuentoneta-publication-card>
-          <cuentoneta-publication-card
-              [editionPrefix]="editionPrefix" 
-              [editionSuffix]="editionSuffix" 
-              [displayDate]="displayDate" 
-              [editionIndex]="editionIndex" 
-              [publication]="publication2">
-          </cuentoneta-publication-card>
-          <cuentoneta-publication-card
-              [editionPrefix]="editionPrefix" 
-              [editionSuffix]="editionSuffix" 
-              [displayDate]="displayDate" 
-              [editionIndex]="editionIndex" 
-              [publication]="publication3">
-          </cuentoneta-publication-card>
+              [editionLabel]="editionLabel" 
+              [publication]="publication"
+              [navigationRoute]="['/']" />
     </div>
 `,
 	}),
 	args: {
-		editionPrefix: 'Episodio',
-		editionSuffix: '',
-		displayDate: false,
-		editionIndex: 0,
-		publication1: publication,
-		publication2: { ...publication, published: false },
-		publication3: null,
-	},
-};
-
-export const Cargando = {
-	render: (args: PublicationCardComponent) => ({
-		props: args,
-	}),
-	args: {
-		editionPrefix: 'Episodio',
-		editionSuffix: '',
-		displayDate: false,
-		editionIndex: 0,
-		publication: null,
+		editionLabel: 'Episodio #1',
+		publication: publication,
 	},
 };

--- a/src/app/components/storylist-card-component/storylist-card-skeleton.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card-skeleton.component.ts
@@ -8,19 +8,6 @@ import { ThemeService } from '../../providers/theme.service';
 	standalone: true,
 	imports: [CommonModule, NgxSkeletonLoaderModule],
 	template: `
-		<ngx-skeleton-loader
-			[animation]="'progress-dark'"
-			[theme]="{
-				'border-radius': '0',
-				'border-top-left-radius': '8px',
-				'border-top-right-radius': '8px',
-				height: '240px',
-				'margin-bottom': 0,
-				width: '100%'
-			}"
-			count="1"
-			appearance="line"
-		></ngx-skeleton-loader>
 		<section class="flex flex-col gap-4 px-4 pt-5">
 			<ngx-skeleton-loader
 				[theme]="{

--- a/src/app/components/storylist-card-component/storylist-card.component.stories.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.stories.ts
@@ -2,116 +2,164 @@ import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { StorylistCardComponent } from './storylist-card.component';
 import { NgOptimizedImage } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
-import { PublicationCardComponent } from '../publication-card/publication-card.component';
+import { StorylistCardSkeletonComponent } from './storylist-card-skeleton.component';
+
+const storylist1 = {
+	count: 60,
+	title: 'La Cuentoneta 1.0',
+	description: [
+		{
+			_key: '58f75b67346a',
+			markDefs: [],
+			children: [
+				{
+					_key: 'e846ec598eb60',
+					_type: 'span',
+					marks: [],
+					text: 'La colección de cuentos de la primera versión de La Cuentoneta, publicados diariamente entre el Año Nuevo y el Martes de Carnaval de 2022. Esta colección consiste de sesenta textos, todos ellos de diferentes autores.',
+				},
+			],
+			_type: 'block',
+			style: 'normal',
+		},
+	],
+	displayDates: true,
+	editionPrefix: 'Día',
+	featuredImage:
+		'https://cdn.sanity.io/images/s4dbqkc5/development/d1a7fc995e0a4d640c9d8e98fb56f56f209f3d89-392x318.webp',
+	publications: [],
+	slug: 'verano-2022',
+	language: 'es',
+	comingNextLabel: 'Próximamente',
+	tags: [
+		{
+			shortDescription: 'Selección de textos a cargo del staff de La Cuentoneta.',
+			description: [
+				{
+					style: 'normal',
+					_key: '6af1079cc442',
+					markDefs: [],
+					children: [
+						{
+							_type: 'span',
+							marks: [],
+							text: 'Selección de textos a cargo del staff de La Cuentoneta.',
+							_key: '9ab33363f0570',
+						},
+					],
+					_type: 'block',
+				},
+			],
+			icon: {
+				provider: 'mdi',
+				name: 'stars',
+				svg: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style="width: 1.5em; height: 1em;"><path fill="none" d="M0 0h24v24H0z"></path><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm4.24 16L12 15.45 7.77 18l1.12-4.81-3.73-3.23 4.92-.42L12 5l1.92 4.53 4.92.42-3.73 3.23L16.23 18z"></path></svg>',
+			},
+			title: 'Curaduría',
+			slug: 'curaduria',
+		},
+	],
+};
+const storylist2 = {
+	slug: 'fec-english-sessions',
+	count: 13,
+	displayDates: false,
+	title: 'FEC English Sessions',
+	editionPrefix: '',
+	comingNextLabel: 'Próximamente',
+	description: [
+		{
+			_key: '58f75b67346a',
+			markDefs: [],
+			children: [
+				{
+					_key: 'e846ec598eb60',
+					_type: 'span',
+					marks: [],
+					text: 'Material para uso del English Study Group de FrontendCafé. Mediante estas historias disparamos charlas y practicamos nuestro reading en las sesiones virtuales de los Martes y Jueves.',
+				},
+			],
+			_type: 'block',
+			style: 'normal',
+		},
+	],
+	publications: [],
+	featuredImage:
+		'https://cdn.sanity.io/images/s4dbqkc5/development/f6be445b251ce65a33721605303069659997bfbf-602x240.jpg?w=2000&fit=max&auto=format',
+	tags: [
+		{
+			title: 'Colaborativa',
+			slug: 'colaborativa',
+			description: 'Lista de textos generada colaborativamente por la comunidad',
+			icon: {
+				name: 'stars',
+				provider: 'mdi',
+				svg: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style="width: 1.5em; height: 1em;"><path fill="none" d="M0 0h24v24H0z"></path><path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"></path></svg>',
+			},
+		},
+		{
+			title: 'Inglés',
+			slug: 'ingles',
+			description: 'Textos íntegramente en idioma inglés',
+			icon: {
+				name: 'people',
+				provider: 'mdi',
+				svg: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style="width: 1.5em; height: 1em;"><path fill="none" d="M0 0h24v24H0V0z"></path><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm6.93 6h-2.95a15.65 15.65 0 00-1.38-3.56A8.03 8.03 0 0118.92 8zM12 4.04c.83 1.2 1.48 2.53 1.91 3.96h-3.82c.43-1.43 1.08-2.76 1.91-3.96zM4.26 14C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2s.06 1.34.14 2H4.26zm.82 2h2.95c.32 1.25.78 2.45 1.38 3.56A7.987 7.987 0 015.08 16zm2.95-8H5.08a7.987 7.987 0 014.33-3.56A15.65 15.65 0 008.03 8zM12 19.96c-.83-1.2-1.48-2.53-1.91-3.96h3.82c-.43 1.43-1.08 2.76-1.91 3.96zM14.34 14H9.66c-.09-.66-.16-1.32-.16-2s.07-1.35.16-2h4.68c.09.65.16 1.32.16 2s-.07 1.34-.16 2zm.25 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95a8.03 8.03 0 01-4.33 3.56zM16.36 14c.08-.66.14-1.32.14-2s-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2h-3.38z"></path></svg>',
+			},
+		},
+	],
+};
 
 const meta: Meta<StorylistCardComponent> = {
 	component: StorylistCardComponent,
 	title: 'StorylistCardComponent',
 	decorators: [
 		moduleMetadata({
-			imports: [NgOptimizedImage, RouterTestingModule],
+			imports: [NgOptimizedImage, RouterTestingModule, StorylistCardSkeletonComponent],
 		}),
 	],
 };
 export default meta;
-type Story = StoryObj<StorylistCardComponent>;
 
-export const Primary: Story = {
+export const Primary = {
 	render: (args: StorylistCardComponent) => ({
 		props: args,
-	}),
-	args: {},
-};
-
-export const Loading: Story = {
-	render: (args: StorylistCardComponent) => ({
-		props: args,
-	}),
-	args: {},
-};
-
-export const Layout = {
-	render: (args: PublicationCardComponent) => ({
-		props: args,
-		styles: [
-			`
-            .grid {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            grid-gap: 1rem;
-            }
-        `,
-		],
 		template: `
-      <div class="grid gap-4">
-          <cuentoneta-storylist-card class="card" [storylist]="storylist1">
-          </cuentoneta-storylist-card>
-          <cuentoneta-storylist-card class="card" [storylist]="storylist2">
-          </cuentoneta-storylist-card>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 bg-gray-100 p-4">
+          <cuentoneta-storylist-card class="card" [storylist]="storylist"/>
+          <cuentoneta-storylist-card-skeleton class="card w-full"/>
     </div>
 `,
 	}),
 	args: {
-		storylist1: {
-			slug: 'verano-2022',
-			count: 60,
-			displayDates: true,
-			title: 'Cuentoneta 1.0',
-			editionPrefix: 'Día',
-			comingNextLabel: 'Próximamente',
-			description: [
-				'La colección “Cuentos de Verano” de la primera versión de La Cuentoneta: una selección de textos publicados diariamente entre el Año Nuevo y el Martes de Carnaval de 2022',
-			],
-			featuredImage:
-				'https://cdn.sanity.io/images/s4dbqkc5/production/d1a7fc995e0a4d640c9d8e98fb56f56f209f3d89-392x318.webp',
-			tags: [
-				{
-					title: 'Curaduría',
-					slug: 'curaduria',
-					description: 'Selección de textos del staff de La Cuentoneta',
-					icon: {
-						name: 'stars',
-						provider: 'mdi',
-						svg: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style="width: 1.5em; height: 1em;"><path fill="none" d="M0 0h24v24H0z"></path><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm4.24 16L12 15.45 7.77 18l1.12-4.81-3.73-3.23 4.92-.42L12 5l1.92 4.53 4.92.42-3.73 3.23L16.23 18z"></path></svg>',
-					},
-				},
-			],
-		},
-		storylist2: {
-			slug: 'fec-english-sessions',
-			count: 13,
-			displayDates: false,
-			title: 'FEC English Sessions',
-			editionPrefix: '',
-			comingNextLabel: 'Próximamente',
-			description: [
-				'Material para uso del English Study Group de FrontendCafé. Mediante estas historias disparamos charlas y practicamos nuestro reading en las sesiones virtuales de los Martes y Jueves.',
-			],
-			publications: [],
-			featuredImage:
-				'https://cdn.sanity.io/images/s4dbqkc5/development/f6be445b251ce65a33721605303069659997bfbf-602x240.jpg?w=2000&fit=max&auto=format',
-			tags: [
-				{
-					title: 'Colaborativa',
-					slug: 'colaborativa',
-					description: 'Lista de textos generada colaborativamente por la comunidad',
-					icon: {
-						name: 'stars',
-						provider: 'mdi',
-						svg: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style="width: 1.5em; height: 1em;"><path fill="none" d="M0 0h24v24H0z"></path><path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"></path></svg>',
-					},
-				},
-				{
-					title: 'Inglés',
-					slug: 'ingles',
-					description: 'Textos íntegramente en idioma inglés',
-					icon: {
-						name: 'people',
-						provider: 'mdi',
-						svg: '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style="width: 1.5em; height: 1em;"><path fill="none" d="M0 0h24v24H0V0z"></path><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm6.93 6h-2.95a15.65 15.65 0 00-1.38-3.56A8.03 8.03 0 0118.92 8zM12 4.04c.83 1.2 1.48 2.53 1.91 3.96h-3.82c.43-1.43 1.08-2.76 1.91-3.96zM4.26 14C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2s.06 1.34.14 2H4.26zm.82 2h2.95c.32 1.25.78 2.45 1.38 3.56A7.987 7.987 0 015.08 16zm2.95-8H5.08a7.987 7.987 0 014.33-3.56A15.65 15.65 0 008.03 8zM12 19.96c-.83-1.2-1.48-2.53-1.91-3.96h3.82c-.43 1.43-1.08 2.76-1.91 3.96zM14.34 14H9.66c-.09-.66-.16-1.32-.16-2s.07-1.35.16-2h4.68c.09.65.16 1.32.16 2s-.07 1.34-.16 2zm.25 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95a8.03 8.03 0 01-4.33 3.56zM16.36 14c.08-.66.14-1.32.14-2s-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2h-3.38z"></path></svg>',
-					},
-				},
-			],
-		},
+		storylist: storylist1,
 	},
+};
+
+export const Loaded = {
+	render: (args: StorylistCardComponent) => ({
+		props: args,
+		template: `
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 bg-gray-100 p-4">
+          <cuentoneta-storylist-card class="card" [storylist]="storylist1"/>
+          <cuentoneta-storylist-card class="card" [storylist]="storylist2"/>
+    </div>
+`,
+	}),
+	args: {
+		storylist1: storylist1,
+		storylist2: storylist2,
+	},
+};
+
+export const Loading = {
+	render: (args: StorylistCardComponent) => ({
+		props: args,
+		template: `
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 bg-gray-100 p-4">
+          <cuentoneta-storylist-card-skeleton class="card w-full"/>
+          <cuentoneta-storylist-card-skeleton class="card w-full"/>
+    </div>
+`,
+	}),
 };

--- a/src/app/components/storylist-card-component/storylist-card.component.stories.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { Meta, moduleMetadata } from '@storybook/angular';
 import { StorylistCardComponent } from './storylist-card.component';
 import { NgOptimizedImage } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';

--- a/src/app/components/storylist-card-component/storylist-card.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.ts
@@ -32,32 +32,35 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 		<article class="shadow-lg hover:shadow-lg-hover">
 			@if (storylist(); as storylist) {
 				<div [routerLink]="['/' + appRoutes.StoryList, storylist.slug]" class="navigation-link">
-					<header class="h-[240px] max-w-[602px] cursor-pointer">
-						<img
-							[ngSrc]="storylist.featuredImage"
-							width="602"
-							height="240"
-							class="h-[240px] rounded-t-lg object-cover"
-							alt=""
-						/>
-					</header>
-					<section class="flex flex-col gap-4 border-1 border-y-0 border-solid border-primary-300 px-4 pt-5">
-						<h1 class="h1 cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap hover:text-interactive-500">
+					<section
+						class="flex max-w-[480px] flex-col gap-4 rounded-t-2xl border-1 border-b-0 border-solid border-primary-300 px-4 pt-5"
+					>
+						<h1
+							class="h3 cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap font-source-serif italic hover:text-interactive-500"
+						>
 							{{ storylist.title }}
 						</h1>
-						<p class="min-h-9">
-							<cuentoneta-portable-text-parser [paragraphs]="storylist.description"></cuentoneta-portable-text-parser>
+						<p class="inter-body-base-regular h-24 text-gray-600">
+							<cuentoneta-portable-text-parser
+								[paragraphs]="storylist.description"
+								class="line-clamp-4 min-h-24 text-ellipsis"
+							></cuentoneta-portable-text-parser>
 						</p>
 						<hr class="text-gray-300" />
 					</section>
 				</div>
 				<footer
-					class="flex justify-end rounded-b-lg border-1 border-t-0 border-solid border-primary-300 px-5 pb-5 pt-4"
+					class="flex justify-between rounded-b-2xl border-1 border-t-0 border-solid border-primary-300 px-5 pb-5 pt-4"
 				>
+					<div class="flex rounded bg-gray-200 px-4.5 py-0.5 uppercase hover:cursor-default">
+						<span class="inter-body-xs-bold flex items-center gap-1">{{ storylist.count }} historias</span>
+					</div>
 					@if (!!storylist.tags && storylist.tags.length > 0) {
-						@for (tag of storylist.tags; track tag.slug) {
-							<cuentoneta-badge [tag]="tag" [showIcon]="true" class="ml-3" />
-						}
+						<div class="flex">
+							@for (tag of storylist.tags; track tag.slug) {
+								<cuentoneta-badge [tag]="tag" [showIcon]="true" class="ml-3" />
+							}
+						</div>
 					}
 				</footer>
 			}
@@ -65,7 +68,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	`,
 	styles: `
 		:host {
-			@apply block max-w-[602px];
+			@apply block rounded-2xl;
 		}
 	`,
 })

--- a/src/app/components/storylist-card-component/storylist-card.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.ts
@@ -33,7 +33,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 			@if (storylist(); as storylist) {
 				<div [routerLink]="['/' + appRoutes.StoryList, storylist.slug]" class="navigation-link">
 					<section
-						class="flex max-w-[480px] flex-col gap-4 rounded-t-2xl border-1 border-b-0 border-solid border-primary-300 px-4 pt-5"
+						class="flex flex-col gap-4 rounded-t-2xl border-1 border-b-0 border-solid border-primary-300 px-4 pt-5"
 					>
 						<h1
 							class="h3 cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap font-source-serif italic hover:text-interactive-500"

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.html
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.html
@@ -63,7 +63,7 @@
 				[attr.aria-busy]="!publication"
 				class="xs:max-md:!col-span-1 md:col-span-6"
 			>
-				@if (publication) {
+				@defer (when !!publication) {
 					@if (publication.published) {
 						<cuentoneta-publication-card
 							[editionLabel]="publication | mapPublicationEditionLabel: storylist()!"
@@ -86,7 +86,7 @@
 							content
 						/>
 					}
-				} @else {
+				} @placeholder {
 					<cuentoneta-story-card-skeleton [animation]="'progress'" />
 				}
 			</div>

--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -42,7 +42,7 @@
 			</p>
 
 			<section class="mb-3 mt-3">
-				<h3>📢 Difundiendo</h3>
+				<h3 class="h3">📢 Difundiendo</h3>
 				<p class="inter-body-base-regular">
 					Si te gusta el proyecto, podés ayudarnos difundiéndolo en tus redes sociales, compartiendo los contenidos que
 					publicamos, y recomendándolo a otras personas. Llegar cada vez a más personas hará que podamos mejorar la
@@ -55,7 +55,7 @@
 			</section>
 
 			<section class="mb-3">
-				<h3>💡 Sugiriendo correcciones y nuevas funcionalidades</h3>
+				<h3 class="h3">💡 Sugiriendo correcciones y nuevas funcionalidades</h3>
 				<p class="inter-body-base-regular">
 					Si tenés una idea para una nueva funcionalidad o realizar alguna corrección o mejora , podés comunicarte con
 					el equipo de desarrollo vía el
@@ -67,7 +67,7 @@
 			</section>
 
 			<section class="mb-3">
-				<h3>📜 Sumando contenidos</h3>
+				<h3 class="h3">📜 Sumando contenidos</h3>
 				<p class="inter-body-base-regular">
 					Podés sugerir contenido para sumar a la plataforma, sea en forma de cuentos, poemas, ensayos o temáticas para
 					nuevas storylists. El contenido puede ser escritura propia o de terceros, con previos permisos de publicación
@@ -85,7 +85,7 @@
 			</section>
 
 			<section class="mb-3">
-				<h3>🎨 Diseño UX/UI</h3>
+				<h3 class="h3">🎨 Diseño UX/UI</h3>
 				<p class="inter-body-base-regular">
 					Si tenés habilidades en diseño UX/UI, podés contribuir al proyecto asistiendo en la creación de wireframes,
 					mockups, y prototipos para mejorar características existentes de la plataforma y contribuir en la gestación de
@@ -98,7 +98,7 @@
 			</section>
 
 			<section class="mb-3">
-				<h3>🖥️ Programando</h3>
+				<h3 class="h3">🖥️ Programando</h3>
 				<p class="inter-body-base-regular">
 					Si sos desarrolladora o desarrollador, podés contribuir al proyecto mediante la creación de issues, pull
 					requests, revisando código, y más en nuestro
@@ -131,7 +131,7 @@
 			<h2 class="h2 mb-5 text-gray-600">Hacemos <em>La Cuentoneta</em></h2>
 
 			<section class="mb-3">
-				<h3>Staff</h3>
+				<h3 class="h3">Staff</h3>
 				<ul>
 					<li class="inter-body-base-regular">
 						Ramiro Olivencia - <em>Líder de Proyecto</em> (<a [href]="'https://twitter.com/rolivenc'" class="underline"
@@ -147,7 +147,7 @@
 			</section>
 
 			<section class="mb-3">
-				<h3>Programación</h3>
+				<h3 class="h3">Programación</h3>
 				<ul>
 					@for (programmer of programmers; track programmer.name) {
 						<li class="inter-body-base-regular">
@@ -159,7 +159,7 @@
 			</section>
 
 			<section class="mb-3">
-				<h3>Generación de contenido</h3>
+				<h3 class="h3">Generación de contenido</h3>
 				<ul>
 					<li class="inter-body-base-regular">
 						Sofía Abramovich (<a [href]="'https://twitter.com/__sofiaabigail'" class="underline">&#64;__sofiaabigail</a
@@ -184,7 +184,7 @@
 			</section>
 
 			<section class="mb-3">
-				<h3>Selección, transcripción y curación de contenido</h3>
+				<h3 class="h3">Selección, transcripción y curación de contenido</h3>
 				<ul>
 					<li class="inter-body-base-regular">
 						Patricio Decoud (<a [href]="'https://twitter.com/arroba_pato'" class="underline">&#64;arrobapato</a>)

--- a/src/app/pages/author/author-skeleton.component.ts
+++ b/src/app/pages/author/author-skeleton.component.ts
@@ -66,7 +66,7 @@ import { ThemeService } from '../../providers/theme.service';
 				count="6"
 			></ngx-skeleton-loader>
 		</section>
-		<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 md:gap-8">
+		<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-8">
 			@for (item of 6 | repeat; track $index) {
 				<cuentoneta-story-card-skeleton [animation]="'progress'" [displayFooter]="false" />
 			}

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -66,10 +66,10 @@ import { StoryCardComponent } from '../../components/story-card/story-card.compo
 						}
 						<cuentoneta-portable-text-parser
 							[paragraphs]="author.biography!"
-							[classes]="'source-serif-pro-body-xl mb-8 leading-8 max-w-[960px]'"
+							[classes]="'source-serif-pro-body-xl mb-8 leading-8'"
 						></cuentoneta-portable-text-parser>
 					</section>
-					<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 md:gap-8">
+					<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-8">
 						@for (story of stories; track $index) {
 							<cuentoneta-story-card [story]="story" [navigationRoute]="story.navigationRoute"></cuentoneta-story-card>
 						}

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -16,7 +16,7 @@
 		</h3>
 	</div>
 
-	<section class="grid grid-cols-1 justify-items-center gap-8 lg:grid-cols-2">
+	<section class="grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2">
 		@defer (when cards.length > 0) {
 			@for (storylist of cards; track storylist.slug) {
 				<cuentoneta-storylist-card [storylist]="storylist" class="card w-full"> </cuentoneta-storylist-card>

--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -24,5 +24,5 @@ h2,
 h3,
 .h3 {
 	@apply text-xl font-medium tracking-normal;
-	@apply lg:text-2xl lg:font-bold;
+	@apply text-2xl font-bold;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,7 +12,7 @@ export default {
 		},
 		screens: {
 			xs: '0px',
-			sm: '640px',
+			sm: '768px',
 			md: '960px',
 			lg: '1280px',
 			xl: '1536px',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,7 +13,7 @@ export default {
 		screens: {
 			xs: '0px',
 			sm: '640px',
-			md: '1024px',
+			md: '960px',
 			lg: '1280px',
 			xl: '1536px',
 		},


### PR DESCRIPTION
## Resumen
Se actualizan los estilos del componente `StorylistCardComponent`, de acuerdo a la primera versión del diseño del componente en el Figma para la v3 de La Cuentoneta, eliminando la imagen de cabecera en la card y ajustando los estilos de texto.

## Otros cambios
- Actualiza ancho máximo del viewport `sm` a 768px y el ancho máximo del viewport `md` a 960px en la configuración de Tailwind.
- Ajusta layout de columnas de el deck de story cards en el template de `AuthorComponent`.
- Configura landing page para usar layout de dos columnas a partir del viewport `sm`.
- Agrega uso de `@defer` en `StorylistCardDeck`, a fin de deferir la carga del componente `PublicationCard` hasta tener cargada al menos una publication.
- Agrega clases `h3` faltantes en headings de nivel 3 de la base de código.

## Screenshots
Screenshot que detalla una instancia ya renderizada de StorylistCard y su versión en formato skeleton correspondiente
![image](https://github.com/user-attachments/assets/a21ed563-914d-4d32-8631-269ccc5309d1)
