### PR TITLE
[#945] - Reimplementación de unit tests para `TooltipDirective`

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"@testing-library/angular": "^17.2.0",
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/jest-dom": "^6.4.8",
+		"@testing-library/user-event": "^14.5.2",
 		"@types/jest": "29.4.4",
 		"@types/node": "^18.16.9",
 		"@types/react": "^18.2.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@testing-library/jest-dom':
         specifier: ^6.4.8
         version: 6.5.0
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.5.2(@testing-library/dom@10.4.0)
       '@types/jest':
         specifier: 29.4.4
         version: 29.4.4
@@ -5170,6 +5173,13 @@ packages:
       { integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA== }
     engines: { node: '>=14', npm: '>=6', yarn: '>=1' }
 
+  '@testing-library/user-event@14.5.2':
+    resolution:
+      { integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ== }
+    engines: { node: '>=12', npm: '>=6' }
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tootallnate/once@2.0.0':
     resolution:
       { integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A== }
@@ -8039,6 +8049,7 @@ packages:
     resolution:
       { integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ== }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@10.1.0:
@@ -20380,7 +20391,7 @@ snapshots:
       get-port: 5.1.1
       giget: 1.1.2
       globby: 11.1.0
-      jscodeshift: 0.14.0(@babel/preset-env@7.24.0(@babel/core@7.24.0))
+      jscodeshift: 0.14.0(@babel/preset-env@7.24.0(@babel/core@7.24.5))
       leven: 3.1.0
       prettier: 2.8.7
       prompts: 2.4.2
@@ -21080,6 +21091,10 @@ snapshots:
       dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
+
+  '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
 
   '@tootallnate/once@2.0.0': {}
 
@@ -25415,7 +25430,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jscodeshift@0.14.0(@babel/preset-env@7.24.0(@babel/core@7.24.0)):
+  jscodeshift@0.14.0(@babel/preset-env@7.24.0(@babel/core@7.24.5)):
     dependencies:
       '@babel/core': 7.24.5
       '@babel/parser': 7.23.9

--- a/src/app/directives/tooltip.directive.spec.ts
+++ b/src/app/directives/tooltip.directive.spec.ts
@@ -1,35 +1,43 @@
-// import { Component, input } from '@angular/core';
-// import { fireEvent, render, screen } from '@testing-library/angular';
-// import { TooltipDirective } from './tooltip.directive';
+import { Component, inject, OnInit } from '@angular/core';
+import { render, screen } from '@testing-library/angular';
+import { TooltipDirective } from './tooltip.directive';
+import userEvent from '@testing-library/user-event';
 
-// const ELEMENT_WIDTH = 500;
-// const ELEMENT_HEIGHT = 500;
-// @Component({
-// 	template: `
-// 		<div [style.width.px]="width" [style.height.px]="height" [position]="position" tooltip text="Tooltip test">
-// 			Host component
-// 		</div>
-// 	`,
-// 	standalone: true,
-// })
-// class HostComponent {
-// 	width = ELEMENT_WIDTH;
-// 	height = ELEMENT_HEIGHT;
-// 	position = input('top');
-// }
+const ELEMENT_WIDTH = 500;
+const ELEMENT_HEIGHT = 500;
 
-xdescribe('TooltipDirective', () => {
+@Component({
+	template: `
+		<div [style.width.px]="width" [style.height.px]="height" [>
+			<p>Host component</p>
+		</div>
+	`,
+	standalone: true,
+	imports: [TooltipDirective],
+	hostDirectives: [TooltipDirective],
+})
+class HostComponent implements OnInit {
+	width = ELEMENT_WIDTH;
+	height = ELEMENT_HEIGHT;
+	private tooltipDirective = inject(TooltipDirective);
+
+	ngOnInit() {
+		this.tooltipDirective.text.set('Tooltip test');
+		this.tooltipDirective.position.set('bottom');
+	}
+}
+
+describe('TooltipDirective', () => {
 	test('Should render a tooltip when the mouse enter the Host component', async () => {
-		// await render(HostComponent, {
-		// 	componentProperties: { position: 'top' },
-		// 	componentImports: [TooltipDirective],
-		// });
-		// const hostComponent = screen.getByText(/Host component/);
-		//
-		// fireEvent.mouseEnter(hostComponent);
-		// expect(screen.getByText('Tooltip test')).toBeTruthy();
-		//
-		// fireEvent.mouseLeave(hostComponent);
-		// expect(screen.queryByText('Tooltip test')).not.toBeTruthy();
+		await render(HostComponent);
+
+		const hostComponent = screen.getByText(/Host component/);
+
+		await userEvent.hover(hostComponent);
+
+		expect(screen.getByText('Tooltip test')).toBeInTheDocument();
+
+		await userEvent.unhover(hostComponent);
+		expect(screen.queryByText('Tooltip test')).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Tareas
- [x] Cambiar la propiedad componentProperties del render de el componente HostComponent en el archivo tooltip.directive.spec.ts.
- [x]  Agregar userEvent de @testing-library/user-event para hacer la interacción con los test parecido a como lo haría un usuario.
- [x]  Importar en los imports del componente HostComponent la directiva TooltipDirective.
- [x]  Usar toBeInTheDocument en lugar de toBeTruthy.
- [x]  Cambiar la definición de la función xdescribe en describe antes de crear la pull request vinculada a este issue.