### PR TITLE
[#1063] - Implementar tests unitarios para `ContentCampaignCarouselComponent`

### DIFF
--- a/src/app/components/content-campaign-carousel/content-campaign-carousel.component.spec.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel.component.spec.ts
@@ -1,6 +1,22 @@
+// Testing library
+import { render, screen } from '@testing-library/angular';
+
+// Components
 import { ContentCampaignCarouselComponent } from './content-campaign-carousel.component';
-import { render } from '@testing-library/angular';
+
+// Services
+import { ThemeService } from '../../providers/theme.service';
+
+// Mocks
 import { contentCampaignMock } from '../../mocks/content-campaign.mock';
+
+// Mocks ad-hoc
+class MockThemeXsViewportService {
+	viewport = 'xs';
+}
+class MockThemeMdViewportService {
+	viewport = 'md';
+}
 
 describe('ContentCampaignCarouselComponent', () => {
 	it('should render the component', async () => {
@@ -8,5 +24,54 @@ describe('ContentCampaignCarouselComponent', () => {
 			inputs: { slides: contentCampaignMock },
 		});
 		expect(container).toBeInTheDocument();
+	});
+	it('should render the correct number of slides', async () => {
+		await render(ContentCampaignCarouselComponent, {
+			inputs: { slides: contentCampaignMock },
+		});
+		const slides = screen.getAllByRole('img');
+		const sourceImages = new Set(slides.map((slide) => slide.getAttribute('src')));
+		expect(sourceImages.size).toBe(contentCampaignMock.length);
+	});
+	it('should apply xs viewport-specific classes correctly', async () => {
+		await render(ContentCampaignCarouselComponent, {
+			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: ThemeService, useClass: MockThemeXsViewportService }],
+		});
+		const slideLinks = screen.getAllByRole('link');
+		slideLinks.forEach((link) => {
+			expect(link).toHaveClass('md:hidden');
+		});
+	});
+	it('should apply md viewport-specific classes correctly', async () => {
+		await render(ContentCampaignCarouselComponent, {
+			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: ThemeService, useClass: MockThemeMdViewportService }],
+		});
+		const slideLinks = screen.getAllByRole('link');
+		slideLinks.forEach((link) => {
+			expect(link).toHaveClass('max-md:hidden');
+		});
+	});
+	it('should render the correct title', async () => {
+		await render(ContentCampaignCarouselComponent, {
+			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: ThemeService, useClass: MockThemeXsViewportService }],
+		});
+		const titles = screen.getAllByRole('heading', { level: 3 });
+		titles.forEach((title) => {
+			expect(title).toBeInTheDocument();
+		});
+	});
+
+	it('should render the correct subtitle', async () => {
+		await render(ContentCampaignCarouselComponent, {
+			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: ThemeService, useClass: MockThemeXsViewportService }],
+		});
+		const subtitles = screen.getAllByRole('heading', { level: 4 });
+		subtitles.forEach((subtitle) => {
+			expect(subtitle).toBeInTheDocument();
+		});
 	});
 });

--- a/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
@@ -22,8 +22,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 
 	template: `
 		<section class="block">
-			<!-- TODO: Eliminar valor harcoded de 960px una vez actualizado el ancho máximo de pantalla -->
-			<owl-carousel-o [options]="options" class="mx-auto block max-w-[960px]">
+			<owl-carousel-o [options]="options" class="mx-auto block">
 				@for (slide of slides(); track slide.slug) {
 					<ng-template carouselSlide>
 						<div class="slide">


### PR DESCRIPTION
## Resumen
- Agregados tests unitarios para `ContentCampaignCarouselComponent`.
- Eliminada clase redundante y comentario en template de componente.