### PR TITLE
[#1197] Definir tests unitarios para `MediaResourceComponent`

### DIFF
--- a/src/app/components/audio-recording-widget/audio-recording-widget.component.spec.ts
+++ b/src/app/components/audio-recording-widget/audio-recording-widget.component.spec.ts
@@ -32,4 +32,12 @@ describe('AudioRecordingWidgetComponent', () => {
 
 		expect(screen.getByText('Lectura del artículo sobre ajedrez en Wikipedia.')).toBeInTheDocument();
 	});
+
+	it('should display the audio recording description', async () => {
+		await render(AudioRecordingWidgetComponent, {
+			inputs: { media: audioRecordingMock },
+		});
+
+		expect(screen.getByText('Lectura del artículo sobre ajedrez en Wikipedia.')).toBeInTheDocument();
+	});
 });

--- a/src/app/components/media-resource/media-resource.component.spec.ts
+++ b/src/app/components/media-resource/media-resource.component.spec.ts
@@ -1,25 +1,81 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { render, screen } from '@testing-library/angular';
 import { MediaResourceComponent } from './media-resource.component';
-import { MediaTypes } from '@models/media.model';
+import { AudioRecording, Media, MediaTypes, SpaceRecording, YouTubeVideo } from '@models/media.model';
+import { AudioRecordingWidgetComponent } from '../audio-recording-widget/audio-recording-widget.component';
+import { SpaceRecordingWidgetComponent } from '../space-recording-widget/space-recording-widget.component';
+import { YoutubeVideoWidgetComponent } from '../youtube-video-widget/youtube-video-widget.component';
 
-const inputMock: MediaTypes[] = [];
+// Mocks
+import { youtubeVideoMock } from '../../mocks/youtube-video.mock';
+import { audioRecordingMock } from '../../mocks/audio-recording.mock';
+import { spaceRecordingMock } from '../../mocks/space-recording.mock';
+
+const mockMediaResources: Media[] = [
+	audioRecordingMock as AudioRecording,
+	spaceRecordingMock as SpaceRecording,
+	youtubeVideoMock as YouTubeVideo,
+];
 
 describe('MediaResourceComponent', () => {
-	let component: MediaResourceComponent;
-	let fixture: ComponentFixture<MediaResourceComponent>;
+	test('should render MediaResourceComponent', async () => {
+		const { container } = await render(MediaResourceComponent, {
+			componentInputs: { mediaResources: mockMediaResources },
+			imports: [AudioRecordingWidgetComponent, SpaceRecordingWidgetComponent, YoutubeVideoWidgetComponent],
+		});
 
-	beforeEach(async () => {
-		await TestBed.configureTestingModule({
-			imports: [MediaResourceComponent],
-		}).compileComponents();
-
-		fixture = TestBed.createComponent(MediaResourceComponent);
-		component = fixture.componentInstance;
-		fixture.componentRef.setInput('mediaResources', inputMock);
-		fixture.detectChanges();
+		expect(container).toBeTruthy();
 	});
 
-	it('should create', () => {
-		expect(component).toBeTruthy();
+	test('should render all types of media widgets', async () => {
+		await render(MediaResourceComponent, {
+			componentInputs: { mediaResources: mockMediaResources },
+			imports: [AudioRecordingWidgetComponent, SpaceRecordingWidgetComponent, YoutubeVideoWidgetComponent],
+		});
+
+		// Verificar que se renderiza el widget de audio
+		expect(screen.getByText('Lectura del artículo sobre ajedrez en Wikipedia.')).toBeInTheDocument();
+
+		// Verificar que se renderiza el widget de space recording
+		expect(screen.getByText('El marajá de San Telmo: discusión y breve análisis')).toBeInTheDocument();
+
+		// Verificar que se renderiza el widget de YouTube video
+		expect(screen.getByText('Video alusivo a la narración de "El espejo del tiempo".')).toBeInTheDocument();
+	});
+
+	test('should render an AudioRecordingWidgetComponent for audio recordings', async () => {
+		await render(MediaResourceComponent, {
+			componentInputs: { mediaResources: [mockMediaResources[0]] },
+			imports: [AudioRecordingWidgetComponent],
+		});
+
+		expect(screen.getByText('Lectura del artículo sobre ajedrez en Wikipedia.')).toBeInTheDocument();
+	});
+
+	test('should render a SpaceRecordingWidgetComponent for space recordings', async () => {
+		await render(MediaResourceComponent, {
+			componentInputs: { mediaResources: [mockMediaResources[1]] },
+			imports: [SpaceRecordingWidgetComponent],
+		});
+
+		expect(screen.getByText('El marajá de San Telmo: discusión y breve análisis')).toBeInTheDocument();
+	});
+
+	test('should render a YoutubeVideoWidgetComponent for YouTube videos', async () => {
+		await render(MediaResourceComponent, {
+			componentInputs: { mediaResources: [mockMediaResources[2]] },
+			imports: [YoutubeVideoWidgetComponent],
+		});
+
+		expect(screen.getByText('Video alusivo a la narración de "El espejo del tiempo".')).toBeInTheDocument();
+	});
+
+	test('should throw an error for unsupported media types', async () => {
+		const unsupportedMedia = [{ type: 'unsupportedType', id: '4', title: 'Unsupported Media' }];
+
+		await expect(
+			render(MediaResourceComponent, {
+				componentInputs: { mediaResources: unsupportedMedia as any },
+			}),
+		).rejects.toThrow('El tipo unsupportedType no está soportado.');
 	});
 });

--- a/src/app/components/media-resource/media-resource.component.spec.ts
+++ b/src/app/components/media-resource/media-resource.component.spec.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/angular';
 import { MediaResourceComponent } from './media-resource.component';
-import { AudioRecording, Media, MediaTypes, SpaceRecording, YouTubeVideo } from '@models/media.model';
+import { AudioRecording, Media, SpaceRecording, YouTubeVideo } from '@models/media.model';
 import { AudioRecordingWidgetComponent } from '../audio-recording-widget/audio-recording-widget.component';
 import { SpaceRecordingWidgetComponent } from '../space-recording-widget/space-recording-widget.component';
 import { YoutubeVideoWidgetComponent } from '../youtube-video-widget/youtube-video-widget.component';
@@ -74,7 +74,7 @@ describe('MediaResourceComponent', () => {
 
 		await expect(
 			render(MediaResourceComponent, {
-				componentInputs: { mediaResources: unsupportedMedia as any },
+				componentInputs: { mediaResources: unsupportedMedia },
 			}),
 		).rejects.toThrow('El tipo unsupportedType no está soportado.');
 	});

--- a/src/app/components/space-recording-widget/space-recording-widget.component.spec.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.component.spec.ts
@@ -57,4 +57,18 @@ describe('SpaceRecordingWidgetComponent', () => {
 		const img = screen.getByRole('img');
 		expect(img).toHaveAttribute('src', spaceRecordingMock.data.tweetBy.profileImage);
 	});
+
+	it('should display the space recording description', async () => {
+		await setup();
+		expect(
+			screen.getByText((content, element) => {
+				return (
+					element?.tagName.toLowerCase() === 'p' &&
+					content.includes('Space de X organizado y dirigido por ') &&
+					content.includes(' que incluye la lectura, análisis y discusión del cuento.') &&
+					Array.from(element.children).some((child) => child.textContent === '@criticocultural')
+				);
+			}),
+		).toBeInTheDocument();
+	});
 });

--- a/src/app/components/space-recording-widget/space-recording-widget.component.spec.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.component.spec.ts
@@ -1,6 +1,6 @@
 import { SpaceRecordingWidgetComponent } from './space-recording-widget.component';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
-import { render, screen } from '@testing-library/angular';
+import { render, screen, within } from '@testing-library/angular';
 import { CommonModule, DatePipe, NgOptimizedImage } from '@angular/common';
 import { spaceRecordingMock } from '../../mocks/space-recording.mock';
 
@@ -66,7 +66,7 @@ describe('SpaceRecordingWidgetComponent', () => {
 					element?.tagName.toLowerCase() === 'p' &&
 					content.includes('Space de X organizado y dirigido por ') &&
 					content.includes(' que incluye la lectura, análisis y discusión del cuento.') &&
-					Array.from(element.children).some((child) => child.textContent === '@criticocultural')
+					within(element as HTMLElement).getByText('@criticocultural') !== null
 				);
 			}),
 		).toBeInTheDocument();

--- a/src/app/components/youtube-video-widget/youtube-video-widget.component.spec.ts
+++ b/src/app/components/youtube-video-widget/youtube-video-widget.component.spec.ts
@@ -18,4 +18,12 @@ describe('YoutubeVideoWidgetComponent', () => {
 
 		expect(screen.getByText('Video alusivo a la narración de "El espejo del tiempo".')).toBeInTheDocument();
 	});
+
+	it('should display the YouTube video description', async () => {
+		await render(YoutubeVideoWidgetComponent, {
+			inputs: { media: youtubeVideoMock },
+		});
+
+		expect(screen.getByText('Video alusivo a la narración de "El espejo del tiempo".')).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
## Resumen
- Agrega tests unitarios para `MediaResourceComponent`, haciendo uso de los mocks preexistentes para los diferentes tipos posibles de Media.
- Fortalece los tests unitarios de `AudioRecordingWidgetComponent`, `SpaceRecordingWidgetComponent` y `YoutubeVideoWidgetComponent`, los cuales tenían tests faltantes relativos al chequeo de la descripción al pie de cada widget.