### PR TITLE
[#1170] Agregar regla `@angular-eslint/prefer-signals`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,6 +61,7 @@ module.exports = [
 					style: 'kebab-case',
 				},
 			],
+			'@angular-eslint/prefer-signals': 'error',
 			'@typescript-eslint/no-inferrable-types': 0,
 			'@typescript-eslint/no-unused-vars': 'error',
 			'@typescript-eslint/no-non-null-assertion': 'error',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,7 +24,7 @@ export class AppComponent implements OnInit {
 	private readonly analytics = inject(AnalyticsService);
 	private readonly isHeaderVisible$ = inject(LayoutService).isHeaderVisible$.pipe(takeUntilDestroyed());
 
-	isHeaderVisible = signal(true);
+	readonly isHeaderVisible = signal(true);
 
 	constructor() {
 		afterNextRender(() => {

--- a/src/app/components/audio-recording-widget/audio-recording-widget.component.ts
+++ b/src/app/components/audio-recording-widget/audio-recording-widget.component.ts
@@ -17,5 +17,5 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AudioRecordingWidgetComponent {
-	media = input.required<AudioRecording>();
+	readonly media = input.required<AudioRecording>();
 }

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
@@ -44,8 +44,8 @@ export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
 	});
 
 	// Propiedades
-	stories = computed(() => this.storiesResource.value());
-	authorSlug = computed(() => this.navigationSlug() ?? '');
+	readonly stories = computed(() => this.storiesResource.value());
+	readonly authorSlug = computed(() => this.navigationSlug() ?? '');
 
 	constructor() {
 		super();

--- a/src/app/components/author-teaser/author-teaser.component.ts
+++ b/src/app/components/author-teaser/author-teaser.component.ts
@@ -57,19 +57,19 @@ import { AppRoutes } from '../../app.routes';
 	</a>`,
 })
 export class AuthorTeaserComponent {
-	author = input.required<Omit<Author, 'biography'>>();
-	variant = input<'sm' | 'md'>('sm');
+	readonly author = input.required<Omit<Author, 'biography'>>();
+	readonly variant = input<'sm' | 'md'>('sm');
 
-	imageSize = computed(() => (this.variant() === 'sm' ? 40 : 64));
+	readonly imageSize = computed(() => (this.variant() === 'sm' ? 40 : 64));
 
 	// Para un mejor scaling, a cargo del browser, se obtiene una imagen del 1.5x el tamaño final renderizado
-	authorImageUrl = computed(() =>
+	readonly authorImageUrl = computed(() =>
 		this.author().imageUrl
 			? `${this.author().imageUrl}?h=${this.imageSize() * 1.5}&w=${this.imageSize() * 1.5}&auto=format`
 			: 'assets/img/default-avatar.jpg',
 	);
 
-	authorFlagUrl = computed(
+	readonly authorFlagUrl = computed(
 		() => `${this.author().nationality.flag}?h=${this.flagImageSize.height}&w=${this.flagImageSize.width}&auto=format`,
 	);
 

--- a/src/app/components/badge/badge.component.ts
+++ b/src/app/components/badge/badge.component.ts
@@ -22,9 +22,9 @@ import { TooltipDirective } from '../../directives/tooltip.directive';
 	`,
 })
 export class BadgeComponent implements OnInit {
-	tag = input.required<Tag>();
-	showIcon = input(false);
-	iconUrl = computed(() => {
+	readonly tag = input.required<Tag>();
+	readonly showIcon = input(false);
+	readonly iconUrl = computed(() => {
 		if (!this.tag().icon?.name) {
 			return '';
 		}

--- a/src/app/components/bio-summary-card/bio-summary-card.component.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.ts
@@ -34,6 +34,6 @@ import { ResourceComponent } from '../resource/resource.component';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BioSummaryCardComponent {
-	story = input.required<Story>();
-	resources = computed(() => [...(this.story().resources ?? []), ...(this.story().author.resources ?? [])]);
+	readonly story = input.required<Story>();
+	readonly resources = computed(() => [...(this.story().resources ?? []), ...(this.story().author.resources ?? [])]);
 }

--- a/src/app/components/card/card.component.ts
+++ b/src/app/components/card/card.component.ts
@@ -18,5 +18,5 @@ import { Router, RouterLink, UrlTree } from '@angular/router';
 })
 export class CardComponent {
 	private router = inject(Router);
-	route = input<UrlTree>(this.router.createUrlTree([]));
+	readonly route = input<UrlTree>(this.router.createUrlTree([]));
 }

--- a/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel.component.ts
@@ -55,11 +55,11 @@ import { LayoutService } from '../../providers/layout.service';
 	`,
 })
 export class ContentCampaignCarouselComponent {
-	slides = input<ContentCampaign[]>([]);
+	readonly slides = input<ContentCampaign[]>([]);
 
 	// Viewport para el que debe renderizarse el contenido.
 	layoutService = inject(LayoutService);
-	viewport = computed(() => {
+	readonly viewport = computed(() => {
 		const isTabletOrDesktop = this.layoutService.biggerThan('xs');
 		return isTabletOrDesktop ? 'md' : 'xs';
 	});

--- a/src/app/components/epigraph/epigraph.component.ts
+++ b/src/app/components/epigraph/epigraph.component.ts
@@ -25,5 +25,5 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EpigraphComponent {
-	epigraph = input.required<Epigraph>();
+	readonly epigraph = input.required<Epigraph>();
 }

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -118,9 +118,9 @@ export class HeaderComponent {
 		{ label: 'Inicio', path: '/home' },
 		{ label: 'Nosotros', path: '/about' },
 	];
-	displayMenu = signal(false);
+	readonly displayMenu = signal(false);
 
-	isVisible = input(VisibilityState.Visible, {
+	readonly isVisible = input(VisibilityState.Visible, {
 		transform: (value) => (value ? VisibilityState.Visible : VisibilityState.Hidden),
 	});
 

--- a/src/app/components/media-resource-tag/media-resource-tag.component.ts
+++ b/src/app/components/media-resource-tag/media-resource-tag.component.ts
@@ -25,8 +25,8 @@ export interface MediaResourcePlatform {
 	`,
 })
 export class MediaResourceTagComponent implements OnInit {
-	platform = input.required<MediaResourcePlatform>();
-	size = input<'md' | 'lg'>('md');
+	readonly platform = input.required<MediaResourcePlatform>();
+	readonly size = input<'md' | 'lg'>('md');
 
 	private tooltipDirective = inject(TooltipDirective);
 

--- a/src/app/components/media-resource-tags/media-resource-tags.component.ts
+++ b/src/app/components/media-resource-tags/media-resource-tags.component.ts
@@ -11,8 +11,8 @@ import { MediaResourcePlatform, MediaResourceTagComponent } from '../media-resou
 	}`,
 })
 export class MediaResourceTagsComponent {
-	resources = input<Media[]>([]);
-	size = input<'md' | 'lg'>('md');
+	readonly resources = input<Media[]>([]);
+	readonly size = input<'md' | 'lg'>('md');
 
 	platforms: { [key in MediaTypeKey]: MediaResourcePlatform } = {
 		audioRecording: {

--- a/src/app/components/media-resource/media-resource.component.ts
+++ b/src/app/components/media-resource/media-resource.component.ts
@@ -23,7 +23,7 @@ type MediaTypeWidgetComponents =
 	`,
 })
 export class MediaResourceComponent {
-	mediaResources = input.required({
+	readonly mediaResources = input.required({
 		transform: (media: Media[]) => media.map((m) => this.mediaTypesAdapter(m)),
 	});
 

--- a/src/app/components/most-read-stories-card-deck/most-read-stories-card-deck.component.ts
+++ b/src/app/components/most-read-stories-card-deck/most-read-stories-card-deck.component.ts
@@ -41,5 +41,5 @@ import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MostReadStoriesCardDeckComponent {
-	stories = input<StoryNavigationTeaserWithAuthor[]>([]);
+	readonly stories = input<StoryNavigationTeaserWithAuthor[]>([]);
 }

--- a/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
+++ b/src/app/components/navigable-publication-teaser/navigable-publication-teaser.component.ts
@@ -52,8 +52,8 @@ import { MapPublicationEditionLabelPipe } from '../../pipes/map-publication-edit
 	`,
 })
 export class NavigablePublicationTeaserComponent {
-	publication = input.required<PublicationNavigationTeaser>();
-	selected = input<boolean>();
-	storylist = input.required<StorylistPublicationsNavigationTeasers>();
+	readonly publication = input.required<PublicationNavigationTeaser>();
+	readonly selected = input<boolean>();
+	readonly storylist = input.required<StorylistPublicationsNavigationTeasers>();
 	protected readonly appRoutes = AppRoutes;
 }

--- a/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
+++ b/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
@@ -45,8 +45,8 @@ import { RouterLink } from '@angular/router';
 	`,
 })
 export class NavigableStoryTeaserComponent {
-	story = input.required<StoryNavigationTeaser>();
-	selected = input<boolean>();
-	authorSlug = input.required<string>();
+	readonly story = input.required<StoryNavigationTeaser>();
+	readonly selected = input<boolean>();
+	readonly authorSlug = input.required<string>();
 	protected readonly appRoutes = AppRoutes;
 }

--- a/src/app/components/portable-text-parser/portable-text-parser.component.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.ts
@@ -20,7 +20,7 @@ import { PortableTextDirective } from '../../directives/portable-text-parser/por
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PortableTextParserComponent {
-	paragraphs = input.required<TextBlockContent[]>();
-	type = input<'paragraph' | 'span'>('paragraph');
-	classes = input<string>('classes');
+	readonly paragraphs = input.required<TextBlockContent[]>();
+	readonly type = input<'paragraph' | 'span'>('paragraph');
+	readonly classes = input<string>('classes');
 }

--- a/src/app/components/publication-card/publication-card.component.ts
+++ b/src/app/components/publication-card/publication-card.component.ts
@@ -48,7 +48,7 @@ import { UrlTree } from '@angular/router';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PublicationCardComponent {
-	editionLabel = input.required<string>();
-	publication = input.required<Publication>();
-	navigationRoute = input.required<UrlTree>();
+	readonly editionLabel = input.required<string>();
+	readonly publication = input.required<Publication>();
+	readonly navigationRoute = input.required<UrlTree>();
 }

--- a/src/app/components/resource/resource.component.ts
+++ b/src/app/components/resource/resource.component.ts
@@ -31,8 +31,8 @@ import { TooltipDirective } from '../../directives/tooltip.directive';
 	`,
 })
 export class ResourceComponent implements OnInit {
-	resource = input.required<Resource>();
-	iconUrl = computed(() => {
+	readonly resource = input.required<Resource>();
+	readonly iconUrl = computed(() => {
 		if (!this.resource().resourceType.icon.name) {
 			return '';
 		}

--- a/src/app/components/share-button/share-button.component.ts
+++ b/src/app/components/share-button/share-button.component.ts
@@ -23,10 +23,10 @@ import { TooltipDirective } from '../../directives/tooltip.directive';
 	}`,
 })
 export class ShareButtonComponent implements OnInit {
-	platform = input.required<SharingPlatform>();
-	params = input<{ [key: string]: string }>({});
-	message = input<string>('');
-	route = input<string>('');
+	readonly platform = input.required<SharingPlatform>();
+	readonly params = input<{ [key: string]: string }>({});
+	readonly message = input<string>('');
+	readonly route = input<string>('');
 
 	onShareToPlatformClicked(event: MouseEvent | KeyboardEvent, platform: SharingPlatform) {
 		const urlParams = Object.keys(this.params())

--- a/src/app/components/share-content/share-content.component.ts
+++ b/src/app/components/share-content/share-content.component.ts
@@ -31,10 +31,10 @@ import { FacebookPlatform, SharingPlatform, TwitterPlatform, WhatsappPlatform } 
 	`,
 })
 export class ShareContentComponent {
-	route = input<string>('');
-	params = input<{ [key: string]: string }>({});
-	message = input<string>('');
-	isLoading = input<boolean>(false);
+	readonly route = input<string>('');
+	readonly params = input<{ [key: string]: string }>({});
+	readonly message = input<string>('');
+	readonly isLoading = input<boolean>(false);
 
 	platforms: SharingPlatform[] = [
 		new FacebookPlatform(),

--- a/src/app/components/space-recording-widget/space-recording-widget.component.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.component.ts
@@ -50,6 +50,6 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SpaceRecordingWidgetComponent {
-	media = input.required<SpaceRecording>();
-	spaceUrl = computed(() => this.media().data.entities.urls[0]);
+	readonly media = input.required<SpaceRecording>();
+	readonly spaceUrl = computed(() => this.media().data.entities.urls[0]);
 }

--- a/src/app/components/story-card-content/story-card-content.component.ts
+++ b/src/app/components/story-card-content/story-card-content.component.ts
@@ -19,6 +19,6 @@ import { TextBlockContent } from '@models/block-content.model';
 	`,
 })
 export class StoryCardContentComponent {
-	title = input.required<string>();
-	body = input.required<TextBlockContent[]>();
+	readonly title = input.required<string>();
+	readonly body = input.required<TextBlockContent[]>();
 }

--- a/src/app/components/story-card-skeleton/story-card-skeleton.component.ts
+++ b/src/app/components/story-card-skeleton/story-card-skeleton.component.ts
@@ -16,11 +16,11 @@ import { ThemeService } from '../../providers/theme.service';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StoryCardSkeletonComponent {
-	animation = input<'progress' | 'progress-dark' | 'pulse' | 'false' | false>(false);
-	displayDate = input<boolean>(false);
-	editionLabel = input<string>('');
-	comingNextLabel = input<string>('');
-	displayFooter = input<boolean>(true);
+	readonly animation = input<'progress' | 'progress-dark' | 'pulse' | 'false' | false>(false);
+	readonly displayDate = input<boolean>(false);
+	readonly editionLabel = input<string>('');
+	readonly comingNextLabel = input<string>('');
+	readonly displayFooter = input<boolean>(true);
 
 	private themeService = inject(ThemeService);
 	skeletonColor = this.themeService.pickColor('zinc', 300);

--- a/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
@@ -84,8 +84,8 @@ import { ThemeService } from '../../providers/theme.service';
 })
 export class StoryCardTeaserSkeletonComponent {
 	// Inputs
-	order = input<number>();
-	showAuthor = input<boolean>(false);
+	readonly order = input<number>();
+	readonly showAuthor = input<boolean>(false);
 
 	// Providers
 	skeletonTextColor = inject(ThemeService).pickColor('zinc', 300);

--- a/src/app/components/story-card-teaser/story-card-teaser.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.ts
@@ -54,13 +54,13 @@ export class StoryCardTeaserComponent {
 	protected readonly appRoutes = AppRoutes;
 
 	// Inputs
-	story = input<StoryNavigationTeaserWithAuthor>();
-	order = input<number>();
-	showAuthor = input<boolean>(false);
-	navigationParams = input<{ navigation: string; navigationSlug: string }>();
+	readonly story = input<StoryNavigationTeaserWithAuthor>();
+	readonly order = input<number>();
+	readonly showAuthor = input<boolean>(false);
+	readonly navigationParams = input<{ navigation: string; navigationSlug: string }>();
 
 	// Propiedades
-	formattedOrder = computed(() => {
+	readonly formattedOrder = computed(() => {
 		const order = this.order();
 		return order && order >= 10 ? order : `0${order}`;
 	});

--- a/src/app/components/story-card/story-card.component.ts
+++ b/src/app/components/story-card/story-card.component.ts
@@ -38,10 +38,10 @@ import { MediaResourceTagsComponent } from '../media-resource-tags/media-resourc
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StoryCardComponent {
-	story = input.required<StoryTeaser>();
-	headerText = computed(() => this.story().originalPublication ?? '');
-	navigationRoute = input.required<UrlTree>();
-	computedRoute = computed(() => {
+	readonly story = input.required<StoryTeaser>();
+	readonly headerText = computed(() => this.story().originalPublication ?? '');
+	readonly navigationRoute = input.required<UrlTree>();
+	readonly computedRoute = computed(() => {
 		return this.navigationRoute()
 			? this.navigationRoute()
 			: this.router.createUrlTree(['/', this.appRoutes.Story, this.story().slug]);

--- a/src/app/components/story-edition-date-label/story-edition-date-label.component.ts
+++ b/src/app/components/story-edition-date-label/story-edition-date-label.component.ts
@@ -26,6 +26,6 @@ import { CommonModule } from '@angular/common';
 	imports: [CommonModule],
 })
 export class StoryEditionDateLabelComponent {
-	label = input<string>();
-	markAsNew = input<boolean>(false);
+	readonly label = input<string>();
+	readonly markAsNew = input<boolean>(false);
 }

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -57,14 +57,14 @@ import { NavigationFrameComponent } from '@models/navigation-frame.component';
 	imports: [CommonModule, NgxSkeletonLoaderModule, RouterLink],
 })
 export class StoryNavigationBarComponent {
-	selectedStorySlug = input<string>();
-	navigation = input.required<'author' | 'storylist'>();
-	navigationSlug = input.required<string>();
+	readonly selectedStorySlug = input<string>();
+	readonly navigation = input.required<'author' | 'storylist'>();
+	readonly navigationSlug = input.required<string>();
 
 	// Inyección de providers
 	private navigationFrameService = inject(NavigationFrameService);
 
-	frame = computed(() => {
+	readonly frame = computed(() => {
 		const storySlug = this.selectedStorySlug() ?? '';
 		const navigation = this.navigation();
 

--- a/src/app/components/storylist-card-component/storylist-card.component.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.ts
@@ -63,6 +63,6 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	`,
 })
 export class StorylistCardComponent {
-	storylist = input<StorylistTeaser>();
+	readonly storylist = input<StorylistTeaser>();
 	protected readonly appRoutes = AppRoutes;
 }

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
@@ -42,8 +42,8 @@ import { ThemeService } from '../../providers/theme.service';
 	`,
 })
 export class StorylistCardDeckComponent {
-	storylist = input<Storylist>();
-	isLoading = input<boolean>(false); // Utilizado para mostrar/ocultar skeletons
+	readonly storylist = input<Storylist>();
+	readonly isLoading = input<boolean>(false); // Utilizado para mostrar/ocultar skeletons
 
 	public router = inject(Router);
 	readonly appRoutes = AppRoutes;

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
@@ -66,7 +66,7 @@ export class StorylistNavigationFrameComponent extends NavigationFrameComponent 
 	// Propiedades
 	displayedPublications: PublicationNavigationTeaser[] = [];
 	dummyList: null[] = Array(9);
-	storylist = computed(() => this.storylistResource.value());
+	readonly storylist = computed(() => this.storylistResource.value());
 
 	constructor() {
 		super();

--- a/src/app/components/youtube-video-widget/youtube-video-widget.component.ts
+++ b/src/app/components/youtube-video-widget/youtube-video-widget.component.ts
@@ -28,5 +28,5 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	`,
 })
 export class YoutubeVideoWidgetComponent {
-	media = input.required<YouTubeVideo>();
+	readonly media = input.required<YouTubeVideo>();
 }

--- a/src/app/directives/portable-text-parser/portable-text-parser.directive.spec.ts
+++ b/src/app/directives/portable-text-parser/portable-text-parser.directive.spec.ts
@@ -13,8 +13,8 @@ import { PortableTextDirective } from './portable-text-parser.directive';
 	</article>`,
 })
 class TestComponent {
-	content = signal(authorMock.biography);
-	classes = signal('test-class');
+	readonly content = signal(authorMock.biography);
+	readonly classes = signal('test-class');
 }
 
 describe('PortableTextDirective', () => {

--- a/src/app/directives/portable-text-parser/portable-text-parser.directive.ts
+++ b/src/app/directives/portable-text-parser/portable-text-parser.directive.ts
@@ -9,8 +9,8 @@ export class PortableTextDirective {
 	private el = inject(ElementRef);
 	private renderer = inject(Renderer2);
 
-	portableText = input.required<TextBlockContent>();
-	classes = input<string>('');
+	readonly portableText = input.required<TextBlockContent>();
+	readonly classes = input<string>('');
 
 	constructor() {
 		effect(() => {

--- a/src/app/directives/tooltip.directive.ts
+++ b/src/app/directives/tooltip.directive.ts
@@ -8,9 +8,9 @@ type TooltipPosition = 'top' | 'right' | 'bottom' | 'left';
 	standalone: true,
 })
 export class TooltipDirective implements OnDestroy {
-	text = signal<string>(''); // Texto para el Tooltip
-	position = signal<TooltipPosition>('top'); // Posición del tooltip
-	offset = signal<number>(6); // Offset del tooltip respecto al elemento
+	readonly text = signal<string>(''); // Texto para el Tooltip
+	readonly position = signal<TooltipPosition>('top'); // Posición del tooltip
+	readonly offset = signal<number>(6); // Offset del tooltip respecto al elemento
 
 	private myPopup: HTMLElement | null = null;
 

--- a/src/app/models/navigation-frame.component.ts
+++ b/src/app/models/navigation-frame.component.ts
@@ -15,9 +15,9 @@ export abstract class NavigationFrameComponent {
 	private navigationFrameService = inject(NavigationFrameService);
 
 	// Inputs
-	selectedStorySlug = input<string>();
-	navigationSlug = input<string>();
-	config = signal<NavigationBarConfig>(this.navigationFrameService.navigationBarConfig());
+	readonly selectedStorySlug = input<string>();
+	readonly navigationSlug = input<string>();
+	readonly config = signal<NavigationBarConfig>(this.navigationFrameService.navigationBarConfig());
 
 	protected constructor() {
 		effect(() => {

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -109,12 +109,12 @@ export default class AuthorComponent {
 	});
 
 	// Propiedades
-	author = computed(() => this.authorResource.value());
-	stories = computed(() => this.storiesResource.value());
-	authorImageUrl = computed(() =>
+	readonly author = computed(() => this.authorResource.value());
+	readonly stories = computed(() => this.storiesResource.value());
+	readonly authorImageUrl = computed(() =>
 		this.author()?.imageUrl ? `${this.author()?.imageUrl}?auto=format` : 'assets/img/default-avatar.jpg',
 	);
-	authorFlagUrl = computed(() => `${this.author()?.nationality.flag}?auto=format`);
+	readonly authorFlagUrl = computed(() => `${this.author()?.nationality.flag}?auto=format`);
 
 	private updateMetaTags(author: Author) {
 		this.metaTagsDirective.setTitle(`${author.name}`);

--- a/src/app/pages/authors/authors.component.ts
+++ b/src/app/pages/authors/authors.component.ts
@@ -29,7 +29,7 @@ export default class AuthorsComponent {
 		loader: () => this.authorService.getAll(),
 	});
 
-	authors = computed(() => this.authorsResource.value() ?? []);
+	readonly authors = computed(() => this.authorsResource.value() ?? []);
 
 	constructor() {
 		this.metaTagsDirective.setTitle('Índice de Autores');

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -37,12 +37,12 @@ xdescribe('HomeComponent', () => {
 	template: '<div></div>',
 })
 class MockPublicationCardComponent {
-	editionPrefix = input<string>();
-	editionSuffix = input<string>();
-	comingNextLabel = input<string>();
-	displayDate = input<boolean>(false);
-	publication = input<Publication>();
-	editionIndex = input<number>(0);
+	readonly editionPrefix = input<string>();
+	readonly editionSuffix = input<string>();
+	readonly comingNextLabel = input<string>();
+	readonly displayDate = input<boolean>(false);
+	readonly publication = input<Publication>();
+	readonly editionIndex = input<number>(0);
 }
 
 @Component({
@@ -52,6 +52,6 @@ class MockPublicationCardComponent {
 	template: '',
 })
 class MockStorylistCardDeckComponent {
-	storylist = input<Storylist>();
-	isLoading = input<boolean>(false);
+	readonly storylist = input<Storylist>();
+	readonly isLoading = input<boolean>(false);
 }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -42,10 +42,10 @@ export default class HomeComponent {
 	});
 
 	// Propiedades
-	landingPageContent = computed(() => this.landingPageResource.value());
-	cards = computed(() => this.landingPageContent()?.cards || []);
-	campaigns = computed(() => this.landingPageContent()?.campaigns || []);
-	mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
+	readonly landingPageContent = computed(() => this.landingPageResource.value());
+	readonly cards = computed(() => this.landingPageContent()?.cards || []);
+	readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
+	readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
 
 	constructor() {
 		this.metaTagsDirective.setDefault();

--- a/src/app/pages/story/story.component.spec.ts
+++ b/src/app/pages/story/story.component.spec.ts
@@ -43,10 +43,10 @@ describe('StoryComponent', () => {
 	template: '',
 })
 class MockShareContentComponent {
-	route = input('');
-	params = input<{ [key: string]: string }>({});
-	message = input('');
-	isLoading = input(false);
+	readonly route = input('');
+	readonly params = input<{ [key: string]: string }>({});
+	readonly message = input('');
+	readonly isLoading = input(false);
 }
 
 @Component({
@@ -55,7 +55,7 @@ class MockShareContentComponent {
 	template: '',
 })
 class MockBioSummaryCardComponent {
-	story = input.required<Story>();
+	readonly story = input.required<Story>();
 }
 
 @Component({
@@ -64,6 +64,6 @@ class MockBioSummaryCardComponent {
 	template: '',
 })
 class MockStoryNavigationBarComponent {
-	selectedStorySlug = input('');
-	storylist = input<Storylist>();
+	readonly selectedStorySlug = input('');
+	readonly storylist = input<Storylist>();
 }

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -88,14 +88,17 @@ export default class StoryComponent implements OnDestroy {
 	});
 
 	// Propiedades
-	story = computed(() => this.storyResource.value());
-	sharingRoute = computed(() => `${AppRoutes.Story}/${this.story()?.slug}`);
-	shareContentParams = computed(() => ({ navigationSlug: this.story()?.author.slug ?? '', navigation: 'author' }));
-	shareMessage = computed(
+	readonly story = computed(() => this.storyResource.value());
+	readonly sharingRoute = computed(() => `${AppRoutes.Story}/${this.story()?.slug}`);
+	readonly shareContentParams = computed(() => ({
+		navigationSlug: this.story()?.author.slug ?? '',
+		navigation: 'author',
+	}));
+	readonly shareMessage = computed(
 		() =>
 			`Leí "${this.story()?.title}" de ${this.story()?.author.name} en La Cuentoneta y te lo comparto. Sumate a leer este y otros cuentos en este link:`,
 	);
-	navigationParams = computed(() => {
+	readonly navigationParams = computed(() => {
 		let { navigation, navigationSlug } = this.queryParams();
 
 		if (!navigation && !navigationSlug) {
@@ -105,7 +108,7 @@ export default class StoryComponent implements OnDestroy {
 
 		return { navigation, navigationSlug };
 	});
-	headerPosition = signal('top-header-height');
+	readonly headerPosition = signal('top-header-height');
 
 	constructor() {
 		this.isHeaderVisible$.subscribe((isVisible) => {

--- a/src/app/pages/storylist/storylist.component.spec.ts
+++ b/src/app/pages/storylist/storylist.component.spec.ts
@@ -44,6 +44,6 @@ xdescribe('StorylistComponent', () => {
 	template: '',
 })
 class MockStorylistCardDeckComponent {
-	storyList = input<Storylist>();
-	isLoading = input(false);
+	readonly storyList = input<Storylist>();
+	readonly isLoading = input(false);
 }

--- a/src/app/pages/storylist/storylist.component.ts
+++ b/src/app/pages/storylist/storylist.component.ts
@@ -47,8 +47,10 @@ export default class StorylistComponent {
 	});
 
 	// Propiedades
-	featuredImageUrl = computed(() => `${this.storylist()?.featuredImage}?h=${256 * 1.5}&w=${192 * 1.5}&auto=format`);
-	storylist = computed(() => this.storylistResource.value());
+	readonly featuredImageUrl = computed(
+		() => `${this.storylist()?.featuredImage}?h=${256 * 1.5}&w=${192 * 1.5}&auto=format`,
+	);
+	readonly storylist = computed(() => this.storylistResource.value());
 
 	private updateMetaTags(storylist: Storylist) {
 		this.metaTagsDirective.setTitle(`${storylist.title}`);

--- a/src/app/providers/layout.service.ts
+++ b/src/app/providers/layout.service.ts
@@ -27,7 +27,7 @@ export class LayoutService {
 	private window = inject(WINDOW);
 	private platformId = inject(PLATFORM_ID);
 
-	private viewport: WritableSignal<Viewport> = signal('xl');
+	private readonly viewport: WritableSignal<Viewport> = signal('xl');
 
 	private _userHasScrolled$ = fromEvent(this.window, 'scroll').pipe(
 		takeUntilDestroyed(),

--- a/src/app/providers/navigation-frame.service.ts
+++ b/src/app/providers/navigation-frame.service.ts
@@ -5,7 +5,7 @@ import { NavigationBarConfig } from '../components/storylist-navigation-frame/st
 	providedIn: 'root',
 })
 export class NavigationFrameService {
-	navigationBarConfig = signal<NavigationBarConfig>({
+	readonly navigationBarConfig = signal<NavigationBarConfig>({
 		headerTitle: '',
 		footerTitle: '',
 		navigationRoute: '',


### PR DESCRIPTION
# Resumen
Añadir la regla `@angular-eslint/prefer-signals` a la configuración de eslint con el objetivo de unificar el formato del proyecto en lo relativo a esta regla de estilo

# Cambios
- Añadir regla `@angular-eslint/prefer-signals` a eslint.config,js
- Ejecutar `pnpm lint` para comprobar que se estaba ejecutando
- Ejecutar `pnpm lint --fix` para aplicar la regla
  - En resumen, se añadió el modificador `readonly` a todas las variables o campos que eran signals
- Ejecutar `pnpm test` y `pnpm test:e2e` para corroborar que no se ha roto ninguna funcionalidad