### PR TITLE
[#1167] - Implementa defaultValue en rxResource

### DIFF
--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
@@ -40,6 +40,7 @@ export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
 	private readonly storiesResource = rxResource({
 		params: () => this.navigationSlug(),
 		stream: ({ params: slug }) => this.storyService.getNavigationTeasersByAuthorSlug(slug),
+		defaultValue: [],
 	});
 
 	// Propiedades

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
@@ -61,6 +61,7 @@ export class StorylistNavigationFrameComponent extends NavigationFrameComponent 
 	private readonly storylistResource = rxResource({
 		params: () => this.navigationSlug(),
 		stream: ({ params }) => this.storylistService.getStorylistNavigationTeasers(params),
+		defaultValue: undefined,
 	});
 
 	// Propiedades

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -101,10 +101,12 @@ export default class AuthorComponent {
 					this.updateMetaTags(author);
 				}),
 			),
+		defaultValue: undefined,
 	});
 	readonly storiesResource = rxResource({
 		params: () => this.params(),
 		stream: ({ params }) => this.stories$(params['slug']),
+		defaultValue: [],
 	});
 
 	// Propiedades

--- a/src/app/pages/authors/authors.component.ts
+++ b/src/app/pages/authors/authors.component.ts
@@ -27,9 +27,10 @@ export default class AuthorsComponent {
 
 	private authorsResource = rxResource({
 		stream: () => this.authorService.getAll(),
+		defaultValue: [],
 	});
 
-	readonly authors = computed(() => this.authorsResource.value() ?? []);
+	readonly authors = computed(() => this.authorsResource.value());
 
 	constructor() {
 		this.metaTagsDirective.setTitle('Índice de Autores');

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -37,6 +37,7 @@ export default class HomeComponent {
 	// Recursos
 	readonly landingPageResource = rxResource({
 		stream: () => this.contentService.getLandingPageContent(),
+		defaultValue: undefined,
 	});
 
 	// Propiedades

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -85,6 +85,7 @@ export default class StoryComponent implements OnDestroy {
 					this.updateMetaTags(story);
 				}),
 			),
+		defaultValue: undefined,
 	});
 
 	// Propiedades

--- a/src/app/pages/storylist/storylist.component.ts
+++ b/src/app/pages/storylist/storylist.component.ts
@@ -44,6 +44,7 @@ export default class StorylistComponent {
 					this.updateMetaTags(storylist);
 				}),
 			),
+		defaultValue: undefined,
 	});
 
 	// Propiedades


### PR DESCRIPTION
  - Agrega soporte para el parámetro `defaultValue` en todas las declaraciones de `rxResource`.
  - Establece `defaultValue: []` para recursos que retornan listas.
  - Establece `defaultValue: undefined` para recursos que retornan un elemento único.
  - Optimiza computed properties eliminando fallbacks innecesarios.
  - Cierra el _issue_ #1167.

  ## Plan de pruebas
  - [x] Ejecutar `pnpm lint` para verificar la ausencia de errores de TypeScript
  - [x] Ejecutar `pnpm test` para confirmar que no se rompe funcionalidad existente
  - [x] Verificar que todos los `rxResource` incluyen el parámetro `defaultValue` apropiado
