### PR TITLE
[#1466] - Actualizar layout y tamaños para pantallas desktop

### DIFF
--- a/src/app/components/carousel/carousel-skeleton.component.ts
+++ b/src/app/components/carousel/carousel-skeleton.component.ts
@@ -7,7 +7,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 @Component({
 	selector: 'cuentoneta-carousel-skeleton',
 	imports: [NgxSkeletonLoaderModule],
-	template: ` <div class="mx-auto max-w-lg">
+	template: ` <div class="mx-auto">
 		<div class="slider">
 			<ngx-skeleton-loader
 				[theme]="{

--- a/src/app/components/carousel/carousel-skeleton.component.ts
+++ b/src/app/components/carousel/carousel-skeleton.component.ts
@@ -7,7 +7,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 @Component({
 	selector: 'cuentoneta-carousel-skeleton',
 	imports: [NgxSkeletonLoaderModule],
-	template: ` <div class="mx-auto max-w-[960px]">
+	template: ` <div class="mx-auto max-w-lg">
 		<div class="slider">
 			<ngx-skeleton-loader
 				[theme]="{
@@ -19,7 +19,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 				}"
 				count="1"
 				appearance="line"
-				class="carousel-image-skeleton grid aspect-[540/220] w-full object-cover md:aspect-[960/280]"
+				class="carousel-image-skeleton grid aspect-[540/220] w-full object-cover md:aspect-[1240/360]"
 			/>
 		</div>
 	</div>`,

--- a/src/app/components/carousel/carousel.component.css
+++ b/src/app/components/carousel/carousel.component.css
@@ -1,10 +1,10 @@
 :host {
-	@apply mx-auto block max-w-[960px];
+	@apply mx-auto block max-w-lg;
 }
 
 .carousel-container {
 	@apply relative overflow-hidden rounded-xl;
-	@apply aspect-[540/220] sm:aspect-[960/280];
+	@apply aspect-[540/220] sm:aspect-[1240/360];
 	@apply outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2;
 }
 

--- a/src/app/components/carousel/carousel.component.css
+++ b/src/app/components/carousel/carousel.component.css
@@ -1,5 +1,5 @@
 :host {
-	@apply mx-auto block max-w-lg;
+	@apply mx-auto block;
 }
 
 .carousel-container {

--- a/src/app/components/carousel/carousel.component.stories.ts
+++ b/src/app/components/carousel/carousel.component.stories.ts
@@ -220,7 +220,7 @@ export const DesktopAndMobile: Story = {
 				<!-- Desktop View -->
 				<div>
 					<h3 class="text-lg font-semibold text-neutral-700 mb-3">Desktop (960px)</h3>
-					<div style="width: 960px; max-width: 100%; justify-self: center;">
+					<div style="width: 1240px; max-width: 100%; justify-self: center;">
 						<cuentoneta-carousel [slides]="slides" [transitionDuration]="transitionDuration" />
 					</div>
 				</div>

--- a/src/app/mocks/content-campaign.mock.ts
+++ b/src/app/mocks/content-campaign.mock.ts
@@ -39,9 +39,9 @@ export const contentCampaignMock: ContentCampaign[] = [
 			},
 			md: {
 				imageUrl:
-					'https://cdn.sanity.io/images/s4dbqkc5/development/ec31c09f54fe53f4de213075d2e73e61805fbf4f-960x280.jpg',
-				imageWidth: 960,
-				imageHeight: 280,
+					'https://cdn.sanity.io/images/s4dbqkc5/development/ec31c09f54fe53f4de213075d2e73e61805fbf4f-1240x360.jpg',
+				imageWidth: 1240,
+				imageHeight: 360,
 			},
 		},
 		title: 'Pluma de la Semana #1: Alejandro Dolina',

--- a/src/app/models/content-campaign.model.ts
+++ b/src/app/models/content-campaign.model.ts
@@ -16,9 +16,17 @@ export const viewportElementSizes = Object.freeze({
 		imageWidth: 540,
 		imageHeight: 220,
 	},
+	sm: {
+		imageWidth: 1240,
+		imageHeight: 360,
+	},
 	md: {
-		imageWidth: 960,
-		imageHeight: 280,
+		imageWidth: 1240,
+		imageHeight: 360,
+	},
+	lg: {
+		imageWidth: 1240,
+		imageHeight: 360,
 	},
 });
 

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -3,7 +3,7 @@
         Las alturas fijadas para los elementos hijos de <main> tienen la finalidad de evitar
         el rebote vertical que puede observarse en el momento de la carga inicial de la página
     -->
-	<section class="mb-8 aspect-[540/220] sm:aspect-[960/280]">
+	<section class="mb-8 aspect-[540/220] sm:aspect-[1240/360]">
 		@defer (when campaigns().length > 0) {
 			<cuentoneta-carousel [slides]="campaigns()" />
 		} @loading (minimum 500ms) {

--- a/src/app/utils/screen.utils.ts
+++ b/src/app/utils/screen.utils.ts
@@ -5,7 +5,7 @@ export const VIEWPORT_WIDTHS_NUMERIC: Record<Viewport, number> = {
 	xs: 0,
 	sm: 768,
 	md: 960,
-	lg: 1280,
+	lg: 1240,
 	xl: 1536,
 };
 
@@ -13,6 +13,6 @@ export const VIEWPORT_WIDTHS_PX: Record<Viewport, string> = {
 	xs: '0px',
 	sm: '768px',
 	md: '960px',
-	lg: '1280px',
+	lg: '1240px',
 	xl: '1536px',
 };

--- a/src/assets/css/layout.css
+++ b/src/assets/css/layout.css
@@ -1,5 +1,5 @@
 .content {
-	@apply my-0 min-h-screen max-w-screen-lg md:m-auto;
+	@apply my-0 min-h-screen max-w-screen-lg lg:m-auto;
 }
 
 .vertical-layout-spacing {

--- a/src/assets/css/layout.css
+++ b/src/assets/css/layout.css
@@ -1,5 +1,5 @@
 .content {
-	@apply my-0 min-h-screen md:m-auto md:max-w-screen-md;
+	@apply my-0 min-h-screen max-w-screen-lg md:m-auto;
 }
 
 .vertical-layout-spacing {

--- a/src/assets/css/layout.css
+++ b/src/assets/css/layout.css
@@ -7,5 +7,5 @@
 }
 
 .horizontal-layout-spacing {
-	@apply mx-5 md:mx-auto;
+	@apply mx-5 lg:mx-auto;
 }

--- a/src/assets/css/theme.css
+++ b/src/assets/css/theme.css
@@ -1,5 +1,5 @@
 body {
-	@apply bg-neutral-100 font-source-serif;
+	@apply bg-white font-source-serif;
 }
 
 h1,


### PR DESCRIPTION
## Resumen
Esta PR actualiza el layout y tamaños de los componentes para pantallas desktop, ajustando el breakpoint `lg` a 1240px y actualizando los aspect ratios del carousel para una mejor presentación visual.

### Cambios principales
- Actualiza el color de fondo del body de `bg-neutral-100` a `bg-white`.
- Redefine el viewport `lg` de 1280px a 1240px en `screen.utils.ts`.
- Actualiza el ancho máximo del contenido para utilizar `max-w-screen-lg` en lugar de `md:max-w-screen-md`.
- Modifica el aspect ratio del carousel de `960/280` a `1240/360` para viewports `sm+`.
- Agrega definiciones de tamaño para viewports `sm` y `lg` en `viewportElementSizes`.
- Ajusta los márgenes horizontales para aplicar `mx-auto` a partir del breakpoint `lg`.

Closes #1466