### PR TITLE
[#1115] - Área de QA: guía para escribir un test plan + reorganización de docs/qa

### DIFF
--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -1,0 +1,51 @@
+<div align="center" width="100%">
+    <h1>La Cuentoneta</h1>
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://github.com/rolivencia/cuentoneta/assets/32349705/b0ea0659-3c9d-4c4f-9d14-ab60d50dd832">
+        <img width="33%" alt="La Cuentoneta" src="https://github.com/rolivencia/cuentoneta/assets/32349705/b0ea0659-3c9d-4c4f-9d14-ab60d50dd832">
+    </picture>
+</div>
+
+---
+
+# Área de QA
+
+Esta carpeta contiene la documentación de **aseguramiento de calidad (QA)** de La Cuentoneta: la guía para escribir test plans, las plantillas y un ejemplo práctico.
+
+En La Cuentoneta un test plan tiene un **doble propósito**: documenta las pruebas de QA **y** funciona como la **especificación que dirige el desarrollo de los tests automatizados** (unitarios, de integración y de regresión).
+
+## Documentos
+
+| Documento                                          | Para qué sirve                                                                   |
+| -------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [`TESTPLAN_GUIDE.md`](./TESTPLAN_GUIDE.md)         | **Empezá acá.** Cómo escribir un test plan: niveles, granularidad, trazabilidad. |
+| [`TEST_PLAN_TEMPLATE.md`](./TEST_PLAN_TEMPLATE.md) | Plantilla para crear un test plan nuevo.                                         |
+| [`TEST_CASE_TEMPLATE.md`](./TEST_CASE_TEMPLATE.md) | Plantilla para los casos de prueba (`TC-NNN`).                                   |
+| [`TEST_PLAN.md`](./TEST_PLAN.md)                   | Ejemplo práctico: el plan de regresión del sitio.                                |
+
+## Glosario
+
+Conviene fijar la terminología para evitar ambigüedades:
+
+| Término              | Definición                                                                                                               |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **Test plan**        | Documento de **alcance, estrategia, criterios y casos** para verificar una feature o el sistema. Tipo A o B (ver abajo). |
+| **Caso de prueba**   | Una verificación concreta, identificada como `TC-NNN`, con su `Nivel` y su test asociado.                                |
+| **Suite**            | El conjunto de tests **automatizados** (código en `*.spec.ts` y `e2e/`).                                                 |
+| **Nivel**            | Cómo se verifica un caso: `unit` \| `integration` \| `e2e` \| `manual`.                                                  |
+| **Test plan tipo A** | Por **feature / issue**: valida una funcionalidad puntual.                                                               |
+| **Test plan tipo B** | De **regresión por release / milestone**: barrido de toda la plataforma antes de un lanzamiento.                         |
+
+## Flujo en una línea
+
+```
+requisito / criterio de aceptación  →  caso de prueba (TC-NNN, con Nivel)  →  test automatizado (archivo + nombre)
+```
+
+Los casos sin test asociado son la **cobertura faltante**: la lista de trabajo para completar la suite automatizada.
+
+## Relacionados
+
+- Tablero de estado de QA — issue #1353.
+- Migración de Jest a Vitest — issue #1494.
+- Tests de integración pendientes — issues #948, #951, #1426.

--- a/docs/qa/TESTPLAN_GUIDE.md
+++ b/docs/qa/TESTPLAN_GUIDE.md
@@ -1,0 +1,219 @@
+<div align="center" width="100%">
+    <h1>La Cuentoneta</h1>
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://github.com/rolivencia/cuentoneta/assets/32349705/b0ea0659-3c9d-4c4f-9d14-ab60d50dd832">
+        <img width="33%" alt="La Cuentoneta" src="https://github.com/rolivencia/cuentoneta/assets/32349705/b0ea0659-3c9d-4c4f-9d14-ab60d50dd832">
+    </picture>
+</div>
+
+---
+
+# Guía de Testing
+
+¡Te damos la bienvenida! En esta guía vas a encontrar cómo escribir un **test plan** en La Cuentoneta: qué es, cuándo se escribe, cómo se estructura y —algo propio de este proyecto— cómo el test plan funciona además como **especificación que dirige el desarrollo de los tests automatizados** (unitarios, de integración y de regresión).
+
+La guía está pensada para dos audiencias:
+
+- **Personas** (colaboradores de QA y desarrolladores) que escriben o ejecutan test plans.
+- **Agentes de Claude Code** que asisten en la redacción de test plans (ver [§10](#10-asistencia-con-agentes-de-claude-code)).
+
+Por eso la guía y sus plantillas usan una **estructura determinística** (encabezados fijos, IDs, campos obligatorios y valores acotados), de modo que tanto una persona como un agente puedan producir documentos consistentes.
+
+Si querés sugerir mejoras a este documento, podés hacerlo en el canal **#🚐 | la-cuentoneta** en Discord o abriendo un issue del tipo **[💼 gestión / proceso](https://github.com/cuentoneta/cuentoneta/issues/new/choose)**.
+
+## Índice
+
+1. [¿Qué es un Test Plan?](#1-qué-es-un-test-plan)
+2. [Propósito](#2-propósito)
+3. [Niveles de prueba](#3-niveles-de-prueba)
+4. [Granularidad: cuándo se escribe un test plan](#4-granularidad-cuándo-se-escribe-un-test-plan)
+5. [Estructura de un Test Plan](#5-estructura-de-un-test-plan)
+6. [Cómo escribir casos de prueba](#6-cómo-escribir-casos-de-prueba)
+7. [Trazabilidad: caso ↔ test](#7-trazabilidad-caso--test)
+8. [Regresión](#8-regresión)
+9. [Estrategias para un buen Test Plan](#9-estrategias-para-un-buen-test-plan)
+10. [Asistencia con agentes de Claude Code](#10-asistencia-con-agentes-de-claude-code)
+11. [Herramientas del proyecto](#11-herramientas-del-proyecto)
+
+---
+
+# 1. ¿Qué es un Test Plan?
+
+Un **test plan** (plan de pruebas) es un documento que describe el **alcance, la estrategia, los criterios de aceptación y los casos de prueba** para verificar una funcionalidad o el sistema completo.
+
+En La Cuentoneta el test plan cumple un doble rol:
+
+1. **Documento de QA**: guía la ejecución de pruebas (manuales y automatizadas) y deja un registro trazable y repetible.
+2. **Especificación de tests**: cada caso de prueba es la fuente de la que se derivan los tests automatizados (unitarios, de integración y de regresión). Escribir el plan primero hace explícito _qué_ hay que verificar, antes de decidir _cómo_ automatizarlo.
+
+> **Terminología.** No confundas **test plan** (el documento de alcance/estrategia/casos) con **caso de prueba** (cada verificación concreta, `TC-NNN`) ni con la **suite** de tests automatizados (el código en `*.spec.ts` / `e2e/`). Ver el glosario en [`README.md`](./README.md).
+
+# 2. Propósito
+
+El objetivo general es **garantizar la calidad** y que la plataforma cumpla con sus requisitos (funcionalidades, rendimiento, experiencia de usuario).
+
+### 2.1 Propósitos específicos
+
+- Definir el alcance y los objetivos de las pruebas.
+- Establecer criterios de entrada y de salida (aceptación).
+- Estructurar un enfoque claro y repetible.
+- Identificar recursos y responsables.
+- Prever riesgos y proponer estrategias.
+- Promover la comunicación entre QA y desarrollo.
+
+### 2.2 El test plan como especificación de tests
+
+En este proyecto, además, el test plan **dirige el desarrollo de los tests automatizados**. La cadena es:
+
+```
+requisito / criterio de aceptación  →  caso de prueba (TC-NNN, con Nivel)  →  test automatizado (archivo + nombre)
+```
+
+Esto nos permite, entre otras cosas, **detectar la cobertura faltante** (casos sin test asociado) y **completar los tests de integración**, hoy ausentes en el proyecto.
+
+# 3. Niveles de prueba
+
+Cada **caso de prueba** declara un **Nivel**, que indica cómo se verifica. Los valores posibles son un conjunto cerrado:
+
+| Nivel         | Qué verifica                                                                  | Dónde vive el test                        | Herramienta |
+| ------------- | ----------------------------------------------------------------------------- | ----------------------------------------- | ----------- |
+| `unit`        | Lógica aislada: funciones puras, mappers, value objects, lógica de componente | `src/**/*.spec.ts`                        | Vitest      |
+| `integration` | Colaboración entre piezas: `service` ↔ `repository` ↔ Sanity/API, contratos   | `src/api/**` / specs de integración       | Vitest      |
+| `e2e`         | Flujo de usuario completo en el navegador (navegación, lectura, etc.)         | `e2e/**`                                  | Playwright  |
+| `manual`      | Lo que no se automatiza (criterio visual, exploratorio, compatibilidad)       | Checklist en el test plan / tablero de QA | Manual      |
+
+**Heurística para asignar el nivel:**
+
+- ¿Es lógica pura o de una sola unidad (un mapper, un value object, un `computed`)? → `unit`.
+- ¿Cruza una frontera (un `service` que llama a un `repository` que consulta Sanity, o un contrato de API)? → `integration`.
+- ¿Es un recorrido del usuario de punta a punta? → `e2e`.
+- ¿No es razonable automatizarlo (revisión visual, navegadores/dispositivos, exploratorio)? → `manual`.
+
+# 4. Granularidad: cuándo se escribe un test plan
+
+En La Cuentoneta usamos **dos niveles de test plan, de forma complementaria**:
+
+### A. Test plan por feature / issue
+
+Cuando se desarrolla una funcionalidad nueva o un cambio relevante, el issue lleva su **test plan acotado**: los casos que validan _esa_ funcionalidad. Sirve de especificación para los tests de esa feature y se enlaza desde el issue/PR.
+
+### B. Test plan de regresión por release / milestone
+
+Existe un **plan de regresión vivo** a nivel de toda la plataforma (ver el ejemplo en [`TEST_PLAN.md`](./TEST_PLAN.md)), que se ejecuta/actualiza antes de cada lanzamiento (milestone). Los casos estables de los planes por feature (A) se **promueven** a este plan de regresión (B) para que pasen a formar parte del barrido previo a cada release.
+
+> **Regla práctica:** una feature nueva nace con un plan tipo A; sus casos automatizados y estables migran al plan de regresión tipo B.
+
+# 5. Estructura de un Test Plan
+
+Usá la plantilla [`TEST_PLAN_TEMPLATE.md`](./TEST_PLAN_TEMPLATE.md). Un test plan incluye:
+
+- **Introducción / objetivo:** qué funcionalidad o sistema se prueba y para qué.
+- **Alcance:** qué se prueba y, explícitamente, **qué no** se prueba.
+- **Estrategia:** niveles involucrados (ver [§3](#3-niveles-de-prueba)) y herramientas.
+- **Criterios de aceptación:** condiciones que deben cumplirse.
+- **Casos de prueba:** la lista de `TC-NNN` (ver [§6](#6-cómo-escribir-casos-de-prueba)).
+- **Riesgos.**
+- **Recursos y responsables:** roles (QA Manual, QA Automation, dev).
+- **Cronograma / criterios de evaluación** (cuándo inician y finalizan las pruebas).
+
+# 6. Cómo escribir casos de prueba
+
+Usá la plantilla [`TEST_CASE_TEMPLATE.md`](./TEST_CASE_TEMPLATE.md). Cada caso es un bloque `TC-NNN` con, al menos:
+
+- **Módulo** y **nombre del caso**.
+- **Nivel** (`unit` | `integration` | `e2e` | `manual`) — ver [§3](#3-niveles-de-prueba).
+- **Objetivo.**
+- **Precondiciones** y **datos de prueba**.
+- **Pasos a seguir.**
+- **Resultado esperado** (no completar el "obtenido" hasta ejecutar).
+- **Estado** (`Pass` / `Fail` / `Blocked`), **Severidad** y **Prioridad**.
+- **Test(s) asociado(s):** ver [§7](#7-trazabilidad-caso--test).
+
+Buenas prácticas: un caso verifica **una** cosa; el objetivo y los pasos deben ser reproducibles por otra persona sin contexto adicional.
+
+# 7. Trazabilidad: caso ↔ test
+
+Cada caso declara su(s) **Test(s) asociado(s)**: la ruta del archivo y el nombre del test que lo cubre. Formato:
+
+```
+src/app/.../story.mapper.spec.ts > "maps a Sanity story to the domain model"
+e2e/navigation.spec.ts > "navigates from home to a story"
+```
+
+Si el caso todavía **no está automatizado**, se marca `pendiente de automatizar` (o `manual` si no corresponde automatizarlo). Esto convierte al test plan en un **mapa de cobertura auditable**: los casos sin test asociado son la lista de trabajo para completar la suite (en particular, los tests de integración faltantes).
+
+# 8. Regresión
+
+La regresión en La Cuentoneta es **mixta**:
+
+- **Automatizada:** la suite que corre en CI en cada PR/release — tests `unit` e `integration` (Vitest) y `e2e` (Playwright).
+- **Manual:** un **checklist** de los casos `manual` (revisión visual, compatibilidad de navegadores/dispositivos, exploratorio) que se ejecuta antes de cada lanzamiento.
+
+El plan de regresión (tipo B, [§4](#4-granularidad-cuándo-se-escribe-un-test-plan)) consolida ambos: enlaza a los tests automatizados y lista el checklist manual.
+
+# 9. Estrategias para un buen Test Plan
+
+### 9.1 Entender los requisitos
+
+Analizá el issue, sus criterios de aceptación y cualquier diseño/wireframe asociado. Priorizá las **funcionalidades críticas** (lectura y navegación de cuentos).
+
+### 9.2 Definir el alcance
+
+Respondé explícitamente: ¿qué se prueba? ¿qué **no** se prueba?
+
+### 9.3 Elegir el enfoque
+
+Identificá los niveles necesarios ([§3](#3-niveles-de-prueba)) y las herramientas. Preferí automatizar lo repetitivo y dejar `manual` solo lo que lo amerite.
+
+### 9.4 Riesgos, roles y cronograma
+
+Anticipá problemas (datos de prueba, entornos), clarificá responsables y definí cuándo inician y terminan las pruebas.
+
+# 10. Asistencia con agentes de Claude Code
+
+Esta documentación está escrita para que un agente de Claude Code pueda **asistir en la redacción de un test plan**. Cuando un agente reciba el pedido de escribir o completar un test plan, debe:
+
+1. **Leer el issue/feature** y extraer sus **criterios de aceptación** y requisitos.
+2. **Preguntar lo ambiguo** antes de redactar: alcance (qué se prueba / qué no), datos y credenciales de prueba, entorno objetivo, y si el plan es tipo A (feature) o B (regresión) — ver [§4](#4-granularidad-cuándo-se-escribe-un-test-plan).
+3. **Derivar un caso `TC-NNN` por cada criterio de aceptación** o comportamiento verificable, usando [`TEST_CASE_TEMPLATE.md`](./TEST_CASE_TEMPLATE.md).
+4. **Asignar el `Nivel`** de cada caso con la heurística de [§3](#3-niveles-de-prueba) (valor del conjunto cerrado `unit|integration|e2e|manual`).
+5. **Enlazar la trazabilidad** ([§7](#7-trazabilidad-caso--test)): si el test ya existe, referenciar `archivo > "nombre"`; si no, marcar `pendiente de automatizar`.
+6. **Respetar la estructura determinística**: encabezados fijos de las plantillas, IDs correlativos `TC-001`, `TC-002`…, y los valores acotados de `Nivel`/`Estado`/`Severidad`/`Prioridad`.
+7. **No inventar resultados**: dejar "Resultado obtenido" vacío hasta que las pruebas se ejecuten.
+8. **Señalar la cobertura faltante**: listar los casos sin test asociado como candidatos a automatizar.
+
+> Esta guía está pensada para exponerse también como archivo de referencia de Claude (`.claude/references/`) y/o alimentar un subagente asistente de QA. Ese cableado se aborda en la iniciativa de adopción de flujos de Claude (epic #1498).
+
+# 11. Herramientas del proyecto
+
+| Herramienta                                                          | Uso                                       |
+| -------------------------------------------------------------------- | ----------------------------------------- |
+| **[Vitest](https://vitest.dev/)**                                    | Tests unitarios y de integración          |
+| **[Playwright](https://playwright.dev/)**                            | Tests e2e                                 |
+| **[Bruno](https://www.usebruno.com/)**                               | Pruebas de la API (`docs/api/`)           |
+| **[GitHub Issues](https://github.com/cuentoneta/cuentoneta/issues)** | Tracking de bugs y casos                  |
+| **GitHub Projects**                                                  | Tablero de estado de QA (ver issue #1353) |
+
+> **Nota sobre el runner:** el proyecto está migrando de Jest a **Vitest** (issue #1494). Mientras la migración no se complete, los tests unitarios corren en Jest; las convenciones de esta guía ya asumen Vitest como destino.
+
+Para el flujo general de desarrollo, ver la [Guía de Desarrollo](../DEVELOPMENT_GUIDE.md).
+
+---
+
+## Nota
+
+Los test plans varían según el proyecto: cada uno tiene sus objetivos, requisitos y desafíos. Aun así, mantener una **estructura estándar** asegura consistencia y evita pasar por alto aspectos clave.
+
+## Documentos relacionados
+
+- [`README.md`](./README.md) — índice y glosario del área de QA.
+- [`TEST_PLAN_TEMPLATE.md`](./TEST_PLAN_TEMPLATE.md) — plantilla de test plan.
+- [`TEST_CASE_TEMPLATE.md`](./TEST_CASE_TEMPLATE.md) — plantilla de casos de prueba.
+- [`TEST_PLAN.md`](./TEST_PLAN.md) — ejemplo práctico (plan de regresión del sitio).
+- [Guía de Desarrollo](../DEVELOPMENT_GUIDE.md).
+
+## Fuentes
+
+- <https://en.wikipedia.org/wiki/Test_plan>
+- <https://www.guru99.com/es/test-planning.html>
+- <https://www.softwaretestingbureau.com/crear-un-buenplan-de-pruebas/>

--- a/docs/qa/TEST_CASE_TEMPLATE.md
+++ b/docs/qa/TEST_CASE_TEMPLATE.md
@@ -8,32 +8,39 @@
 
 ---
 
-## Plan de pruebas manuales
+# Plantilla de Casos de Prueba
 
-### ¿Qué es?
+Un **caso de prueba** define una verificación concreta: qué se prueba, bajo qué condiciones, los pasos, el resultado esperado y obtenido, y su estado. Es la unidad que hace que el software se verifique de forma completa, trazable y repetible.
 
-Es un documento que define y describe cada prueba que se va a realizar sobre un sistema o sitio web. Cada caso de prueba debe contener, al menos, qué se va a probar, bajo qué condiciones, pasos a seguir, resultado esperado y obtenido, estado final.
+Cada caso lleva, además, dos campos propios de este proyecto (ver [`TESTPLAN_GUIDE.md`](./TESTPLAN_GUIDE.md)):
 
-Es una herramienta clave en la ejecución de pruebas, mejora la comunicación entre devs y QAs, y garantiza que el software se verifique de manera completa, trazable y repetible.
+- **Nivel** — cómo se verifica: `unit` | `integration` | `e2e` | `manual`.
+- **Test(s) asociado(s)** — la ruta y el nombre del test automatizado que cubre el caso, o `pendiente de automatizar`.
 
-A manera de ejemplo, se incluyen en el presente documento plantillas para definir planes de pruebas manuales para validar funcionalidades de la plataforma.
+> Copiá el bloque `TC-NNN` tantas veces como casos necesites, con IDs correlativos.
 
-## Plantilla
+---
 
-### Caso de prueba: TC-001
+## Caso de prueba: TC-001
 
-**Módulo**:<br>
+**Módulo:**<br>
 **Nombre del caso:**
+
+### Nivel
+
+- [ ] `unit`
+- [ ] `integration`
+- [ ] `e2e`
+- [ ] `manual`
 
 ### Objetivo
 
-Descripción breve de lo que se busca al realizar las pruebas.
+Descripción breve de lo que se busca verificar.
 
 ### Precondiciones
 
 - [ ] (Ejemplo 1)
 - [ ] (Ejemplo 2)
-- [ ] (Ejemplo 3)
 
 ### Pasos a seguir
 
@@ -52,7 +59,11 @@ Descripción breve de lo que se busca al realizar las pruebas.
 
 ### Resultado obtenido
 
-Comportamiento observado durante la ejecución.
+Comportamiento observado durante la ejecución. _(No completar hasta ejecutar la prueba.)_
+
+### Test(s) asociado(s)
+
+- `ruta/al/archivo.spec.ts > "nombre del test"` — o `pendiente de automatizar`.
 
 ### Estado
 
@@ -80,18 +91,24 @@ Comportamiento observado durante la ejecución.
 
 ## Caso de prueba: TC-002
 
-**Módulo**:
+**Módulo:**<br>
 **Nombre del caso:**
+
+### Nivel
+
+- [ ] `unit`
+- [ ] `integration`
+- [ ] `e2e`
+- [ ] `manual`
 
 ### Objetivo
 
-Descripción breve de lo que se busca al realizar las pruebas.
+Descripción breve de lo que se busca verificar.
 
 ### Precondiciones
 
 - [ ] (Ejemplo 1)
 - [ ] (Ejemplo 2)
-- [ ] (Ejemplo 3)
 
 ### Pasos a seguir
 
@@ -110,7 +127,11 @@ Descripción breve de lo que se busca al realizar las pruebas.
 
 ### Resultado obtenido
 
-Comportamiento observado durante la ejecución.
+Comportamiento observado durante la ejecución. _(No completar hasta ejecutar la prueba.)_
+
+### Test(s) asociado(s)
+
+- `ruta/al/archivo.spec.ts > "nombre del test"` — o `pendiente de automatizar`.
 
 ### Estado
 

--- a/docs/qa/TEST_PLAN.md
+++ b/docs/qa/TEST_PLAN.md
@@ -6,6 +6,8 @@
     </picture>
 </div>
 
+> **Nota:** este documento es un **ejemplo de test plan tipo B (regresión del sitio)**. Para escribir uno nuevo, ver la [guía](./TESTPLAN_GUIDE.md) y el [índice del área de QA](./README.md).
+
 # 1. **Objetivo**
 
 Este documento tiene como finalidad asegurar la calidad del sitio web de cuentos "Cuentoneta". Esto incluye:

--- a/docs/qa/TEST_PLAN_TEMPLATE.md
+++ b/docs/qa/TEST_PLAN_TEMPLATE.md
@@ -1,0 +1,71 @@
+<div align="center" width="100%">
+    <h1>La Cuentoneta</h1>
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://github.com/rolivencia/cuentoneta/assets/32349705/b0ea0659-3c9d-4c4f-9d14-ab60d50dd832">
+        <img width="33%" alt="La Cuentoneta" src="https://github.com/rolivencia/cuentoneta/assets/32349705/b0ea0659-3c9d-4c4f-9d14-ab60d50dd832">
+    </picture>
+</div>
+
+---
+
+# Plantilla de Test Plan
+
+> Copiá esta plantilla para crear un test plan nuevo. Completá todas las secciones; si una no aplica, escribí explícitamente "No aplica" y por qué. Para la metodología, ver [`TESTPLAN_GUIDE.md`](./TESTPLAN_GUIDE.md).
+
+**Título del plan:**
+**Tipo:** `A (feature / issue)` | `B (regresión por release / milestone)`
+**Issue / Milestone asociado:** #
+**Autor/es:**
+**Fecha:**
+
+---
+
+## 1. Objetivo
+
+Breve descripción de la funcionalidad o sistema a probar y qué se busca verificar.
+
+## 2. Alcance
+
+### Se prueba
+
+-
+
+### No se prueba
+
+-
+
+## 3. Estrategia
+
+- **Niveles involucrados:** `unit` / `integration` / `e2e` / `manual` (indicar cuáles y por qué).
+- **Herramientas:** Vitest (unit/integration), Playwright (e2e), Bruno (API), manual.
+
+## 4. Criterios de aceptación
+
+- [ ]
+- [ ]
+
+## 5. Casos de prueba
+
+> Un bloque `TC-NNN` por caso, usando [`TEST_CASE_TEMPLATE.md`](./TEST_CASE_TEMPLATE.md). Tabla resumen:
+
+| ID     | Caso | Nivel                               | Prioridad       | Test asociado                   | Estado                           |
+| ------ | ---- | ----------------------------------- | --------------- | ------------------------------- | -------------------------------- |
+| TC-001 |      | `unit`/`integration`/`e2e`/`manual` | Alta/Media/Baja | `ruta > "nombre"` / _pendiente_ | Pass/Fail/Blocked/_sin ejecutar_ |
+
+## 6. Riesgos
+
+-
+
+## 7. Recursos y responsables
+
+| Rol           | Responsable |
+| ------------- | ----------- |
+| QA Manual     |             |
+| QA Automation |             |
+| Desarrollo    |             |
+
+## 8. Cronograma y criterios de evaluación
+
+- **Inicio de las pruebas:**
+- **Fin de las pruebas / criterio de salida:**
+- **Entregables:** (informe de resultados, bugs, cobertura faltante).


### PR DESCRIPTION
Closes #1115

## Resumen

Reorganiza el área de QA (`docs/qa`) en un set coherente y agrega la **guía metodológica para escribir test plans**, pensada tanto para personas (QA y devs) como para la **asistencia de agentes de Claude Code**.

En La Cuentoneta un test plan cumple doble propósito: documenta el QA **y** funciona como **especificación que dirige el desarrollo de los tests automatizados** (unitarios, de integración y de regresión).

## Cambios

| Archivo | Qué es |
|---|---|
| `docs/qa/README.md` | Índice + **glosario** (plan/caso/suite/nivel; tipo A/B) — fija la terminología |
| `docs/qa/TESTPLAN_GUIDE.md` | La guía: niveles (`unit`/`integration`/`e2e`/`manual`), granularidad **A+B**, estructura, casos, **trazabilidad caso↔test**, regresión (auto + manual), estrategias, **asistencia con agentes**, herramientas |
| `docs/qa/TEST_PLAN_TEMPLATE.md` | Plantilla de test plan (con tabla resumen de casos) |
| `docs/qa/TEST_CASE_TEMPLATE.md` | Plantilla de casos (renombra `TEST_TEMPLATE.md`) con campos **Nivel** y **Test(s) asociado(s)** |
| `docs/qa/TEST_PLAN.md` | El ejemplo existente, marcado como plan de regresión (tipo B) |

## Notas

- Los casos llevan un `Nivel` (`unit`/`integration`/`e2e`/`manual`) y su(s) **test(s) asociado(s)** (ruta + nombre), de modo que el plan sirva de mapa de cobertura auditable y guíe la creación de los tests de integración faltantes.
- La guía incluye una sección de instrucciones para que **agentes de Claude Code** asistan en la redacción.
- **Construye sobre la PR #1414** de @c-godoy (toma su `TESTPLAN_GUIDE.md` como base y lo expande con la spec del issue). Sugerido cerrar #1414 en favor de esta. Co-autores: @rolivencia, @c-godoy.
- Relacionados: #1494 (Vitest), #948 / #951 / #1426 (integración), #1353 (tablero QA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
