### PR TITLE
[1201] - Desactiva las pruebas de Playwright para Safari/WebKit

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,10 +40,10 @@ export default defineConfig({
 			use: { ...devices['Desktop Firefox'] },
 		},
 
-		{
-			name: 'webkit',
-			use: { ...devices['Desktop Safari'] },
-		},
+		/* {
+		 	name: 'webkit',
+		 	use: { ...devices['Desktop Safari'] },
+		 },*/
 
 		// Uncomment for mobile browsers support
 		/* {


### PR DESCRIPTION
  ## Resumen:
- Se comentó la configuración del navegador WebKit en `playwright.config.ts` para desactivar las pruebas en Safari.
- Cierra el _issue_ #1201 .