### PR TITLE
[#1273] Integra plugin ESLint para prevenir archivos barrel

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ const storybook = require('eslint-plugin-storybook');
 const jest = require('eslint-plugin-jest');
 const jestDom = require('eslint-plugin-jest-dom');
 const testingLibrary = require('eslint-plugin-testing-library');
+const noBarrelFiles = require('eslint-plugin-no-barrel-files');
 
 module.exports = [
 	{
@@ -45,6 +46,7 @@ module.exports = [
 		plugins: {
 			'@stylistic/js': stylisticJs,
 			jest: jest,
+			'no-barrel-files': noBarrelFiles,
 		},
 		rules: {
 			'@angular-eslint/directive-selector': [
@@ -70,6 +72,7 @@ module.exports = [
 			'@typescript-eslint/no-explicit-any': 'error',
 			'@stylistic/js/no-extra-semi': 'off',
 			'jest/no-focused-tests': 'error',
+			'no-barrel-files/no-barrel-files': 'error',
 		},
 	},
 	{

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
 		"eslint-config-prettier": "10.1.8",
 		"eslint-plugin-jest": "^29.0.1",
 		"eslint-plugin-jest-dom": "^5.5.0",
+		"eslint-plugin-no-barrel-files": "^1.2.2",
 		"eslint-plugin-playwright": "^2.2.2",
 		"eslint-plugin-storybook": "^9.1.5",
 		"eslint-plugin-testing-library": "^7.6.8",
@@ -104,6 +105,7 @@
 		"jest": "30.1.3",
 		"jest-environment-jsdom": "30.1.2",
 		"jest-preset-angular": "15.0.0",
+		"jest-util": "~30.0.0",
 		"nx": "21.5.1",
 		"nx-cloud": "19.1.0",
 		"nx-stylelint": "^18.0.0",
@@ -126,7 +128,6 @@
 		"ts-node": "10.9.2",
 		"typescript": "5.9.2",
 		"typescript-eslint": "8.43.0",
-		"webpack": "5.99.9",
-		"jest-util": "~30.0.0"
+		"webpack": "5.99.9"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       eslint-plugin-jest-dom:
         specifier: ^5.5.0
         version: 5.5.0(@testing-library/dom@10.4.0)(eslint@9.35.0(jiti@1.21.7))
+      eslint-plugin-no-barrel-files:
+        specifier: ^1.2.2
+        version: 1.2.2(eslint@9.35.0(jiti@1.21.7))(typescript@5.9.2)
       eslint-plugin-playwright:
         specifier: ^2.2.2
         version: 2.2.2(eslint@9.35.0(jiti@1.21.7))
@@ -6341,6 +6344,10 @@ packages:
         optional: true
       jest:
         optional: true
+
+  eslint-plugin-no-barrel-files@1.2.2:
+    resolution:
+      { integrity: sha512-DF2bnHuEHClmL1+maBO5TD2HnnRsLj8J69FFtVkjObkELyjCXaWBsk+URJkqBpdOWURlL+raGX9AEpWCAiOV0g== }
 
   eslint-plugin-playwright@2.2.2:
     resolution:
@@ -18433,6 +18440,14 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@1.21.7))(typescript@5.9.2))(eslint@9.35.0(jiti@1.21.7))(typescript@5.9.2)
       jest: 30.1.3(@types/node@22.17.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.5.0(esbuild@0.25.5))(ts-node@10.9.2(@types/node@22.17.1)(typescript@5.9.2))
     transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-plugin-no-barrel-files@1.2.2(eslint@9.35.0(jiti@1.21.7))(typescript@5.9.2):
+    dependencies:
+      '@typescript-eslint/utils': 8.43.0(eslint@9.35.0(jiti@1.21.7))(typescript@5.9.2)
+    transitivePeerDependencies:
+      - eslint
       - supports-color
       - typescript
 


### PR DESCRIPTION
  - Agrega plugin `eslint-plugin-no-barrel-files` para prevenir el uso de archivos barrel.
  - Configura la regla `no-barrel-files/no-barrel-files` como error en TypeScript.
  - Mejora el rendimiento de build y previene dependencias circulares.

  ## Plan de pruebas
  - [x] Ejecutar `pnpm lint` para verificar la integración del plugin.
  - [x] Ejecutar `pnpm test` para confirmar que no se rompe funcionalidad existente.
  - [x] Verificar que la regla detecta correctamente archivos barrel en el proyecto.
