### PR TITLE
[HF] - Hace opcional el campo de redes sociales del colaborador

### DIFF
--- a/cms/schemas/contributor.ts
+++ b/cms/schemas/contributor.ts
@@ -49,7 +49,6 @@ export default defineType({
 			options: {
 				collapsible: false,
 			},
-			validation: (Rule) => Rule.required(),
 		}),
 		defineField({
 			name: 'notes',


### PR DESCRIPTION
## Contexto

Surgido del trabajo en #1510 (Author Teaser), donde se detectó que **un colaborador puede no tener redes sociales asignadas a su perfil**. El campo `link` del schema de `contributor` tenía una validación `required` que impedía guardar colaboradores sin RRSS.

## Cambio

- Elimina `validation: (Rule) => Rule.required()` del campo `link` (Redes sociales) en `cms/schemas/contributor.ts`.

## Verificación hacia arriba en el stack

El render condicional de RRSS ya estaba correctamente contemplado en todas las capas, por lo que **no se requieren ajustes adicionales**:

| Capa | Archivo | Estado |
|------|---------|--------|
| GROQ | `src/api/_queries/contributor.query.ts` | Proyecta `link { handle, url }`; devuelve `null` si no existe |
| Modelo | `src/app/models/contributor.model.ts` | `ContributorLink` con `handle?` y `url?` opcionales |
| Mapper | `src/api/modules/contributor/contributor.repository.ts` | Optional chaining `link?.handle \|\| undefined` (`null`→`undefined`) |
| Endpoint | `contributor.controller.ts` / `.service.ts` | Pasa el objeto sin transformar |
| Template | `src/app/pages/about/about.component.html` | `@if (contributor.link.url) { <a>…</a> }` — render condicional |

Si un colaborador no tiene RRSS, el frontend muestra solo el nombre (y notas si las hubiera); no se rompe ni renderiza un enlace vacío.

🤖 Generated with [Claude Code](https://claude.com/claude-code)