### PR TITLE
[#926] - Reimplementación de unit tests para `resourceComponent`

### DIFF
--- a/src/app/components/resource/resource.component.spec.ts
+++ b/src/app/components/resource/resource.component.spec.ts
@@ -1,21 +1,36 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { render, screen } from '@testing-library/angular';
 import { ResourceComponent } from './resource.component';
+import { resourceMock } from 'src/app/mocks/resource.mock';
 
-xdescribe('ResourceComponent', () => {
-	let component: ResourceComponent;
-	let fixture: ComponentFixture<ResourceComponent>;
+describe('ResourceComponent', () => {
+	const regexTitle = new RegExp(resourceMock.title, 'i');
+	const url = resourceMock.url;
 
-	beforeEach(async () => {
-		await TestBed.configureTestingModule({
-			imports: [ResourceComponent],
-		}).compileComponents();
+	const setup = async () => {
+		return await render(ResourceComponent, {
+			inputs: {
+				resource: resourceMock,
+			},
+		});
+	};
 
-		fixture = TestBed.createComponent(ResourceComponent);
-		component = fixture.componentInstance;
-		fixture.detectChanges();
+	it('should render the component', async () => {
+		const { container } = await setup();
+
+		expect(container).toBeInTheDocument();
 	});
 
-	it('should create', () => {
-		expect(component).toBeTruthy();
+	it('should render title', async () => {
+		await setup();
+		const titleResourceElement = screen.getByAltText(regexTitle);
+
+		expect(titleResourceElement).toBeInTheDocument();
+	});
+
+	it('should confirm the URL of the link', async () => {
+		await setup();
+		const linkResourceElement = screen.getByRole('link');
+
+		expect(linkResourceElement).toHaveAttribute('href', url);
 	});
 });

--- a/src/app/mocks/resource.mock.ts
+++ b/src/app/mocks/resource.mock.ts
@@ -1,0 +1,31 @@
+import { Resource } from '@models/resource.model';
+
+export const resourceMock: Resource = {
+	title: 'Recurso original',
+	url: 'https://biblioteca.es/el-espejo-del-tiempo',
+	resourceType: {
+		title: 'Recurso Original',
+		shortDescription: 'Recurso original de este contenido',
+		description: [
+			{
+				markDefs: [],
+				children: [
+					{
+						_type: 'span',
+						marks: [],
+						text: 'Recurso original de este contenido',
+						_key: 'd92a239f37e50',
+					},
+				],
+				_type: 'block',
+				style: 'normal',
+				_key: '05dc9f3aa317',
+			},
+		],
+		icon: {
+			provider: 'fa',
+			name: 'fa-medal',
+			svg: 'data:image/svg+xml,<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style="width: 1.5em; height: 1em;"><path d="M223.75 130.75L154.62 15.54A31.997 31.997 0 0 0 127.18 0H16.03C3.08 0-4.5 14.57 2.92 25.18l111.27 158.96c29.72-27.77 67.52-46.83 109.56-53.39zM495.97 0H384.82c-11.24 0-21.66 5.9-27.44 15.54l-69.13 115.21c42.04 6.56 79.84 25.62 109.56 53.38L509.08 25.18C516.5 14.57 508.92 0 495.97 0zM256 160c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm92.52 157.26l-37.93 36.96 8.97 52.22c1.6 9.36-8.26 16.51-16.65 12.09L256 393.88l-46.9 24.65c-8.4 4.45-18.25-2.74-16.65-12.09l8.97-52.22-37.93-36.96c-6.82-6.64-3.05-18.23 6.35-19.59l52.43-7.64 23.43-47.52c2.11-4.28 6.19-6.39 10.28-6.39 4.11 0 8.22 2.14 10.33 6.39l23.43 47.52 52.43 7.64c9.4 1.36 13.17 12.95 6.35 19.59z"></path></svg>',
+		},
+	},
+};


### PR DESCRIPTION
## Tareas 
- [x] Migrar la implementación del archivo resource.component.spec.ts de TestBed a Angular Testing Library.
- [x] Agregar un objeto mock de tipo Resource para pasar como propiedad al objeto componentInputs de la función render de Angular Testing Library.
- [x] Usar toBeInTheDocument en lugar de toBeTruthy.
- [x] Testear que el url y el title aparezcan en el documento.
- [x] Cambiar la definición de la función xdescribe en describe antes de crear la pull request vinculada a este issue.