### PR TITLE
[#1416] - Corrige estilos en fondos de widget

### DIFF
--- a/src/app/components/space-recording-widget/space-recording-widget.component.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.component.ts
@@ -44,11 +44,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 		}
 
 		.spaces-card {
-			background-image: linear-gradient(
-				60deg,
-				hsl(230, calc(100 * 1%), calc(50 * 1%)) -15%,
-				hsl(260, calc(100 * 1%), calc(60 * 1%)) 100%
-			);
+			background-image: linear-gradient(60deg, hsl(230, 100%, 50%) -15%, hsl(260, 100%, 60%) 100%);
 		}
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
Agrega uso de la función `calc`, requerido por CSS nativo para operaciones aritméticas en la definición de colores hsl.