### PR TITLE
[#1169] Agregar regla eslint `prefer-ngsrc`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,6 +74,7 @@ module.exports = [
 		rules: {
 			'@angular-eslint/template/prefer-control-flow': 'error',
 			'@angular-eslint/template/prefer-self-closing-tags': 'error',
+			'@angular-eslint/template/prefer-ngsrc': 'error',
 		},
 	},
 	{

--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -114,7 +114,9 @@
 			<h2 class="h2 mb-5 text-gray-600">Comunidad</h2>
 			<img
 				alt="logo-frontendcafe"
-				src="https://user-images.githubusercontent.com/78808163/228854353-cbd1f9b2-68a3-4cf0-851c-d2c49b3eb85c.svg"
+				ngSrc="https://user-images.githubusercontent.com/78808163/228854353-cbd1f9b2-68a3-4cf0-851c-d2c49b3eb85c.svg"
+				width="200"
+				height="40"
 			/>
 			<p class="inter-body-base-regular">
 				Este proyecto se desarrolla con la participación y el apoyo de FrontendCafé. Es requerido unirte a nuestro


### PR DESCRIPTION
# Resumen
Añadir la regla `@angular-eslint/template/prefer-ngsrc` a la configuración de eslint con el objetivo de unificar el formato del proyecto en lo relativo a esta regla de estilo

# Cambios
- Añadir regla `@angular-eslint/template/prefer-ngsrc` a eslint.config,js
- Ejecutar `pnpm lint` para comprobar que se estaba ejecutando
- Modificar `src/app/pages/about/about.component.html` para cumplir la nueva regla
  - Fue necesario añadir un `width` y `height`, para lo cual usé los originales de la imagen