### PR TITLE
[#1206] - Eliminar dependencia @angular/platform-browser-dynamic

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
 		"@angular/core": "19.2.1",
 		"@angular/forms": "19.2.1",
 		"@angular/platform-browser": "19.2.1",
-		"@angular/platform-browser-dynamic": "19.2.1",
 		"@angular/platform-server": "19.2.1",
 		"@angular/router": "19.2.1",
 		"@angular/youtube-player": "19.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,9 +25,6 @@ importers:
       '@angular/platform-browser':
         specifier: 19.2.1
         version: 19.2.1(@angular/animations@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))
-      '@angular/platform-browser-dynamic':
-        specifier: 19.2.1
-        version: 19.2.1(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.2.1(@angular/animations@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))
       '@angular/platform-server':
         specifier: 19.2.1
         version: 19.2.1(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.2.1(@angular/animations@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))
@@ -54,7 +51,7 @@ importers:
         version: 31.4.0
       '@nx/angular':
         specifier: 21.0.3
-        version: 21.0.3(@angular-devkit/build-angular@19.2.1(hpdh6qdc6k2pkrrtw5yvqd4s7i))(@angular-devkit/core@19.2.1(chokidar@4.0.1))(@angular-devkit/schematics@19.2.1(chokidar@4.0.1))(@babel/traverse@7.26.9)(@module-federation/enhanced@0.10.0(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@module-federation/node@2.6.28(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@rspack/core@1.3.10)(@schematics/angular@19.2.1(chokidar@4.0.1))(@types/express@4.17.17)(@zkochan/js-yaml@0.0.7)(esbuild@0.21.4)(eslint@9.14.0(jiti@1.21.0))(html-webpack-plugin@5.5.0(webpack@5.94.0(esbuild@0.21.4)))(less@4.1.3)(nx@21.0.3)(react-dom@18.2.0(react@18.2.0))(react-refresh@0.17.0)(react@18.2.0)(rxjs@7.8.1)(typescript@5.7.3)(webpack-hot-middleware@2.25.3)
+        version: 21.0.3(@angular-devkit/build-angular@19.2.1(667806b8238cb658bfd67806f2b62066))(@angular-devkit/core@19.2.1(chokidar@4.0.1))(@angular-devkit/schematics@19.2.1(chokidar@4.0.1))(@babel/traverse@7.26.9)(@module-federation/enhanced@0.10.0(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@module-federation/node@2.6.28(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@rspack/core@1.3.10)(@schematics/angular@19.2.1(chokidar@4.0.1))(@types/express@4.17.17)(@zkochan/js-yaml@0.0.7)(esbuild@0.21.4)(eslint@9.14.0(jiti@1.21.0))(html-webpack-plugin@5.5.0(webpack@5.94.0(esbuild@0.21.4)))(less@4.1.3)(nx@21.0.3)(react-dom@18.2.0(react@18.2.0))(react-refresh@0.17.0)(react@18.2.0)(rxjs@7.8.1)(typescript@5.7.3)(webpack-hot-middleware@2.25.3)
       '@sanity/client':
         specifier: ^6.21.3
         version: 6.22.3
@@ -103,7 +100,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 19.2.1
-        version: 19.2.1(hpdh6qdc6k2pkrrtw5yvqd4s7i)
+        version: 19.2.1(667806b8238cb658bfd67806f2b62066)
       '@angular-eslint/eslint-plugin':
         specifier: 19.2.1
         version: 19.2.1(@typescript-eslint/utils@8.19.0(eslint@9.14.0(jiti@1.21.0))(typescript@5.7.3))(eslint@9.14.0(jiti@1.21.0))(typescript@5.7.3)
@@ -124,7 +121,7 @@ importers:
         version: 19.2.1
       '@angular/ssr':
         specifier: 19.2.1
-        version: 19.2.1(3bitrtgjsrwwgyc2zpsv6gqv5e)
+        version: 19.2.1(fefad0e05ef0236bd50554b25c694372)
       '@eslint/eslintrc':
         specifier: ^3.1.0
         version: 3.1.0
@@ -169,7 +166,7 @@ importers:
         version: 8.6.11(storybook@8.6.11(prettier@3.2.5))
       '@storybook/angular':
         specifier: 8.6.11
-        version: 8.6.11(pfw7jrdmruzmdh36fsvge67xoy)
+        version: 8.6.11(ebca2c84c8d76a61bece1adebfa30a07)
       '@storybook/core-server':
         specifier: 8.6.11
         version: 8.6.11(storybook@8.6.11(prettier@3.2.5))
@@ -11396,13 +11393,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@19.2.1(hpdh6qdc6k2pkrrtw5yvqd4s7i)':
+  '@angular-devkit/build-angular@19.2.1(667806b8238cb658bfd67806f2b62066)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1902.1(chokidar@4.0.1)
       '@angular-devkit/build-webpack': 0.1902.1(chokidar@4.0.1)(webpack-dev-server@5.2.0(webpack@5.98.0(esbuild@0.25.0)))(webpack@5.98.0(esbuild@0.25.0))
       '@angular-devkit/core': 19.2.1(chokidar@4.0.1)
-      '@angular/build': 19.2.1(@angular/compiler-cli@19.2.1(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/platform-server@19.2.1(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.2.1(@angular/animations@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))))(@angular/ssr@19.2.1(3bitrtgjsrwwgyc2zpsv6gqv5e))(@types/node@18.16.9)(chokidar@4.0.1)(jiti@1.21.0)(less@4.2.2)(postcss@8.5.2)(sass-embedded@1.85.1)(stylus@0.64.0)(tailwindcss@3.4.1(ts-node@10.9.1(@types/node@18.16.9)(typescript@5.7.3)))(terser@5.39.0)(typescript@5.7.3)(yaml@2.7.0)
+      '@angular/build': 19.2.1(@angular/compiler-cli@19.2.1(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/platform-server@19.2.1(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.2.1(@angular/animations@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))))(@angular/ssr@19.2.1(fefad0e05ef0236bd50554b25c694372))(@types/node@18.16.9)(chokidar@4.0.1)(jiti@1.21.0)(less@4.2.2)(postcss@8.5.2)(sass-embedded@1.85.1)(stylus@0.64.0)(tailwindcss@3.4.1(ts-node@10.9.1(@types/node@18.16.9)(typescript@5.7.3)))(terser@5.39.0)(typescript@5.7.3)(yaml@2.7.0)
       '@angular/compiler-cli': 19.2.1(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3)
       '@babel/core': 7.26.9
       '@babel/generator': 7.26.9
@@ -11457,7 +11454,7 @@ snapshots:
       webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.0(webpack@5.94.0(esbuild@0.21.4)))(webpack@5.98.0(esbuild@0.25.0))
     optionalDependencies:
       '@angular/platform-server': 19.2.1(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.2.1(@angular/animations@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))
-      '@angular/ssr': 19.2.1(3bitrtgjsrwwgyc2zpsv6gqv5e)
+      '@angular/ssr': 19.2.1(fefad0e05ef0236bd50554b25c694372)
       browser-sync: 3.0.2
       esbuild: 0.25.0
       jest: 29.7.0(@types/node@18.16.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@18.16.9)(typescript@5.7.3))
@@ -11604,7 +11601,7 @@ snapshots:
       '@angular/core': 19.2.1(rxjs@7.8.1)(zone.js@0.15.0)
       tslib: 2.8.1
 
-  '@angular/build@19.2.1(@angular/compiler-cli@19.2.1(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/platform-server@19.2.1(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.2.1(@angular/animations@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))))(@angular/ssr@19.2.1(3bitrtgjsrwwgyc2zpsv6gqv5e))(@types/node@18.16.9)(chokidar@4.0.1)(jiti@1.21.0)(less@4.2.2)(postcss@8.5.2)(sass-embedded@1.85.1)(stylus@0.64.0)(tailwindcss@3.4.1(ts-node@10.9.1(@types/node@18.16.9)(typescript@5.7.3)))(terser@5.39.0)(typescript@5.7.3)(yaml@2.7.0)':
+  '@angular/build@19.2.1(@angular/compiler-cli@19.2.1(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/platform-server@19.2.1(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.2.1(@angular/animations@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))))(@angular/ssr@19.2.1(fefad0e05ef0236bd50554b25c694372))(@types/node@18.16.9)(chokidar@4.0.1)(jiti@1.21.0)(less@4.2.2)(postcss@8.5.2)(sass-embedded@1.85.1)(stylus@0.64.0)(tailwindcss@3.4.1(ts-node@10.9.1(@types/node@18.16.9)(typescript@5.7.3)))(terser@5.39.0)(typescript@5.7.3)(yaml@2.7.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1902.1(chokidar@4.0.1)
@@ -11637,7 +11634,7 @@ snapshots:
       watchpack: 2.4.2
     optionalDependencies:
       '@angular/platform-server': 19.2.1(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.2.1(@angular/animations@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0)))
-      '@angular/ssr': 19.2.1(3bitrtgjsrwwgyc2zpsv6gqv5e)
+      '@angular/ssr': 19.2.1(fefad0e05ef0236bd50554b25c694372)
       less: 4.2.2
       lmdb: 3.2.6
       postcss: 8.5.2
@@ -11756,7 +11753,7 @@ snapshots:
       rxjs: 7.8.1
       tslib: 2.8.1
 
-  '@angular/ssr@19.2.1(3bitrtgjsrwwgyc2zpsv6gqv5e)':
+  '@angular/ssr@19.2.1(fefad0e05ef0236bd50554b25c694372)':
     dependencies:
       '@angular/common': 19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
       '@angular/core': 19.2.1(rxjs@7.8.1)(zone.js@0.15.0)
@@ -13980,9 +13977,9 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@nx/angular@21.0.3(@angular-devkit/build-angular@19.2.1(hpdh6qdc6k2pkrrtw5yvqd4s7i))(@angular-devkit/core@19.2.1(chokidar@4.0.1))(@angular-devkit/schematics@19.2.1(chokidar@4.0.1))(@babel/traverse@7.26.9)(@module-federation/enhanced@0.10.0(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@module-federation/node@2.6.28(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@rspack/core@1.3.10)(@schematics/angular@19.2.1(chokidar@4.0.1))(@types/express@4.17.17)(@zkochan/js-yaml@0.0.7)(esbuild@0.21.4)(eslint@9.14.0(jiti@1.21.0))(html-webpack-plugin@5.5.0(webpack@5.94.0(esbuild@0.21.4)))(less@4.1.3)(nx@21.0.3)(react-dom@18.2.0(react@18.2.0))(react-refresh@0.17.0)(react@18.2.0)(rxjs@7.8.1)(typescript@5.7.3)(webpack-hot-middleware@2.25.3)':
+  '@nx/angular@21.0.3(@angular-devkit/build-angular@19.2.1(667806b8238cb658bfd67806f2b62066))(@angular-devkit/core@19.2.1(chokidar@4.0.1))(@angular-devkit/schematics@19.2.1(chokidar@4.0.1))(@babel/traverse@7.26.9)(@module-federation/enhanced@0.10.0(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@module-federation/node@2.6.28(@rspack/core@1.3.10)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.3)(webpack@5.94.0(esbuild@0.21.4)))(@rspack/core@1.3.10)(@schematics/angular@19.2.1(chokidar@4.0.1))(@types/express@4.17.17)(@zkochan/js-yaml@0.0.7)(esbuild@0.21.4)(eslint@9.14.0(jiti@1.21.0))(html-webpack-plugin@5.5.0(webpack@5.94.0(esbuild@0.21.4)))(less@4.1.3)(nx@21.0.3)(react-dom@18.2.0(react@18.2.0))(react-refresh@0.17.0)(react@18.2.0)(rxjs@7.8.1)(typescript@5.7.3)(webpack-hot-middleware@2.25.3)':
     dependencies:
-      '@angular-devkit/build-angular': 19.2.1(hpdh6qdc6k2pkrrtw5yvqd4s7i)
+      '@angular-devkit/build-angular': 19.2.1(667806b8238cb658bfd67806f2b62066)
       '@angular-devkit/core': 19.2.1(chokidar@4.0.1)
       '@angular-devkit/schematics': 19.2.1(chokidar@4.0.1)
       '@nx/devkit': 21.0.3(nx@21.0.3)
@@ -14869,10 +14866,10 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.6.11(prettier@3.2.5)
 
-  '@storybook/angular@8.6.11(pfw7jrdmruzmdh36fsvge67xoy)':
+  '@storybook/angular@8.6.11(ebca2c84c8d76a61bece1adebfa30a07)':
     dependencies:
       '@angular-devkit/architect': 0.1902.1(chokidar@4.0.1)
-      '@angular-devkit/build-angular': 19.2.1(hpdh6qdc6k2pkrrtw5yvqd4s7i)
+      '@angular-devkit/build-angular': 19.2.1(667806b8238cb658bfd67806f2b62066)
       '@angular-devkit/core': 19.2.1(chokidar@4.0.1)
       '@angular/common': 19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
       '@angular/compiler': 19.2.1(@angular/core@19.2.1(rxjs@7.8.1)(zone.js@0.15.0))


### PR DESCRIPTION
# Resumen
- Ejecutar `pnpm remove @angular/platform-browser-dynamic`
- Pese a que la dependencia no se estaba usando de forma directa, ejecutar `pnpm run dev`, `pnpm build`, `pnpm run test` y `pnpm run test:e2e` para asegurar que seguía funcionando corretamente

# Notas extra

Es posible que, tras el merge y posterior `pnpm install`, sea necesario borrar la carpeta `.angular` para deshacerse de la caché de vite, ya que he tenido algún problema proveniente de vite tras ejecutar el primer comando que se ha resuelto al eliminar la caché.