### PR TITLE
[#1510] - Implementa el componente StoryMediaSelectors

### DIFF
--- a/src/app/components/story-media-selectors/story-media-selectors.component.spec.ts
+++ b/src/app/components/story-media-selectors/story-media-selectors.component.spec.ts
@@ -36,6 +36,13 @@ describe('StoryMediaSelectorsComponent', () => {
 			await render(StoryMediaSelectorsComponent, { inputs: { media } });
 			expect(screen.queryAllByRole('button')).toHaveLength(0);
 		});
+
+		it('should expose each selector as an image with the count folded into its accessible name', async () => {
+			await render(StoryMediaSelectorsComponent, { inputs: { media } });
+			// El badge visual es decorativo: el conteo se anuncia en el nombre accesible del recuadro.
+			expect(screen.getByRole('img', { name: 'YouTube (2)' })).toBeInTheDocument();
+			expect(screen.getByRole('img', { name: 'Spotify' })).toBeInTheDocument();
+		});
 	});
 
 	describe('Selectable mode (selectable = true)', () => {

--- a/src/app/components/story-media-selectors/story-media-selectors.component.spec.ts
+++ b/src/app/components/story-media-selectors/story-media-selectors.component.spec.ts
@@ -1,0 +1,71 @@
+import { StoryMediaSelectorsComponent } from './story-media-selectors.component';
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { Media } from '@models/media.model';
+
+describe('StoryMediaSelectorsComponent', () => {
+	const youTube1: Media = { title: 'Video 1', type: 'youTubeVideo', description: [], data: { videoId: 'a' } };
+	const youTube2: Media = { title: 'Video 2', type: 'youTubeVideo', description: [], data: { videoId: 'b' } };
+	const spotify: Media = {
+		title: 'Podcast',
+		type: 'spotifyPodcastEpisode',
+		description: [],
+		data: { url: 'https://s' },
+	};
+	const media: Media[] = [youTube1, youTube2, spotify];
+
+	it('should render nothing when there is no media', async () => {
+		await render(StoryMediaSelectorsComponent, { inputs: { media: [] } });
+		expect(screen.queryAllByTestId('media-selector')).toHaveLength(0);
+	});
+
+	describe('Grouped mode (selectable = false, default)', () => {
+		it('should render one selector per platform', async () => {
+			await render(StoryMediaSelectorsComponent, { inputs: { media } });
+			// 3 media items but only 2 distinct platforms (YouTube, Spotify) => 2 selectors.
+			expect(screen.getAllByTestId('media-selector')).toHaveLength(2);
+		});
+
+		it('should show a count badge for platforms with more than one resource', async () => {
+			await render(StoryMediaSelectorsComponent, { inputs: { media } });
+			// 2 YouTube videos => badge "2"; the single Spotify episode shows no badge.
+			expect(screen.getByText('2')).toBeInTheDocument();
+		});
+
+		it('should render decorative (non-button) selectors', async () => {
+			await render(StoryMediaSelectorsComponent, { inputs: { media } });
+			expect(screen.queryAllByRole('button')).toHaveLength(0);
+		});
+	});
+
+	describe('Selectable mode (selectable = true)', () => {
+		it('should render one clickable button per resource (no grouping)', async () => {
+			await render(StoryMediaSelectorsComponent, { inputs: { media, selectable: true } });
+			// 3 resources => 3 buttons.
+			expect(screen.getAllByRole('button')).toHaveLength(3);
+		});
+
+		it('should not render a count badge', async () => {
+			await render(StoryMediaSelectorsComponent, { inputs: { media, selectable: true } });
+			expect(screen.queryByText('2')).not.toBeInTheDocument();
+		});
+
+		it('should emit the corresponding resource when a selector is clicked', async () => {
+			const onSelected = jest.fn();
+			await render(StoryMediaSelectorsComponent, {
+				inputs: { media, selectable: true },
+				on: { selected: onSelected },
+			});
+			const buttons = screen.getAllByRole('button');
+			await userEvent.click(buttons[0]);
+			expect(onSelected).toHaveBeenCalledTimes(1);
+			expect(onSelected).toHaveBeenCalledWith(youTube1);
+		});
+
+		it('should expose an accessible label per platform', async () => {
+			await render(StoryMediaSelectorsComponent, { inputs: { media, selectable: true } });
+			expect(screen.getAllByLabelText('YouTube')).toHaveLength(2);
+			expect(screen.getByLabelText('Spotify')).toBeInTheDocument();
+		});
+	});
+});

--- a/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
+++ b/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
@@ -1,0 +1,126 @@
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular';
+
+import { StoryMediaSelectorsComponent } from './story-media-selectors.component';
+import { Media } from '@models/media.model';
+
+// Conjunto de medios variado: 3 videos de YouTube (muestra el contador en modo agrupado),
+// un Space de X y un episodio de Spotify.
+const media: Media[] = [
+	{ title: 'Video 1', type: 'youTubeVideo', description: [], data: { videoId: 'a' } },
+	{ title: 'Video 2', type: 'youTubeVideo', description: [], data: { videoId: 'b' } },
+	{ title: 'Video 3', type: 'youTubeVideo', description: [], data: { videoId: 'c' } },
+	{
+		title: 'Space',
+		type: 'spaceRecording',
+		description: [],
+		data: { url: null, duration: '', hostName: '', date: '' },
+	},
+	{ title: 'Podcast', type: 'spotifyPodcastEpisode', description: [], data: { url: 'https://spotify.com' } },
+];
+
+const meta: Meta<StoryMediaSelectorsComponent> = {
+	component: StoryMediaSelectorsComponent,
+	title: 'Componentes/StoryMediaSelectors',
+	parameters: {
+		docs: {
+			description: {
+				component: `<div>
+					<p>El componente **StoryMediaSelectorsComponent** renderiza los selectores de los recursos multimedia
+					(YouTube, X, Spotify, audio) asociados a una historia. Es un componente de presentación: no monta los
+					widgets, solo emite el recurso seleccionado vía el output <code>selected</code>.</p>
+					<ul>
+						<li><code>selectable = false</code> (por defecto): agrupa por plataforma con un contador (badge). Decorativo.</li>
+						<li><code>selectable = true</code>: un selector clickeable por recurso; al click emite el <code>Media</code> vía <code>selected</code>.</li>
+					</ul>
+					<p>El input <code>theme</code> (<code>subtle</code> / <code>solid</code> / <code>bordered</code>) y
+					<code>orientation</code> (<code>horizontal</code> / <code>vertical</code>) controlan la presentación.</p>
+				</div>`,
+			},
+		},
+		layout: 'padded',
+	},
+	argTypes: {
+		media: { control: { type: 'object' }, description: 'Recursos multimedia de la historia' },
+		theme: {
+			control: { type: 'inline-radio' },
+			options: ['subtle', 'solid', 'bordered'],
+			description: 'Tema visual del recuadro y el contador',
+			table: { defaultValue: { summary: 'subtle' } },
+		},
+		orientation: {
+			control: { type: 'inline-radio' },
+			options: ['horizontal', 'vertical'],
+			table: { defaultValue: { summary: 'horizontal' } },
+		},
+		selectable: {
+			control: { type: 'boolean' },
+			description: 'Si es true, un selector clickeable por recurso que emite `selected`; si es false, agrupa con badge',
+			table: { defaultValue: { summary: 'false' } },
+		},
+		selected: { action: 'selected' },
+	},
+};
+
+export default meta;
+type Story = StoryObj<StoryMediaSelectorsComponent>;
+
+// Modo agrupado (decorativo) — usado por StoryCardTeaserV3.
+export const Grouped: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-story-media-selectors ${argsToTemplate(args)} />` }),
+	args: { media, theme: 'subtle', orientation: 'horizontal', selectable: false },
+	parameters: {
+		docs: {
+			description: { story: 'Modo agrupado: un selector por plataforma con contador. Tema `subtle` (OnWhite).' },
+		},
+	},
+};
+
+// Modo seleccionable (interactivo) — pensado para la vista Story.
+export const Selectable: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-story-media-selectors ${argsToTemplate(args)} />` }),
+	args: { media, theme: 'solid', orientation: 'horizontal', selectable: true },
+	parameters: {
+		docs: {
+			description: {
+				story: 'Modo seleccionable: un botón por recurso. Al hacer click emite el `Media` (ver la pestaña Actions).',
+			},
+		},
+	},
+};
+
+// Vitrina de los tres temas en sus contextos de fondo.
+// Nota: se usan bindings explícitos (en lugar de argsToTemplate) porque theme/orientation difieren
+// por instancia; argsToTemplate genera `[theme]="theme"` que apunta a un único `props.theme`.
+export const Themes: Story = {
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="flex flex-col gap-6">
+				<div class="space-y-2">
+					<h3 class="text-sm font-semibold text-neutral-600">subtle (sobre blanco)</h3>
+					<cuentoneta-story-media-selectors [media]="media" [selectable]="selectable" theme="subtle" />
+				</div>
+				<div class="space-y-2">
+					<h3 class="text-sm font-semibold text-neutral-600">solid (sobre gris)</h3>
+					<div class="rounded-lg bg-neutral-100 p-6">
+						<cuentoneta-story-media-selectors [media]="media" [selectable]="selectable" theme="solid" />
+					</div>
+				</div>
+				<div class="space-y-2">
+					<h3 class="text-sm font-semibold text-neutral-600">bordered (tarjeta destacada)</h3>
+					<div class="rounded-lg border border-neutral-200 bg-neutral-50 p-6">
+						<cuentoneta-story-media-selectors [media]="media" [selectable]="selectable" theme="bordered" />
+					</div>
+				</div>
+				<div class="space-y-2">
+					<h3 class="text-sm font-semibold text-neutral-600">orientation vertical</h3>
+					<cuentoneta-story-media-selectors [media]="media" [selectable]="selectable" theme="solid" orientation="vertical" />
+				</div>
+			</div>
+		`,
+	}),
+	args: { media, selectable: false },
+	parameters: {
+		docs: { description: { story: 'Los tres temas en su contexto de fondo y la orientación vertical.' } },
+	},
+};

--- a/src/app/components/story-media-selectors/story-media-selectors.component.ts
+++ b/src/app/components/story-media-selectors/story-media-selectors.component.ts
@@ -1,0 +1,135 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { simpleSpotify, simpleX, simpleYoutube } from '@ng-icons/simple-icons';
+import { faSolidFileAudio } from '@ng-icons/font-awesome/solid';
+
+import { Media, MediaTypeKey } from '@models/media.model';
+
+/**
+ * Tema visual de los selectores, desacoplado de las variantes de StoryCardTeaserV3:
+ *
+ * - `subtle`: pensado para fondos blancos.
+ * - `solid`: pensado para fondos grises/contenedores.
+ * - `bordered`: pensado para tarjetas destacadas.
+ */
+export type StoryMediaSelectorsTheme = 'subtle' | 'solid' | 'bordered';
+
+interface MediaSelectorItem {
+	iconName: string;
+	label: string;
+	count: number;
+	media?: Media;
+}
+
+/**
+ * Renderiza los selectores de los recursos multimedia asociados a una
+ * historia. Es un componente de presentación: no monta los widgets de los recursos, solo emite el
+ * recurso seleccionado para que el componente padre decida qué renderizar.
+ *
+ * Comportamiento según el input `selectable`:
+ *
+ * - `false` (por defecto): los recursos se agrupan por plataforma y se muestra un contador (badge)
+ *   cuando hay más de uno del mismo tipo. Los selectores son decorativos (no clickeables). Es el
+ *   modo usado por la tarjeta StoryCardTeaserV3.
+ * - `true`: se renderiza un selector clickeable por cada recurso (sin agrupar ni contador) y al
+ *   hacer click se emite, vía el output `selected`, el `Media` correspondiente. Es el modo pensado
+ *   para la vista Story, donde se monta el widget del recurso seleccionado.
+ */
+@Component({
+	selector: 'cuentoneta-story-media-selectors',
+	imports: [NgIcon],
+	providers: [provideIcons({ simpleYoutube, simpleX, simpleSpotify, faSolidFileAudio })],
+	template: `
+		@for (selector of selectors(); track $index) {
+			@if (selectable()) {
+				<button
+					(click)="selected.emit(selector.media!)"
+					[class]="selectorClasses()"
+					[attr.aria-label]="selector.label"
+					type="button"
+					class="relative flex items-center justify-center rounded-lg px-2.5 py-2"
+					data-testid="media-selector"
+				>
+					<ng-icon [name]="selector.iconName" size="18px" class="text-neutral-900" />
+				</button>
+			} @else {
+				<div
+					[class]="selectorClasses()"
+					class="relative flex items-center justify-center rounded-lg px-2.5 py-2"
+					data-testid="media-selector"
+				>
+					<ng-icon [name]="selector.iconName" [attr.aria-label]="selector.label" size="18px" class="text-neutral-900" />
+					@if (selector.count > 1) {
+						<span
+							[class]="badgeClasses()"
+							class="absolute -top-1 -right-1 flex size-4 items-center justify-center rounded-[10px] font-inter text-xxs font-bold text-neutral-900"
+						>
+							{{ selector.count }}
+						</span>
+					}
+				</div>
+			}
+		}
+	`,
+	host: {
+		'[class]': 'containerClasses()',
+	},
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StoryMediaSelectorsComponent {
+	// Inputs
+	readonly media = input<Media[]>([]);
+	readonly orientation = input<'horizontal' | 'vertical'>('horizontal');
+	readonly theme = input<StoryMediaSelectorsTheme>('subtle');
+	readonly selectable = input<boolean>(false);
+
+	readonly selected = output<Media>();
+
+	// Mapeo de cada tipo de media del dominio a su ícono y etiqueta accesible.
+	private readonly mediaPlatforms: Record<MediaTypeKey, { iconName: string; label: string }> = {
+		youTubeVideo: { iconName: 'simpleYoutube', label: 'YouTube' },
+		spaceRecording: { iconName: 'simpleX', label: 'Spaces de X' },
+		spotifyPodcastEpisode: { iconName: 'simpleSpotify', label: 'Spotify' },
+		audioRecording: { iconName: 'faSolidFileAudio', label: 'Audio' },
+	};
+
+	readonly selectors = computed<MediaSelectorItem[]>(() => {
+		const media = this.media();
+		if (this.selectable()) {
+			return media.map((item) => ({ ...this.mediaPlatforms[item.type], count: 1, media: item }));
+		}
+		const counts = new Map<MediaTypeKey, number>();
+		for (const item of media) {
+			counts.set(item.type, (counts.get(item.type) ?? 0) + 1);
+		}
+		return [...counts.entries()].map(([type, count]) => ({ ...this.mediaPlatforms[type], count }));
+	});
+
+	readonly containerClasses = computed(() =>
+		this.orientation() === 'vertical' ? 'flex flex-col items-center gap-2.5' : 'flex items-center gap-2.5',
+	);
+
+	// Estilos del recuadro de cada selector según el tema.
+	readonly selectorClasses = computed(() => {
+		switch (this.theme()) {
+			case 'solid':
+				return 'bg-white';
+			case 'bordered':
+				return 'border border-neutral-150 bg-white';
+			default:
+				return 'bg-neutral-100';
+		}
+	});
+
+	// Estilos del contador (badge) que se superpone al selector según el tema.
+	readonly badgeClasses = computed(() => {
+		switch (this.theme()) {
+			case 'solid':
+				return 'border-2 border-neutral-100 bg-white';
+			case 'bordered':
+				return 'border border-neutral-150 bg-white';
+			default:
+				return 'border-2 border-white bg-neutral-100';
+		}
+	});
+}

--- a/src/app/components/story-media-selectors/story-media-selectors.component.ts
+++ b/src/app/components/story-media-selectors/story-media-selectors.component.ts
@@ -45,9 +45,8 @@ interface MediaSelectorItem {
 				<button
 					(click)="selected.emit(selector.media!)"
 					[class]="selectorClasses()"
-					[attr.aria-label]="selector.label"
+					[attr.aria-label]="ariaLabel(selector)"
 					type="button"
-					class="relative flex items-center justify-center rounded-lg px-2.5 py-2"
 					data-testid="media-selector"
 				>
 					<ng-icon [name]="selector.iconName" size="18px" class="text-neutral-900" />
@@ -55,7 +54,8 @@ interface MediaSelectorItem {
 			} @else {
 				<div
 					[class]="selectorClasses()"
-					class="relative flex items-center justify-center rounded-lg px-2.5 py-2"
+					[attr.aria-label]="ariaLabel(selector)"
+					role="img"
 					data-testid="media-selector"
 				>
 					<ng-icon [name]="selector.iconName" [attr.aria-label]="selector.label" size="18px" class="text-neutral-900" />
@@ -63,6 +63,7 @@ interface MediaSelectorItem {
 						<span
 							[class]="badgeClasses()"
 							class="absolute -top-1 -right-1 flex size-4 items-center justify-center rounded-[10px] font-inter text-xxs font-bold text-neutral-900"
+							aria-hidden="true"
 						>
 							{{ selector.count }}
 						</span>
@@ -109,17 +110,29 @@ export class StoryMediaSelectorsComponent {
 		this.orientation() === 'vertical' ? 'flex flex-col items-center gap-2.5' : 'flex items-center gap-2.5',
 	);
 
-	// Estilos del recuadro de cada selector según el tema.
+	// Clases base del recuadro, compartidas por ambas variantes (selectores y botones).
+	private readonly selectorBaseClasses = 'relative flex items-center justify-center rounded-lg px-2.5 py-2';
+
+	// Estilos del recuadro de cada selector: clases base + las propias del tema.
 	readonly selectorClasses = computed(() => {
-		switch (this.theme()) {
-			case 'solid':
-				return 'bg-white';
-			case 'bordered':
-				return 'border border-neutral-150 bg-white';
-			default:
-				return 'bg-neutral-100';
-		}
+		const theme = (() => {
+			switch (this.theme()) {
+				case 'solid':
+					return 'bg-white';
+				case 'bordered':
+					return 'border border-neutral-150 bg-white';
+				default:
+					return 'bg-neutral-100';
+			}
+		})();
+		return `${this.selectorBaseClasses} ${theme}`;
 	});
+
+	// Nombre accesible del selector: incluye el conteo cuando se agrupan varios recursos de la
+	// misma plataforma, de modo que el badge visual pueda marcarse como decorativo (aria-hidden).
+	ariaLabel(selector: MediaSelectorItem): string {
+		return selector.count > 1 ? `${selector.label} (${selector.count})` : selector.label;
+	}
 
 	// Estilos del contador (badge) que se superpone al selector según el tema.
 	readonly badgeClasses = computed(() => {


### PR DESCRIPTION
## Descripción

Agrega `StoryMediaSelectorsComponent` (`cuentoneta-story-media-selectors`): componente de presentación que renderiza los selectores de los recursos multimedia (YouTube, X, Spotify, audio) asociados a una historia.

Es un componente *stateless*: **no monta los widgets** de los recursos, solo emite el recurso seleccionado para que el componente padre decida qué renderizar (en el teaser es decorativo; en la futura vista Story montará el widget correspondiente).

### API

- **Inputs**
  - `media: Media[]` — recursos multimedia de la historia.
  - `theme: subtle | solid | bordered` — estilo del recuadro/contador según el fondo.
  - `orientation: horizontal | vertical`.
  - `selectable: boolean` (default `false`).
- **Output**
  - `selected: Media` — recurso elegido al hacer click (solo se emite con `selectable=true`).

### Comportamiento según `selectable`

- `false` (default): agrupa por plataforma con un contador (badge) y los selectores son **decorativos**. Es el modo que usa `StoryCardTeaserV3`.
- `true`: renderiza un **botón por recurso** (sin agrupar) y emite el `Media` al click. Pensado para reusar en la vista Story.

> Se optó por un input explícito (`selectable`) en lugar de detectar suscriptores del output (`.observed`/`listeners` privado de `OutputEmitterRef`), por ser declarativo, tipado y testeable.

## Cambios

- Nuevo componente + stories de Storybook (modos agrupado/seleccionable + vitrina de temas).
- Tests unitarios (agrupación, contador, emisión del recurso, accesibilidad).

## Notas para el revisor

- **PR base de un stack.** El segundo PR (`StoryCardTeaserV3`, que consume este componente) apunta a esta rama como base y se abrirá a continuación.
- Parte de #1510 (no lo cierra; lo completa el PR del card).

## Verificación

- `nx test` (8 tests del componente) ✅
- `nx lint` ✅ — la rama compila de forma aislada (sin el card).
- Verificación visual en Storybook de los 3 temas y ambas orientaciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@