### PR TITLE
[#1268] - Agrega regla preserve-caught-error a ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,6 +73,7 @@ module.exports = [
 			'@stylistic/js/no-extra-semi': 'off',
 			'jest/no-focused-tests': 'error',
 			'no-barrel-files/no-barrel-files': 'error',
+			'preserve-caught-error': 'error',
 		},
 	},
 	{


### PR DESCRIPTION
Esta regla garantiza que los errores capturados se preserven al relanzarlos usando la propiedad cause, mejorando la trazabilidad y depuración de errores.