### PR TITLE
[#921] - Solucionar problemas en tests de SpaceRecordingWidgetComponent

### DIFF
--- a/src/app/components/space-recording-widget/space-recording-widget.component.spec.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.component.spec.ts
@@ -1,21 +1,58 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SpaceRecordingWidgetComponent } from './space-recording-widget.component';
+import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
+import { render, screen } from '@testing-library/angular';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { spaceRecordingMock } from '../../mocks/space-recording.mock';
 
-xdescribe('SpaceRecordingWidgetComponent', () => {
-	let component: SpaceRecordingWidgetComponent;
-	let fixture: ComponentFixture<SpaceRecordingWidgetComponent>;
+describe('SpaceRecordingWidgetComponent', () => {
+	const setup = async () => {
+		return await render(SpaceRecordingWidgetComponent, {
+			componentImports: [CommonModule, NgOptimizedImage, PortableTextParserComponent],
+			componentProviders: [],
+			inputs: {
+				media: spaceRecordingMock,
+			},
+		});
+	};
 
-	beforeEach(async () => {
-		await TestBed.configureTestingModule({
-			imports: [SpaceRecordingWidgetComponent],
-		}).compileComponents();
-
-		fixture = TestBed.createComponent(SpaceRecordingWidgetComponent);
-		component = fixture.componentInstance;
-		fixture.detectChanges();
+	test('should render SpaceRecordingWidgetComponent', async () => {
+		expect(await setup()).toBeTruthy();
 	});
 
-	it('should create', () => {
-		expect(component).toBeTruthy();
+	it('should display the correct title', async () => {
+		await setup();
+		expect(screen.getByText(spaceRecordingMock.title)).toBeInTheDocument();
+	});
+
+	it('should display the host name', async () => {
+		await setup();
+		expect(screen.getByText('@' + spaceRecordingMock.data.tweetBy.userName)).toBeInTheDocument();
+	});
+
+	it('should display the recording date', async () => {
+		await setup();
+		expect(screen.getByText('March 27, 2024')).toBeInTheDocument();
+	});
+
+	it('should display the recording duration', async () => {
+		await setup();
+		expect(screen.getByText(spaceRecordingMock.data.duration)).toBeInTheDocument();
+	});
+
+	it('should have the correct href for the space recording', async () => {
+		await setup();
+		const link = screen.getByRole('link', { name: 'space-recording-href' });
+		expect(link).toHaveAttribute('href', spaceRecordingMock.data.entities.urls[0]);
+	});
+
+	it('should display the "Play Recording on X" button', async () => {
+		await setup();
+		expect(screen.getByText('Reproducir Grabación en X')).toBeInTheDocument();
+	});
+
+	it('should render the profile image', async () => {
+		await setup();
+		const img = screen.getByRole('img');
+		expect(img).toHaveAttribute('src', spaceRecordingMock.data.tweetBy.profileImage);
 	});
 });

--- a/src/app/components/space-recording-widget/space-recording-widget.component.spec.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.component.spec.ts
@@ -1,7 +1,7 @@
 import { SpaceRecordingWidgetComponent } from './space-recording-widget.component';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 import { render, screen } from '@testing-library/angular';
-import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { CommonModule, DatePipe, NgOptimizedImage } from '@angular/common';
 import { spaceRecordingMock } from '../../mocks/space-recording.mock';
 
 describe('SpaceRecordingWidgetComponent', () => {
@@ -31,7 +31,9 @@ describe('SpaceRecordingWidgetComponent', () => {
 
 	it('should display the recording date', async () => {
 		await setup();
-		expect(screen.getByText('March 27, 2024')).toBeInTheDocument();
+		const datePipe = new DatePipe('en-US');
+		const date = datePipe.transform(new Date(spaceRecordingMock.data.createdAt), 'MMMM d, YYYY') as string;
+		expect(screen.getByText(date)).toBeInTheDocument();
 	});
 
 	it('should display the recording duration', async () => {

--- a/src/app/components/space-recording-widget/space-recording-widget.component.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, input } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { SpaceRecording } from '@models/media.model';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
@@ -8,7 +8,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	standalone: true,
 	imports: [CommonModule, NgOptimizedImage, PortableTextParserComponent],
 	template: `
-		<a [href]="spaceUrl" target="_blank" class="mb-2 block">
+		<a [href]="spaceUrl()" aria-label="space-recording-href" target="_blank" class="mb-2 block">
 			<section class="spaces-card inter-body-base grid grid-rows-3-auto rounded-lg p-4 text-white">
 				<div class="flex items-center justify-between text-base">
 					<div class="spaces-host flex gap-2.5">
@@ -51,12 +51,5 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 })
 export class SpaceRecordingWidgetComponent {
 	media = input.required<SpaceRecording>();
-
-	public spaceUrl: string = '';
-
-	constructor() {
-		effect(() => {
-			this.spaceUrl = this.media().data.entities.urls[0];
-		});
-	}
+	spaceUrl = computed(() => this.media().data.entities.urls[0]);
 }

--- a/src/app/components/space-recording-widget/space-recording-widget.component.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, effect, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { SpaceRecording } from '@models/media.model';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';

--- a/src/app/mocks/space-recording.mock.ts
+++ b/src/app/mocks/space-recording.mock.ts
@@ -1,0 +1,73 @@
+import { SpaceRecording } from '@models/media.model';
+
+export const spaceRecordingMock: SpaceRecording = {
+	title: 'El marajá de San Telmo: discusión y breve análisis',
+	type: 'spaceRecording',
+	description: [
+		{
+			style: 'normal',
+			_key: '43863eebea59',
+			markDefs: [
+				{
+					_type: 'link',
+					href: 'https://x.com/criticocultural',
+					_key: 'e7ed51a5d48b',
+				},
+			],
+			children: [
+				{
+					_key: '325f3119262a0',
+					_type: 'span',
+					marks: [],
+					text: 'Space de X organizado y dirigido por ',
+				},
+				{
+					_key: '400efa9c0dfb',
+					_type: 'span',
+					marks: ['e7ed51a5d48b'],
+					text: '@criticocultural',
+				},
+				{
+					_type: 'span',
+					marks: [],
+					text: ' que incluye la lectura, análisis y discusión del cuento.',
+					_key: 'f7739e8f5c02',
+				},
+			],
+			_type: 'block',
+		},
+	],
+	data: {
+		id: '1773161072247164990',
+		createdAt: 'Thu Mar 28 01:31:58 +0000 2024',
+		tweetBy: {
+			id: '736315211389472769',
+			userName: 'criticocultural',
+			fullName: 'Crítico Cultural',
+			createdAt: 'Fri May 27 21:56:41 +0000 2016',
+			description: 'Otro crítico más',
+			isVerified: false,
+			likeCount: 141211,
+			followersCount: 6958,
+			followingsCount: 1400,
+			statusesCount: 47045,
+			pinnedTweet: '1366391960026689523',
+			profileBanner: 'https://pbs.twimg.com/profile_banners/736315211389472769/1674041435',
+			profileImage: 'https://pbs.twimg.com/profile_images/1610082924069588992/xCKlsPnA_normal.jpg',
+		},
+		entities: {
+			hashtags: [],
+			mentionedUsers: [],
+			urls: ['https://x.com/i/spaces/1OOJXrjymndJY'],
+		},
+		fullText: 'https://t.co/VQJOzMFL6q',
+		lang: 'zxx',
+		quoteCount: 0,
+		replyCount: 9,
+		retweetCount: 0,
+		likeCount: 8,
+		viewCount: 1172,
+		bookmarkCount: 2,
+		duration: '2:19:23',
+	},
+};


### PR DESCRIPTION
## Descripción
- Agrega `aria-label` al anchor principal definido en `SpaceRecordingWidgetComponent`.
- Agrega mock para el tipo `SpaceRecording`.
- Define assertions para tests unitarios de `SpaceRecordingWidgetComponent`
- Reemplaza uso de `effect` por una signal `computed` para la propiedad `spaceUrl`