### PR TITLE
[#949] - Reimplementación de unit tests para `PublicationCardComponent`

### DIFF
--- a/src/app/components/publication-card/publication-card.component.spec.ts
+++ b/src/app/components/publication-card/publication-card.component.spec.ts
@@ -1,10 +1,28 @@
 import { render } from '@testing-library/angular';
-
+import { publicationMock } from '../../mocks/story.mock';
 import { PublicationCardComponent } from './publication-card.component';
+import { DefaultUrlSerializer, UrlTree } from '@angular/router';
 
-xdescribe('PublicationCardComponent', () => {
-	it('should create', async () => {
-		const view = await render(PublicationCardComponent);
-		expect(view).toBeTruthy();
+describe('PublicationCardComponent', () => {
+	let urlTree: UrlTree;
+
+	const setup = async () => {
+		const urlSerializer = new DefaultUrlSerializer();
+		urlTree = urlSerializer.parse(
+			'/story/la-gallina-degollada?navigation=storylist&navigationSlug=cuentos-de-terror-de-alberto-laiseca',
+		);
+
+		return await render(PublicationCardComponent, {
+			inputs: {
+				editionLabel: ' Episodio 1 ',
+				publication: publicationMock,
+				navigationRoute: urlTree,
+			},
+		});
+	};
+
+	it('should render the component', async () => {
+		const { container } = await setup();
+		expect(container).toBeInTheDocument();
 	});
 });

--- a/src/app/mocks/story.mock.ts
+++ b/src/app/mocks/story.mock.ts
@@ -1,5 +1,6 @@
 import { Story, StoryPreview, StoryTeaser } from '@models/story.model';
 import { authorMock, authorTeaserMock } from './author.mock';
+import { Publication } from '@models/storylist.model';
 
 export const storyMock: Story = {
 	resources: [
@@ -537,4 +538,11 @@ export const storyTeaserMock: StoryTeaser = {
 			markDefs: [],
 		},
 	],
+};
+
+export const publicationMock: Publication = {
+	publishingOrder: 54,
+	published: true,
+	publishingDate: '2024-10-27',
+	story: storyPreviewMock,
 };


### PR DESCRIPTION
- [x]  Agregar un objeto mock de tipo Publication<StoryPreview>, y uno de tipo UrlTree para pasar como propiedad al objeto componentInputs de la función render de Angular Testing Library.
- [x]  Usar toBeInTheDocument en lugar de toBeTruthy.
- [x]  Cambiar la definición de la función xdescribe en describe antes de crear la pull request vinculada a este issue.