### PR TITLE
[#1156] - Exportar componentes como default y actualizar notación de rutas

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -17,42 +17,42 @@ export enum AppRoutes {
 export const appRoutes: Routes = [
 	{
 		path: AppRoutes.Home,
-		loadComponent: () => import('./pages/home/home.component').then((m) => m.HomeComponent),
+		loadComponent: () => import('./pages/home/home.component'),
 	},
 	{
 		path: `${AppRoutes.Author}/:slug`,
-		loadComponent: () => import('./pages/author/author.component').then((m) => m.AuthorComponent),
+		loadComponent: () => import('./pages/author/author.component'),
 	},
 	{
 		path: `${AppRoutes.Story}/:slug`,
-		loadComponent: () => import('./pages/story/story.component').then((m) => m.StoryComponent),
+		loadComponent: () => import('./pages/story/story.component'),
 	},
 	{
 		path: `${AppRoutes.Story}/:slug/:list`,
-		loadComponent: () => import('./pages/story/story.component').then((m) => m.StoryComponent),
+		loadComponent: () => import('./pages/story/story.component'),
 		canActivate: [redirectParamsForStorylistInStoryRouteGuard],
 	},
 	{
 		path: `${AppRoutes.Story}`, // Ruta definida por cuestiones de retrocompatibilidad. Redirecciona de '/story' con queryParams a params
-		loadComponent: () => import('./pages/story/story.component').then((m) => m.StoryComponent),
+		loadComponent: () => import('./pages/story/story.component'),
 		canActivate: [redirectQueryParamsBasedStoryUrlsGuard],
 	},
 	{
 		path: `${AppRoutes.StoryList}/:slug`,
-		loadComponent: () => import('./pages/storylist/storylist.component').then((m) => m.StorylistComponent),
+		loadComponent: () => import('./pages/storylist/storylist.component'),
 	},
 	{
 		path: `${AppRoutes.StoryList}`,
-		loadComponent: () => import('./pages/storylist/storylist.component').then((m) => m.StorylistComponent),
+		loadComponent: () => import('./pages/storylist/storylist.component'),
 		canActivate: [redirectQueryParamsBasedStorylistUrlsGuard],
 	},
 	{
 		path: AppRoutes.About,
-		loadComponent: () => import('./pages/about/about.component').then((m) => m.AboutComponent),
+		loadComponent: () => import('./pages/about/about.component'),
 	},
 	{
 		path: AppRoutes.Dmca,
-		loadComponent: () => import('./pages/dmca/dmca.component').then((m) => m.DmcaComponent),
+		loadComponent: () => import('./pages/dmca/dmca.component'),
 	},
 	{
 		path: '',

--- a/src/app/pages/about/about.component.spec.ts
+++ b/src/app/pages/about/about.component.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/angular';
 
-import { AboutComponent } from './about.component';
+import AboutComponent from './about.component';
 
 describe('AboutComponent', () => {
 	it('should create', async () => {

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -8,7 +8,7 @@ import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 	hostDirectives: [MetaTagsDirective],
 	templateUrl: './about.component.html',
 })
-export class AboutComponent {
+export default class AboutComponent {
 	readonly links = {
 		CONTRIBUTING: 'https://github.com/rolivencia/cuentoneta/blob/master/CONTRIBUTING.md',
 		GITHUB_REPO: 'https://github.com/rolivencia/cuentoneta',

--- a/src/app/pages/author/author.component.spec.ts
+++ b/src/app/pages/author/author.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { AuthorComponent } from './author.component';
+import AuthorComponent from './author.component';
 
 xdescribe('AuthorComponent', () => {
 	let component: AuthorComponent;

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -81,7 +81,7 @@ import { rxResource } from '@angular/core/rxjs-interop';
 		</main>
 	`,
 })
-export class AuthorComponent {
+export default class AuthorComponent {
 	private readonly appRoutes = AppRoutes;
 
 	// Providers

--- a/src/app/pages/dmca/dmca.component.spec.ts
+++ b/src/app/pages/dmca/dmca.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { DmcaComponent } from './dmca.component';
+import DmcaComponent from './dmca.component';
 
 describe('DmcaComponent', () => {
 	let component: DmcaComponent;

--- a/src/app/pages/dmca/dmca.component.ts
+++ b/src/app/pages/dmca/dmca.component.ts
@@ -110,7 +110,7 @@ import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 		</main>
 	`,
 })
-export class DmcaComponent {
+export default class DmcaComponent {
 	private metaTagsDirective = inject(MetaTagsDirective);
 	constructor() {
 		this.metaTagsDirective.setTitle('DMCA');

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,4 +1,4 @@
-import { HomeComponent } from './home.component';
+import HomeComponent from './home.component';
 import { render } from '@testing-library/angular';
 import { CommonModule, NgForOf, NgIf, NgOptimizedImage } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -29,7 +29,7 @@ import { MostReadStoriesCardDeckComponent } from '../../components/most-read-sto
 	],
 	hostDirectives: [MetaTagsDirective],
 })
-export class HomeComponent {
+export default class HomeComponent {
 	// Services
 	private contentService = inject(ContentService);
 

--- a/src/app/pages/story/story.component.spec.ts
+++ b/src/app/pages/story/story.component.spec.ts
@@ -12,7 +12,7 @@ import { Storylist } from '@models/storylist.model';
 import { Story } from '@models/story.model';
 
 // Components
-import { StoryComponent } from './story.component';
+import StoryComponent from './story.component';
 
 describe('StoryComponent', () => {
 	const setup = async () => {

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -67,7 +67,7 @@ import { PortableTextParserComponent } from '../../components/portable-text-pars
 	],
 	hostDirectives: [MetaTagsDirective],
 })
-export class StoryComponent {
+export default class StoryComponent {
 	// Routes
 	readonly appRoutes = AppRoutes;
 

--- a/src/app/pages/storylist/storylist.component.spec.ts
+++ b/src/app/pages/storylist/storylist.component.spec.ts
@@ -16,7 +16,7 @@ import { Storylist } from '@models/storylist.model';
 import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 
 // Componentes
-import { StorylistComponent } from './storylist.component';
+import StorylistComponent from './storylist.component';
 
 xdescribe('StorylistComponent', () => {
 	const setup = async () => {

--- a/src/app/pages/storylist/storylist.component.ts
+++ b/src/app/pages/storylist/storylist.component.ts
@@ -34,7 +34,7 @@ import { rxResource } from '@angular/core/rxjs-interop';
 	],
 	hostDirectives: [MetaTagsDirective],
 })
-export class StorylistComponent {
+export default class StorylistComponent {
 	// Providers
 	private params = injectParams();
 	private metaTagsDirective = inject(MetaTagsDirective);


### PR DESCRIPTION
### Resumen
Cambios en base a #1156 
- Actualiza export de componentes con *default*
- Actualiza import de componentes en `app.routes.ts` con notación reducida en base a la version 15.0 de router en Angular.