### PR TITLE
[#934] - Migra tests unitarios de `AuthorNavigationFrameComponent` a Angular Test Library

### DIFF
--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
@@ -1,16 +1,33 @@
 import { AuthorNavigationFrameComponent } from './author-navigation-frame.component';
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 import { FetchContentDirective } from '../../directives/fetch-content.directive';
 import { CommonModule } from '@angular/common';
 import { StoryService } from '../../providers/story.service';
 import { Observable, of } from 'rxjs';
 import { storyTeaserMock } from '../../mocks/story.mock';
 import { StoryTeaser } from '@models/story.model';
+import { RouterTestingModule } from '@angular/router/testing';
+import * as ngExtension from 'ngxtension/inject-query-params';
+import { signal } from '@angular/core';
+import { NavigableStoryTeaserComponent } from '../navigable-story-teaser/navigable-story-teaser.component';
+
+jest.mock('ngxtension/inject-query-params', () => ({
+	__esModule: true,
+	...jest.requireActual('ngxtension/inject-query-params'),
+}));
+
+// Add a jest mock for the injectQueryParams function
+jest.spyOn(ngExtension, 'injectQueryParams').mockReturnValue(
+	signal({
+		navigation: 'author',
+		navigationSlug: 'francois-onoff',
+	}),
+);
 
 describe('AuthorNavigationFrameComponent', () => {
 	const setup = async () => {
 		return await render(AuthorNavigationFrameComponent, {
-			componentImports: [CommonModule],
+			componentImports: [CommonModule, RouterTestingModule, NavigableStoryTeaserComponent],
 			inputs: {},
 			providers: [
 				{
@@ -36,5 +53,13 @@ describe('AuthorNavigationFrameComponent', () => {
 	test('should render AuthorNavigationFrameComponent', async () => {
 		const view = await setup();
 		expect(view).toBeTruthy();
+	});
+
+	test('should render AuthorNavigationFrameComponent with stories', async () => {
+		const view = await setup();
+		view.detectChanges();
+		expect(screen.getByText(storyTeaserMock.title)).toBeInTheDocument();
+		expect(screen.getByText(storyTeaserMock.originalPublication)).toBeInTheDocument();
+		expect(screen.getByText(`${storyTeaserMock.approximateReadingTime} minutos de lectura`)).toBeInTheDocument();
 	});
 });

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
@@ -52,7 +52,7 @@ describe('AuthorNavigationFrameComponent', () => {
 				{
 					provide: StoryService,
 					useValue: {
-						getByAuthorSlug(slug: string): Observable<StoryTeaser[]> {
+						getByAuthorSlug(): Observable<StoryTeaser[]> {
 							return of([storyTeaserMock]);
 						},
 					},

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
@@ -1,14 +1,26 @@
-import { AuthorNavigationFrameComponent } from './author-navigation-frame.component';
-import { render, screen } from '@testing-library/angular';
-import { FetchContentDirective } from '../../directives/fetch-content.directive';
-import { CommonModule } from '@angular/common';
-import { StoryService } from '../../providers/story.service';
-import { Observable, of } from 'rxjs';
-import { storyTeaserMock } from '../../mocks/story.mock';
-import { StoryTeaser } from '@models/story.model';
-import * as ngExtension from 'ngxtension/inject-query-params';
 import { signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Observable, of } from 'rxjs';
+
+// Components
 import { NavigableStoryTeaserComponent } from '../navigable-story-teaser/navigable-story-teaser.component';
+import { AuthorNavigationFrameComponent } from './author-navigation-frame.component';
+
+// Directives
+import { FetchContentDirective } from '../../directives/fetch-content.directive';
+
+// Models
+import { StoryTeaser } from '@models/story.model';
+
+// Mocks
+import { storyTeaserMock } from '../../mocks/story.mock';
+
+// Services
+import { StoryService } from '../../providers/story.service';
+
+// 3rd party libs
+import * as ngExtension from 'ngxtension/inject-query-params';
+import { render, screen } from '@testing-library/angular';
 
 jest.mock('ngxtension/inject-query-params', () => ({
 	__esModule: true,

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
@@ -6,7 +6,6 @@ import { StoryService } from '../../providers/story.service';
 import { Observable, of } from 'rxjs';
 import { storyTeaserMock } from '../../mocks/story.mock';
 import { StoryTeaser } from '@models/story.model';
-import { RouterTestingModule } from '@angular/router/testing';
 import * as ngExtension from 'ngxtension/inject-query-params';
 import { signal } from '@angular/core';
 import { NavigableStoryTeaserComponent } from '../navigable-story-teaser/navigable-story-teaser.component';
@@ -27,7 +26,7 @@ jest.spyOn(ngExtension, 'injectQueryParams').mockReturnValue(
 describe('AuthorNavigationFrameComponent', () => {
 	const setup = async () => {
 		return await render(AuthorNavigationFrameComponent, {
-			componentImports: [CommonModule, RouterTestingModule, NavigableStoryTeaserComponent],
+			componentImports: [CommonModule, NavigableStoryTeaserComponent],
 			inputs: {},
 			providers: [
 				{

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
@@ -1,21 +1,40 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AuthorNavigationFrameComponent } from './author-navigation-frame.component';
+import { render } from '@testing-library/angular';
+import { FetchContentDirective } from '../../directives/fetch-content.directive';
+import { CommonModule } from '@angular/common';
+import { StoryService } from '../../providers/story.service';
+import { Observable, of } from 'rxjs';
+import { storyTeaserMock } from '../../mocks/story.mock';
+import { StoryTeaser } from '@models/story.model';
 
-xdescribe('AuthorNavigationFrameComponent', () => {
-	let component: AuthorNavigationFrameComponent;
-	let fixture: ComponentFixture<AuthorNavigationFrameComponent>;
+describe('AuthorNavigationFrameComponent', () => {
+	const setup = async () => {
+		return await render(AuthorNavigationFrameComponent, {
+			componentImports: [CommonModule],
+			inputs: {},
+			providers: [
+				{
+					provide: FetchContentDirective,
+					useValue: {
+						fetchContent$<T>(source$: Observable<T>): Observable<T> {
+							return source$;
+						},
+					},
+				},
+				{
+					provide: StoryService,
+					useValue: {
+						getByAuthorSlug(slug: string): Observable<StoryTeaser[]> {
+							return of([storyTeaserMock]);
+						},
+					},
+				},
+			],
+		});
+	};
 
-	beforeEach(async () => {
-		await TestBed.configureTestingModule({
-			imports: [AuthorNavigationFrameComponent],
-		}).compileComponents();
-
-		fixture = TestBed.createComponent(AuthorNavigationFrameComponent);
-		component = fixture.componentInstance;
-		fixture.detectChanges();
-	});
-
-	it('should create', () => {
-		expect(component).toBeTruthy();
+	test('should render AuthorNavigationFrameComponent', async () => {
+		const view = await setup();
+		expect(view).toBeTruthy();
 	});
 });


### PR DESCRIPTION
## Resumen
- Migra tests del archivo `author-navigation-frame.component.spec.ts` a Angular Testing Library.
- Agrega nuevamente smoke test del componente.
- Añade test adicional para comprobar si la información de un StoryTeaser se renderiza correctamente en el componente.