### PR TITLE
[#1426] Agregar excepciones a los repositorios y a los servicios

### DIFF
--- a/src/api/exceptions/exceptions.ts
+++ b/src/api/exceptions/exceptions.ts
@@ -1,0 +1,13 @@
+export class InternalError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'Internal server error';
+	}
+}
+
+export class NotFoundError extends InternalError {
+	constructor(message: string) {
+		super(message);
+		this.name = 'Not found error';
+	}
+}

--- a/src/api/modules/author/author.repository.ts
+++ b/src/api/modules/author/author.repository.ts
@@ -4,10 +4,21 @@ import { client } from '../../_helpers/sanity-connector';
 // Queries
 import { authorBySlugQuery, authorsQuery } from '../../_queries/author.query';
 
+// Errors
+
+import { InternalError, NotFoundError } from '../../exceptions/exceptions';
 export async function fetchAuthorBySlug(slug: string) {
-	return client.fetch(authorBySlugQuery, { slug });
+	try {
+		return await client.fetch(authorBySlugQuery, { slug });
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }
 
 export async function fetchAllAuthors() {
-	return client.fetch(authorsQuery);
+	try {
+		return await client.fetch(authorsQuery);
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }

--- a/src/api/modules/author/author.repository.ts
+++ b/src/api/modules/author/author.repository.ts
@@ -6,11 +6,12 @@ import { authorBySlugQuery, authorsQuery } from '../../_queries/author.query';
 
 // Errors
 
-import { InternalError, NotFoundError } from '../../exceptions/exceptions';
+import { InternalError } from '../../exceptions/exceptions';
 export async function fetchAuthorBySlug(slug: string) {
 	try {
 		return await client.fetch(authorBySlugQuery, { slug });
 	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }
@@ -19,6 +20,7 @@ export async function fetchAllAuthors() {
 	try {
 		return await client.fetch(authorsQuery);
 	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }

--- a/src/api/modules/author/author.service.ts
+++ b/src/api/modules/author/author.service.ts
@@ -7,11 +7,14 @@ import { mapAuthor, mapAuthorTeaser } from '../../_utils/functions';
 // Funciones de repository
 import { fetchAllAuthors, fetchAuthorBySlug } from './author.repository';
 
+// Excepciones
+import { NotFoundError } from '../../exceptions/exceptions';
+
 export async function getAuthorBySlug(slug: string): Promise<Author> {
 	const result = await fetchAuthorBySlug(slug);
 
 	if (!result) {
-		throw new Error(`Author with slug ${slug} not found.`);
+		throw new NotFoundError(`Author with slug ${slug} not found.`);
 	}
 
 	return mapAuthor(result);
@@ -21,7 +24,7 @@ export async function getAllAuthors(): Promise<AuthorTeaser[]> {
 	const result = await fetchAllAuthors();
 
 	if (!result) {
-		throw new Error(`Could not fetch authors data.`);
+		throw new NotFoundError(`Could not fetch authors data.`);
 	}
 
 	const authors = result.map((author) => mapAuthorTeaser(author));

--- a/src/api/modules/content/content.repository.ts
+++ b/src/api/modules/content/content.repository.ts
@@ -36,6 +36,7 @@ export async function fetchLandingPagesList(slugs: string[]): Promise<LandingPag
 	try {
 		return await client.fetch(landingPageListQuery, { slugs });
 	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }
@@ -44,6 +45,7 @@ export async function fetchRotatingContent(): Promise<RotatingContentQueryResult
 	try {
 		return await client.fetch(rotatingContentQuery);
 	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }
@@ -61,6 +63,7 @@ export async function createLandingPages(
 	try {
 		return Promise.all(landingPageObjects.map((object) => client.create(object)));
 	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }
@@ -80,6 +83,7 @@ export async function updateRotatingContentMostRead(
 
 		await client.patch(rotatingContent._id, { set: { mostRead: stories } }).commit();
 	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }

--- a/src/api/modules/content/content.repository.ts
+++ b/src/api/modules/content/content.repository.ts
@@ -20,6 +20,7 @@ export async function fetchLandingPageContent(slug: string): Promise<LandingPage
 	try {
 		return await client.fetch(landingPageContentQuery, { slug });
 	} catch (err) {
+		console.log('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }
@@ -28,6 +29,7 @@ export async function fetchLatestLandingPageReferences(): Promise<LatestLandingP
 	try {
 		return await client.fetch(latestLandingPageReferencesQuery);
 	} catch (err) {
+		console.log('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }

--- a/src/api/modules/content/content.repository.ts
+++ b/src/api/modules/content/content.repository.ts
@@ -1,4 +1,5 @@
 // Sanity
+import { InternalError } from '../../exceptions/exceptions';
 import { client } from '../../_helpers/sanity-connector';
 
 // Queries
@@ -16,19 +17,35 @@ import {
 } from '../../sanity/types';
 
 export async function fetchLandingPageContent(slug: string): Promise<LandingPageContentQueryResult> {
-	return client.fetch(landingPageContentQuery, { slug });
+	try {
+		return await client.fetch(landingPageContentQuery, { slug });
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }
 
 export async function fetchLatestLandingPageReferences(): Promise<LatestLandingPageReferencesQueryResult> {
-	return client.fetch(latestLandingPageReferencesQuery);
+	try {
+		return await client.fetch(latestLandingPageReferencesQuery);
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }
 
 export async function fetchLandingPagesList(slugs: string[]): Promise<LandingPageListQueryResult> {
-	return client.fetch(landingPageListQuery, { slugs });
+	try {
+		return await client.fetch(landingPageListQuery, { slugs });
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }
 
 export async function fetchRotatingContent(): Promise<RotatingContentQueryResult> {
-	return client.fetch(rotatingContentQuery);
+	try {
+		return await client.fetch(rotatingContentQuery);
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }
 
 export async function createLandingPages(
@@ -41,7 +58,11 @@ export async function createLandingPages(
 		latestReads: Array<{ _key: string; _type: string; _ref: string }>;
 	}>,
 ) {
-	return Promise.all(landingPageObjects.map((object) => client.create(object)));
+	try {
+		return Promise.all(landingPageObjects.map((object) => client.create(object)));
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }
 
 /**
@@ -49,11 +70,16 @@ export async function createLandingPages(
  */
 export async function updateRotatingContentMostRead(
 	stories: Array<{ _key: string; _type: string; _ref: string }>,
-): Promise<void> {
-	const rotatingContent = await fetchRotatingContent();
-	if (!rotatingContent) {
-		throw new Error('Rotating content not found');
-	}
+): Promise<void | null> {
+	try {
+		const rotatingContent = await fetchRotatingContent();
 
-	await client.patch(rotatingContent._id, { set: { mostRead: stories } }).commit();
+		if (!rotatingContent) {
+			return null;
+		}
+
+		await client.patch(rotatingContent._id, { set: { mostRead: stories } }).commit();
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }

--- a/src/api/modules/content/content.service.ts
+++ b/src/api/modules/content/content.service.ts
@@ -15,6 +15,9 @@ import { addWeeks, getWeek, getYear } from 'date-fns';
 import { mapLandingPageContent, mapStoryNavigationTeaserWithAuthor } from '../../_utils/functions';
 import slugify from 'slugify';
 
+// Excepciones
+import { NotFoundError } from '../../exceptions/exceptions';
+
 export async function getLandingPageContent(): Promise<LandingPageContent> {
 	const weekOfYear = getWeek(new Date());
 	const year = getYear(new Date());
@@ -24,7 +27,7 @@ export async function getLandingPageContent(): Promise<LandingPageContent> {
 	const rotatingContentResult = await fetchRotatingContent();
 
 	if (!landingPageResult || !rotatingContentResult) {
-		throw new Error('Landing page content not found');
+		throw new NotFoundError('Landing page content not found');
 	}
 
 	return {
@@ -36,7 +39,7 @@ export async function getRotatingContent(): Promise<RotatingContent> {
 	const result = await fetchRotatingContent();
 
 	if (!result) {
-		throw new Error('Rotating content not found');
+		throw new NotFoundError('Rotating content not found');
 	}
 
 	return { ...result, mostRead: mapStoryNavigationTeaserWithAuthor(result.mostRead) };
@@ -60,7 +63,9 @@ export async function addNextWeeksLandingPageContent(weeksInTheFuture: number = 
 	const existingLandingPagesList = await fetchLandingPagesList(slugs);
 
 	if (!existingLandingPagesList) {
-		throw new Error(`Could not retrieve the landing page configs for the [${slugs.join(', ')}] slugs not found.`);
+		throw new NotFoundError(
+			`Could not retrieve the landing page configs for the [${slugs.join(', ')}] slugs not found.`,
+		);
 	}
 
 	if (existingLandingPagesList.length >= weeksInTheFuture) {
@@ -72,7 +77,7 @@ export async function addNextWeeksLandingPageContent(weeksInTheFuture: number = 
 	const latestLandingPageConfig = await fetchLatestLandingPageReferences();
 
 	if (!latestLandingPageConfig) {
-		throw new Error(`Latest landing page for the '${currentLandingPageSlug}' slug content not found`);
+		throw new NotFoundError(`Latest landing page for the '${currentLandingPageSlug}' slug content not found`);
 	}
 
 	const notLoadedWeeks = slugs.filter((t) => !existingLandingPagesList.find((r) => r.config === t));

--- a/src/api/modules/contributor/contributor.repository.ts
+++ b/src/api/modules/contributor/contributor.repository.ts
@@ -1,4 +1,5 @@
 // Sanity
+import { InternalError } from '../../exceptions/exceptions';
 import { client } from '../../_helpers/sanity-connector';
 import { allContributorsQuery } from '../../_queries/contributor.query';
 
@@ -9,20 +10,25 @@ import { Contributor, CONTRIBUTOR_AREA_LABELS } from '@models/contributor.model'
  * Obtiene todos los colaboradores ordenados alfabéticamente por nombre
  */
 export async function fetchAllContributors(): Promise<Contributor[] | null> {
-	const result = await client.fetch(allContributorsQuery);
+	try {
+		const result = await client.fetch(allContributorsQuery);
 
-	if (!result) {
-		return null;
+		if (!result) {
+			return null;
+		}
+
+		return result.map((contributor) => ({
+			slug: contributor.slug,
+			name: contributor.name,
+			area: { slug: contributor.area, name: CONTRIBUTOR_AREA_LABELS[contributor.area] },
+			link: {
+				handle: contributor.link?.handle || undefined,
+				url: contributor.link?.url || undefined,
+			},
+			notes: contributor.notes || undefined,
+		}));
+	} catch (err) {
+		console.error('Internal server error: ', err);
+		throw new InternalError('Internal server error');
 	}
-
-	return result.map((contributor) => ({
-		slug: contributor.slug,
-		name: contributor.name,
-		area: { slug: contributor.area, name: CONTRIBUTOR_AREA_LABELS[contributor.area] },
-		link: {
-			handle: contributor.link?.handle || undefined,
-			url: contributor.link?.url || undefined,
-		},
-		notes: contributor.notes || undefined,
-	}));
 }

--- a/src/api/modules/contributor/contributor.repository.ts
+++ b/src/api/modules/contributor/contributor.repository.ts
@@ -8,11 +8,11 @@ import { Contributor, CONTRIBUTOR_AREA_LABELS } from '@models/contributor.model'
 /**
  * Obtiene todos los colaboradores ordenados alfabéticamente por nombre
  */
-export async function fetchAllContributors(): Promise<Contributor[]> {
+export async function fetchAllContributors(): Promise<Contributor[] | null> {
 	const result = await client.fetch(allContributorsQuery);
 
 	if (!result) {
-		throw new Error('Could not fetch the list of contributors.');
+		return null;
 	}
 
 	return result.map((contributor) => ({

--- a/src/api/modules/contributor/contributor.service.ts
+++ b/src/api/modules/contributor/contributor.service.ts
@@ -1,6 +1,13 @@
 import { Contributor } from '@models/contributor.model';
 import { fetchAllContributors } from './contributor.repository';
+import { NotFoundError } from '../../exceptions/exceptions';
 
 export async function getAllContributors(): Promise<Contributor[]> {
-	return fetchAllContributors();
+	const contributors = await fetchAllContributors();
+
+	if (!contributors) {
+		throw new NotFoundError('Could not fetch the list of contributors.');
+	}
+
+	return contributors;
 }

--- a/src/api/modules/story/story.repository.ts
+++ b/src/api/modules/story/story.repository.ts
@@ -15,6 +15,7 @@ export async function fetchStoryBySlug(slug: string) {
 	try {
 		return await client.fetch(storyBySlugQuery, { slug });
 	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }
@@ -23,6 +24,7 @@ export async function fetchStoriesByAuthorSlug(slug: string, start: number, end:
 	try {
 		return await client.fetch(storiesByAuthorSlugQuery, { slug, start, end });
 	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }
@@ -31,6 +33,7 @@ export async function fetchNavigationTeasersByAuthorSlug(slug: string, start: nu
 	try {
 		return await client.fetch(storyNavigationTeasersByAuthorSlugQuery, { slug, start, end });
 	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }
@@ -39,6 +42,7 @@ export async function fetchStoriesBySlugs(slugs: string[]) {
 	try {
 		return await client.fetch(storiesBySlugsQuery, { slugs });
 	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }
@@ -47,6 +51,7 @@ export async function fetchStories(start: number, end: number) {
 	try {
 		return await client.fetch(allStoriesQuery, { start, end });
 	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }

--- a/src/api/modules/story/story.repository.ts
+++ b/src/api/modules/story/story.repository.ts
@@ -1,4 +1,5 @@
 // Sanity
+import { InternalError } from '../../exceptions/exceptions';
 import { client } from '../../_helpers/sanity-connector';
 
 // Queries
@@ -11,21 +12,41 @@ import {
 } from '../../_queries/story.query';
 
 export async function fetchStoryBySlug(slug: string) {
-	return client.fetch(storyBySlugQuery, { slug });
+	try {
+		return await client.fetch(storyBySlugQuery, { slug });
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }
 
 export async function fetchStoriesByAuthorSlug(slug: string, start: number, end: number) {
-	return client.fetch(storiesByAuthorSlugQuery, { slug, start, end });
+	try {
+		return await client.fetch(storiesByAuthorSlugQuery, { slug, start, end });
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }
 
 export async function fetchNavigationTeasersByAuthorSlug(slug: string, start: number, end: number) {
-	return client.fetch(storyNavigationTeasersByAuthorSlugQuery, { slug, start, end });
+	try {
+		return await client.fetch(storyNavigationTeasersByAuthorSlugQuery, { slug, start, end });
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }
 
 export async function fetchStoriesBySlugs(slugs: string[]) {
-	return client.fetch(storiesBySlugsQuery, { slugs });
+	try {
+		return await client.fetch(storiesBySlugsQuery, { slugs });
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }
 
 export async function fetchStories(start: number, end: number) {
-	return client.fetch(allStoriesQuery, { start, end });
+	try {
+		return await client.fetch(allStoriesQuery, { start, end });
+	} catch (err) {
+		throw new InternalError('Internal server error');
+	}
 }

--- a/src/api/modules/storylist/storylist.repository.ts
+++ b/src/api/modules/storylist/storylist.repository.ts
@@ -15,7 +15,8 @@ import { InternalError } from '../../exceptions/exceptions';
 export async function fetchAllStorylistTeasers(): Promise<StorylistTeasersQueryResult> {
 	try {
 		return await client.fetch(storylistTeasersQuery);
-	} catch {
+	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }
@@ -23,7 +24,8 @@ export async function fetchAllStorylistTeasers(): Promise<StorylistTeasersQueryR
 export async function fetchStorylistBySlug(slug: string): Promise<StorylistQueryResult> {
 	try {
 		return await client.fetch(storylistQuery, { slug });
-	} catch {
+	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }
@@ -39,7 +41,8 @@ export async function fetchStorylistNavigationTeaserByStorylistSlug(
 ): Promise<StorylistNavigationTeasersQueryResult> {
 	try {
 		return await client.fetch(storylistNavigationTeasersQuery, params);
-	} catch {
+	} catch (err) {
+		console.error('Internal server error: ', err);
 		throw new InternalError('Internal server error');
 	}
 }

--- a/src/api/modules/storylist/storylist.repository.ts
+++ b/src/api/modules/storylist/storylist.repository.ts
@@ -9,12 +9,23 @@ import {
 	StorylistTeasersQueryResult,
 } from '../../sanity/types';
 
+// Excepciones
+import { InternalError } from '../../exceptions/exceptions';
+
 export async function fetchAllStorylistTeasers(): Promise<StorylistTeasersQueryResult> {
-	return client.fetch(storylistTeasersQuery);
+	try {
+		return await client.fetch(storylistTeasersQuery);
+	} catch {
+		throw new InternalError('Internal server error');
+	}
 }
 
 export async function fetchStorylistBySlug(slug: string): Promise<StorylistQueryResult> {
-	return client.fetch(storylistQuery, { slug });
+	try {
+		return await client.fetch(storylistQuery, { slug });
+	} catch {
+		throw new InternalError('Internal server error');
+	}
 }
 
 type FetchStorylistNavigationTeasersByStorylistSlugParams = {
@@ -22,8 +33,13 @@ type FetchStorylistNavigationTeasersByStorylistSlugParams = {
 	start: number;
 	end: number;
 };
+
 export async function fetchStorylistNavigationTeaserByStorylistSlug(
 	params: FetchStorylistNavigationTeasersByStorylistSlugParams,
 ): Promise<StorylistNavigationTeasersQueryResult> {
-	return client.fetch(storylistNavigationTeasersQuery, params);
+	try {
+		return await client.fetch(storylistNavigationTeasersQuery, params);
+	} catch {
+		throw new InternalError('Internal server error');
+	}
 }

--- a/src/api/modules/storylist/storylist.service.ts
+++ b/src/api/modules/storylist/storylist.service.ts
@@ -12,6 +12,9 @@ import {
 	fetchStorylistNavigationTeaserByStorylistSlug,
 } from './storylist.repository';
 
+// Excepciones
+import { NotFoundError } from '../../exceptions/exceptions';
+
 export async function getAllStorylistTeasers(): Promise<StorylistTeaser[]> {
 	const result = await fetchAllStorylistTeasers();
 	return mapStorylistTeasers(result);
@@ -21,7 +24,7 @@ export async function getStorylistBySlug(args: StoryListBySlugArgs): Promise<Sto
 	const result = await fetchStorylistBySlug(args.slug);
 
 	if (!result) {
-		throw new Error(`Storylist with slug ${args.slug} not found`);
+		throw new NotFoundError(`Storylist with slug ${args.slug} not found`);
 	}
 
 	return mapStorylist(result);
@@ -39,7 +42,7 @@ export async function getStorylistNavigationTeasersByStorylistSlug(args: {
 	});
 
 	if (!result) {
-		throw new Error(`Storylist with slug ${args.slug} not found`);
+		throw new NotFoundError(`Storylist with slug ${args.slug} not found`);
 	}
 
 	return mapStorylistNavigationTeasers(result);

--- a/src/app/components/space-recording-widget/space-recording-widget.component.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.component.ts
@@ -44,7 +44,11 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 		}
 
 		.spaces-card {
-			background-image: linear-gradient(60deg, hsl(230, 100 * 1%, 50 * 1%) -15%, hsl(260, 100 * 1%, 60 * 1%) 100%);
+			background-image: linear-gradient(
+				60deg,
+				hsl(230, calc(100 * 1%), calc(50 * 1%)) -15%,
+				hsl(260, calc(100 * 1%), calc(60 * 1%)) 100%
+			);
 		}
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/components/space-recording-widget/space-recording-widget.component.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.component.ts
@@ -44,11 +44,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 		}
 
 		.spaces-card {
-			background-image: linear-gradient(
-				60deg,
-				hsl(230, calc(100 * 1%), calc(50 * 1%)) -15%,
-				hsl(260, calc(100 * 1%), calc(60 * 1%)) 100%
-			);
+			background-image: linear-gradient(60deg, hsl(230, 100%, 50%) -15%, hsl(260, 100%, 60%) 100%);
 		}
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/directives/meta-tags.directive.spec.ts
+++ b/src/app/directives/meta-tags.directive.spec.ts
@@ -77,14 +77,16 @@ describe('MetaTagsDirective', () => {
 	});
 
 	describe('setDefault', () => {
-		it('should set default title and description', () => {
+		it('should set default title, description and keywords', () => {
 			const setTitleSpy = jest.spyOn(directive, 'setTitle');
 			const setDefaultDescriptionSpy = jest.spyOn(directive, 'setDefaultDescription');
+			const setDefaultKeywordsSpy = jest.spyOn(directive, 'setDefaultKeywords');
 
 			directive.setDefault();
 
 			expect(setTitleSpy).toHaveBeenCalledWith('La Cuentoneta', false);
 			expect(setDefaultDescriptionSpy).toHaveBeenCalled();
+			expect(setDefaultKeywordsSpy).toHaveBeenCalled();
 		});
 	});
 
@@ -97,6 +99,16 @@ describe('MetaTagsDirective', () => {
 			expect(setDescriptionSpy).toHaveBeenCalledWith(
 				'Una iniciativa que busca fomentar y hacer accesible la lectura digital.',
 			);
+		});
+	});
+
+	describe('setDefaultKeywords', () => {
+		it('should set default keywords', () => {
+			const setKeywordsSpy = jest.spyOn(directive, 'setKeywords');
+
+			directive.setDefaultKeywords();
+
+			expect(setKeywordsSpy).toHaveBeenCalledWith(['cuentos', 'literatura', 'poemas', 'podcast', 'narraciones']);
 		});
 	});
 

--- a/src/app/directives/meta-tags.directive.ts
+++ b/src/app/directives/meta-tags.directive.ts
@@ -56,10 +56,15 @@ export class MetaTagsDirective implements OnDestroy {
 	setDefault() {
 		this.setTitle('La Cuentoneta', false);
 		this.setDefaultDescription();
+		this.setDefaultKeywords();
 	}
 
 	setDefaultDescription() {
 		this.setDescription('Una iniciativa que busca fomentar y hacer accesible la lectura digital.');
+	}
+
+	setDefaultKeywords() {
+		this.setKeywords(['cuentos', 'literatura', 'poemas', 'podcast', 'narraciones']);
 	}
 
 	setCanonicalUrl(url: string) {

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -130,6 +130,7 @@ import { InitialsPipe } from '../../pipes/initials.pipe';
 										<cuentoneta-portable-text-parser
 											[paragraphs]="author.biography"
 											[classes]="'source-serif-pro-body-xl leading-8'"
+											class="flex flex-col gap-4"
 										/>
 										@if (author.resources && author.resources.length > 0) {
 											<hr class="text-gray-500" />


### PR DESCRIPTION
- Se agregaron excepciones a las capas de repositorios y servicios.
- Se envolvieron los repositorios en bloques 'try/catch' para poder lanzar 'InternalError'.
- Se creó el archivo 'exceptions.ts' y se cambió el uso de 'Error' a 'NotFoundError' en donde aplica. 
- Se cambiaron algunos repositorios para que devuelvan 'null' cuando Sanity no encuentra datos para que sea consistente el hecho de que los servicios sean los que lanzan excepciones que no sean HTTP (500)
Closes #1426 