### PR TITLE
[#1165] - Agregar regla self-closing-tag de angular-eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,6 +73,7 @@ module.exports = [
 		files: ['**/*.html'],
 		rules: {
 			'@angular-eslint/template/prefer-control-flow': 'error',
+			'@angular-eslint/template/prefer-self-closing-tags': 'error',
 		},
 	},
 	{

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
@@ -22,7 +22,7 @@ import { rxResource } from '@angular/core/rxjs-interop';
 				[story]="story"
 				[selected]="selectedStorySlug() === story.slug"
 				[authorSlug]="authorSlug()"
-			></cuentoneta-navigable-story-teaser>
+			/>
 		}
 	}`,
 	styles: `

--- a/src/app/components/card/card.component.ts
+++ b/src/app/components/card/card.component.ts
@@ -9,10 +9,10 @@ import { Router, RouterLink, UrlTree } from '@angular/router';
 		class="card flex flex-col gap-2 border-1 border-solid border-primary-300 p-5 shadow-lg hover:shadow-lg-hover md:gap-4 md:p-8"
 	>
 		<a [routerLink]="route()" class="flex flex-col gap-2 md:gap-4">
-			<ng-content select="[slot=header]"></ng-content>
-			<ng-content select="[slot=content]"></ng-content>
+			<ng-content select="[slot=header]" />
+			<ng-content select="[slot=content]" />
 		</a>
-		<ng-content select="[slot=footer]"></ng-content>
+		<ng-content select="[slot=footer]" />
 	</article>`,
 	styles: ``,
 })

--- a/src/app/components/content-campaign-carousel/content-campaign-carousel-skeleton.component.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel-skeleton.component.ts
@@ -25,7 +25,7 @@ import { ThemeService } from '../../providers/theme.service';
 					count="1"
 					appearance="line"
 					class="grid"
-				></ngx-skeleton-loader>
+				/>
 
 				<ngx-skeleton-loader
 					[theme]="{
@@ -38,7 +38,7 @@ import { ThemeService } from '../../providers/theme.service';
 					count="1"
 					appearance="line"
 					class="grid"
-				></ngx-skeleton-loader>
+				/>
 			</header>
 			<ngx-skeleton-loader
 				[theme]="{
@@ -52,7 +52,7 @@ import { ThemeService } from '../../providers/theme.service';
 				count="1"
 				appearance="line"
 				class="grid aspect-[540/220] w-full object-cover md:aspect-[960/280]"
-			></ngx-skeleton-loader>
+			/>
 		</div>
 		<div class="footer mt-[10px] h-[27px]">
 			<ngx-skeleton-loader
@@ -68,7 +68,7 @@ import { ThemeService } from '../../providers/theme.service';
 				count="1"
 				appearance="line"
 				class="grid"
-			></ngx-skeleton-loader>
+			/>
 		</div>
 	</div>`,
 	styles: ``,

--- a/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
@@ -25,14 +25,10 @@ import { LayoutService } from '../../providers/layout.service';
 							<a [routerLink]="slide.url" [ngClass]="viewportSpecificClasses[viewport()]">
 								<header class="mb-3">
 									<h2 class="text-lg font-bold tracking-normal">
-										<cuentoneta-portable-text-parser
-											[paragraphs]="slide.contents[viewport()].title"
-										></cuentoneta-portable-text-parser>
+										<cuentoneta-portable-text-parser [paragraphs]="slide.contents[viewport()].title" />
 									</h2>
 									<h3 class="h4 subtitle text-gray-600">
-										<cuentoneta-portable-text-parser
-											[paragraphs]="slide.contents[viewport()].subtitle"
-										></cuentoneta-portable-text-parser>
+										<cuentoneta-portable-text-parser [paragraphs]="slide.contents[viewport()].subtitle" />
 									</h3>
 								</header>
 								<img

--- a/src/app/components/epigraph/epigraph.component.ts
+++ b/src/app/components/epigraph/epigraph.component.ts
@@ -9,18 +9,10 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	template: `
 		<div class="mr-4 border-l-3 border-solid border-primary-500"></div>
 		<div class="source-serif-pro-body-lg flex flex-1 flex-col flex-wrap items-end justify-end text-gray-700">
-			<cuentoneta-portable-text-parser
-				[classes]="'self-baseline'"
-				[paragraphs]="epigraph().text"
-			></cuentoneta-portable-text-parser>
+			<cuentoneta-portable-text-parser [classes]="'self-baseline'" [paragraphs]="epigraph().text" />
 			<div class="text-end">
 				@if (epigraph().reference) {
-					<em>
-						<cuentoneta-portable-text-parser
-							[classes]="'self-baseline'"
-							[paragraphs]="epigraph().reference"
-						></cuentoneta-portable-text-parser
-					></em>
+					<em> <cuentoneta-portable-text-parser [classes]="'self-baseline'" [paragraphs]="epigraph().reference" /></em>
 				}
 			</div>
 		</div>

--- a/src/app/components/media-resource/media-resource.component.ts
+++ b/src/app/components/media-resource/media-resource.component.ts
@@ -14,7 +14,7 @@ type MediaTypeWidgetComponents =
 	selector: 'cuentoneta-media-resource',
 	imports: [CommonModule],
 	template: ` @for (media of mediaResources(); track $index) {
-		<ng-container *ngComponentOutlet="media.component; inputs: media.inputs"></ng-container>
+		<ng-container *ngComponentOutlet="media.component; inputs: media.inputs" />
 	}`,
 	styles: `
 		:host {

--- a/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
+++ b/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
@@ -45,7 +45,7 @@ import { MapPublicationEditionLabelPipe } from '../../pipes/map-publication-edit
 						<cuentoneta-media-resource-tags [resources]="publication().story.media" />
 					</div>
 				} @else {
-					<ngx-skeleton-loader count="2" appearance="line" animation="false"></ngx-skeleton-loader>
+					<ngx-skeleton-loader count="2" appearance="line" animation="false" />
 				}
 			</article>
 		</a>

--- a/src/app/components/story-card-content/story-card-content.component.ts
+++ b/src/app/components/story-card-content/story-card-content.component.ts
@@ -14,7 +14,7 @@ import { TextBlockContent } from '@models/block-content.model';
 				[paragraphs]="body()"
 				data-testid="portable-text-parser"
 				class="sm:source-serif-pro-body-base hidden sm:relative sm:line-clamp-3 sm:min-h-18 sm:text-ellipsis sm:text-justify"
-			></cuentoneta-portable-text-parser>
+			/>
 		</section>
 	`,
 })

--- a/src/app/components/story-card-skeleton/story-card-skeleton.component.html
+++ b/src/app/components/story-card-skeleton/story-card-skeleton.component.html
@@ -16,7 +16,7 @@
 			}"
 			count="1"
 			appearance="line"
-		></ngx-skeleton-loader>
+		/>
 	}
 
 	<div>
@@ -31,7 +31,7 @@
 			}"
 			count="1"
 			appearance="line"
-		></ngx-skeleton-loader>
+		/>
 		<ngx-skeleton-loader
 			[animation]="animation()"
 			[theme]="{
@@ -42,7 +42,7 @@
 			class="hidden md:block"
 			count="3"
 			appearance="line"
-		></ngx-skeleton-loader>
+		/>
 	</div>
 	<ngx-skeleton-loader
 		[animation]="animation()"
@@ -54,7 +54,7 @@
 		}"
 		count="1"
 		appearance="line"
-	></ngx-skeleton-loader>
+	/>
 	@if (displayFooter()) {
 		<hr class="text-gray-300" />
 		<div class="flex">
@@ -70,7 +70,7 @@
 				}"
 				count="1"
 				appearance="line"
-			></ngx-skeleton-loader>
+			/>
 			<div>
 				<ngx-skeleton-loader
 					[animation]="animation()"
@@ -82,7 +82,7 @@
 					}"
 					count="1"
 					appearance="line"
-				></ngx-skeleton-loader>
+				/>
 				<div class="flex">
 					<ngx-skeleton-loader
 						[animation]="animation()"
@@ -95,7 +95,7 @@
 						}"
 						count="1"
 						appearance="line"
-					></ngx-skeleton-loader>
+					/>
 					<ngx-skeleton-loader
 						[animation]="animation()"
 						[theme]="{
@@ -106,7 +106,7 @@
 						}"
 						count="1"
 						appearance="line"
-					></ngx-skeleton-loader>
+					/>
 				</div>
 			</div>
 		</div>

--- a/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
@@ -18,7 +18,7 @@ import { ThemeService } from '../../providers/theme.service';
 				}"
 				count="1"
 				appearance="line"
-			></ngx-skeleton-loader>
+			/>
 		}
 		<div class="flex flex-1 flex-col  gap-1">
 			@if (showAuthor()) {
@@ -32,7 +32,7 @@ import { ThemeService } from '../../providers/theme.service';
 						count="1"
 						appearance="circle"
 						class="flex items-center"
-					></ngx-skeleton-loader>
+					/>
 					<ngx-skeleton-loader
 						[theme]="{
 							height: '20px',
@@ -41,7 +41,7 @@ import { ThemeService } from '../../providers/theme.service';
 						class="w-full"
 						count="1"
 						appearance="line"
-					></ngx-skeleton-loader>
+					/>
 				</div>
 			}
 			<div class="flex flex-col gap-1">
@@ -54,7 +54,7 @@ import { ThemeService } from '../../providers/theme.service';
 					class="w-full"
 					count="1"
 					appearance="line"
-				></ngx-skeleton-loader>
+				/>
 				<footer class="inter-body-xs flex gap-1 text-gray-500">
 					<ngx-skeleton-loader
 						[theme]="{
@@ -64,7 +64,7 @@ import { ThemeService } from '../../providers/theme.service';
 						}"
 						count="1"
 						appearance="line"
-					></ngx-skeleton-loader>
+					/>
 					<span>•</span>
 					<ngx-skeleton-loader
 						[theme]="{
@@ -74,7 +74,7 @@ import { ThemeService } from '../../providers/theme.service';
 						}"
 						count="1"
 						appearance="line"
-					></ngx-skeleton-loader>
+					/>
 				</footer>
 			</div>
 		</div>

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -24,12 +24,12 @@ import { NavigationFrameComponent } from '@models/navigation-frame.component';
 						<h2 class="h3 hover:text-interactive-500">{{ frameConfig().headerTitle }}</h2>
 					</a>
 				} @else {
-					<ng-container *ngTemplateOutlet="titleSkeleton"></ng-container>
+					<ng-container *ngTemplateOutlet="titleSkeleton" />
 				}
 			</header>
 
 			@if (frame(); as frame) {
-				<ng-container *ngComponentOutlet="frame.component; inputs: frame.inputs"></ng-container>
+				<ng-container *ngComponentOutlet="frame.component; inputs: frame.inputs" />
 			}
 
 			<footer class="bg-gray-50 px-7 py-5">
@@ -38,7 +38,7 @@ import { NavigationFrameComponent } from '@models/navigation-frame.component';
 						<h3 class="h3 inter-body-xl-bold hover:text-interactive-500">Ver más...</h3>
 					</a>
 				} @else {
-					<ng-container *ngTemplateOutlet="titleSkeleton"></ng-container>
+					<ng-container *ngTemplateOutlet="titleSkeleton" />
 				}
 			</footer>
 		</section>
@@ -51,7 +51,7 @@ import { NavigationFrameComponent } from '@models/navigation-frame.component';
 				}"
 				count="2"
 				appearance="line"
-			></ngx-skeleton-loader>
+			/>
 		</ng-template>
 	`,
 	imports: [CommonModule, NgxSkeletonLoaderModule, RouterLink],

--- a/src/app/components/storylist-card-component/storylist-card-skeleton.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card-skeleton.component.ts
@@ -17,7 +17,7 @@ import { ThemeService } from '../../providers/theme.service';
 				}"
 				count="1"
 				appearance="line"
-			></ngx-skeleton-loader>
+			/>
 			<div>
 				<ngx-skeleton-loader
 					[theme]="{
@@ -27,7 +27,7 @@ import { ThemeService } from '../../providers/theme.service';
 					}"
 					count="2"
 					appearance="line"
-				></ngx-skeleton-loader>
+				/>
 				<ngx-skeleton-loader
 					[theme]="{
 						height: '16px',
@@ -36,7 +36,7 @@ import { ThemeService } from '../../providers/theme.service';
 					}"
 					count="1"
 					appearance="line"
-				></ngx-skeleton-loader>
+				/>
 			</div>
 			<hr class="text-gray-300" />
 		</section>
@@ -50,7 +50,7 @@ import { ThemeService } from '../../providers/theme.service';
 				}"
 				count="1"
 				appearance="line"
-			></ngx-skeleton-loader>
+			/>
 			<ngx-skeleton-loader
 				[theme]="{
 					'background-color': skeletonColor,
@@ -61,7 +61,7 @@ import { ThemeService } from '../../providers/theme.service';
 				}"
 				count="1"
 				appearance="line"
-			></ngx-skeleton-loader>
+			/>
 		</footer>
 	`,
 })

--- a/src/app/components/storylist-card-component/storylist-card.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.ts
@@ -35,7 +35,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 						<cuentoneta-portable-text-parser
 							[paragraphs]="storylist.description"
 							class="inter-body-base-regular line-clamp-4 h-24 min-h-24 text-ellipsis text-gray-600"
-						></cuentoneta-portable-text-parser>
+						/>
 						<hr class="text-gray-300" />
 					</section>
 					<footer

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.html
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.html
@@ -1,5 +1,5 @@
 <!-- Renderizado de tarjetas de stories -->
-<ng-container *ngTemplateOutlet="storylist()?.publications ? publicationsTemplate : skeletonsTemplate"> </ng-container>
+<ng-container *ngTemplateOutlet="storylist()?.publications ? publicationsTemplate : skeletonsTemplate" />
 
 <ng-template #skeletonsTemplate>
 	@for (skeleton of [1, 2, 3, 4, 5, 6, 7, 9, 10]; track $index) {

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
@@ -40,7 +40,7 @@ export type NavigationBarConfig = {
 		} @else {
 			@for (skeleton of dummyList; track $index) {
 				<article [attr.aria-busy]="true" class="bg-gray-50 px-7 py-5">
-					<ngx-skeleton-loader count="2" appearance="line"></ngx-skeleton-loader>
+					<ngx-skeleton-loader count="2" appearance="line" />
 				</article>
 			}
 		}`,

--- a/src/app/components/youtube-video-widget/youtube-video-widget.component.ts
+++ b/src/app/components/youtube-video-widget/youtube-video-widget.component.ts
@@ -13,7 +13,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 			placeholderImageQuality="low"
 		/>
 		<p class="inter-body-xs-medium text-primary-500">
-			<cuentoneta-portable-text-parser [paragraphs]="media().description"> </cuentoneta-portable-text-parser>
+			<cuentoneta-portable-text-parser [paragraphs]="media().description" />
 		</p>`,
 	styles: `
 		::ng-deep {

--- a/src/app/pages/author/author-skeleton.component.ts
+++ b/src/app/pages/author/author-skeleton.component.ts
@@ -18,7 +18,7 @@ import { ThemeService } from '../../providers/theme.service';
 				}"
 				count="1"
 				appearance="line"
-			></ngx-skeleton-loader>
+			/>
 			<div class="flex items-center gap-4">
 				<ngx-skeleton-loader
 					[theme]="{
@@ -29,7 +29,7 @@ import { ThemeService } from '../../providers/theme.service';
 					}"
 					count="1"
 					appearance="line"
-				></ngx-skeleton-loader>
+				/>
 				<ngx-skeleton-loader
 					[theme]="{
 						'height.px': 40,
@@ -39,7 +39,7 @@ import { ThemeService } from '../../providers/theme.service';
 					}"
 					count="1"
 					appearance="line"
-				></ngx-skeleton-loader>
+				/>
 			</div>
 			<div class="flex justify-start gap-4 sm:justify-end">
 				@for (item of 3 | repeat; track $index) {
@@ -52,7 +52,7 @@ import { ThemeService } from '../../providers/theme.service';
 						}"
 						count="1"
 						appearance="circle"
-					></ngx-skeleton-loader>
+					/>
 				}
 			</div>
 			<ngx-skeleton-loader
@@ -63,7 +63,7 @@ import { ThemeService } from '../../providers/theme.service';
 				}"
 				class="max-width-[960px] flex flex-col"
 				count="6"
-			></ngx-skeleton-loader>
+			/>
 		</section>
 		<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-8">
 			@for (item of 6 | repeat; track $index) {

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -60,18 +60,18 @@ import { rxResource } from '@angular/core/rxjs-interop';
 						@if (author.resources && author.resources.length > 0) {
 							<div class="flex justify-start gap-4 sm:justify-end">
 								@for (resource of author.resources; track $index) {
-									<cuentoneta-resource [resource]="resource"></cuentoneta-resource>
+									<cuentoneta-resource [resource]="resource" />
 								}
 							</div>
 						}
 						<cuentoneta-portable-text-parser
 							[paragraphs]="author.biography!"
 							[classes]="'source-serif-pro-body-xl mb-8 leading-8'"
-						></cuentoneta-portable-text-parser>
+						/>
 					</section>
 					<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-8">
 						@for (story of stories(); track $index) {
-							<cuentoneta-story-card [story]="story" [navigationRoute]="story.navigationRoute"></cuentoneta-story-card>
+							<cuentoneta-story-card [story]="story" [navigationRoute]="story.navigationRoute" />
 						}
 					</section>
 				} @else {

--- a/src/app/pages/storylist/storylist.component.html
+++ b/src/app/pages/storylist/storylist.component.html
@@ -1,7 +1,7 @@
 <main class="content horizontal-layout-spacing vertical-layout-spacing block">
 	<article [attr.aria-busy]="!storylist()" [lang]="storylist()?.language" class="grid grid-cols-1 gap-y-8">
 		<!-- Renderizado de título y descripción -->
-		<ng-container *ngTemplateOutlet="storylistTitleTemplate"> </ng-container>
+		<ng-container *ngTemplateOutlet="storylistTitleTemplate" />
 
 		<section>
 			<!-- Renderizado de tarjetas de stories -->
@@ -17,10 +17,7 @@
 				<h1 class="h1 mb-5">
 					{{ storylist.title }}
 				</h1>
-				<cuentoneta-portable-text-parser
-					[paragraphs]="storylist.description"
-					[classes]="'source-serif-pro-body-xl'"
-				></cuentoneta-portable-text-parser>
+				<cuentoneta-portable-text-parser [paragraphs]="storylist.description" [classes]="'source-serif-pro-body-xl'" />
 			</div>
 		</div>
 	} @else {
@@ -34,7 +31,7 @@
 				}"
 				count="1"
 				appearance="line"
-			></ngx-skeleton-loader>
+			/>
 			<ngx-skeleton-loader
 				[theme]="{
 					'margin-bottom.px': 10,
@@ -44,7 +41,7 @@
 				}"
 				count="3"
 				appearance="line"
-			></ngx-skeleton-loader>
+			/>
 		</div>
 	}
 </ng-template>


### PR DESCRIPTION
# Resumen
Añadir la regla `@angular-eslint/template/prefer-self-closing-tags` a la configuración de eslint con el objetivo de unificar el formato del proyecto en lo relativo a esta regla de estilo
# Cambios
- Añadir regla `@angular-eslint/template/prefer-self-closing-tags` a `eslint.config,js`
- Ejecutar `pnpm lint --fix` para aplicar los cambios relativos a la nueva regla