### PR TITLE
[#1283] - Storybook y Jest: Reemplazo de `RouterTestingModule` por `provideRouter`

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,18 +1,17 @@
 import { AppComponent } from './app.component';
 import { render } from '@testing-library/angular';
-import { CommonModule, NgOptimizedImage } from '@angular/common';
-import { RouterTestingModule } from '@angular/router/testing';
-import { provideMock } from '@testing-library/angular/jest-utils';
-import { ContentService } from './providers/content.service';
+import { NgOptimizedImage } from '@angular/common';
+import { provideRouter, RouterModule } from '@angular/router';
 import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
-import { AnalyticsService } from './providers/analytics.service';
+import { AnalyticsService } from './providers/analytics/analytics.service';
+import { AnalyticsMockService } from './providers/analytics/analytics.mock.service';
 
 describe('AppComponent', () => {
 	const setup = async () => {
 		return await render(AppComponent, {
-			componentImports: [HeaderComponent, FooterComponent, CommonModule, NgOptimizedImage, RouterTestingModule],
-			componentProviders: [provideMock(ContentService), provideMock(AnalyticsService)],
+			componentImports: [HeaderComponent, FooterComponent, NgOptimizedImage, RouterModule],
+			providers: [provideRouter([]), { provide: AnalyticsService, useClass: AnalyticsMockService }],
 		});
 	};
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,7 +6,7 @@ import { RouterModule } from '@angular/router';
 import { environment } from './environments/environment';
 
 // Services
-import { AnalyticsService } from './providers/analytics.service';
+import { AnalyticsService } from './providers/analytics/analytics.service';
 import { LayoutService } from './providers/layout.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 

--- a/src/app/components/author-teaser/author-teaser.component.stories.ts
+++ b/src/app/components/author-teaser/author-teaser.component.stories.ts
@@ -1,15 +1,18 @@
 import { AuthorTeaserComponent } from './author-teaser.component';
-import { Meta, moduleMetadata } from '@storybook/angular';
+import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { authorTeaserMock } from '../../mocks/author.mock';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 export default {
 	title: 'AuthorTeaserComponent',
 	component: AuthorTeaserComponent,
 	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
 		moduleMetadata({
-			imports: [CommonModule, NgOptimizedImage, RouterTestingModule],
+			imports: [CommonModule, NgOptimizedImage],
 			providers: [],
 		}),
 	],

--- a/src/app/components/bio-summary-card/bio-summary-card.component.stories.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.stories.ts
@@ -1,24 +1,20 @@
-import { Meta, moduleMetadata } from '@storybook/angular';
+import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
 import { BioSummaryCardComponent } from './bio-summary-card.component';
 import { storyMock } from '../../mocks/story.mock';
 import { CommonModule, NgIf, NgOptimizedImage } from '@angular/common';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 import { ResourceComponent } from '../resource/resource.component';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 export default {
 	title: 'BioSummaryCardComponent',
 	component: BioSummaryCardComponent,
 	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
 		moduleMetadata({
-			imports: [
-				CommonModule,
-				NgOptimizedImage,
-				NgIf,
-				ResourceComponent,
-				PortableTextParserComponent,
-				RouterTestingModule,
-			],
+			imports: [CommonModule, NgOptimizedImage, NgIf, ResourceComponent, PortableTextParserComponent],
 		}),
 	],
 } as Meta<BioSummaryCardComponent>;

--- a/src/app/components/content-campaign-carousel/content-campaign-carousel.component.stories.ts
+++ b/src/app/components/content-campaign-carousel/content-campaign-carousel.component.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, moduleMetadata } from '@storybook/angular';
+import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
 import { ContentCampaignCarouselComponent } from './content-campaign-carousel.component';
 import { ContentService } from '../../providers/content.service';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -6,19 +6,21 @@ import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { CarouselModule } from 'ngx-owl-carousel-o';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 import { contentCampaignMock } from '../../mocks/content-campaign.mock';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { ContentCampaignCarouselSkeletonComponent } from './content-campaign-carousel-skeleton.component';
 
 export default {
 	title: 'ContentCampaignCarouselComponent',
 	component: ContentCampaignCarouselComponent,
 	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
 		moduleMetadata({
 			imports: [
 				CommonModule,
 				CarouselModule,
 				NgOptimizedImage,
-				RouterTestingModule,
 				PortableTextParserComponent,
 				NoopAnimationsModule,
 				ContentCampaignCarouselSkeletonComponent,

--- a/src/app/components/footer/footer.component.spec.ts
+++ b/src/app/components/footer/footer.component.spec.ts
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/angular';
 import { FooterComponent } from './footer.component';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 describe('FooterComponent', () => {
 	it('should display the logo image correctly', async () => {
 		await render(FooterComponent, {
-			imports: [RouterTestingModule],
+			providers: [provideRouter([])],
 		});
 
 		const logo = screen.getByAltText("Logo de 'La Cuentoneta'");
@@ -17,7 +17,7 @@ describe('FooterComponent', () => {
 
 	it('should render navigable navLinks', async () => {
 		const view = await render(FooterComponent, {
-			imports: [RouterTestingModule],
+			providers: [provideRouter([])],
 		});
 
 		view.fixture.componentInstance.navLinks.forEach((link) => {
@@ -29,7 +29,7 @@ describe('FooterComponent', () => {
 
 	it('should display social link icons as expected', async () => {
 		const view = await render(FooterComponent, {
-			imports: [RouterTestingModule],
+			providers: [provideRouter([])],
 		});
 
 		view.fixture.componentInstance.socialLinks.forEach((link) => {

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -1,37 +1,27 @@
 import { render, screen } from '@testing-library/angular';
-import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
-import { provideMock } from '@testing-library/angular/jest-utils';
-
+import { RouterModule, provideRouter } from '@angular/router';
 import { HeaderComponent } from './header.component';
-import { ContentService } from 'src/app/providers/content.service';
 
 describe('HeaderComponent', () => {
-	it('should render Header component', async () => {
-		const { container } = await render(HeaderComponent, {
-			componentImports: [CommonModule, NgOptimizedImage, RouterTestingModule, HttpClientTestingModule],
-			componentProviders: [provideMock(ContentService)],
+	const setup = async () =>
+		await render(HeaderComponent, {
+			componentImports: [CommonModule, NgOptimizedImage, RouterModule],
+			providers: [provideRouter([])],
 		});
 
+	it('should render Header component', async () => {
+		const { container } = await setup();
 		expect(container).toBeInTheDocument();
 	});
 
 	it('should show the Cuentoneta alt text', async () => {
-		await render(HeaderComponent, {
-			componentImports: [CommonModule, NgOptimizedImage, RouterTestingModule, HttpClientTestingModule],
-			componentProviders: [provideMock(ContentService)],
-		});
-
+		await setup();
 		expect(screen.getByAltText(/Cuentoneta/)).toBeInTheDocument();
 	});
 
 	it('should show the navbar links', async () => {
-		await render(HeaderComponent, {
-			componentImports: [CommonModule, NgOptimizedImage, RouterTestingModule, HttpClientTestingModule],
-			componentProviders: [provideMock(ContentService)],
-		});
-
+		await setup();
 		expect(screen.getByText(/Inicio/)).toHaveProperty('href', expect.stringMatching(/home/));
 		expect(screen.getByText(/Nosotros/)).toHaveProperty('href', expect.stringMatching(/about/));
 	});

--- a/src/app/components/publication-card/publication-card.component.stories.ts
+++ b/src/app/components/publication-card/publication-card.component.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, moduleMetadata } from '@storybook/angular';
+import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
 import { PublicationCardComponent } from './publication-card.component';
 
 import { DatePipe, NgOptimizedImage, registerLocaleData } from '@angular/common';
@@ -14,20 +14,17 @@ registerLocaleData(localeEs);
 // Modelos
 import { Publication } from '@models/storylist.model';
 import { storyPreviewMock } from '../../mocks/story.mock';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 export default {
 	title: 'PublicationCardComponent',
 	component: PublicationCardComponent,
 	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
 		moduleMetadata({
-			imports: [
-				NgOptimizedImage,
-				NgxSkeletonLoaderModule,
-				StoryCardSkeletonComponent,
-				StoryEditionDateLabelComponent,
-				RouterTestingModule,
-			],
+			imports: [NgOptimizedImage, NgxSkeletonLoaderModule, StoryCardSkeletonComponent, StoryEditionDateLabelComponent],
 			providers: [DatePipe, { provide: LOCALE_ID, useValue: 'es-419' }],
 		}),
 	],

--- a/src/app/components/story-card-content/story-card-content.stories.ts
+++ b/src/app/components/story-card-content/story-card-content.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, moduleMetadata } from '@storybook/angular';
+import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
 
 import { CommonModule, NgOptimizedImage, registerLocaleData } from '@angular/common';
 import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
@@ -9,7 +9,7 @@ import localeEs from '@angular/common/locales/es-419';
 import { StoryCardContentComponent } from './story-card-content.component';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
 import { RouterLink } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { storyPreviewMock } from '../../mocks/story.mock';
 
 registerLocaleData(localeEs);
@@ -18,6 +18,9 @@ export default {
 	title: 'StoryCardContentComponent',
 	component: StoryCardContentComponent,
 	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
 		moduleMetadata({
 			imports: [
 				CommonModule,
@@ -25,7 +28,6 @@ export default {
 				PortableTextParserComponent,
 				NgOptimizedImage,
 				RouterLink,
-				RouterTestingModule,
 			],
 		}),
 	],

--- a/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
@@ -1,34 +1,36 @@
-import { argsToTemplate, Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig, argsToTemplate, Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
 import { StoryCardTeaserComponent } from './story-card-teaser.component';
 import { storyTeaserMock } from '../../mocks/story.mock';
 import { authorTeaserMock } from '../../mocks/author.mock';
 import { CommonModule } from '@angular/common';
-import { RouterTestingModule } from '@angular/router/testing';
 import { StoryTeaserWithAuthor } from '@models/story.model';
+import { provideRouter } from '@angular/router';
 
 const meta: Meta<StoryCardTeaserComponent> = {
 	component: StoryCardTeaserComponent,
 	title: 'Componentes/StoryCardTeaser',
 	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
 		moduleMetadata({
-			imports: [CommonModule, RouterTestingModule],
+			imports: [CommonModule],
 		}),
 	],
 	parameters: {
 		docs: {
 			description: {
-				component: `<div>
-					<p>El componente **StoryCardTeaserComponent** representa una vista previa de una entidad story del sistema. El componente posee inputs opcionales que permiten visualizar:</p>
-					<ul>
-						<li>Contenido de historia o estado de carga esqueleto</li>
-						<li>Información opcional del autor</li>
-						<li>Numeración/orden opcional</li>
-						<li>Extracto opcional con líneas configurables</li>
-						<li>Parámetros de navegación para enrutamiento</li>
-					</ul>
-					<p>Puedes utilizar los controles interactivos en la primera historia de abajo para ver cómo se comporta el componente en ambos estados: cargado y esqueleto.</p>
-				</div>`,
+				component: `
+					**StoryCardTeaserComponent** muestra una vista previa de historia con elementos opcionales:
+					- Contenido de historia o estado de carga esqueleto
+					- Información opcional del autor
+					- Numeración/orden opcional
+					- Extracto opcional con líneas configurables
+					- Parámetros de navegación para enrutamiento
+
+					Usa los controles interactivos en la primera historia de abajo para ver cómo se comporta el componente en ambos estados: cargado y esqueleto.
+				`,
 			},
 		},
 		layout: 'padded',

--- a/src/app/components/storylist-card-component/storylist-card.component.stories.ts
+++ b/src/app/components/storylist-card-component/storylist-card.component.stories.ts
@@ -1,7 +1,7 @@
-import { Meta, moduleMetadata } from '@storybook/angular';
+import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
 import { StorylistCardComponent } from './storylist-card.component';
 import { NgOptimizedImage } from '@angular/common';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { StorylistCardSkeletonComponent } from './storylist-card-skeleton.component';
 
 const storylist1 = {
@@ -111,8 +111,11 @@ const meta: Meta<StorylistCardComponent> = {
 	component: StorylistCardComponent,
 	title: 'StorylistCardComponent',
 	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
 		moduleMetadata({
-			imports: [NgOptimizedImage, RouterTestingModule, StorylistCardSkeletonComponent],
+			imports: [NgOptimizedImage, StorylistCardSkeletonComponent],
 		}),
 	],
 };

--- a/src/app/components/storylist-card-deck/story-list-card-deck.component.stories.ts
+++ b/src/app/components/storylist-card-deck/story-list-card-deck.component.stories.ts
@@ -1,6 +1,6 @@
-import { Meta, moduleMetadata } from '@storybook/angular';
+import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
 import { StorylistCardDeckComponent } from './storylist-card-deck.component';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 const fullyLoadedStorylist = {
 	_id: 'de027057-130b-473d-a4f7-f561c878feeb',
@@ -298,8 +298,11 @@ export default {
 	title: 'StorylistCardDeckComponent',
 	component: StorylistCardDeckComponent,
 	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
 		moduleMetadata({
-			imports: [RouterTestingModule],
+			imports: [],
 		}),
 	],
 } as Meta<StorylistCardDeckComponent>;

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,7 +1,7 @@
 import HomeComponent from './home.component';
 import { render } from '@testing-library/angular';
 import { CommonModule, NgForOf, NgIf, NgOptimizedImage } from '@angular/common';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { provideMock } from '@testing-library/angular/jest-utils';
 import { ContentService } from '../../providers/content.service';
@@ -19,9 +19,8 @@ xdescribe('HomeComponent', () => {
 				NgOptimizedImage,
 				MockPublicationCardComponent,
 				MockStorylistCardDeckComponent,
-				RouterTestingModule,
 			],
-			componentProviders: [{ provide: ContentService, useClass: provideMock(ContentService) }],
+			componentProviders: [provideRouter([]), { provide: ContentService, useClass: provideMock(ContentService) }],
 		});
 	};
 

--- a/src/app/pages/storylist/storylist.component.spec.ts
+++ b/src/app/pages/storylist/storylist.component.spec.ts
@@ -2,7 +2,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, input } from '@angular/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 // 3rd party modules
 import { render } from '@testing-library/angular';
@@ -26,9 +26,8 @@ xdescribe('StorylistComponent', () => {
 				HttpClientTestingModule,
 				MockStorylistCardDeckComponent,
 				NgxSkeletonLoaderModule,
-				RouterTestingModule,
 			],
-			componentProviders: [provideMock(MetaTagsDirective)],
+			componentProviders: [provideRouter([]), provideMock(MetaTagsDirective)],
 		});
 	};
 

--- a/src/app/providers/analytics/analytics.mock.service.ts
+++ b/src/app/providers/analytics/analytics.mock.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+import { AnalyticsService } from './analytics.service';
+
+@Injectable({
+	providedIn: 'root',
+})
+export class AnalyticsMockService extends AnalyticsService {
+	async init() {}
+}

--- a/src/app/providers/analytics/analytics.mock.service.ts
+++ b/src/app/providers/analytics/analytics.mock.service.ts
@@ -5,5 +5,6 @@ import { AnalyticsService } from './analytics.service';
 	providedIn: 'root',
 })
 export class AnalyticsMockService extends AnalyticsService {
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	async init() {}
 }

--- a/src/app/providers/analytics/analytics.service.ts
+++ b/src/app/providers/analytics/analytics.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { injectSpeedInsights } from '@vercel/speed-insights';
-import { environment } from '../environments/environment';
+import { environment } from '../../environments/environment';
 
 @Injectable({
 	providedIn: 'root',


### PR DESCRIPTION
## Resumen
- Reemplaza `RouterTestingModule` por uso de `provideRouter` en stories de Storybook mediante el uso de `applicationConfig`
- Reemplaza `RouterTestingModule` por uso de `provideRouter` en tests unitarios.

## Otros cambios
- Genera mock explícito para `AnalyticsService`, reemplazando el uso de `provideMock` para esta clase en `AppComponent` por `AnalyticsServiceMock`.
- Elimina imports redundantes en tests de `HeaderComponent` y `AppComponent`.