### PR TITLE
[#1175] - Índice de autores V1

### DIFF
--- a/resources/apidocs/insomnia.json
+++ b/resources/apidocs/insomnia.json
@@ -1,7 +1,7 @@
 {
 	"_type": "export",
 	"__export_format": 4,
-	"__export_date": "2025-02-25T01:35:51.522Z",
+	"__export_date": "2025-03-17T11:01:07.202Z",
 	"__export_source": "insomnia.desktop.app:v2023.5.8",
 	"resources": [
 		{
@@ -52,7 +52,7 @@
 		{
 			"_id": "req_267b1db03b6846d9968caeb872fbaf21",
 			"parentId": "fld_253698ba99e3499b92d3e95bcd92593d",
-			"modified": 1739170814833,
+			"modified": 1741056713475,
 			"created": 1732774812182,
 			"url": "www.clarity.ms/export-data/api/v1/project-live-insights",
 			"name": "Clarity",
@@ -60,7 +60,7 @@
 			"method": "GET",
 			"body": {},
 			"parameters": [
-				{ "id": "pair_d4ce18a641f64045b3a125153cd15cc8", "name": "numOfDays", "value": "3", "description": "" }
+				{ "id": "pair_d4ce18a641f64045b3a125153cd15cc8", "name": "numOfDays", "value": "1", "description": "" }
 			],
 			"headers": [{ "name": "User-Agent", "value": "insomnia/2023.5.8" }],
 			"authentication": {
@@ -125,6 +125,41 @@
 			"_type": "request_group"
 		},
 		{
+			"_id": "req_8b1a7c546b7343aeb04f2bca6a2dfd0c",
+			"parentId": "fld_ec3d00e24fde46ef95f2daa68743f059",
+			"modified": 1742209246367,
+			"created": 1742209224515,
+			"url": "{{apiUrl}}/api/author/",
+			"name": "/",
+			"description": "",
+			"method": "GET",
+			"body": {},
+			"parameters": [],
+			"headers": [{ "name": "User-Agent", "value": "insomnia/2023.5.8" }],
+			"authentication": {},
+			"metaSortKey": -1742209224515,
+			"isPrivate": false,
+			"settingStoreCookies": true,
+			"settingSendCookies": true,
+			"settingDisableRenderRequestBody": false,
+			"settingEncodeUrl": true,
+			"settingRebuildPath": true,
+			"settingFollowRedirects": "global",
+			"_type": "request"
+		},
+		{
+			"_id": "fld_ec3d00e24fde46ef95f2daa68743f059",
+			"parentId": "wrk_e4d7e8c59a91416289f4e29aeda7a561",
+			"modified": 1713844613694,
+			"created": 1713844613694,
+			"name": "/author",
+			"description": "",
+			"environment": {},
+			"environmentPropertyOrder": null,
+			"metaSortKey": -1713844613694,
+			"_type": "request_group"
+		},
+		{
 			"_id": "req_a3492b8be4b944d4814c58d5cb5a75ee",
 			"parentId": "fld_ec3d00e24fde46ef95f2daa68743f059",
 			"modified": 1740427988318,
@@ -146,18 +181,6 @@
 			"settingRebuildPath": true,
 			"settingFollowRedirects": "global",
 			"_type": "request"
-		},
-		{
-			"_id": "fld_ec3d00e24fde46ef95f2daa68743f059",
-			"parentId": "wrk_e4d7e8c59a91416289f4e29aeda7a561",
-			"modified": 1713844613694,
-			"created": 1713844613694,
-			"name": "/author",
-			"description": "",
-			"environment": {},
-			"environmentPropertyOrder": null,
-			"metaSortKey": -1713844613694,
-			"_type": "request_group"
 		},
 		{
 			"_id": "req_cb063c0f13854008a57ca94062b472ce",

--- a/src/api/_queries/author.query.ts
+++ b/src/api/_queries/author.query.ts
@@ -20,3 +20,15 @@ export const authorBySlugQuery = defineQuery(`
         } 
     }, [])
 }`);
+
+export const authorsQuery = defineQuery(`
+*[_type == 'author' && !(_id in path('drafts.**'))]
+{
+    _id,
+    slug,
+    name,
+    image,
+    nationality->,
+    'biography': [],
+    'resources': []
+}|order(name asc)`);

--- a/src/api/author/author.controller.ts
+++ b/src/api/author/author.controller.ts
@@ -5,6 +5,7 @@ const router = express.Router();
 
 // Routes
 router.get('/:slug', getBySlug);
+router.get('/', getAll);
 
 export default router;
 
@@ -13,6 +14,13 @@ function getBySlug(req: express.Request, res: express.Response, next: express.Ne
 
 	authorService
 		.getBySlug(slug as string)
+		.then((result) => res.json(result))
+		.catch((err) => next(err));
+}
+
+function getAll(req: express.Request, res: express.Response, next: express.NextFunction) {
+	authorService
+		.getAll()
 		.then((result) => res.json(result))
 		.catch((err) => next(err));
 }

--- a/src/api/author/author.service.ts
+++ b/src/api/author/author.service.ts
@@ -1,12 +1,12 @@
 // Sanity
 import { client } from '../_helpers/sanity-connector';
-import { authorBySlugQuery } from '../_queries/author.query';
+import { authorBySlugQuery, authorsQuery } from '../_queries/author.query';
 
 // Funciones
-import { mapAuthor } from '../_utils/functions';
+import { mapAuthor, mapAuthorTeaser } from '../_utils/functions';
 
 // Interfaces
-import { Author } from '@models/author.model';
+import { Author, AuthorTeaser } from '@models/author.model';
 
 export async function getBySlug(slug: string): Promise<Author> {
 	const result = await client.fetch(authorBySlugQuery, { slug });
@@ -16,4 +16,10 @@ export async function getBySlug(slug: string): Promise<Author> {
 	}
 
 	return mapAuthor(result);
+}
+
+export async function getAll(): Promise<AuthorTeaser[]> {
+	const result = await client.fetch(authorsQuery);
+	const authors = result.map((author) => mapAuthorTeaser(author));
+	return authors;
 }

--- a/src/api/sanity/types.ts
+++ b/src/api/sanity/types.ts
@@ -1183,6 +1183,45 @@ export type AuthorBySlugQueryResult = {
 		  }>
 		| Array<never>;
 } | null;
+// Variable: authorsQuery
+// Query: *[_type == 'author' && !(_id in path('drafts.**'))]{    _id,    slug,    name,    image,    nationality->,    'biography': [],    'resources': []}|order(name asc)
+export type AuthorsQueryResult = Array<{
+	_id: string;
+	slug: Slug;
+	name: string;
+	image: {
+		asset?: {
+			_ref: string;
+			_type: 'reference';
+			_weak?: boolean;
+			[internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+		};
+		hotspot?: SanityImageHotspot;
+		crop?: SanityImageCrop;
+		_type: 'image';
+	};
+	nationality: {
+		_id: string;
+		_type: 'nationality';
+		_createdAt: string;
+		_updatedAt: string;
+		_rev: string;
+		country: string;
+		flag: {
+			asset?: {
+				_ref: string;
+				_type: 'reference';
+				_weak?: boolean;
+				[internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+			};
+			hotspot?: SanityImageHotspot;
+			crop?: SanityImageCrop;
+			_type: 'image';
+		};
+	};
+	biography: Array<never>;
+	resources: Array<never>;
+}>;
 
 // Source: ../src/api/_queries/content.query.ts
 // Variable: landingPageContentQuery
@@ -3271,6 +3310,7 @@ import '@sanity/client';
 declare module '@sanity/client' {
 	interface SanityQueries {
 		"\n*[_type == 'author' && slug.current == $slug && !(_id in path('drafts.**'))][0]\n{\n    _id,\n    slug,\n    name,\n    image,\n    nationality->,\n    biography,\n    'resources': coalesce(resources[]{ \n        title, \n        url, \n        resourceType->{ \n        \ttitle, \n        \tshortDescription,\n        \tdescription, \n            icon\n        } \n    }, [])\n}": AuthorBySlugQueryResult;
+		"\n*[_type == 'author' && !(_id in path('drafts.**'))]\n{\n    _id,\n    slug,\n    name,\n    image,\n    nationality->,\n    'biography': [],\n    'resources': []\n}|order(name asc)": AuthorsQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**'))][0]{\n    _id,\n    'cards': coalesce(cards[]->{\n        _id,\n        title,\n        'slug': slug.current,\n        description,\n        language,\n        displayDates,\n        editionPrefix,\n        comingNextLabel,\n        featuredImage,\n        'tags': coalesce(tags[] -> {\n            title, \n            'slug': slug.current, \n            shortDescription,\n            description, \n            icon\n        }, []),\n        'publications': [],\n        'count': coalesce(count(publications), 0)\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'description': coalesce(description, []),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'title': coalesce(contents.xs.title, []),\n                'subtitle': coalesce(contents.xs.subtitle, []),\n                'image': contents.xs.image\n            },\n            'md': {\n                'title': coalesce(contents.md.title, []),\n                'subtitle': coalesce(contents.md.subtitle, []),\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'mostRead': coalesce(mostRead[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        language,\n        badLanguage,\n        'body': [],\n        originalPublication,\n        approximateReadingTime,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> { \n            _id,\n            slug,\n            name,\n            image,\n            nationality->,\n            'biography': [],\n            'resources': [],\n        }\n    },[]),\n}": LandingPageContentQueryResult;
 		"\n*[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))][$start...$end]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'language': coalesce(language, 'es'),\n    'badLanguage': coalesce(badLanguage, false),\n    'body': coalesce(body[0...3], []),\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': coalesce(resources[]{ \n        title, \n        url, \n        resourceType->{ \n            title, \n            shortDescription,\n            description, \n            icon\n        } \n    }, []),\n}|order(title asc)": StoriesByAuthorSlugQueryResult;
 		"\n*[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'language': coalesce(language, 'es'),\n    'badLanguage': coalesce(badLanguage, false),\n    'body': [],\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': [],\n}|order(title asc)[$start...$end]": StoryNavigationTeasersByAuthorSlugQueryResult;

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -1,40 +1,45 @@
 import { RenderMode, ServerRoute } from '@angular/ssr';
+import { AppRoutes } from './app.routes';
 
 export const serverRoutes: Array<ServerRoute> = [
 	{
-		path: 'home',
+		path: AppRoutes.Home,
 		renderMode: RenderMode.Server,
 	},
 	{
-		path: 'about',
+		path: AppRoutes.Authors,
 		renderMode: RenderMode.Prerender,
 	},
 	{
-		path: 'dmca',
+		path: AppRoutes.About,
 		renderMode: RenderMode.Prerender,
 	},
 	{
-		path: 'author/:slug',
+		path: AppRoutes.Dmca,
+		renderMode: RenderMode.Prerender,
+	},
+	{
+		path: `${AppRoutes.Author}/:slug`,
 		renderMode: RenderMode.Server,
 	},
 	{
-		path: 'story',
+		path: AppRoutes.Story,
 		renderMode: RenderMode.Server,
 	},
 	{
-		path: 'story/:slug',
+		path: `${AppRoutes.Story}/:slug`,
 		renderMode: RenderMode.Server,
 	},
 	{
-		path: 'story/:slug/:list',
+		path: `${AppRoutes.Story}/:slug/:list`,
 		renderMode: RenderMode.Server,
 	},
 	{
-		path: 'storylist',
+		path: `${AppRoutes.StoryList}`,
 		renderMode: RenderMode.Server,
 	},
 	{
-		path: 'storylist/:slug',
+		path: `${AppRoutes.StoryList}/:slug`,
 		renderMode: RenderMode.Server,
 	},
 	{

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -10,6 +10,7 @@ export enum AppRoutes {
 	Story = 'story',
 	StoryList = 'storylist',
 	Author = 'author',
+	Authors = 'authors',
 	About = 'about',
 	Dmca = 'dmca',
 }
@@ -18,6 +19,10 @@ export const appRoutes: Routes = [
 	{
 		path: AppRoutes.Home,
 		loadComponent: () => import('./pages/home/home.component'),
+	},
+	{
+		path: AppRoutes.Authors,
+		loadComponent: () => import('./pages/authors/authors.component'),
 	},
 	{
 		path: `${AppRoutes.Author}/:slug`,

--- a/src/app/pages/authors/authors.component.ts
+++ b/src/app/pages/authors/authors.component.ts
@@ -1,0 +1,38 @@
+import { Component, computed, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AuthorService } from '../../providers/author.service';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+import { MetaTagsDirective } from '../../directives/meta-tags.directive';
+
+@Component({
+	imports: [CommonModule, RouterLink],
+	hostDirectives: [MetaTagsDirective],
+	template: `<main>
+		<ul class="list-inside list-disc">
+			@for (author of authors(); track author.slug) {
+				<li>
+					<span>
+						<a [routerLink]="['/', 'author', author.slug]" class="underline">{{ author.name }}</a>
+					</span>
+				</li>
+			}
+		</ul>
+	</main>`,
+	styles: ``,
+})
+export default class AuthorsComponent {
+	private authorService = inject(AuthorService);
+	private metaTagsDirective = inject(MetaTagsDirective);
+
+	private authorsResource = rxResource({
+		loader: () => this.authorService.getAll(),
+	});
+
+	authors = computed(() => this.authorsResource.value() ?? []);
+
+	constructor() {
+		this.metaTagsDirective.setTitle('Índice de Autores');
+		this.metaTagsDirective.setDefaultDescription();
+	}
+}

--- a/src/app/providers/author.service.ts
+++ b/src/app/providers/author.service.ts
@@ -7,7 +7,7 @@ import { Observable } from 'rxjs';
 import { environment } from '../environments/environment';
 
 // Interfaces
-import { Author } from '@models/author.model';
+import { Author, AuthorTeaser } from '@models/author.model';
 import { ApiUrl, Endpoints } from './endpoints';
 
 @Injectable({
@@ -16,6 +16,10 @@ import { ApiUrl, Endpoints } from './endpoints';
 export class AuthorService {
 	private readonly url: ApiUrl = `${environment.apiUrl}${Endpoints.Author}`;
 	private http = inject(HttpClient);
+
+	public getAll(): Observable<AuthorTeaser[]> {
+		return this.http.get<AuthorTeaser[]>(this.url);
+	}
 
 	public getBySlug(slug: string): Observable<Author> {
 		return this.http.get<Author>(`${this.url}/${slug}`);


### PR DESCRIPTION
## Resumen

Se implementa una primera versión completamente funcional del índice de autores, a fin de entregar esta información a los crawlers de los buscadores.

### Backend
- Creación de query `authorsQuery` con su correspondiente tipado.
- Implementación del método `getAll` en AuthorService.
- Creación del endpoint `/api/author`.
- Adición de documentación en Insomnia para el endpoint `/api/author`.
- Generalización de la función de mapeo para generar objetos de tipo `AuthorTeaser` a partir de resultados de queries.

### Frontend
- Desarrollo del componente `AuthorsComponent`.
- Configuración del routing para `AuthorsComponent`.
- Agregado del método `getAll` en `AuthorService`.