### PR TITLE
[#1237] - Agregar ng-icons a dependencias del proyecto

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"@angular/youtube-player": "19.2.2",
 		"@floating-ui/dom": "^1.6.5",
 		"@microsoft/clarity": "^1.0.0",
+		"@ng-icons/core": "^31.4.0",
 		"@nx/angular": "21.0.3",
 		"@sanity/client": "^6.21.3",
 		"@sanity/image-url": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
 		"@floating-ui/dom": "^1.6.5",
 		"@microsoft/clarity": "^1.0.0",
 		"@ng-icons/core": "^31.4.0",
+		"@ng-icons/feather-icons": "^31.4.0",
+		"@ng-icons/simple-icons": "^31.4.0",
 		"@nx/angular": "21.0.3",
 		"@sanity/client": "^6.21.3",
 		"@sanity/image-url": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,12 @@ importers:
       '@ng-icons/core':
         specifier: ^31.4.0
         version: 31.4.0(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
+      '@ng-icons/feather-icons':
+        specifier: ^31.4.0
+        version: 31.4.0
+      '@ng-icons/simple-icons':
+        specifier: ^31.4.0
+        version: 31.4.0
       '@nx/angular':
         specifier: 21.0.3
         version: 21.0.3(@angular-devkit/build-angular@19.2.1(hpdh6qdc6k2pkrrtw5yvqd4s7i))(@angular-devkit/core@19.2.1(chokidar@4.0.1))(@angular-devkit/schematics@19.2.1(chokidar@4.0.1))(@babel/traverse@7.26.9)(@module-federation/enhanced@0.10.0(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@module-federation/node@2.6.28(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@rspack/core@1.3.10)(@schematics/angular@19.2.1(chokidar@4.0.1))(@types/express@4.17.17)(@zkochan/js-yaml@0.0.7)(esbuild@0.21.4)(eslint@9.14.0(jiti@1.21.0))(html-webpack-plugin@5.5.0(webpack@5.94.0(esbuild@0.21.4)))(less@4.1.3)(nx@21.0.3)(react-dom@18.2.0(react@18.2.0))(react-refresh@0.17.0)(react@18.2.0)(rxjs@7.8.1)(typescript@5.7.3)(webpack-hot-middleware@2.25.3)
@@ -2738,6 +2744,14 @@ packages:
       '@angular/common': '>=18.0.0'
       '@angular/core': '>=18.0.0'
       rxjs: ^6.5.3 || ^7.4.0
+
+  '@ng-icons/feather-icons@31.4.0':
+    resolution:
+      { integrity: sha512-0Nvo0l+wIr+a+BuQ6a9hDFfQIJepefBPbsbwmaAs5kRNu19/gX0Mco9O/dnudOaiF6TnDmKezNl6yC7lPtKPPA== }
+
+  '@ng-icons/simple-icons@31.4.0':
+    resolution:
+      { integrity: sha512-/rUQeVzkTeE4Bs+LQuODMksh6oPIaBqyRaiMI8qLhBfvKqihiRkyiVltH9fQa38A3AR5CsgjRHV7fgB8xqjC5A== }
 
   '@ngtools/webpack@19.2.1':
     resolution:
@@ -13852,6 +13866,14 @@ snapshots:
       '@angular/common': 19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
       '@angular/core': 19.2.1(rxjs@7.8.1)(zone.js@0.15.0)
       rxjs: 7.8.1
+      tslib: 2.8.1
+
+  '@ng-icons/feather-icons@31.4.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@ng-icons/simple-icons@31.4.0':
+    dependencies:
       tslib: 2.8.1
 
   '@ngtools/webpack@19.2.1(@angular/compiler-cli@19.2.1(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(typescript@5.7.3)(webpack@5.98.0(esbuild@0.25.0))':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@microsoft/clarity':
         specifier: ^1.0.0
         version: 1.0.0
+      '@ng-icons/core':
+        specifier: ^31.4.0
+        version: 31.4.0(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
       '@nx/angular':
         specifier: 21.0.3
         version: 21.0.3(@angular-devkit/build-angular@19.2.1(hpdh6qdc6k2pkrrtw5yvqd4s7i))(@angular-devkit/core@19.2.1(chokidar@4.0.1))(@angular-devkit/schematics@19.2.1(chokidar@4.0.1))(@babel/traverse@7.26.9)(@module-federation/enhanced@0.10.0(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@module-federation/node@2.6.28(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@rspack/core@1.3.10)(@schematics/angular@19.2.1(chokidar@4.0.1))(@types/express@4.17.17)(@zkochan/js-yaml@0.0.7)(esbuild@0.21.4)(eslint@9.14.0(jiti@1.21.0))(html-webpack-plugin@5.5.0(webpack@5.94.0(esbuild@0.21.4)))(less@4.1.3)(nx@21.0.3)(react-dom@18.2.0(react@18.2.0))(react-refresh@0.17.0)(react@18.2.0)(rxjs@7.8.1)(typescript@5.7.3)(webpack-hot-middleware@2.25.3)
@@ -2727,6 +2730,14 @@ packages:
   '@napi-rs/wasm-runtime@0.2.4':
     resolution:
       { integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ== }
+
+  '@ng-icons/core@31.4.0':
+    resolution:
+      { integrity: sha512-JfLiJGDX/ihWmawcnLGXtwyCqMi2qXz7gMJyXXWdUN5JA18EAnt3JnyuxDAGkoU/u7wRlcOI7irlXHU4spAKOg== }
+    peerDependencies:
+      '@angular/common': '>=18.0.0'
+      '@angular/core': '>=18.0.0'
+      rxjs: ^6.5.3 || ^7.4.0
 
   '@ngtools/webpack@19.2.1':
     resolution:
@@ -13835,6 +13846,13 @@ snapshots:
       '@emnapi/core': 1.2.0
       '@emnapi/runtime': 1.2.0
       '@tybys/wasm-util': 0.9.0
+
+  '@ng-icons/core@31.4.0(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)':
+    dependencies:
+      '@angular/common': 19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
+      '@angular/core': 19.2.1(rxjs@7.8.1)(zone.js@0.15.0)
+      rxjs: 7.8.1
+      tslib: 2.8.1
 
   '@ngtools/webpack@19.2.1(@angular/compiler-cli@19.2.1(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(typescript@5.7.3)(webpack@5.98.0(esbuild@0.25.0))':
     dependencies:


### PR DESCRIPTION
### Resumen
- Agrega `ng-icons` a dependencias del proyecto.
- Agrega los paquetes de `ng-icons` para importar íconos de las bibliotecas de FeatherIcons y SimpleIcons.