### PR TITLE
[#1275] - Agregar variantes con resumen de texto para componente `StoryCardTeaserComponent`

### DIFF
--- a/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
@@ -16,13 +16,14 @@ import { ThemeService } from '../../providers/theme.service';
 					width: '40px',
 					'background-color': orderColor,
 				}"
+				data-testid="show-order"
 				count="1"
 				appearance="line"
 			/>
 		}
 		<div class="flex flex-1 flex-col gap-1">
 			@if (showAuthor()) {
-				<div class="flex items-center gap-2">
+				<div class="flex items-center gap-2" data-testid="show-author">
 					<ngx-skeleton-loader
 						[theme]="{
 							height: '24px',
@@ -58,9 +59,10 @@ import { ThemeService } from '../../providers/theme.service';
 					appearance="line"
 				/>
 				@if (showExcerpt()) {
-					<div class="flex flex-col gap-1">
+					<div class="flex flex-col gap-1" data-testid="show-excerpt">
 						@for (line of excerptArrayLines(); track $index) {
 							<ngx-skeleton-loader
+								[attr.data-testid]="'excerpt-skeleton-line-' + $index"
 								[theme]="{
 									height: '16px',
 									'margin-top': $index === 0 ? '2px' : '0px',

--- a/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { ThemeService } from '../../providers/theme.service';
@@ -14,20 +14,20 @@ import { ThemeService } from '../../providers/theme.service';
 					height: '36px',
 					'margin-bottom': 0,
 					width: '40px',
-					'background-color': orderColor
+					'background-color': orderColor,
 				}"
 				count="1"
 				appearance="line"
 			/>
 		}
-		<div class="flex flex-1 flex-col  gap-1">
+		<div class="flex flex-1 flex-col gap-1">
 			@if (showAuthor()) {
 				<div class="flex items-center gap-2">
 					<ngx-skeleton-loader
 						[theme]="{
 							height: '24px',
 							margin: 0,
-							width: '24px'
+							width: '24px',
 						}"
 						count="1"
 						appearance="circle"
@@ -36,7 +36,8 @@ import { ThemeService } from '../../providers/theme.service';
 					<ngx-skeleton-loader
 						[theme]="{
 							height: '20px',
-							'margin-bottom': 0
+							'margin-bottom': 0,
+							'max-width': '160px',
 						}"
 						class="w-full"
 						count="1"
@@ -49,18 +50,35 @@ import { ThemeService } from '../../providers/theme.service';
 					[theme]="{
 						height: '28px',
 						'margin-bottom': 0,
-						'background-color': skeletonTextColor
+						'max-width': '192px',
+						'background-color': skeletonTextColor,
 					}"
 					class="w-full"
 					count="1"
 					appearance="line"
 				/>
+				@if (showExcerpt()) {
+					<div class="flex flex-col gap-1">
+						@for (line of excerptArrayLines(); track $index) {
+							<ngx-skeleton-loader
+								[theme]="{
+									height: '16px',
+									'margin-top': $index === 0 ? '2px' : '0px',
+									'margin-bottom': $index === excerptLines() - 1 ? '6px' : '4px',
+									width: $index === excerptLines() - 1 ? '80%' : '100%',
+								}"
+								count="1"
+								appearance="line"
+							/>
+						}
+					</div>
+				}
 				<footer class="inter-body-xs flex gap-1 text-gray-500">
 					<ngx-skeleton-loader
 						[theme]="{
 							height: '16px',
 							'margin-bottom': 0,
-							width: '120px'
+							width: '120px',
 						}"
 						count="1"
 						appearance="line"
@@ -70,7 +88,7 @@ import { ThemeService } from '../../providers/theme.service';
 						[theme]="{
 							height: '16px',
 							'margin-bottom': 0,
-							width: '40px'
+							width: '40px',
 						}"
 						count="1"
 						appearance="line"
@@ -79,13 +97,22 @@ import { ThemeService } from '../../providers/theme.service';
 			</div>
 		</div>
 	</article>`,
-	styles: ``,
+	styles: `
+		:host {
+			@apply w-full;
+		}
+	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StoryCardTeaserSkeletonComponent {
 	// Inputs
 	readonly order = input<number>();
 	readonly showAuthor = input<boolean>(false);
+	readonly showExcerpt = input<boolean>(false);
+	readonly excerptLines = input<number>(3);
+
+	// Usado de auxiliar para iterar a través de la cantidad de líneas del extracto de texto
+	readonly excerptArrayLines = computed(() => Array(this.excerptLines()).fill(0));
 
 	// Providers
 	skeletonTextColor = inject(ThemeService).pickColor('zinc', 300);

--- a/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
@@ -26,9 +26,9 @@ import { ThemeService } from '../../providers/theme.service';
 				<div class="flex items-center gap-2" data-testid="show-author">
 					<ngx-skeleton-loader
 						[theme]="{
-							height: '24px',
+							height: '20px',
 							margin: 0,
-							width: '24px',
+							width: '20px',
 						}"
 						count="1"
 						appearance="circle"
@@ -49,7 +49,7 @@ import { ThemeService } from '../../providers/theme.service';
 			<div class="flex flex-col gap-1">
 				<ngx-skeleton-loader
 					[theme]="{
-						height: '28px',
+						height: '32px',
 						'margin-bottom': 0,
 						'max-width': '192px',
 						'background-color': skeletonTextColor,

--- a/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
@@ -21,7 +21,7 @@ import { ThemeService } from '../../providers/theme.service';
 				appearance="line"
 			/>
 		}
-		<div class="flex flex-1 flex-col gap-1">
+		<div class="flex flex-1 flex-col">
 			@if (showAuthor()) {
 				<div class="flex items-center gap-2" data-testid="show-author">
 					<ngx-skeleton-loader

--- a/src/app/components/story-card-teaser/story-card-teaser.component.spec.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.spec.ts
@@ -1,7 +1,9 @@
 import { StoryCardTeaserComponent } from './story-card-teaser.component';
 import { DefaultUrlSerializer, UrlTree } from '@angular/router';
 import { render, screen } from '@testing-library/angular';
-import { storyNavigationTeaserWithAuthorMock } from '../../mocks/story.mock';
+import { storyNavigationTeaserWithAuthorMock, storyTeaserMock } from '../../mocks/story.mock';
+import { authorTeaserMock } from '../../mocks/author.mock';
+import { StoryTeaserWithAuthor } from '@models/story.model';
 
 describe('StoryCardTeaserComponent', () => {
 	const storyUrl = '/story/el-espejo-del-tiempo?navigation=author&navigationSlug=francois-onoff';
@@ -18,7 +20,7 @@ describe('StoryCardTeaserComponent', () => {
 
 	it('should render the component', async () => {
 		const { container } = await render(StoryCardTeaserComponent, {
-			componentInputs: {
+			inputs: {
 				story: storyNavigationTeaserWithAuthorMock,
 				navigationParams: navigationParams,
 			},
@@ -28,7 +30,7 @@ describe('StoryCardTeaserComponent', () => {
 
 	it('should display the mock story title', async () => {
 		await render(StoryCardTeaserComponent, {
-			componentInputs: {
+			inputs: {
 				story: storyNavigationTeaserWithAuthorMock,
 				navigationParams: navigationParams,
 			},
@@ -39,7 +41,7 @@ describe('StoryCardTeaserComponent', () => {
 
 	it('should display the approximate reading time', async () => {
 		await render(StoryCardTeaserComponent, {
-			componentInputs: {
+			inputs: {
 				story: storyNavigationTeaserWithAuthorMock,
 				navigationParams: navigationParams,
 			},
@@ -52,7 +54,7 @@ describe('StoryCardTeaserComponent', () => {
 
 	it('should display the link to navigate to the story', async () => {
 		await render(StoryCardTeaserComponent, {
-			componentInputs: {
+			inputs: {
 				story: storyNavigationTeaserWithAuthorMock,
 				navigationParams: navigationParams,
 			},
@@ -64,7 +66,7 @@ describe('StoryCardTeaserComponent', () => {
 
 	it('should display the story order', async () => {
 		await render(StoryCardTeaserComponent, {
-			componentInputs: {
+			inputs: {
 				story: storyNavigationTeaserWithAuthorMock,
 				navigationParams: navigationParams,
 				order: 3,
@@ -76,7 +78,7 @@ describe('StoryCardTeaserComponent', () => {
 
 	it('should not display the story order', async () => {
 		await render(StoryCardTeaserComponent, {
-			componentInputs: {
+			inputs: {
 				story: storyNavigationTeaserWithAuthorMock,
 				navigationParams: navigationParams,
 			},
@@ -87,7 +89,7 @@ describe('StoryCardTeaserComponent', () => {
 
 	it('should display the author name and avatar', async () => {
 		await render(StoryCardTeaserComponent, {
-			componentInputs: {
+			inputs: {
 				story: storyNavigationTeaserWithAuthorMock,
 				navigationParams: navigationParams,
 				showAuthor: true,
@@ -101,7 +103,7 @@ describe('StoryCardTeaserComponent', () => {
 
 	it('should display the link to navigate to the author profile', async () => {
 		await render(StoryCardTeaserComponent, {
-			componentInputs: {
+			inputs: {
 				story: storyNavigationTeaserWithAuthorMock,
 				navigationParams: navigationParams,
 				showAuthor: true,
@@ -116,7 +118,7 @@ describe('StoryCardTeaserComponent', () => {
 
 	it('should not display the author name and avatar', async () => {
 		await render(StoryCardTeaserComponent, {
-			componentInputs: {
+			inputs: {
 				story: storyNavigationTeaserWithAuthorMock,
 				navigationParams: navigationParams,
 				showAuthor: false,
@@ -130,12 +132,252 @@ describe('StoryCardTeaserComponent', () => {
 
 	it('should display the skeleton', async () => {
 		await render(StoryCardTeaserComponent, {
-			componentInputs: {
+			inputs: {
 				story: undefined,
 				navigationParams: navigationParams,
 			},
 		});
 		const skeleton = screen.getByTestId('skeleton');
 		expect(skeleton).toBeInTheDocument();
+	});
+
+	describe('Excerpt functionality', () => {
+		const storyWithExcerpt: StoryTeaserWithAuthor = {
+			...storyTeaserMock,
+			author: authorTeaserMock,
+		};
+
+		it('should display excerpt when showExcerpt is true and story has paragraphs', async () => {
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: storyWithExcerpt,
+					showExcerpt: true,
+					excerptLines: 3,
+				},
+			});
+			const excerptElement = screen.getByTestId('portable-text-parser');
+			expect(excerptElement).toBeInTheDocument();
+		});
+
+		it('should not display excerpt when showExcerpt is false', async () => {
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: storyWithExcerpt,
+					showExcerpt: false,
+					excerptLines: 3,
+				},
+			});
+			const excerptElement = screen.queryByTestId('portable-text-parser');
+			expect(excerptElement).not.toBeInTheDocument();
+		});
+
+		it('should apply correct CSS class for excerpt lines', async () => {
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: storyWithExcerpt,
+					showExcerpt: true,
+					excerptLines: 4,
+				},
+			});
+			const excerptElement = screen.getByTestId('portable-text-parser');
+			expect(excerptElement).toHaveClass('sm:line-clamp-4');
+		});
+
+		it('should not display excerpt when story has no paragraphs', async () => {
+			const storyWithoutParagraphs = {
+				...storyWithExcerpt,
+				paragraphs: [],
+			};
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: storyWithoutParagraphs,
+					showExcerpt: true,
+					excerptLines: 3,
+				},
+			});
+			const excerptElement = screen.queryByTestId('portable-text-parser');
+			expect(excerptElement).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Order formatting', () => {
+		it('should format single digit orders with leading zero', async () => {
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: storyNavigationTeaserWithAuthorMock,
+					order: 5,
+				},
+			});
+			const orderElement = screen.getByText('05.');
+			expect(orderElement).toBeInTheDocument();
+		});
+
+		it('should not format double digit orders', async () => {
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: storyNavigationTeaserWithAuthorMock,
+					order: 15,
+				},
+			});
+			const orderElement = screen.getByText('15.');
+			expect(orderElement).toBeInTheDocument();
+		});
+
+		it('should handle order value of 10 without leading zero', async () => {
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: storyNavigationTeaserWithAuthorMock,
+					order: 10,
+				},
+			});
+			const orderElement = screen.getByText('10.');
+			expect(orderElement).toBeInTheDocument();
+		});
+	});
+
+	describe('Skeleton states', () => {
+		it('should pass showAuthor to skeleton component', async () => {
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: undefined,
+					showAuthor: true,
+				},
+			});
+			const skeleton = screen.getByTestId('skeleton');
+			const showAuthorElement = screen.getByTestId('show-author');
+			expect(skeleton).toBeInTheDocument();
+			expect(showAuthorElement).toBeInTheDocument();
+		});
+
+		it('should pass showExcerpt to skeleton component and render correct number of excerpt lines', async () => {
+			const excerptLines = 5;
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: undefined,
+					showExcerpt: true,
+					excerptLines: excerptLines,
+				},
+			});
+			const skeleton = screen.getByTestId('skeleton');
+			const showExcerptElement = screen.getByTestId('show-excerpt');
+			expect(skeleton).toBeInTheDocument();
+			expect(showExcerptElement).toBeInTheDocument();
+
+			// Check that exactly the correct number of excerpt lines are rendered
+			for (let i = 0; i < excerptLines; i++) {
+				expect(screen.getByTestId(`excerpt-skeleton-line-${i}`)).toBeInTheDocument();
+			}
+			// Check that no extra lines are rendered
+			expect(screen.queryByTestId(`excerpt-skeleton-line-${excerptLines}`)).not.toBeInTheDocument();
+		});
+
+		it('should pass order to skeleton component', async () => {
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: undefined,
+					order: 7,
+				},
+			});
+			const skeleton = screen.getByTestId('skeleton');
+			const showOrder = screen.getByTestId('show-order');
+
+			expect(skeleton).toBeInTheDocument();
+			expect(showOrder).toBeInTheDocument();
+		});
+	});
+
+	describe('Navigation parameters', () => {
+		it('should include navigation params in story link when provided', async () => {
+			const customNavigationParams = {
+				navigation: 'collection',
+				navigationSlug: 'fantasy-stories',
+			};
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: storyNavigationTeaserWithAuthorMock,
+					navigationParams: customNavigationParams,
+				},
+			});
+			const storyLinks = screen.getAllByRole('link');
+			const storyLink = storyLinks.find((link) => link.getAttribute('href')?.includes('/story/')) as HTMLAnchorElement;
+			expect(storyLink.href).toContain('navigation=collection');
+			expect(storyLink.href).toContain('navigationSlug=fantasy-stories');
+		});
+
+		it('should work without navigation params', async () => {
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: storyNavigationTeaserWithAuthorMock,
+					navigationParams: undefined,
+				},
+			});
+			const storyLinks = screen.getAllByRole('link');
+			const storyLink = storyLinks.find((link) => link.getAttribute('href')?.includes('/story/')) as HTMLAnchorElement;
+			expect(storyLink).toBeInTheDocument();
+		});
+	});
+
+	describe('Combined scenarios', () => {
+		it('should display all elements when all options are enabled', async () => {
+			const storyWithExcerpt: StoryTeaserWithAuthor = {
+				...storyTeaserMock,
+				author: authorTeaserMock,
+			};
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: storyWithExcerpt,
+					order: 8,
+					showAuthor: true,
+					showExcerpt: true,
+					excerptLines: 3,
+					navigationParams: {
+						navigation: 'author',
+						navigationSlug: 'test-author',
+					},
+				},
+			});
+
+			const orderElement = screen.getByText('08.');
+			expect(orderElement).toBeInTheDocument();
+
+			const authorName = screen.getByText(authorTeaserMock.name);
+			expect(authorName).toBeInTheDocument();
+
+			const excerptElement = screen.getByTestId('portable-text-parser');
+			expect(excerptElement).toBeInTheDocument();
+			expect(excerptElement).toHaveClass('sm:line-clamp-3');
+
+			const titleElement = screen.getByText(storyWithExcerpt.title);
+			expect(titleElement).toBeInTheDocument();
+
+			const readingTimeElement = screen.getByText(`${storyWithExcerpt.approximateReadingTime} minutos de lectura`);
+			expect(readingTimeElement).toBeInTheDocument();
+		});
+
+		it('should only display minimal elements when no optional features are enabled', async () => {
+			await render(StoryCardTeaserComponent, {
+				inputs: {
+					story: storyNavigationTeaserWithAuthorMock,
+					showAuthor: false,
+					showExcerpt: false,
+				},
+			});
+
+			// Should have title and reading time
+			const titleElement = screen.getByText(storyNavigationTeaserWithAuthorMock.title);
+			const readingTimeElement = screen.getByText(
+				`${storyNavigationTeaserWithAuthorMock.approximateReadingTime} minutos de lectura`,
+			);
+			expect(titleElement).toBeInTheDocument();
+			expect(readingTimeElement).toBeInTheDocument();
+
+			// Should not have author, order, or excerpt
+			const authorName = screen.queryByText(storyNavigationTeaserWithAuthorMock.author.name);
+			const orderElement = screen.queryByText(/^\d{2}\.$/);
+			const excerptElement = screen.queryByTestId('portable-text-parser');
+			expect(authorName).not.toBeInTheDocument();
+			expect(orderElement).not.toBeInTheDocument();
+			expect(excerptElement).not.toBeInTheDocument();
+		});
 	});
 });

--- a/src/app/components/story-card-teaser/story-card-teaser.component.spec.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.spec.ts
@@ -180,7 +180,7 @@ describe('StoryCardTeaserComponent', () => {
 				},
 			});
 			const excerptElement = screen.getByTestId('portable-text-parser');
-			expect(excerptElement).toHaveClass('sm:line-clamp-4');
+			expect(excerptElement).toHaveClass('line-clamp-4');
 		});
 
 		it('should not display excerpt when story has no paragraphs', async () => {
@@ -345,7 +345,7 @@ describe('StoryCardTeaserComponent', () => {
 
 			const excerptElement = screen.getByTestId('portable-text-parser');
 			expect(excerptElement).toBeInTheDocument();
-			expect(excerptElement).toHaveClass('sm:line-clamp-3');
+			expect(excerptElement).toHaveClass('line-clamp-3');
 
 			const titleElement = screen.getByText(storyWithExcerpt.title);
 			expect(titleElement).toBeInTheDocument();

--- a/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
@@ -1,126 +1,371 @@
-import { Meta, moduleMetadata } from '@storybook/angular';
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
 import { StoryCardTeaserComponent } from './story-card-teaser.component';
 import { storyNavigationTeaserMock, storyTeaserMock } from '../../mocks/story.mock';
 import { authorTeaserMock } from '../../mocks/author.mock';
 import { CommonModule } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
+import { StoryNavigationTeaserWithAuthor, StoryTeaserWithAuthor } from '@models/story.model';
 
 const meta: Meta<StoryCardTeaserComponent> = {
 	component: StoryCardTeaserComponent,
-	title: 'StoryCardTeaserComponent',
+	title: 'Componentes/StoryCardTeaser',
 	decorators: [
 		moduleMetadata({
 			imports: [CommonModule, RouterTestingModule],
 		}),
 	],
-};
-export default meta;
+	parameters: {
+		docs: {
+			description: {
+				component: `
+					**StoryCardTeaserComponent** muestra una vista previa de historia con elementos opcionales:
+					- Contenido de historia o estado de carga esqueleto
+					- Información opcional del autor
+					- Numeración/orden opcional
+					- Extracto opcional con líneas configurables
+					- Parámetros de navegación para enrutamiento
 
-export const Primary = {
-	render: (args: StoryCardTeaserComponent) => ({
+					Usa los controles interactivos en la primera historia de abajo para ver cómo se comporta el componente en ambos estados: cargado y esqueleto.
+				`,
+			},
+		},
+		layout: 'padded',
+	},
+	argTypes: {
+		story: {
+			control: { type: 'object' },
+			description: 'Objeto de datos de la historia con título, autor, contenido, etc.',
+			table: {
+				type: { summary: 'StoryNavigationTeaserWithAuthor | StoryTeaserWithAuthor' },
+				defaultValue: { summary: 'undefined' },
+			},
+		},
+		order: {
+			control: { type: 'number', min: 1, max: 99 },
+			description: 'Numeración opcional para la historia (se muestra como orden formateado)',
+			table: {
+				type: { summary: 'number' },
+				defaultValue: { summary: 'undefined' },
+			},
+		},
+		showAuthor: {
+			control: { type: 'boolean' },
+			description: 'Mostrar información del autor con avatar y nombre',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'false' },
+			},
+		},
+		showExcerpt: {
+			control: { type: 'boolean' },
+			description: 'Mostrar extracto/texto de vista previa de la historia',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'false' },
+			},
+		},
+		excerptLines: {
+			control: { type: 'range', min: 1, max: 6, step: 1 },
+			description: 'Número de líneas a mostrar para el extracto (cuando showExcerpt es verdadero)',
+			table: {
+				type: { summary: 'number' },
+				defaultValue: { summary: '3' },
+			},
+		},
+		navigationParams: {
+			control: { type: 'object' },
+			description: 'Parámetros de navegación para contexto de enrutamiento',
+			table: {
+				type: { summary: '{ navigation: string; navigationSlug: string }' },
+				defaultValue: { summary: 'undefined' },
+			},
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<StoryCardTeaserComponent>;
+
+// Historia de documentación/Playground interactivo
+export const Docs: Story = {
+	render: (args) => ({
 		props: args,
 		template: `
-	<div class="grid grid-cols-2 gap-8">
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Versión base</span>
-			<cuentoneta-story-card-teaser
-			[story]="story"
-			[order]="false"
-			[showAuthor]="false"
-			/>
-		</div>
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Esqueleto</span>
-			<cuentoneta-story-card-teaser
-			[order]="false"
-			[showAuthor]="false"
-			/>
-		</div>
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Opción sin autor y con índice</span>
-			<cuentoneta-story-card-teaser
-			[story]="story"
-			[order]="3"
-			[showAuthor]="false"
-			/>
-		</div>
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Esqueleto</span>
-			<cuentoneta-story-card-teaser
-			[order]="3"
-			[showAuthor]="false"
-			/>
-		</div>
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Opción con autor y con índice</span>
-			<cuentoneta-story-card-teaser
-			  [story]="story"
-			  [order]="3"
-			  [showAuthor]="true"
-			/>
-		</div>
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Esqueleto</span>
-			<cuentoneta-story-card-teaser
-			[order]="3"
-			[showAuthor]="true"
-			/>
-		</div>
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Opción con autor, sin índice y sin extracto</span>
-			<cuentoneta-story-card-teaser
-			  [story]="story"
-			  [showAuthor]="true"
-			/>
-		</div>
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Esqueleto</span>
-			<cuentoneta-story-card-teaser
-			[showAuthor]="true"
-			/>
-		</div>
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Opción con autor, sin índice y con extracto</span>
-			<cuentoneta-story-card-teaser
-			  [story]="story"
-			  [showAuthor]="true"
-			  [showExcerpt]="true"
-			  [excerptLines]="3"
-			/>
-		</div>
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Esqueleto</span>
-			<cuentoneta-story-card-teaser
-			[showAuthor]="true"
-			[showExcerpt]="true"
-			[excerptLines]="3"
-			/>
-		</div>
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Opción sin autor, sin índice y con extracto</span>
-			<cuentoneta-story-card-teaser
-			  [story]="story"
-			  [showAuthor]="false"
-			  [showExcerpt]="true"
-			  [excerptLines]="4"
-			/>
-		</div>
-		<div class="flex flex-col gap-2">
-			<span class="inter-body-base">Esqueleto</span>
-			<cuentoneta-story-card-teaser
-			[showAuthor]="false"
-			[showExcerpt]="true"
-			[excerptLines]="4"
-			/>
-		</div>
-	</div>
-`,
+			<div class="grid grid-cols-2 gap-6">
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Estado Cargado</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate(args)} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Estado Esqueleto</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ ...args, story: undefined })} />
+				</div>
+			</div>
+		`,
 	}),
 	args: {
-		story: { ...storyTeaserMock, author: authorTeaserMock },
+		story: { ...storyTeaserMock, author: authorTeaserMock } as StoryTeaserWithAuthor,
 		showAuthor: false,
-		order: 1,
 		showExcerpt: false,
 		excerptLines: 3,
+		order: undefined,
+		navigationParams: undefined,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Playground interactivo que muestra ambos estados: cargado y esqueleto. Usa los controles de abajo para ver cómo diferentes configuraciones afectan ambos estados.',
+			},
+		},
+	},
+};
+
+// Historia por defecto con configuración básica
+export const Default: Story = {
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="grid grid-cols-2 gap-6">
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Cargado</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate(args)} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Esqueleto</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ ...args, story: undefined })} />
+				</div>
+			</div>
+		`,
+	}),
+	args: {
+		story: { ...storyTeaserMock, author: authorTeaserMock } as StoryTeaserWithAuthor,
+		showAuthor: false,
+		showExcerpt: false,
+		excerptLines: 3,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Tarjeta de historia básica con título y tiempo de lectura, mostrada junto a su estado esqueleto.',
+			},
+		},
+	},
+};
+
+// Con información del autor
+export const WithAuthor: Story = {
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="grid grid-cols-2 gap-6">
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Cargado</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate(args)} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Esqueleto</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ ...args, story: undefined })} />
+				</div>
+			</div>
+		`,
+	}),
+	args: {
+		story: { ...storyTeaserMock, author: authorTeaserMock } as StoryTeaserWithAuthor,
+		showAuthor: true,
+		showExcerpt: false,
+		excerptLines: 3,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Tarjeta de historia mostrando avatar y nombre del autor, junto a su estado esqueleto.',
+			},
+		},
+	},
+};
+
+// Con número de orden
+export const WithOrder: Story = {
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="grid grid-cols-2 gap-6">
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Cargado</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate(args)} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Esqueleto</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ ...args, story: undefined })} />
+				</div>
+			</div>
+		`,
+	}),
+	args: {
+		story: { ...storyTeaserMock, author: authorTeaserMock } as StoryTeaserWithAuthor,
+		order: 3,
+		showAuthor: false,
+		showExcerpt: false,
+		excerptLines: 3,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Tarjeta de historia con numeración/orden, mostrada junto a su estado esqueleto.',
+			},
+		},
+	},
+};
+
+// Con extracto
+export const WithExcerpt: Story = {
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="grid grid-cols-2 gap-6">
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Cargado</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate(args)} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Esqueleto</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ ...args, story: undefined })} />
+				</div>
+			</div>
+		`,
+	}),
+	args: {
+		story: { ...storyTeaserMock, author: authorTeaserMock } as StoryTeaserWithAuthor,
+		showAuthor: false,
+		showExcerpt: true,
+		excerptLines: 3,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Tarjeta de historia con vista previa de extracto de texto, mostrada junto a su estado esqueleto.',
+			},
+		},
+	},
+};
+
+// Variante con todas las características
+export const FullFeatured: Story = {
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="grid grid-cols-2 gap-6">
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Cargado</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate(args)} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Esqueleto</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ ...args, story: undefined })} />
+				</div>
+			</div>
+		`,
+	}),
+	args: {
+		story: { ...storyTeaserMock, author: authorTeaserMock } as StoryTeaserWithAuthor,
+		order: 5,
+		showAuthor: true,
+		showExcerpt: true,
+		excerptLines: 4,
+		navigationParams: {
+			navigation: 'author',
+			navigationSlug: 'sample-author',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Tarjeta de historia con todas las características habilitadas: orden, autor, extracto y navegación, mostrada junto a su estado esqueleto.',
+			},
+		},
+	},
+};
+
+// Diferentes cantidades de líneas de extracto
+export const ExcerptVariations: Story = {
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="space-y-6">
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Extracto de 1 Línea</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ ...args, excerptLines: 1 })} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Extracto de 3 Líneas</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ ...args, excerptLines: 3 })} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Extracto de 5 Líneas</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ ...args, excerptLines: 5 })} />
+				</div>
+			</div>
+		`,
+	}),
+	args: {
+		story: { ...storyTeaserMock, author: authorTeaserMock } as StoryTeaserWithAuthor,
+		showAuthor: true,
+		showExcerpt: true,
+		excerptLines: 3,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Comparación de diferentes cantidades de líneas de extracto.',
+			},
+		},
+	},
+};
+
+// Vitrina de todas las variantes
+export const AllVariants: Story = {
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Básico</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ story: args.story })} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Cargando</h3>
+					<cuentoneta-story-card-teaser />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Con Orden</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ story: args.story, order: 3 })} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Con Autor</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ story: args.story, showAuthor: true })} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Con Extracto</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ story: args.story, showExcerpt: true, excerptLines: 3 })} />
+				</div>
+				<div class="space-y-2">
+					<h3 class="font-semibold text-sm text-gray-600">Completo</h3>
+					<cuentoneta-story-card-teaser ${argsToTemplate({ story: args.story, order: 7, showAuthor: true, showExcerpt: true, excerptLines: 4 })} />
+				</div>
+			</div>
+		`,
+	}),
+	args: {
+		story: { ...storyTeaserMock, author: authorTeaserMock } as StoryTeaserWithAuthor,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Vista general de todas las variantes y estados del componente.',
+			},
+		},
 	},
 };

--- a/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
@@ -1,6 +1,6 @@
 import { Meta, moduleMetadata } from '@storybook/angular';
 import { StoryCardTeaserComponent } from './story-card-teaser.component';
-import { storyNavigationTeaserMock } from '../../mocks/story.mock';
+import { storyNavigationTeaserMock, storyTeaserMock } from '../../mocks/story.mock';
 import { authorTeaserMock } from '../../mocks/author.mock';
 import { CommonModule } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -66,12 +66,61 @@ export const Primary = {
 			[showAuthor]="true"
 			/>
 		</div>
+		<div class="flex flex-col gap-2">
+			<span class="inter-body-base">Opción con autor, sin índice y sin extracto</span>
+			<cuentoneta-story-card-teaser
+			  [story]="story"
+			  [showAuthor]="true"
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<span class="inter-body-base">Esqueleto</span>
+			<cuentoneta-story-card-teaser
+			[showAuthor]="true"
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<span class="inter-body-base">Opción con autor, sin índice y con extracto</span>
+			<cuentoneta-story-card-teaser
+			  [story]="story"
+			  [showAuthor]="true"
+			  [showExcerpt]="true"
+			  [excerptLines]="3"
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<span class="inter-body-base">Esqueleto</span>
+			<cuentoneta-story-card-teaser
+			[showAuthor]="true"
+			[showExcerpt]="true"
+			[excerptLines]="3"
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<span class="inter-body-base">Opción sin autor, sin índice y con extracto</span>
+			<cuentoneta-story-card-teaser
+			  [story]="story"
+			  [showAuthor]="false"
+			  [showExcerpt]="true"
+			  [excerptLines]="4"
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<span class="inter-body-base">Esqueleto</span>
+			<cuentoneta-story-card-teaser
+			[showAuthor]="false"
+			[showExcerpt]="true"
+			[excerptLines]="4"
+			/>
+		</div>
 	</div>
 `,
 	}),
 	args: {
-		story: { ...storyNavigationTeaserMock, author: authorTeaserMock },
+		story: { ...storyTeaserMock, author: authorTeaserMock },
 		showAuthor: false,
 		order: 1,
+		showExcerpt: false,
+		excerptLines: 3,
 	},
 };

--- a/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
@@ -1,11 +1,11 @@
 import { argsToTemplate, Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
 import { StoryCardTeaserComponent } from './story-card-teaser.component';
-import { storyNavigationTeaserMock, storyTeaserMock } from '../../mocks/story.mock';
+import { storyTeaserMock } from '../../mocks/story.mock';
 import { authorTeaserMock } from '../../mocks/author.mock';
 import { CommonModule } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
-import { StoryNavigationTeaserWithAuthor, StoryTeaserWithAuthor } from '@models/story.model';
+import { StoryTeaserWithAuthor } from '@models/story.model';
 
 const meta: Meta<StoryCardTeaserComponent> = {
 	component: StoryCardTeaserComponent,

--- a/src/app/components/story-card-teaser/story-card-teaser.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.ts
@@ -1,13 +1,14 @@
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
-import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
+import { StoryNavigationTeaserWithAuthor, StoryTeaserWithAuthor } from '@models/story.model';
 import { RouterLink } from '@angular/router';
 import { StoryCardTeaserSkeletonComponent } from './story-card-teaser-skeleton.component';
 import { AppRoutes } from '../../app.routes';
+import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 
 @Component({
 	selector: 'cuentoneta-story-card-teaser',
-	imports: [NgOptimizedImage, RouterLink, StoryCardTeaserSkeletonComponent],
+	imports: [NgOptimizedImage, RouterLink, StoryCardTeaserSkeletonComponent, PortableTextParserComponent],
 	template: `<article class="flex gap-4">
 		@if (story(); as story) {
 			<article class="flex gap-4">
@@ -30,11 +31,20 @@ import { AppRoutes } from '../../app.routes';
 					<a
 						[routerLink]="['/', appRoutes.Story, story.slug]"
 						[queryParams]="navigationParams()"
-						class="flex flex-col gap-1"
+						class="grid h-full grid-rows-[auto_auto_auto] gap-1"
 					>
 						<header class="inter-body-xl-bold">
 							{{ story.title }}
 						</header>
+						@if (showExcerpt() && story.paragraphs.length > 0) {
+							<cuentoneta-portable-text-parser
+								[type]="'span'"
+								[paragraphs]="story.paragraphs"
+								[class]="'sm:line-clamp-' + excerptLines()"
+								data-testid="portable-text-parser"
+								class="sm:source-serif-pro-body-base hidden sm:relative sm:min-h-18 sm:text-ellipsis sm:text-justify"
+							/>
+						}
 						<footer class="inter-body-xs flex gap-1 text-gray-500">
 							<span> {{ story.approximateReadingTime }} minutos de lectura </span>
 							<span>•</span>
@@ -44,7 +54,13 @@ import { AppRoutes } from '../../app.routes';
 				</div>
 			</article>
 		} @else {
-			<cuentoneta-story-card-teaser-skeleton [order]="order()" [showAuthor]="showAuthor()" data-testid="skeleton" />
+			<cuentoneta-story-card-teaser-skeleton
+				[order]="order()"
+				[showAuthor]="showAuthor()"
+				[showExcerpt]="showExcerpt()"
+				[excerptLines]="excerptLines()"
+				data-testid="skeleton"
+			/>
 		}
 	</article> `,
 	styles: ``,
@@ -54,9 +70,11 @@ export class StoryCardTeaserComponent {
 	protected readonly appRoutes = AppRoutes;
 
 	// Inputs
-	readonly story = input<StoryNavigationTeaserWithAuthor>();
+	readonly story = input<StoryNavigationTeaserWithAuthor | StoryTeaserWithAuthor>();
 	readonly order = input<number>();
 	readonly showAuthor = input<boolean>(false);
+	readonly showExcerpt = input<boolean>(false);
+	readonly excerptLines = input<number>(3);
 	readonly navigationParams = input<{ navigation: string; navigationSlug: string }>();
 
 	// Propiedades

--- a/src/app/components/story-card-teaser/story-card-teaser.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.ts
@@ -15,7 +15,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 				@if (order()) {
 					<span class="source-serif-pro-heading-2-bold leading-none text-primary-500">{{ formattedOrder() }}.</span>
 				}
-				<div class="flex flex-1 flex-col gap-2">
+				<div class="flex flex-1 flex-col">
 					@if (showAuthor() && 'author' in story) {
 						<a [routerLink]="['/', appRoutes.Author, story.author.slug]" class="flex items-center gap-2">
 							<img

--- a/src/app/components/story-card-teaser/story-card-teaser.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.ts
@@ -15,15 +15,15 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 				@if (order()) {
 					<span class="source-serif-pro-heading-2-bold leading-none text-primary-500">{{ formattedOrder() }}.</span>
 				}
-				<div class="flex flex-1 flex-col gap-1">
+				<div class="flex flex-1 flex-col gap-2">
 					@if (showAuthor() && 'author' in story) {
 						<a [routerLink]="['/', appRoutes.Author, story.author.slug]" class="flex items-center gap-2">
 							<img
 								[ngSrc]="story.author.imageUrl"
 								[alt]="'Retrato de ' + story.author.name"
-								width="24"
-								height="24"
-								class="h-6 w-6 rounded-full"
+								width="20"
+								height="20"
+								class="h-5 w-5 rounded-full"
 							/>
 							<span class="inter-body-sm-semibold text-gray-500">{{ story.author.name }}</span>
 						</a>
@@ -31,9 +31,10 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 					<a
 						[routerLink]="['/', appRoutes.Story, story.slug]"
 						[queryParams]="navigationParams()"
-						class="grid h-full grid-rows-[auto_auto_auto] gap-1"
+						[class]="showExcerpt() ? 'gap-2' : 'gap-1'"
+						class="grid h-full grid-rows-[auto_auto_auto]"
 					>
-						<header class="inter-body-xl-bold">
+						<header class="inter-heading-3-bold">
 							{{ story.title }}
 						</header>
 						@if (showExcerpt() && story.paragraphs.length > 0) {

--- a/src/app/components/story-card-teaser/story-card-teaser.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
-import { StoryNavigationTeaserWithAuthor, StoryTeaserWithAuthor } from '@models/story.model';
+import { StoryNavigationTeaserWithAuthor, StoryTeaser, StoryTeaserWithAuthor } from '@models/story.model';
 import { RouterLink } from '@angular/router';
 import { StoryCardTeaserSkeletonComponent } from './story-card-teaser-skeleton.component';
 import { AppRoutes } from '../../app.routes';
@@ -16,7 +16,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 					<span class="source-serif-pro-heading-2-bold leading-none text-primary-500">{{ formattedOrder() }}.</span>
 				}
 				<div class="flex flex-1 flex-col gap-1">
-					@if (showAuthor()) {
+					@if (showAuthor() && 'author' in story) {
 						<a [routerLink]="['/', appRoutes.Author, story.author.slug]" class="flex items-center gap-2">
 							<img
 								[ngSrc]="story.author.imageUrl"
@@ -40,9 +40,9 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 							<cuentoneta-portable-text-parser
 								[type]="'span'"
 								[paragraphs]="story.paragraphs"
-								[class]="'sm:line-clamp-' + excerptLines()"
+								[class]="'line-clamp-' + excerptLines()"
 								data-testid="portable-text-parser"
-								class="sm:source-serif-pro-body-base hidden sm:relative sm:min-h-18 sm:text-ellipsis sm:text-justify"
+								class="source-serif-pro-body-base relative min-h-18 text-ellipsis text-justify"
 							/>
 						}
 						<footer class="inter-body-xs flex gap-1 text-gray-500">
@@ -70,7 +70,7 @@ export class StoryCardTeaserComponent {
 	protected readonly appRoutes = AppRoutes;
 
 	// Inputs
-	readonly story = input<StoryNavigationTeaserWithAuthor | StoryTeaserWithAuthor>();
+	readonly story = input<StoryNavigationTeaserWithAuthor | StoryTeaserWithAuthor | StoryTeaser>();
 	readonly order = input<number>();
 	readonly showAuthor = input<boolean>(false);
 	readonly showExcerpt = input<boolean>(false);

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -40,6 +40,10 @@ export interface StoryTeaser extends StoryBase {
 	paragraphs: [TextBlockContent, TextBlockContent, TextBlockContent];
 }
 
+export interface StoryTeaserWithAuthor extends StoryTeaser {
+	author: AuthorTeaser;
+}
+
 /**
  * @deprecated Reemplazar uso por interfaces StoryTeaser, StoryNavigationTeaser o StoryNavigationTeaserWithAuthor
  */

--- a/src/assets/scss/typography.scss
+++ b/src/assets/scss/typography.scss
@@ -85,6 +85,14 @@
 		@apply inter-heading-2 font-semibold;
 	}
 
+	.inter-heading-3-semibold {
+		@apply inter-heading-3 font-semibold;
+	}
+
+	.inter-heading-3-bold {
+		@apply inter-heading-3 font-bold;
+	}
+
 	// endregion
 	// region Source Serif Pro font mixins to tailwind class
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,12 @@ import { HEADER_HEIGHT_STRING_PX } from './src/app/utils/spacing.utils';
 
 export default {
 	content: [join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'), ...createGlobPatternsForDependencies(__dirname)],
+	safelist: [
+		{
+			pattern: /line-clamp-(1|2|3|4|5|6|7|8|9|10)/,
+			variants: ['sm'],
+		},
+	],
 	theme: {
 		colors: extendedColors,
 		content: {
@@ -21,6 +27,15 @@ export default {
 			4: '4px',
 		},
 		extend: {
+			lineClamp: {
+				4: '4',
+				5: '5',
+				6: '6',
+				7: '7',
+				8: '8',
+				9: '9',
+				10: '10',
+			},
 			boxShadow: {
 				lg: '0px 0px 8px rgba(63, 63, 70, 0.08)',
 				'lg-hover': '0px 12px 16px rgba(63, 63, 70, 0.12)',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,7 +10,6 @@ export default {
 	safelist: [
 		{
 			pattern: /line-clamp-(1|2|3|4|5|6|7|8|9|10)/,
-			variants: ['sm'],
 		},
 	],
 	theme: {


### PR DESCRIPTION
## Resumen
Se implementan cambios para visualizar teasers de stories que incluyen un extracto de texto, con las consiguientes modificaciones orientadas a proveer de un skeleton acorde y ajustar el diseño de todas las variantes implementadas de `StoryCardTeaserComponent` para que coincidan con la especificación de Figma.

## Cambios
- Agregado de interface `StoryTeaserWithAuthor`, el cual representa teasers de stories que incluyen un extracto de texto en los datos.
- Agregada batería de tests unitarios para probar los cambios relacionados a las nuevas variantes de `StoryCardTeaserComponent`.
- Agregados cambios en stories de Storybook para visualizar todas las variantes de `StoryCardTeaserComponent`

## Otros cambios
- Agregado de variantes de `lineClamp` a safelist de Tailwind, para agregar las clases dinámicamente.
- Agregado de clase para variante `Inter/Heading 3/Semi Bold` y `Inter/Heading 3/Bold` en tipografías y en [especificaciones de Figma](https://www.figma.com/design/A9PdBCdmoyZrN7FKMpann8/La-Cuentoneta-v3?node-id=1841-7922&m=dev).
- Agregadas modificaciones varias a diseños de [Figma para el componente](https://www.figma.com/design/A9PdBCdmoyZrN7FKMpann8/La-Cuentoneta-v3?node-id=3233-8637&m=dev), orientadas a unificar los estilos, layout y spacing del componente.