### PR TITLE
[#1478] - Habilitar fechas a.C. en perfiles de autor

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -22,7 +22,7 @@
 		"@sanity/icons": "^3.4.0",
 		"@sanity/import": "^6.0.1",
 		"@sanity/vision": "^5.19.0",
-		"dayjs": "^1.11.20",
+		"date-fns": "^4.1.0",
 		"prop-types": "^15.8.1",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",

--- a/cms/pnpm-lock.yaml
+++ b/cms/pnpm-lock.yaml
@@ -22,9 +22,9 @@ importers:
       '@sanity/vision':
         specifier: ^5.19.0
         version: 5.19.0(@babel/runtime@7.29.2)(@codemirror/lint@6.8.5)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.19.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@22.15.33)(jiti@2.6.1)(yaml@2.8.3))(@types/node@22.15.33)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-toolbelt@9.6.0)(typescript@5.8.3))(styled-components@6.3.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      dayjs:
-        specifier: ^1.11.20
-        version: 1.11.20
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -3126,10 +3126,6 @@ packages:
   date-fns@4.1.0:
     resolution:
       { integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg== }
-
-  dayjs@1.11.20:
-    resolution:
-      { integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ== }
 
   debounce@1.2.1:
     resolution:
@@ -8895,8 +8891,6 @@ snapshots:
   dataloader@2.2.3: {}
 
   date-fns@4.1.0: {}
-
-  dayjs@1.11.20: {}
 
   debounce@1.2.1: {}
 

--- a/cms/schemas/author.ts
+++ b/cms/schemas/author.ts
@@ -62,7 +62,7 @@ export default defineType({
 			title: 'Fecha de nacimiento',
 			type: 'string',
 			description:
-				'Formato: YYYY-MM-DD. Para fechas a.C., usar guión inicial (ej: -0043-03-20 para 20 de marzo de 43 a.C.).',
+				'Formato: YYYY-MM-DD para d.C. y -YYYY-MM-DD para a.C. (ej: -0043-03-20 = 20 de marzo de 43 a.C.). Se utiliza numeración histórica: -43 representa 43 a.C. (no se aplica el corrimiento astronómico de ISO-8601).',
 			validation: (Rule) => Rule.custom(validateHistoricalDate),
 		}),
 		defineField({
@@ -84,7 +84,7 @@ export default defineType({
 			title: 'Fecha de fallecimiento',
 			type: 'string',
 			description:
-				'Formato: YYYY-MM-DD. Para fechas a.C., usar guión inicial (ej: -0043-03-20 para 20 de marzo de 43 a.C.).',
+				'Formato: YYYY-MM-DD para d.C. y -YYYY-MM-DD para a.C. (ej: -0043-03-20 = 20 de marzo de 43 a.C.). Se utiliza numeración histórica: -43 representa 43 a.C. (no se aplica el corrimiento astronómico de ISO-8601).',
 			validation: (Rule) => Rule.custom(validateHistoricalDate),
 		}),
 		defineField({

--- a/cms/schemas/author.ts
+++ b/cms/schemas/author.ts
@@ -1,6 +1,7 @@
 import { UsersIcon } from '@sanity/icons';
 import { resource } from './resourceType';
 import { defineArrayMember, defineField, defineType } from 'sanity';
+import { validateHistoricalDate } from '../utils/validations';
 
 const defaultAuthorImage = {
 	asset: {
@@ -8,6 +9,14 @@ const defaultAuthorImage = {
 		_ref: 'image-76250a3cd5acc91a1013e2acd1f97df69b33825c-360x360-jpg',
 	},
 };
+
+const reduceHistoricalYear =
+	<K extends string>(fieldName: K) =>
+	(result: { draft?: Record<K, string>; published: Record<K, string> }) => {
+		const value = result.draft?.[fieldName] || result.published?.[fieldName];
+		const match = value && /^(-?\d{4})-/.exec(value);
+		return match ? parseInt(match[1], 10) : null;
+	};
 
 export default defineType({
 	name: 'author',
@@ -51,55 +60,45 @@ export default defineType({
 		defineField({
 			name: 'bornOn',
 			title: 'Fecha de nacimiento',
-			type: 'date',
-			options: {
-				dateFormat: 'YYYY-MM-DD',
-			},
+			type: 'string',
+			description:
+				'Formato: YYYY-MM-DD. Para fechas a.C., usar guión inicial (ej: -0043-03-20 para 20 de marzo de 43 a.C.).',
+			validation: (Rule) => Rule.custom(validateHistoricalDate),
 		}),
 		defineField({
 			name: 'bornOnYear',
 			title: 'Año de nacimiento',
 			type: 'computedNumber',
-			description: 'Se calcula automáticamente desde la fecha completa. Ingrese manualmente si solo conoce el año.',
-			validation: (Rule) => Rule.min(500).max(2100).integer(),
+			description:
+				'Se calcula automáticamente desde la fecha completa. Ingrese manualmente si solo conoce el año (use valores negativos para a.C.).',
+			validation: (Rule) => Rule.min(-3000).max(2100).integer(),
 			readOnly: ({ document }) => !!document?.bornOn,
 			options: {
 				buttonText: 'Recalcular desde fecha',
 				documentQuerySelection: `_id, _type, bornOn`,
-				reduceQueryResult: (result: { draft?: { bornOn: string }; published: { bornOn: string } }) => {
-					const bornOn = result.draft?.bornOn || result.published?.bornOn;
-					if (bornOn) {
-						return parseInt(bornOn.split('-')[0]);
-					}
-					return null;
-				},
+				reduceQueryResult: reduceHistoricalYear('bornOn'),
 			},
 		}),
 		defineField({
 			name: 'diedOn',
 			title: 'Fecha de fallecimiento',
-			type: 'date',
-			options: {
-				dateFormat: 'YYYY-MM-DD',
-			},
+			type: 'string',
+			description:
+				'Formato: YYYY-MM-DD. Para fechas a.C., usar guión inicial (ej: -0043-03-20 para 20 de marzo de 43 a.C.).',
+			validation: (Rule) => Rule.custom(validateHistoricalDate),
 		}),
 		defineField({
 			name: 'diedOnYear',
 			title: 'Año de fallecimiento',
 			type: 'computedNumber',
-			description: 'Se calcula automáticamente desde la fecha completa. Ingrese manualmente si solo conoce el año.',
-			validation: (Rule) => Rule.min(500).max(2100).integer(),
+			description:
+				'Se calcula automáticamente desde la fecha completa. Ingrese manualmente si solo conoce el año (use valores negativos para a.C.).',
+			validation: (Rule) => Rule.min(-3000).max(2100).integer(),
 			readOnly: ({ document }) => !!document?.diedOn,
 			options: {
 				buttonText: 'Recalcular desde fecha',
 				documentQuerySelection: `_id, _type, diedOn`,
-				reduceQueryResult: (result: { draft?: { diedOn: string }; published: { diedOn: string } }) => {
-					const diedOn = result.draft?.diedOn || result.published?.diedOn;
-					if (diedOn) {
-						return parseInt(diedOn.split('-')[0]);
-					}
-					return null;
-				},
+				reduceQueryResult: reduceHistoricalYear('diedOn'),
 			},
 		}),
 		defineField({

--- a/cms/utils/validations.ts
+++ b/cms/utils/validations.ts
@@ -1,4 +1,16 @@
+import { isValid, parseISO } from 'date-fns';
+
 export const localizedRequire = (value) => {
 	if (!value) return 'Este campo es requerido';
 	return true;
 };
+
+export function validateHistoricalDate(value?: string): true | string {
+	if (!value) return true;
+	const match = /^(-?)(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+	if (!match) return 'Formato inválido. Usar YYYY-MM-DD o -YYYY-MM-DD para fechas a.C.';
+	const [, sign, y, m, d] = match;
+	const iso = sign === '-' ? `-${y.padStart(6, '0')}-${m}-${d}` : `${y}-${m}-${d}`;
+	if (!isValid(parseISO(iso))) return 'Fecha calendario inválida.';
+	return true;
+}

--- a/cms/utils/validations.ts
+++ b/cms/utils/validations.ts
@@ -10,7 +10,10 @@ export function validateHistoricalDate(value?: string): true | string {
 	const match = /^(-?)(\d{4})-(\d{2})-(\d{2})$/.exec(value);
 	if (!match) return 'Formato inválido. Usar YYYY-MM-DD o -YYYY-MM-DD para fechas a.C.';
 	const [, sign, y, m, d] = match;
+	const year = parseInt(sign + y, 10);
+	if (year === 0) return 'No existe el año 0 en numeración histórica (1 a.C. precede a 1 d.C.).';
+	if (year < -3000 || year > 2100) return 'Año fuera de rango admitido (-3000 a 2100).';
 	const iso = sign === '-' ? `-${y.padStart(6, '0')}-${m}-${d}` : `${y}-${m}-${d}`;
-	if (!isValid(parseISO(iso))) return 'Fecha calendario inválida.';
+	if (!isValid(parseISO(iso))) return 'Fecha calendario inválida (revisar día y mes para el año indicado).';
 	return true;
 }

--- a/src/api/sanity/types.ts
+++ b/src/api/sanity/types.ts
@@ -12,6 +12,8 @@
  * ---------------------------------------------------------------------------------
  */
 
+export declare const internalGroqTypeReferenceTo: unique symbol;
+
 // Source: schema.json
 export type StoryReference = {
 	_ref: string;
@@ -567,9 +569,7 @@ export type AllSanitySchemaTypes =
 	| SanityImageAsset
 	| Geopoint;
 
-export declare const internalGroqTypeReferenceTo: unique symbol;
-
-// Source: ..\src\api\_queries\author.query.ts
+// Source: ../src/api/_queries/author.query.ts
 // Variable: authorBySlugQuery
 // Query: *[_type == 'author' && slug.current == $slug && !(_id in path('drafts.**'))][0]{    _id,    'slug': slug.current,    name,    image,    nationality->,    biography,    bornOn,		bornOnYear,    diedOn,		diedOnYear,    'resources': coalesce(resources[]{        title,        url,        resourceType->{        	'slug': slug.current,        	title,        	shortDescription,        	description,            icon        }    }, [])}
 export type AuthorBySlugQueryResult = {
@@ -618,7 +618,7 @@ export type AuthorBySlugQueryResult = {
 		| Array<never>;
 } | null;
 
-// Source: ..\src\api\_queries\author.query.ts
+// Source: ../src/api/_queries/author.query.ts
 // Variable: authorsQuery
 // Query: *[_type == 'author' && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    name,    image,    nationality->,    'biography': [],    bornOn, 		bornOnYear,    diedOn,    diedOnYear,    'resources': []}|order(name asc)
 export type AuthorsQueryResult = Array<{
@@ -655,7 +655,7 @@ export type AuthorsQueryResult = Array<{
 	resources: Array<never>;
 }>;
 
-// Source: ..\src\api\_queries\content.query.ts
+// Source: ../src/api/_queries/content.query.ts
 // Variable: rotatingContentQuery
 // Query: *[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{    _id,    name,    'mostRead': coalesce(mostRead[]->{        _id,        'slug': slug.current,        title,        badLanguage,        'body': [],        originalPublication,        approximateReadingTime,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {            _id,            'slug': slug.current,            name,            image,            nationality->,            'biography': [],						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[])}
 export type RotatingContentQueryResult = {
@@ -742,7 +742,7 @@ export type RotatingContentQueryResult = {
 		| Array<never>;
 } | null;
 
-// Source: ..\src\api\_queries\content.query.ts
+// Source: ../src/api/_queries/content.query.ts
 // Variable: landingPageListQuery
 // Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current in $slugs]{		_id,		'slug': slug.current,		config,}
 export type LandingPageListQueryResult = Array<{
@@ -751,7 +751,7 @@ export type LandingPageListQueryResult = Array<{
 	config: string;
 }>;
 
-// Source: ..\src\api\_queries\content.query.ts
+// Source: ../src/api/_queries/content.query.ts
 // Variable: latestLandingPageReferencesQuery
 // Query: *[_type == 'landingPage' && !(_id in path('drafts.**'))]{    _id,    _type,    'slug': slug.current,    config,    'cards': coalesce(cards[],[]),    'campaigns': coalesce(campaigns[],[]),    'latestReads': coalesce(latestReads,[]),} | order(_createdAt desc)[0]
 export type LatestLandingPageReferencesQueryResult = {
@@ -782,7 +782,7 @@ export type LatestLandingPageReferencesQueryResult = {
 		| Array<never>;
 } | null;
 
-// Source: ..\src\api\_queries\content.query.ts
+// Source: ../src/api/_queries/content.query.ts
 // Variable: landingPageContentQuery
 // Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{    _id,    'slug': slug.current,    config,    'cards': coalesce(cards[]->{        _id,        title,        'slug': slug.current,        description,        featuredImage,        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            shortDescription,            description,            icon        }, []),        'stories': [],        'count': coalesce(count(stories), 0),				config,				'tabs': [],	      'mediaSources': coalesce(mediaSources[], []),    },[]),    'campaigns': coalesce(campaigns[]->{        _id,        'title': coalesce(title, ''),        'slug': coalesce(slug.current, ''),        'description': coalesce(description, []),        'url': coalesce(url, ''),        'contents': {            'xs': {                'title': coalesce(contents.xs.title, []),                'subtitle': coalesce(contents.xs.subtitle, []),                'image': contents.xs.image            },            'md': {                'title': coalesce(contents.md.title, []),                'subtitle': coalesce(contents.md.subtitle, []),                'image': contents.md.image            }        }    },[]),    'latestReads': coalesce(latestReads[]->{        _id,        'slug': slug.current,        title,        badLanguage,        'body': [],        originalPublication,        approximateReadingTime,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {             _id,            'slug': slug.current,            name,            image,            nationality->,            'biography': [],						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[]),}
 export type LandingPageContentQueryResult = {
@@ -967,7 +967,7 @@ export type LandingPageContentQueryResult = {
 		| Array<never>;
 } | null;
 
-// Source: ..\src\api\_queries\contributor.query.ts
+// Source: ../src/api/_queries/contributor.query.ts
 // Variable: allContributorsQuery
 // Query: *[_type == 'contributor' && !(_id in path('drafts.**'))]{	name,	'slug': slug.current,	area,	link {		handle,		url	},	notes}|order(name asc)
 export type AllContributorsQueryResult = Array<{
@@ -981,7 +981,7 @@ export type AllContributorsQueryResult = Array<{
 	notes: string | null;
 }>;
 
-// Source: ..\src\api\_queries\sitemap.query.ts
+// Source: ../src/api/_queries/sitemap.query.ts
 // Variable: sitemapSlugsQuery
 // Query: {	"stories": *[_type == "story" && !(_id in path('drafts.**'))]{ "slug": slug.current, "lastmod": _updatedAt },	"authors": *[_type == "author" && !(_id in path('drafts.**'))]{ "slug": slug.current, "lastmod": _updatedAt },	"storylists": *[_type == "storylist" && !(_id in path('drafts.**'))]{ "slug": slug.current, "lastmod": _updatedAt }}
 export type SitemapSlugsQueryResult = {
@@ -999,7 +999,7 @@ export type SitemapSlugsQueryResult = {
 	}>;
 };
 
-// Source: ..\src\api\_queries\story.query.ts
+// Source: ../src/api/_queries/story.query.ts
 // Variable: storiesByAuthorSlugQuery
 // Query: *[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))][$start...$end]{    _id,    'slug': slug.current,    title,    'badLanguage': coalesce(badLanguage, false),    'body': coalesce(body[0...3], []),    'originalPublication': coalesce(originalPublication, ''),    approximateReadingTime,    'mediaSources': coalesce(mediaSources[], []),    'resources': coalesce(resources[]{         title,         url,         resourceType->{            'slug': slug.current,            title,             shortDescription,            description,             icon        }     }, []),}|order(title asc)
 export type StoriesByAuthorSlugQueryResult = Array<{
@@ -1088,7 +1088,7 @@ export type StoriesByAuthorSlugQueryResult = Array<{
 		| Array<never>;
 }>;
 
-// Source: ..\src\api\_queries\story.query.ts
+// Source: ../src/api/_queries/story.query.ts
 // Variable: storyNavigationTeasersByAuthorSlugQuery
 // Query: *[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    'badLanguage': coalesce(badLanguage, false),    'body': [],    'originalPublication': coalesce(originalPublication, ''),    approximateReadingTime,    'mediaSources': coalesce(mediaSources[], []),    'resources': [],}|order(title asc)[$start...$end]
 export type StoryNavigationTeasersByAuthorSlugQueryResult = Array<{
@@ -1136,7 +1136,7 @@ export type StoryNavigationTeasersByAuthorSlugQueryResult = Array<{
 	resources: Array<never>;
 }>;
 
-// Source: ..\src\api\_queries\story.query.ts
+// Source: ../src/api/_queries/story.query.ts
 // Variable: storyBySlugQuery
 // Query: *[_type == 'story' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,     'badLanguage': coalesce(badLanguage, false),    'epigraphs': coalesce(epigraphs[]{        text,        'reference': coalesce(reference[], [])    }, []),    'body': coalesce(body, []),    'review': coalesce(review, []),    'originalPublication': coalesce(originalPublication, ''),    approximateReadingTime,    'mediaSources': coalesce(mediaSources[], []),    'resources': coalesce(resources[]{        title,         url,         resourceType->{            'slug': slug.current,            title,             shortDescription,            description,            icon        }    }, []),    'author': author-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{             title,             url,             resourceType->{                'slug': slug.current,                title,                 shortDescription,                description,                 icon            }         }, [])    }}[0]
 export type StoryBySlugQueryResult = {
@@ -1277,7 +1277,7 @@ export type StoryBySlugQueryResult = {
 	};
 } | null;
 
-// Source: ..\src\api\_queries\story.query.ts
+// Source: ../src/api/_queries/story.query.ts
 // Variable: storiesBySlugsQuery
 // Query: *[_type == 'story' && slug.current in $slugs && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    'badLanguage': coalesce(badLanguage, false),    'epigraphs': [],    'body': [],    'review': [],    'originalPublication': coalesce(originalPublication, ''),    approximateReadingTime,    'mediaSources': coalesce(mediaSources[], []),    'resources': [],    'author': author-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        'biography': [],        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': []    }}
 export type StoriesBySlugsQueryResult = Array<{
@@ -1360,7 +1360,7 @@ export type StoriesBySlugsQueryResult = Array<{
 	};
 }>;
 
-// Source: ..\src\api\_queries\story.query.ts
+// Source: ../src/api/_queries/story.query.ts
 // Variable: allStoriesQuery
 // Query: *[_type == 'story' && !(_id in path('drafts.**'))][$start...$end]{    _id,    'slug': slug.current,    title,    'badLanguage': coalesce(badLanguage, false),    'body': [],    'review': [],    'originalPublication': coalesce(originalPublication, ''),    approximateReadingTime,    'mediaSources': coalesce(mediaSources[], []),    'resources': [],    'author': author-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        'biography': [],        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': []    }}|order(title asc)
 export type AllStoriesQueryResult = Array<{
@@ -1442,7 +1442,7 @@ export type AllStoriesQueryResult = Array<{
 	};
 }>;
 
-// Source: ..\src\api\_queries\storylist.query.ts
+// Source: ../src/api/_queries/storylist.query.ts
 // Variable: storylistTeasersQuery
 // Query: *[_type == 'storylist' && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    description,    featuredImage,    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription,        description,        icon    }, []),    'stories': [],    'count': coalesce(count(stories), 0),    config,    'tabs': [],		'mediaSources': coalesce(mediaSources[], []),    }
 export type StorylistTeasersQueryResult = Array<{
@@ -1508,7 +1508,7 @@ export type StorylistTeasersQueryResult = Array<{
 		  >;
 }>;
 
-// Source: ..\src\api\_queries\storylist.query.ts
+// Source: ../src/api/_queries/storylist.query.ts
 // Variable: storylistStoriesNavigationTeasersQuery
 // Query: *[_type == 'storylist' && slug.current == $slug && !(_id in path('drafts.**'))][0]{		_id,    'slug': slug.current,    title,    description,    featuredImage,    'tags': [],    'stories': coalesce(stories[$start...$end]->{    		_id,        'slug': slug.current,        title,        badLanguage,        'body': [],        originalPublication,        approximateReadingTime,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author->{            _id,            'slug': slug.current,            name,            image,            nationality->,            'biography': [],						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    }, []),    'count': coalesce(count(stories), 0),    config,    'tabs': [],		'mediaSources': [],    }
 export type StorylistStoriesNavigationTeasersQueryResult = {
@@ -1611,7 +1611,7 @@ export type StorylistStoriesNavigationTeasersQueryResult = {
 	mediaSources: Array<never>;
 } | null;
 
-// Source: ..\src\api\_queries\storylist.query.ts
+// Source: ../src/api/_queries/storylist.query.ts
 // Variable: storylistQuery
 // Query: *[_type == 'storylist' && slug.current == $slug && !(_id in path('drafts.**'))][0]{    _id,    'slug': slug.current,    title,    description,    featuredImage,    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription,        description,        icon    }, []),    'stories': coalesce(stories[]->{        _id,        'slug': slug.current,        title,        badLanguage,        'body': coalesce(body[0...3], []),        originalPublication,        approximateReadingTime,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author->{            _id,            'slug': slug.current,            name,            image,            nationality->,            'biography': [],						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    }, []),    'count': coalesce(count(stories), 0),    config,    'tabs': coalesce(tabs[], []),		'mediaSources': coalesce(mediaSources[], []),    }
 export type StorylistQueryResult = {


### PR DESCRIPTION
## Resumen
Esta PR habilita el registro de fechas anteriores al año 1 d.C. en los perfiles de autor del CMS, permitiendo cargar autores clásicos como Ovidio (43 a.C. – 17 d.C.) sin necesidad de migrar datos existentes.

### Cambios principales
- Migra los campos `bornOn` y `diedOn` del esquema `author` de `type: 'date'` a `type: 'string'`, sumando un validador personalizado que admite formato `YYYY-MM-DD` para d.C. y `-YYYY-MM-DD` para a.C. (ej.: `-0043-03-20`).
- Implementa `validateHistoricalDate` en `cms/utils/validations.ts` apoyado en `parseISO`/`isValid` de `date-fns` para verificar validez calendario real (días por mes, años bisiestos en calendario gregoriano proléptico).
- Reemplaza `dayjs` (declarado como dependencia en `cms/` pero no utilizado en código fuente) por `date-fns@^4.1.0` en el proyecto de Sanity Studio.
- Relaja la validación de `bornOnYear` y `diedOnYear` a `Rule.min(-3000).max(2100).integer()` para admitir años negativos.
- Refactoriza el `reduceQueryResult` del botón "Recalcular desde fecha" en una fábrica genérica `reduceHistoricalYear<K>(fieldName)`, evitando duplicación entre los dos campos y extrayendo correctamente años negativos del string completo.
- Regenera `cms/schema.json` y `src/api/sanity/types.ts` vía `sanity typegen generate` para reflejar el cambio de tipo en los campos de fecha.

Closes #1478