### PR TITLE
[HF] - Elimina chequeo de PLATFORM_ID para cargar contenido

### DIFF
--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,7 +1,7 @@
 // Core
-import { Component, inject, PLATFORM_ID } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { CommonModule } from '@angular/common';
 
 // Services
 import { ContentService } from '../../providers/content.service';

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -42,21 +42,12 @@ export class HomeComponent {
 	private fetchContentDirective = inject(FetchContentDirective);
 	private metaTagsDirective = inject(MetaTagsDirective);
 
+	// Asignación inicial para dibujar skeletons
 	cards: StorylistTeaser[] = [];
 	campaigns: ContentCampaign[] = [];
 
 	constructor() {
-		// Asignación inicial para dibujar skeletons
-		this.cards = [];
 		this.metaTagsDirective.setDefault();
-
-		const platformId = inject(PLATFORM_ID);
-		if (!isPlatformBrowser(platformId)) {
-			return;
-		}
-
-		// En cliente-side, posteriormente, se cargan los decks con las historias y
-		// las campañas de contenido, según la configuración
 		this.loadLandingPageContent();
 	}
 


### PR DESCRIPTION
## Resumen
Se elimina un condicional que impedía el indexado del contenido de la landing page y su acceso en modo SSR.