### PR TITLE
[#1185] - Manejo de URLs canónicas para mejorar SEO

### DIFF
--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -120,5 +120,5 @@ writeFile(targetPath, environmentFileContent, { flag: 'w' }, function (err: Errn
 	console.log('Ambiente de Vercel - VERCEL_ENV = ', process.env['VERCEL_ENV']);
 	console.log('Ambiente de Vercel - VERCEL_URL = ', process.env['VERCEL_URL']);
 	console.log('URL de branch de Vercel - VERCEL_BRANCH_URL = ', process.env['VERCEL_BRANCH_URL']);
-	console.log('URL de API = ', apiUrl);
+	console.log('URL de API y Website = ', apiUrl);
 });

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -91,7 +91,7 @@ const apiUrl = generateApiUrl(environment);
 
 const exportedEnvironment = {
 	environment: `${environment ?? 'development'}`,
-	website: `${process.env['VERCEL_PROJECT_PRODUCTION_URL'] ?? 'https://cuentoneta.ar/'}`,
+	website: `${apiUrl ?? 'https://cuentoneta.ar/'}`,
 	apiUrl: `${apiUrl}`,
 	clarityProjectId: '',
 };

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
@@ -1,4 +1,3 @@
-import { signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Observable, of } from 'rxjs';
 
@@ -10,33 +9,23 @@ import { AuthorNavigationFrameComponent } from './author-navigation-frame.compon
 import { StoryTeaser } from '@models/story.model';
 
 // Mocks
-import { storyTeaserMock } from '../../mocks/story.mock';
+import { storyMock, storyTeaserMock } from '../../mocks/story.mock';
 
 // Services
 import { StoryService } from '../../providers/story.service';
 
 // 3rd party libs
-import * as ngExtension from 'ngxtension/inject-query-params';
 import { render, screen } from '@testing-library/angular';
-
-jest.mock('ngxtension/inject-query-params', () => ({
-	__esModule: true,
-	...jest.requireActual('ngxtension/inject-query-params'),
-}));
-
-// Add a jest mock for the injectQueryParams function
-jest.spyOn(ngExtension, 'injectQueryParams').mockReturnValue(
-	signal({
-		navigation: 'author',
-		navigationSlug: 'francois-onoff',
-	}),
-);
+import { authorMock } from '../../mocks/author.mock';
 
 describe('AuthorNavigationFrameComponent', () => {
 	const setup = async () => {
 		return await render(AuthorNavigationFrameComponent, {
 			componentImports: [CommonModule, NavigableStoryTeaserComponent],
-			inputs: {},
+			inputs: {
+				selectedStorySlug: storyMock.slug,
+				navigationSlug: authorMock.slug,
+			},
 			providers: [
 				{
 					provide: StoryService,

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
@@ -2,9 +2,6 @@
 import { Component, computed, effect, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-// 3rd party modules
-import { injectQueryParams } from 'ngxtension/inject-query-params';
-
 // Routing
 import { AppRoutes } from '../../app.routes';
 
@@ -38,29 +35,25 @@ export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
 	readonly appRoutes = AppRoutes;
 
 	// Providers
-	private queryParams = injectQueryParams();
 	private storyService = inject(StoryService);
 
 	// Recursos
 	private readonly storiesResource = rxResource({
-		request: () => this.queryParams(),
-		loader: (params) => this.storyService.getNavigationTeasersByAuthorSlug(params.request['navigationSlug']),
+		request: () => this.navigationSlug(),
+		loader: (params) => this.storyService.getNavigationTeasersByAuthorSlug(params.request),
 	});
 
 	// Propiedades
 	stories = computed(() => this.storiesResource.value());
-	authorSlug = computed(() => this.queryParams()?.['navigationSlug'] ?? '');
+	authorSlug = computed(() => this.navigationSlug() ?? '');
 
 	constructor() {
 		super();
-
 		effect(() => {
-			const { navigationSlug } = this.queryParams();
-
 			this.config.set({
 				headerTitle: 'Más del autor',
 				footerTitle: 'Ver más...',
-				navigationRoute: this.router.createUrlTree([this.appRoutes.Author, navigationSlug]),
+				navigationRoute: this.router.createUrlTree([this.appRoutes.Author, this.navigationSlug()]),
 				showFooter: true,
 			});
 		});

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.spec.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.spec.ts
@@ -1,10 +1,55 @@
 import { StoryNavigationBarComponent } from './story-navigation-bar.component';
 
 import { render } from '@testing-library/angular';
+import { Observable, of } from 'rxjs';
+import { StoryService } from '../../providers/story.service';
+import { StoryTeaser } from '@models/story.model';
+import { storyMock, storyTeaserMock } from '../../mocks/story.mock';
+import { StorylistService } from '../../providers/storylist.service';
+import { Storylist } from '@models/storylist.model';
+import { storyListMock } from '../../mocks/storylist.mock';
+import { authorMock } from '../../mocks/author.mock';
 
 describe('StoryNavigationBarComponent', () => {
-	it('should create', async () => {
-		const view = await render(StoryNavigationBarComponent);
+	it('should create for AuthorNavigationFrameComponent', async () => {
+		const view = await render(StoryNavigationBarComponent, {
+			inputs: {
+				selectedStorySlug: storyMock.slug,
+				navigation: 'author',
+				navigationSlug: authorMock.slug,
+			},
+			providers: [
+				{
+					provide: StoryService,
+					useValue: {
+						getNavigationTeasersByAuthorSlug(): Observable<StoryTeaser[]> {
+							return of([storyTeaserMock]);
+						},
+					},
+				},
+			],
+		});
+		expect(view).toBeTruthy();
+	});
+
+	it('should create for StorylistNavigationFrameComponent', async () => {
+		const view = await render(StoryNavigationBarComponent, {
+			inputs: {
+				selectedStorySlug: storyMock.slug,
+				navigation: 'storylist',
+				navigationSlug: storyListMock.slug,
+			},
+			providers: [
+				{
+					provide: StorylistService,
+					useValue: {
+						getStorylistNavigationTeasers(): Observable<Storylist> {
+							return of(storyListMock);
+						},
+					},
+				},
+			],
+		});
 		expect(view).toBeTruthy();
 	});
 });

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -1,12 +1,10 @@
 // Core
-import { Component, computed, inject, Type } from '@angular/core';
+import { Component, computed, inject, input, Type } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
 
 // 3rd Party modules
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
-import { injectParams } from 'ngxtension/inject-params';
-import { injectQueryParams } from 'ngxtension/inject-query-params';
 
 // Services
 import { NavigationFrameService } from '../../providers/navigation-frame.service';
@@ -59,26 +57,28 @@ import { NavigationFrameComponent } from '@models/navigation-frame.component';
 	imports: [CommonModule, NgxSkeletonLoaderModule, RouterLink],
 })
 export class StoryNavigationBarComponent {
-	private params = injectParams();
-	private queryParams = injectQueryParams();
+	selectedStorySlug = input<string>();
+	navigation = input.required<'author' | 'storylist'>();
+	navigationSlug = input.required<string>();
 
 	// Inyección de providers
 	private navigationFrameService = inject(NavigationFrameService);
 
 	frame = computed(() => {
-		const { slug } = this.params();
-		const { navigation } = this.queryParams();
-		return this.setNavigationFrame(slug, navigation);
+		const storySlug = this.selectedStorySlug() ?? '';
+		const navigation = this.navigation();
+
+		return this.setNavigationFrame(storySlug, navigation);
 	});
 
 	frameConfig = this.navigationFrameService.navigationBarConfig;
 
 	private setNavigationFrame(
-		slug: string,
-		navigation: 'author | storylist',
+		storySlug: string,
+		navigation: 'author' | 'storylist',
 	): {
 		component: Type<NavigationFrameComponent> | null;
-		inputs: { selectedStorySlug: string };
+		inputs: { selectedStorySlug: string; navigationSlug: string };
 	} {
 		const navigationFrames = [
 			{ navigation: 'author', component: AuthorNavigationFrameComponent },
@@ -87,6 +87,6 @@ export class StoryNavigationBarComponent {
 
 		const component = navigationFrames.find((c) => c.navigation === navigation)?.component ?? null;
 
-		return { component, inputs: { selectedStorySlug: slug } };
+		return { component, inputs: { selectedStorySlug: storySlug, navigationSlug: this.navigationSlug() ?? '' } };
 	}
 }

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.spec.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.spec.ts
@@ -1,4 +1,3 @@
-import { signal } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
 import { Observable, of } from 'rxjs';
 
@@ -11,34 +10,24 @@ import { Storylist } from '@models/storylist.model';
 
 // Mocks
 import { storyListMock } from '../../mocks/storylist.mock';
+import { storyMock } from '../../mocks/story.mock';
 
 // Services
 import { StorylistService } from '../../providers/storylist.service';
 
 // 3rd party libs
-import * as ngExtension from 'ngxtension/inject-query-params';
 import { render, screen } from '@testing-library/angular';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { MapPublicationEditionLabelPipe } from '../../pipes/map-publication-edition-label.pipe';
-
-jest.mock('ngxtension/inject-query-params', () => ({
-	__esModule: true,
-	...jest.requireActual('ngxtension/inject-query-params'),
-}));
-
-// Add a jest mock for the injectQueryParams function
-jest.spyOn(ngExtension, 'injectQueryParams').mockReturnValue(
-	signal({
-		navigation: 'storylist',
-		navigationSlug: 'verano-2022',
-	}),
-);
 
 describe('StorylistNavigationFrameComponent', () => {
 	const setup = async () => {
 		return await render(StorylistNavigationFrameComponent, {
 			componentImports: [CommonModule, NavigablePublicationTeaserComponent, NgxSkeletonLoaderModule],
-			inputs: {},
+			inputs: {
+				selectedStorySlug: storyMock.slug,
+				navigationSlug: storyListMock.slug,
+			},
 			providers: [
 				DatePipe,
 				MapPublicationEditionLabelPipe,

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
@@ -4,7 +4,6 @@ import { UrlTree } from '@angular/router';
 
 // 3rd party modules
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
-import { injectQueryParams } from 'ngxtension/inject-query-params';
 
 // Models
 import { PublicationNavigationTeaser } from '@models/storylist.model';
@@ -56,13 +55,12 @@ export class StorylistNavigationFrameComponent extends NavigationFrameComponent 
 	readonly appRoutes = AppRoutes;
 
 	// Providers
-	private queryParams = injectQueryParams();
 	private storylistService = inject(StorylistService);
 
 	// Recursos
 	private readonly storylistResource = rxResource({
-		request: () => this.queryParams(),
-		loader: (params) => this.storylistService.getStorylistNavigationTeasers(params.request['navigationSlug']),
+		request: () => this.navigationSlug(),
+		loader: (params) => this.storylistService.getStorylistNavigationTeasers(params.request),
 	});
 
 	// Propiedades

--- a/src/app/directives/meta-tags.directive.ts
+++ b/src/app/directives/meta-tags.directive.ts
@@ -60,4 +60,11 @@ export class MetaTagsDirective {
 		element.setAttribute('rel', 'canonical');
 		element.setAttribute('href', url);
 	}
+
+	removeCanonicalUrl() {
+		const element = this.document.querySelector(`link[rel='canonical']`);
+		if (element) {
+			element.remove();
+		}
+	}
 }

--- a/src/app/directives/meta-tags.directive.ts
+++ b/src/app/directives/meta-tags.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, inject, PLATFORM_ID, Renderer2 } from '@angular/core';
+import { Directive, inject, PLATFORM_ID } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 

--- a/src/app/directives/meta-tags.directive.ts
+++ b/src/app/directives/meta-tags.directive.ts
@@ -1,12 +1,13 @@
-import { Directive, inject, PLATFORM_ID } from '@angular/core';
+import { Directive, inject, PLATFORM_ID, Renderer2 } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
-import { isPlatformBrowser } from '@angular/common';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 
 @Directive({
 	selector: '[cuentonetaMetaTags]',
 	standalone: true,
 })
 export class MetaTagsDirective {
+	private document = inject(DOCUMENT);
 	private metaTagService = inject(Meta);
 	private platformId = inject(PLATFORM_ID);
 	private titleService = inject(Title);
@@ -47,5 +48,16 @@ export class MetaTagsDirective {
 
 	setDefaultDescription() {
 		this.setDescription('Una iniciativa que busca fomentar y hacer accesible la lectura digital.');
+	}
+
+	setCanonicalUrl(url: string) {
+		const head = this.document.getElementsByTagName('head')[0];
+		let element: HTMLLinkElement | null = this.document.querySelector(`link[rel='canonical']`) || null;
+		if (!element) {
+			element = this.document.createElement('link') as HTMLLinkElement;
+			head.appendChild(element);
+		}
+		element.setAttribute('rel', 'canonical');
+		element.setAttribute('href', url);
 	}
 }

--- a/src/app/models/navigation-frame.component.ts
+++ b/src/app/models/navigation-frame.component.ts
@@ -16,6 +16,7 @@ export abstract class NavigationFrameComponent {
 
 	// Inputs
 	selectedStorySlug = input<string>();
+	navigationSlug = input<string>();
 	config = signal<NavigationBarConfig>(this.navigationFrameService.navigationBarConfig());
 
 	protected constructor() {

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -1,5 +1,11 @@
 <aside class="hidden md:block">
-	<cuentoneta-story-navigation-bar />
+	@if (navigationParams(); as navigationParams) {
+		<cuentoneta-story-navigation-bar
+			[selectedStorySlug]="story()?.slug"
+			[navigation]="navigationParams.navigation"
+			[navigationSlug]="navigationParams.navigationSlug"
+		/>
+	}
 </aside>
 
 <main>

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -29,6 +29,8 @@ import { ShareContentComponent } from '../../components/share-content/share-cont
 import { EpigraphComponent } from '../../components/epigraph/epigraph.component';
 import { MediaResourceComponent } from '../../components/media-resource/media-resource.component';
 import { PortableTextParserComponent } from '../../components/portable-text-parser/portable-text-parser.component';
+import { environment } from '../../environments/environment';
+import { injectQueryParams } from 'ngxtension/inject-query-params';
 
 @Component({
 	selector: 'cuentoneta-story',
@@ -73,6 +75,7 @@ export default class StoryComponent {
 
 	// Providers
 	private params = injectParams();
+	private queryParams = injectQueryParams();
 	private storyService = inject(StoryService);
 	private themeService = inject(ThemeService);
 	private meta = inject(MetaTagsDirective);
@@ -98,11 +101,22 @@ export default class StoryComponent {
 		() =>
 			`Leí "${this.story()?.title}" de ${this.story()?.author.name} en La Cuentoneta y te lo comparto. Sumate a leer este y otros cuentos en este link:`,
 	);
+	navigationParams = computed(() => {
+		let { navigation, navigationSlug } = this.queryParams();
+
+		if (!navigation && !navigationSlug) {
+			navigation = 'author';
+			navigationSlug = this.story()?.author.slug ?? '';
+		}
+
+		return { navigation, navigationSlug };
+	});
 
 	private updateMetaTags(story: Story) {
 		this.meta.setTitle(`${story.title} - ${story.author.name}`);
 		this.meta.setDescription(
 			`Una lectura en La Cuentoneta: Una iniciativa que busca fomentar y hacer accesible la lectura digital.`,
 		);
+		this.meta.setCanonicalUrl(`${environment.website}${AppRoutes.Story}/${story.slug}`);
 	}
 }

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -1,5 +1,5 @@
 // Core
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, inject, OnDestroy } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { tap } from 'rxjs';
 import { CommonModule } from '@angular/common';
@@ -69,7 +69,7 @@ import { injectQueryParams } from 'ngxtension/inject-query-params';
 	],
 	hostDirectives: [MetaTagsDirective],
 })
-export default class StoryComponent {
+export default class StoryComponent implements OnDestroy {
 	// Routes
 	readonly appRoutes = AppRoutes;
 
@@ -111,6 +111,10 @@ export default class StoryComponent {
 
 		return { navigation, navigationSlug };
 	});
+
+	ngOnDestroy() {
+		this.meta.removeCanonicalUrl();
+	}
 
 	private updateMetaTags(story: Story) {
 		this.meta.setTitle(`${story.title} - ${story.author.name}`);


### PR DESCRIPTION
## Resumen
- Agregado manejo de URLs canónicas para mejorar SEO, agregando métodos `setCanonicalUrl` y `removeCanonicalUrl` y utilizándolos en `StoryComponent` para actualizar la URL canónica al navegar hacia y desde la vista de lectura de una Story.
- Adaptados componentes `StoryNavigationBarComponent`, `FrameNavigationComponent`, `AuthorNavigationFrameComponent` y `StorylistNavigationFrameComponent` para utilizar inputs en vez de obtener slugs de navegación de manera independiente desde la URL.