### PR TITLE
[#1413] - Corregir margen inferior en textos de biografías de autor

### DIFF
--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -131,6 +131,7 @@ import { InitialsPipe } from '../../pipes/initials.pipe';
 										<cuentoneta-portable-text-parser
 											[paragraphs]="author.biography"
 											[classes]="'source-serif-pro-body-xl leading-8'"
+											class="flex flex-col gap-4"
 										/>
 										@if (author.resources && author.resources.length > 0) {
 											<hr class="text-gray-500" />


### PR DESCRIPTION
## Resumen
Agregadas clases `flex flex-col gap-4` a componente `cuentoneta-portable-text-parser` usado para renderizar las biografías de autor en `AuthorComponent`.