### PR TITLE
[#1101] - Actualizar layout de vista /storylist

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"build": "nx run cuentoneta:build:production --skip-nx-cache",
 		"build:watch": "nx run cuentoneta:build:production --skip-nx-cache --watch",
 		"config": "node -r ts-node/register ./scripts/set-environment.ts",
-		"delete-unused-assets": "$ node -r ts-node/register --env-file=.env ./scripts/delete-unused-assets.ts",
+		"delete-unused-assets": "node -r ts-node/register --env-file=.env ./scripts/delete-unused-assets.ts",
 		"storybook": "nx run cuentoneta:storybook",
 		"storybook:build": "nx run cuentoneta:build-storybook",
 		"lint": "npx nx lint --skip-nx-cache",

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.html
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.html
@@ -1,53 +1,5 @@
-<article
-	[attr.aria-busy]="!storylist()"
-	[lang]="storylist()?.language"
-	class="grid grid-cols-1 gap-y-5 md:grid-cols-12 md:gap-8"
->
-	<!-- Renderizado de título y descripción -->
-	<ng-container *ngTemplateOutlet="storylistTitleTemplate"> </ng-container>
-
-	<!-- Renderizado de tarjetas de stories -->
-	<ng-container *ngTemplateOutlet="storylist()?.publications ? publicationsTemplate : skeletonsTemplate">
-	</ng-container>
-</article>
-
-<ng-template #storylistTitleTemplate>
-	@if (!!storylist()) {
-		<div class="xs:max-md:!col-span-1 md:col-span-6">
-			<h1 class="h1 mb-5">
-				{{ storylist()?.title }}
-			</h1>
-			<h2 class="h3 subtitle text-gray-600">
-				<cuentoneta-portable-text-parser
-					[paragraphs]="storylist()?.description ?? []"
-				></cuentoneta-portable-text-parser>
-			</h2>
-		</div>
-	} @else {
-		<div class="xs:max-md:col-span-1 md:col-span-6">
-			<ngx-skeleton-loader
-				[theme]="{
-					'margin-bottom.px': 20,
-					'height.px': 40,
-					width: '100%',
-					'background-color': skeletonColor
-				}"
-				count="1"
-				appearance="line"
-			></ngx-skeleton-loader>
-			<ngx-skeleton-loader
-				[theme]="{
-					'margin-bottom.px': 10,
-					'height.px': 20,
-					width: '100%',
-					'background-color': skeletonColor
-				}"
-				count="3"
-				appearance="line"
-			></ngx-skeleton-loader>
-		</div>
-	}
-</ng-template>
+<!-- Renderizado de tarjetas de stories -->
+<ng-container *ngTemplateOutlet="storylist()?.publications ? publicationsTemplate : skeletonsTemplate"> </ng-container>
 
 <ng-template #skeletonsTemplate>
 	@for (skeleton of [1, 2, 3, 4, 5, 6, 7, 9, 10]; track $index) {

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
@@ -12,7 +12,6 @@ import { Storylist } from '@models/storylist.model';
 // Components
 import { PublicationCardComponent } from '../publication-card/publication-card.component';
 import { StoryCardSkeletonComponent } from '../story-card-skeleton/story-card-skeleton.component';
-import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 
 // Pipes
 import { MapPublicationComingNextLabelPipe } from '../../pipes/map-publication-coming-next-label.pipe';

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
@@ -32,12 +32,16 @@ import { ThemeService } from '../../providers/theme.service';
 		MapPublicationComingNextLabelPipe,
 		MapPublicationEditionLabelPipe,
 		NgxSkeletonLoaderModule,
-		PortableTextParserComponent,
 		PublicationCardComponent,
 		StoryCardSkeletonComponent,
 	],
 	templateUrl: './storylist-card-deck.component.html',
 	changeDetection: ChangeDetectionStrategy.OnPush,
+	styles: `
+		:host {
+			@apply grid grid-cols-1 gap-6 md:grid-cols-12 md:gap-8;
+		}
+	`,
 })
 export class StorylistCardDeckComponent {
 	storylist = input<Storylist>();
@@ -46,6 +50,5 @@ export class StorylistCardDeckComponent {
 	public router = inject(Router);
 	readonly appRoutes = AppRoutes;
 
-	private themeService = inject(ThemeService);
-	skeletonColor = this.themeService.pickColor('zinc', 300);
+	skeletonColor = inject(ThemeService).pickColor('zinc', 300);
 }

--- a/src/app/pages/storylist/storylist.component.html
+++ b/src/app/pages/storylist/storylist.component.html
@@ -1,3 +1,58 @@
 <main class="block lg:mt-28">
-	<cuentoneta-storylist-card-deck [storylist]="storylist" [isLoading]="fetchContentDirective.isLoading" />
+	<article [attr.aria-busy]="!storylist" [lang]="storylist?.language" class="grid grid-cols-1 gap-y-8">
+		<!-- Renderizado de título y descripción -->
+		<ng-container *ngTemplateOutlet="storylistTitleTemplate"> </ng-container>
+
+		<section>
+			<!-- Renderizado de tarjetas de stories -->
+			<cuentoneta-storylist-card-deck [storylist]="storylist" [isLoading]="fetchContentDirective.isLoading" />
+		</section>
+	</article>
 </main>
+
+<ng-template #storylistTitleTemplate>
+	@if (!!storylist) {
+		<div class="grid grid-cols-1 gap-4 xs:max-md:!col-span-1 md:grid-cols-[1fr]">
+			<div class="flex items-center justify-center">
+				<img
+					[src]="storylist.featuredImage"
+					[alt]="'Imagen alusiva de la storylist ' + storylist.title"
+					class="max-h-[220px] rounded-xl"
+				/>
+			</div>
+
+			<div class="flex flex-col">
+				<h1 class="h1 mb-5 text-center">
+					{{ storylist?.title }}
+				</h1>
+				<cuentoneta-portable-text-parser
+					[paragraphs]="storylist?.description ?? []"
+					[classes]="'source-serif-pro-body-xl text-justify'"
+				></cuentoneta-portable-text-parser>
+			</div>
+		</div>
+	} @else {
+		<div class="xs:max-md:col-span-1 md:col-span-6">
+			<ngx-skeleton-loader
+				[theme]="{
+					'margin-bottom.px': 20,
+					'height.px': 40,
+					width: '100%',
+					'background-color': skeletonColor
+				}"
+				count="1"
+				appearance="line"
+			></ngx-skeleton-loader>
+			<ngx-skeleton-loader
+				[theme]="{
+					'margin-bottom.px': 10,
+					'height.px': 20,
+					width: '100%',
+					'background-color': skeletonColor
+				}"
+				count="3"
+				appearance="line"
+			></ngx-skeleton-loader>
+		</div>
+	}
+</ng-template>

--- a/src/app/pages/storylist/storylist.component.ts
+++ b/src/app/pages/storylist/storylist.component.ts
@@ -1,7 +1,7 @@
 // Core
 import { Component, effect, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { CommonModule } from '@angular/common';
 
 // 3rd party modules
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';

--- a/src/app/pages/storylist/storylist.component.ts
+++ b/src/app/pages/storylist/storylist.component.ts
@@ -1,7 +1,7 @@
 // Core
 import { Component, effect, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { CommonModule } from '@angular/common';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
 
 // 3rd party modules
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
@@ -19,12 +19,14 @@ import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 
 // Componentes
 import { StorylistCardDeckComponent } from 'src/app/components/storylist-card-deck/storylist-card-deck.component';
+import { PortableTextParserComponent } from '../../components/portable-text-parser/portable-text-parser.component';
+import { ThemeService } from '../../providers/theme.service';
 
 @Component({
 	selector: 'cuentoneta-storylist',
 	templateUrl: './storylist.component.html',
 	standalone: true,
-	imports: [CommonModule, StorylistCardDeckComponent, NgxSkeletonLoaderModule],
+	imports: [CommonModule, StorylistCardDeckComponent, NgxSkeletonLoaderModule, PortableTextParserComponent],
 	hostDirectives: [FetchContentDirective, MetaTagsDirective],
 })
 export class StorylistComponent {
@@ -34,6 +36,7 @@ export class StorylistComponent {
 	private metaTagsDirective = inject(MetaTagsDirective);
 	private storylistService = inject(StorylistService);
 
+	skeletonColor = inject(ThemeService).pickColor('zinc', 300);
 	storylist!: Storylist | undefined;
 
 	constructor() {


### PR DESCRIPTION
### Resumen
- Agregados cambios para separar gestión del layout entre `StorylistComponent` y `StorylistCardDeckComponent`, delegando la responsabilidad de visualizar la información e imagen alusiva de la storylist a `StorylistComponent`

### Otros cambios
- Corrección en script `delete-unused-assets`.

### Screenshots
![image](https://github.com/user-attachments/assets/0adbd8f1-6c88-43cc-8e05-f6977168fe73)
![image](https://github.com/user-attachments/assets/597f9e90-91a2-4520-bab2-20beefed3670)
