### PR TITLE
[#1515] - Componentes Tag y TagsList (DS v3) con recorte por ancho

### DIFF
--- a/src/app/components/tag/tag.component.spec.ts
+++ b/src/app/components/tag/tag.component.spec.ts
@@ -1,0 +1,26 @@
+import { TagComponent } from './tag.component';
+import { render, screen } from '@testing-library/angular';
+
+describe('TagComponent', () => {
+	it('should render the label', async () => {
+		await render(TagComponent, { inputs: { label: 'Crónica' } });
+		expect(screen.getByText('Crónica')).toBeInTheDocument();
+	});
+
+	it('should apply the soft variant by default (text only, no background)', async () => {
+		await render(TagComponent, { inputs: { label: 'Crónica' } });
+		const tag = screen.getByText('Crónica');
+		expect(tag).toHaveClass('text-xs', 'text-brand-500');
+		expect(tag).not.toHaveClass('bg-brand-50');
+	});
+
+	it('should apply the filled variant chrome (uppercase pill)', async () => {
+		await render(TagComponent, { inputs: { label: 'Crónica', variant: 'filled' } });
+		expect(screen.getByText('Crónica')).toHaveClass('bg-brand-50', 'text-brand-500', 'text-xxs', 'uppercase');
+	});
+
+	it('should apply the gray variant chrome (translucent pill)', async () => {
+		await render(TagComponent, { inputs: { label: 'Crónica', variant: 'gray' } });
+		expect(screen.getByText('Crónica')).toHaveClass('bg-neutral-950-40', 'text-neutral-50', 'text-xxs');
+	});
+});

--- a/src/app/components/tag/tag.component.stories.ts
+++ b/src/app/components/tag/tag.component.stories.ts
@@ -1,0 +1,65 @@
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular';
+
+import { TagComponent } from './tag.component';
+
+const meta: Meta<TagComponent> = {
+	component: TagComponent,
+	title: 'Componentes/Tag',
+	parameters: {
+		docs: {
+			description: {
+				component: `<div>
+					<p>El componente **TagComponent** es la etiqueta (tag) del Design System v3. Reemplaza progresivamente
+					a <code>BadgeComponent</code>. Soporta tres variantes (input <code>variant</code>):</p>
+					<ul>
+						<li><strong>soft</strong> (default): solo texto en brand-500, sin fondo.</li>
+						<li><strong>filled</strong>: pill brand-50 con texto brand-500 en mayúsculas.</li>
+						<li><strong>gray</strong>: pill translúcido oscuro con texto claro, para mostrarse sobre imágenes.</li>
+					</ul>
+				</div>`,
+			},
+		},
+		layout: 'padded',
+	},
+	argTypes: {
+		label: { control: { type: 'text' } },
+		variant: {
+			control: { type: 'inline-radio' },
+			options: ['soft', 'filled', 'gray'],
+			table: { defaultValue: { summary: 'soft' } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<TagComponent>;
+
+export const Soft: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-tag ${argsToTemplate(args)} />` }),
+	args: { label: 'Crónica', variant: 'soft' },
+};
+
+export const Filled: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-tag ${argsToTemplate(args)} />` }),
+	args: { label: 'Crónica', variant: 'filled' },
+};
+
+export const Gray: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-tag ${argsToTemplate(args)} />` }),
+	args: { label: 'Crónica', variant: 'gray' },
+};
+
+export const Showcase: Story = {
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="flex items-center gap-3">
+				<cuentoneta-tag [label]="label" variant="soft" />
+				<cuentoneta-tag [label]="label" variant="filled" />
+				<cuentoneta-tag [label]="label" variant="gray" />
+			</div>
+		`,
+	}),
+	args: { label: 'Crónica' },
+	parameters: { docs: { description: { story: 'Las tres variantes: soft, filled y gray.' } } },
+};

--- a/src/app/components/tag/tag.component.ts
+++ b/src/app/components/tag/tag.component.ts
@@ -1,0 +1,39 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+/**
+ * Variantes visuales del tag (Design System v3):
+ * - `soft` (default): solo texto en `brand-500`, sin fondo.
+ * - `filled`: pill `brand-50` con texto `brand-500` en mayúsculas.
+ * - `gray`: pill translúcido oscuro (`neutral-950-40`) con texto claro (`neutral-50`), pensado para
+ *   mostrarse sobre imágenes.
+ */
+export type TagVariant = 'soft' | 'filled' | 'gray';
+
+/**
+ * Etiqueta (tag) del Design System v3. Componente de presentación que reemplaza progresivamente a
+ * `BadgeComponent`: muestra un texto con el estilo de la variante indicada.
+ */
+@Component({
+	selector: 'cuentoneta-tag',
+	template: `{{ label() }}`,
+	host: {
+		'[class]': 'hostClasses()',
+	},
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TagComponent {
+	// Inputs
+	readonly label = input.required<string>();
+	readonly variant = input<TagVariant>('soft');
+
+	// Clases (chrome + tipografía) por variante. Las dimensiones/colores salen de tokens del DS v3.
+	private readonly variantClasses: Record<TagVariant, string> = {
+		soft: 'text-xs text-brand-500',
+		filled: 'rounded-sm bg-brand-50 px-2 py-1 text-xxs text-brand-500 uppercase',
+		gray: 'rounded-sm bg-neutral-950-40 px-1.5 py-1 text-xxs text-neutral-50',
+	};
+
+	readonly hostClasses = computed(
+		() => `inline-flex items-center font-inter font-bold whitespace-nowrap ${this.variantClasses[this.variant()]}`,
+	);
+}

--- a/src/app/components/tags-list/intersection-observer.stub.ts
+++ b/src/app/components/tags-list/intersection-observer.stub.ts
@@ -1,0 +1,48 @@
+// TODO(#1494): eliminar este stub al migrar a Vitest. Su browser mode provee un IntersectionObserver
+// real, lo que permitiría testear el recorte con layout real en vez de simular el callback a mano.
+//
+// Stub de IntersectionObserver para tests (jsdom no lo implementa). Captura el callback del observer y
+// las opciones con que se creó, y permite simular que ciertos elementos entran o no en el contenedor.
+let callback: IntersectionObserverCallback | undefined;
+let options: IntersectionObserverInit | undefined;
+
+class IntersectionObserverStub {
+	constructor(cb: IntersectionObserverCallback, init?: IntersectionObserverInit) {
+		callback = cb;
+		options = init;
+	}
+	observe(): void {
+		return;
+	}
+	disconnect(): void {
+		return;
+	}
+}
+
+/** Instala el stub como `IntersectionObserver` global y resetea el estado. Llamar en `beforeEach`. */
+export function installIntersectionObserverStub(): void {
+	(globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver = IntersectionObserverStub;
+	callback = undefined;
+	options = undefined;
+}
+
+/** Simula que los elementos quedaron fuera del contenedor (no entran). */
+export function markOutsideViewport(...elements: Element[]): void {
+	callback?.(
+		elements.map((target) => ({ target, intersectionRatio: 0 }) as IntersectionObserverEntry),
+		{} as IntersectionObserver,
+	);
+}
+
+/** Simula que los elementos volvieron a entrar completos en el contenedor. */
+export function markInsideViewport(...elements: Element[]): void {
+	callback?.(
+		elements.map((target) => ({ target, intersectionRatio: 1 }) as IntersectionObserverEntry),
+		{} as IntersectionObserver,
+	);
+}
+
+/** Opciones con que se creó el último observer (p. ej. para inspeccionar el `rootMargin`). */
+export function lastObserverOptions(): IntersectionObserverInit | undefined {
+	return options;
+}

--- a/src/app/components/tags-list/tags-list.component.spec.ts
+++ b/src/app/components/tags-list/tags-list.component.spec.ts
@@ -1,83 +1,58 @@
 import { TagsListComponent } from './tags-list.component';
 import { TagComponent } from '../tag/tag.component';
 import { render, screen } from '@testing-library/angular';
+import {
+	installIntersectionObserverStub,
+	lastObserverOptions,
+	markOutsideViewport,
+} from './intersection-observer.stub';
 
-// jsdom no implementa IntersectionObserver. El stub captura el callback para simular, en los tests,
-// que ciertos tags no entran en el contenedor (intersectionRatio < 1).
-let intersectionCallback: IntersectionObserverCallback | undefined;
-class IntersectionObserverStub {
-	constructor(callback: IntersectionObserverCallback) {
-		intersectionCallback = callback;
-	}
-	observe(): void {
-		return;
-	}
-	disconnect(): void {
-		return;
-	}
-}
-
-/** Simula que los tags dados quedaron fuera del contenedor (overflow). */
-const markOverflowing = (...elements: Element[]) =>
-	intersectionCallback?.(
-		elements.map((target) => ({ target, intersectionRatio: 0 }) as IntersectionObserverEntry),
-		{} as IntersectionObserver,
-	);
-
-// Los tags se proyectan: la API del componente es por content projection.
-const renderList = (labels: string[], maxVisible?: number) =>
+// Los tags se proyectan: la API del componente es por content projection. Se les da variant 'gray'
+// para verificar que el contador toma la variante de los tags proyectados.
+const renderList = (labels: string[]) =>
 	render(
-		`<cuentoneta-tags-list [maxVisible]="maxVisible">
+		`<cuentoneta-tags-list>
 			@for (label of labels; track label) {
-				<cuentoneta-tag [label]="label" />
+				<cuentoneta-tag [label]="label" variant="gray" />
 			}
 		</cuentoneta-tags-list>`,
-		{ imports: [TagsListComponent, TagComponent], componentProperties: { labels, maxVisible } },
+		{ imports: [TagsListComponent, TagComponent], componentProperties: { labels } },
 	);
 
 describe('TagsListComponent', () => {
-	beforeAll(() => {
-		(globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver = IntersectionObserverStub;
-	});
+	beforeEach(() => installIntersectionObserverStub());
+	afterEach(() => jest.restoreAllMocks());
 
-	beforeEach(() => (intersectionCallback = undefined));
-
-	it('proyecta y renderiza todos los tags provistos', async () => {
+	it('should project and render the tags, with no counter when they all fit', async () => {
 		await renderList(['Crónica', 'Ensayo', 'Memoria']);
 		for (const label of ['Crónica', 'Ensayo', 'Memoria']) {
 			expect(screen.getByText(label)).toBeInTheDocument();
 		}
-	});
-
-	it('muestra todos los tags y ningún contador cuando entran en el ancho', async () => {
-		await renderList(['A', 'B', 'C', 'D']);
-		for (const label of ['A', 'B', 'C', 'D']) {
-			expect(screen.getByText(label)).not.toHaveStyle({ visibility: 'hidden' });
-		}
 		expect(screen.queryByTestId('tags-overflow')).not.toBeInTheDocument();
 	});
 
-	it('colapsa con "+N" los tags que no entran por ancho y los oculta con visibility:hidden', async () => {
+	it('should show the "+N" counter on overflow, taking the variant from the projected tags', async () => {
 		const { fixture } = await renderList(['A', 'B', 'C', 'D', 'E']);
 
-		markOverflowing(screen.getByText('D'), screen.getByText('E'));
+		markOutsideViewport(screen.getByText('D'), screen.getByText('E'));
 		await fixture.whenStable();
 
-		expect(screen.getByTestId('tags-overflow')).toHaveTextContent('+2');
-		expect(screen.getByText('C')).not.toHaveStyle({ visibility: 'hidden' });
-		expect(screen.getByText('D')).toHaveStyle({ visibility: 'hidden' });
-		expect(screen.getByText('E')).toHaveStyle({ visibility: 'hidden' });
+		const counter = screen.getByTestId('tags-overflow');
+		expect(counter).toHaveTextContent('+2');
+		expect(counter).toHaveClass('bg-neutral-950-40');
 	});
 
-	it('respeta maxVisible como tope duro aunque haya ancho de sobra', async () => {
-		await renderList(['A', 'B', 'C', 'D', 'E'], 2);
+	it('should reserve the measured counter width in the observer', async () => {
+		jest.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(30);
+		const { fixture } = await renderList(['A', 'B', 'C', 'D', 'E']);
 
-		expect(screen.getByTestId('tags-overflow')).toHaveTextContent('+3');
-		expect(screen.getByText('B')).not.toHaveStyle({ visibility: 'hidden' });
-		expect(screen.getByText('C')).toHaveStyle({ visibility: 'hidden' });
+		markOutsideViewport(screen.getByText('D'), screen.getByText('E'));
+		await fixture.whenStable();
+
+		expect(lastObserverOptions()?.rootMargin).toBe('0px -30px 0px 0px');
 	});
 
-	it('no muestra contador cuando no se proyecta ningún tag', async () => {
+	it('should not show a counter when no tag is projected', async () => {
 		await renderList([]);
 		expect(screen.queryByTestId('tags-overflow')).not.toBeInTheDocument();
 	});

--- a/src/app/components/tags-list/tags-list.component.spec.ts
+++ b/src/app/components/tags-list/tags-list.component.spec.ts
@@ -1,0 +1,84 @@
+import { TagsListComponent } from './tags-list.component';
+import { TagComponent } from '../tag/tag.component';
+import { render, screen } from '@testing-library/angular';
+
+// jsdom no implementa IntersectionObserver. El stub captura el callback para simular, en los tests,
+// que ciertos tags no entran en el contenedor (intersectionRatio < 1).
+let intersectionCallback: IntersectionObserverCallback | undefined;
+class IntersectionObserverStub {
+	constructor(callback: IntersectionObserverCallback) {
+		intersectionCallback = callback;
+	}
+	observe(): void {
+		return;
+	}
+	disconnect(): void {
+		return;
+	}
+}
+
+/** Simula que los tags dados quedaron fuera del contenedor (overflow). */
+const markOverflowing = (...elements: Element[]) =>
+	intersectionCallback?.(
+		elements.map((target) => ({ target, intersectionRatio: 0 }) as IntersectionObserverEntry),
+		{} as IntersectionObserver,
+	);
+
+// Los tags se proyectan: la API del componente es por content projection.
+const renderList = (labels: string[], maxVisible?: number) =>
+	render(
+		`<cuentoneta-tags-list [maxVisible]="maxVisible">
+			@for (label of labels; track label) {
+				<cuentoneta-tag [label]="label" />
+			}
+		</cuentoneta-tags-list>`,
+		{ imports: [TagsListComponent, TagComponent], componentProperties: { labels, maxVisible } },
+	);
+
+describe('TagsListComponent', () => {
+	beforeAll(() => {
+		(globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver = IntersectionObserverStub;
+	});
+
+	beforeEach(() => (intersectionCallback = undefined));
+
+	it('proyecta y renderiza todos los tags provistos', async () => {
+		await renderList(['Crónica', 'Ensayo', 'Memoria']);
+		for (const label of ['Crónica', 'Ensayo', 'Memoria']) {
+			expect(screen.getByText(label)).toBeInTheDocument();
+		}
+	});
+
+	it('muestra todos los tags y ningún contador cuando entran en el ancho', async () => {
+		await renderList(['A', 'B', 'C', 'D']);
+		for (const label of ['A', 'B', 'C', 'D']) {
+			expect(screen.getByText(label)).not.toHaveStyle({ visibility: 'hidden' });
+		}
+		expect(screen.queryByTestId('tags-overflow')).not.toBeInTheDocument();
+	});
+
+	it('colapsa con "+N" los tags que no entran por ancho y los oculta con visibility:hidden', async () => {
+		const { fixture } = await renderList(['A', 'B', 'C', 'D', 'E']);
+
+		markOverflowing(screen.getByText('D'), screen.getByText('E'));
+		await fixture.whenStable();
+
+		expect(screen.getByTestId('tags-overflow')).toHaveTextContent('+2');
+		expect(screen.getByText('C')).not.toHaveStyle({ visibility: 'hidden' });
+		expect(screen.getByText('D')).toHaveStyle({ visibility: 'hidden' });
+		expect(screen.getByText('E')).toHaveStyle({ visibility: 'hidden' });
+	});
+
+	it('respeta maxVisible como tope duro aunque haya ancho de sobra', async () => {
+		await renderList(['A', 'B', 'C', 'D', 'E'], 2);
+
+		expect(screen.getByTestId('tags-overflow')).toHaveTextContent('+3');
+		expect(screen.getByText('B')).not.toHaveStyle({ visibility: 'hidden' });
+		expect(screen.getByText('C')).toHaveStyle({ visibility: 'hidden' });
+	});
+
+	it('no muestra contador cuando no se proyecta ningún tag', async () => {
+		await renderList([]);
+		expect(screen.queryByTestId('tags-overflow')).not.toBeInTheDocument();
+	});
+});

--- a/src/app/components/tags-list/tags-list.component.stories.ts
+++ b/src/app/components/tags-list/tags-list.component.stories.ts
@@ -1,0 +1,150 @@
+import { componentWrapperDecorator, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+
+import { TagsListComponent } from './tags-list.component';
+import { TagComponent } from '../tag/tag.component';
+import { Tag } from '@models/tag.model';
+
+const tags: Tag[] = [
+	{ title: 'Crónica', slug: 'cronica', shortDescription: '', description: [] },
+	{ title: 'Ensayo', slug: 'ensayo', shortDescription: '', description: [] },
+	{ title: 'Memoria', slug: 'memoria', shortDescription: '', description: [] },
+	{ title: 'Histórico', slug: 'historico', shortDescription: '', description: [] },
+	{ title: 'Política', slug: 'politica', shortDescription: '', description: [] },
+];
+
+/** Proyecta los tags dentro del componente (la API es por content projection). */
+const projected = `<cuentoneta-tags-list [variant]="variant" [maxVisible]="maxVisible">
+		@for (tag of tags; track tag.slug) {
+			<cuentoneta-tag [label]="tag.title" [variant]="variant" />
+		}
+	</cuentoneta-tags-list>`;
+
+/** Caja con ancho fijo y borde punteado para evidenciar dónde recorta el contenedor. */
+const boxed = (width: string) =>
+	componentWrapperDecorator(
+		(story) => `<div style="width:${width}; outline:1px dashed #cbd5e1; border-radius:8px; padding:8px">${story}</div>`,
+	);
+
+const meta: Meta<TagsListComponent & { tags: Tag[]; maxVisible?: number }> = {
+	component: TagsListComponent,
+	title: 'Componentes/TagsList',
+	decorators: [moduleMetadata({ imports: [TagComponent] })],
+	parameters: {
+		docs: {
+			description: {
+				component: `<div>
+					<p>El componente **TagsListComponent** recibe los tags por <strong>content projection</strong>
+					(<code>&lt;ng-content&gt;</code>) y, cuando <strong>no entran en el ancho del contenedor</strong>,
+					colapsa el excedente detrás de un contador <strong>"+N"</strong> de ancho fijo ubicado justo
+					después del último tag visible.</p>
+					<p>El recorte es <strong>por ancho real</strong> (vía <code>IntersectionObserver</code>, sin
+					<code>ResizeObserver</code>), no por cantidad, y vive en <code>TagsOverflowDirective</code> aplicada
+					como <code>hostDirective</code>. <code>maxVisible</code> es un <strong>tope duro opcional</strong>.</p>
+					<p>Probá el <em>Playground</em> para arrastrar el ancho y ver el contador aparecer/desaparecer en vivo.</p>
+				</div>`,
+			},
+		},
+		layout: 'padded',
+	},
+	argTypes: {
+		variant: {
+			control: { type: 'inline-radio' },
+			options: ['soft', 'filled', 'gray'],
+			table: { defaultValue: { summary: 'filled' } },
+		},
+		maxVisible: {
+			control: { type: 'number' },
+			description: 'Tope duro opcional de tags visibles. Vacío = recorte solo por ancho.',
+			table: { defaultValue: { summary: '— (sin tope)' } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<TagsListComponent & { tags: Tag[]; maxVisible?: number }>;
+
+// Contenedor ancho: entran todos, no se muestra contador.
+export const Default: Story = {
+	render: (args) => ({ props: { ...args, tags }, template: projected }),
+	args: { variant: 'filled' },
+	decorators: [boxed('100%')],
+	parameters: { docs: { description: { story: 'Con espacio de sobra, los 5 tags se muestran sin contador.' } } },
+};
+
+// Contenedor acotado: el excedente que no entra por ancho se colapsa en "+N".
+export const WidthOverflow: Story = {
+	render: (args) => ({ props: { ...args, tags }, template: projected }),
+	args: { variant: 'filled' },
+	decorators: [boxed('240px')],
+	parameters: {
+		docs: {
+			description: {
+				story: 'En 240px no entran los 5 tags: los que sobran se colapsan tras un "+N" después del último visible.',
+			},
+		},
+	},
+};
+
+// Contenedor muy angosto: entran muy pocos y el contador refleja el resto.
+export const NarrowWidth: Story = {
+	render: (args) => ({ props: { ...args, tags }, template: projected }),
+	args: { variant: 'filled' },
+	decorators: [boxed('130px')],
+	parameters: { docs: { description: { story: 'A 130px casi nada entra; el contador refleja todo lo colapsado.' } } },
+};
+
+// Tope duro: el contenedor daría para más, pero maxVisible corta antes.
+export const MaxVisibleCap: Story = {
+	render: (args) => ({ props: { ...args, tags }, template: projected }),
+	args: { variant: 'filled', maxVisible: 2 },
+	decorators: [boxed('100%')],
+	parameters: {
+		docs: {
+			description: {
+				story: 'Con ancho de sobra pero maxVisible=2, se muestran 2 + "+3"; el tope manda sobre el ancho.',
+			},
+		},
+	},
+};
+
+// Las tres variantes recortando por ancho en cajas idénticas.
+export const Variants: Story = {
+	render: () => ({
+		props: { tags },
+		template: `
+			<div class="flex flex-col gap-6">
+				@for (variant of ['soft', 'filled', 'gray']; track variant) {
+					<div style="width:240px; outline:1px dashed #cbd5e1; border-radius:8px; padding:8px">
+						<cuentoneta-tags-list [variant]="variant">
+							@for (tag of tags; track tag.slug) {
+								<cuentoneta-tag [label]="tag.title" [variant]="variant" />
+							}
+						</cuentoneta-tags-list>
+					</div>
+				}
+			</div>
+		`,
+	}),
+	parameters: {
+		docs: { description: { story: 'soft / filled / gray recortando por ancho en contenedores de 240px.' } },
+	},
+};
+
+// Caja redimensionable: arrastrá el borde inferior-derecho para ver el contador reaccionar al ancho.
+export const Playground: Story = {
+	render: (args) => ({ props: { ...args, tags }, template: projected }),
+	args: { variant: 'filled' },
+	decorators: [
+		componentWrapperDecorator(
+			(story) =>
+				`<div style="width:260px; max-width:100%; resize:horizontal; overflow:hidden; outline:1px dashed #cbd5e1; border-radius:8px; padding:8px">${story}</div>`,
+		),
+	],
+	parameters: {
+		docs: {
+			description: {
+				story: 'Arrastrá el handle de resize del contenedor: el "+N" aparece/desaparece según el ancho disponible.',
+			},
+		},
+	},
+};

--- a/src/app/components/tags-list/tags-list.component.stories.ts
+++ b/src/app/components/tags-list/tags-list.component.stories.ts
@@ -1,8 +1,10 @@
 import { componentWrapperDecorator, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 
 import { TagsListComponent } from './tags-list.component';
-import { TagComponent } from '../tag/tag.component';
+import { TagComponent, TagVariant } from '../tag/tag.component';
 import { Tag } from '@models/tag.model';
+
+type Args = TagsListComponent & { tags: Tag[]; variant: TagVariant; maxVisible?: number };
 
 const tags: Tag[] = [
 	{ title: 'Crónica', slug: 'cronica', shortDescription: '', description: [] },
@@ -13,7 +15,7 @@ const tags: Tag[] = [
 ];
 
 /** Proyecta los tags dentro del componente (la API es por content projection). */
-const projected = `<cuentoneta-tags-list [variant]="variant" [maxVisible]="maxVisible">
+const projected = `<cuentoneta-tags-list [maxVisible]="maxVisible">
 		@for (tag of tags; track tag.slug) {
 			<cuentoneta-tag [label]="tag.title" [variant]="variant" />
 		}
@@ -25,7 +27,7 @@ const boxed = (width: string) =>
 		(story) => `<div style="width:${width}; outline:1px dashed #cbd5e1; border-radius:8px; padding:8px">${story}</div>`,
 	);
 
-const meta: Meta<TagsListComponent & { tags: Tag[]; maxVisible?: number }> = {
+const meta: Meta<Args> = {
 	component: TagsListComponent,
 	title: 'Componentes/TagsList',
 	decorators: [moduleMetadata({ imports: [TagComponent] })],
@@ -61,7 +63,7 @@ const meta: Meta<TagsListComponent & { tags: Tag[]; maxVisible?: number }> = {
 };
 
 export default meta;
-type Story = StoryObj<TagsListComponent & { tags: Tag[]; maxVisible?: number }>;
+type Story = StoryObj<Args>;
 
 // Contenedor ancho: entran todos, no se muestra contador.
 export const Default: Story = {
@@ -115,7 +117,7 @@ export const Variants: Story = {
 			<div class="flex flex-col gap-6">
 				@for (variant of ['soft', 'filled', 'gray']; track variant) {
 					<div style="width:240px; outline:1px dashed #cbd5e1; border-radius:8px; padding:8px">
-						<cuentoneta-tags-list [variant]="variant">
+						<cuentoneta-tags-list>
 							@for (tag of tags; track tag.slug) {
 								<cuentoneta-tag [label]="tag.title" [variant]="variant" />
 							}

--- a/src/app/components/tags-list/tags-list.component.ts
+++ b/src/app/components/tags-list/tags-list.component.ts
@@ -1,0 +1,50 @@
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+
+import { TagComponent, TagVariant } from '../tag/tag.component';
+import { TagsOverflowDirective } from './tags-overflow.directive';
+
+/**
+ * Lista de tags del Design System v3. Los tags se **proyectan** (`<ng-content>`) y, cuando no entran en
+ * el ancho del contenedor, se colapsa el excedente detrás de un contador "+N" de ancho fijo ubicado
+ * justo después del último tag visible.
+ *
+ * Toda la lógica de recorte por ancho vive en {@link TagsOverflowDirective}, aplicada como `hostDirective`
+ * (el propio host del componente es el contenedor/root del observer — sin `<div>` wrapper). El componente
+ * solo proyecta el contenido, renderiza el contador y expone `maxVisible` (vía la hostDirective). El
+ * `variant` aplica al contador (los tags proyectados llevan el suyo).
+ *
+ * Uso:
+ * ```html
+ * <cuentoneta-tags-list [maxVisible]="3">
+ *   @for (tag of tags(); track tag.slug) {
+ *     <cuentoneta-tag [label]="tag.title" variant="filled" />
+ *   }
+ * </cuentoneta-tags-list>
+ * ```
+ */
+@Component({
+	selector: 'cuentoneta-tags-list',
+	imports: [TagComponent],
+	hostDirectives: [{ directive: TagsOverflowDirective, inputs: ['maxVisible'] }],
+	template: `
+		<ng-content />
+		@if (overflow.hiddenCount() > 0) {
+			<!-- Ancho fijo (de su contenido), ubicado justo después del último tag visible (left medido). -->
+			<cuentoneta-tag
+				[style.left.px]="overflow.counterLeft()"
+				[label]="'+' + overflow.hiddenCount()"
+				[variant]="variant()"
+				class="absolute top-1/2 -translate-y-1/2"
+				data-testid="tags-overflow"
+			/>
+		}
+	`,
+	host: { class: 'relative flex items-center gap-1.5 overflow-hidden' },
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TagsListComponent {
+	/** Variante del contador "+N" (los tags proyectados llevan la suya). */
+	readonly variant = input<TagVariant>('filled');
+
+	protected readonly overflow = inject(TagsOverflowDirective);
+}

--- a/src/app/components/tags-list/tags-list.component.ts
+++ b/src/app/components/tags-list/tags-list.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import {
+	afterRenderEffect,
+	ChangeDetectionStrategy,
+	Component,
+	ElementRef,
+	inject,
+	input,
+	viewChild,
+} from '@angular/core';
 
 import { TagComponent, TagVariant } from '../tag/tag.component';
 import { TagsOverflowDirective } from './tags-overflow.directive';
@@ -31,7 +39,12 @@ import { TagsOverflowDirective } from './tags-overflow.directive';
 		@if (overflow.hiddenCount() > 0) {
 			<!-- Un tag más, in-flow: la directiva ordena (flex order) los ocultos después, así cae justo
 				 a la derecha del último visible, con el gap natural de la fila. -->
-			<cuentoneta-tag [label]="'+' + overflow.hiddenCount()" [variant]="variant()" data-testid="tags-overflow" />
+			<cuentoneta-tag
+				[label]="'+' + overflow.hiddenCount()"
+				[variant]="variant()"
+				#counter
+				data-testid="tags-overflow"
+			/>
 		}
 	`,
 	host: { class: 'relative flex items-center gap-1.5 overflow-hidden' },
@@ -42,4 +55,21 @@ export class TagsListComponent {
 	readonly variant = input<TagVariant>('filled');
 
 	protected readonly overflow = inject(TagsOverflowDirective);
+	private readonly hostRef = inject<ElementRef<HTMLElement>>(ElementRef);
+	private readonly counterRef = viewChild('counter', { read: ElementRef });
+
+	// Mide el ancho real del contador "+N" (tras el render, browser-only) y le pasa su huella —ancho + el
+	// gap de la fila— a la directiva como reserva: así el espacio reservado es exacto, sin tamaño
+	// hardcodeado. Se re-mide cuando el contador aparece/desaparece o cambia su "+N" (su ancho varía con
+	// los dígitos). El feedback reserva → recorte → "+N" se separa por el callback asíncrono del observer.
+	private readonly measureReserve = afterRenderEffect(() => {
+		const counter = this.counterRef()?.nativeElement as HTMLElement | undefined;
+		this.overflow.hiddenCount();
+		if (!counter) {
+			this.overflow.groupedTagsSlotReservedSpace.set(0);
+			return;
+		}
+		const gap = parseFloat(getComputedStyle(this.hostRef.nativeElement).columnGap) || 0;
+		this.overflow.groupedTagsSlotReservedSpace.set(counter.offsetWidth + gap);
+	});
 }

--- a/src/app/components/tags-list/tags-list.component.ts
+++ b/src/app/components/tags-list/tags-list.component.ts
@@ -1,25 +1,27 @@
 import {
-	afterRenderEffect,
 	ChangeDetectionStrategy,
 	Component,
+	computed,
+	contentChildren,
+	effect,
 	ElementRef,
 	inject,
-	input,
+	PLATFORM_ID,
 	viewChild,
 } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 
-import { TagComponent, TagVariant } from '../tag/tag.component';
+import { TagComponent } from '../tag/tag.component';
 import { TagsOverflowDirective } from './tags-overflow.directive';
 
 /**
- * Lista de tags del Design System v3. Los tags se **proyectan** (`<ng-content>`) y, cuando no entran en
- * el ancho del contenedor, se colapsa el excedente detrás de un contador "+N" de ancho fijo ubicado
- * justo después del último tag visible.
+ * Lista de tags del Design System v3. Los tags se proyectan (`<ng-content>`) y, cuando no entran en el
+ * ancho del contenedor, se colapsa el excedente detrás de un contador "+N" ubicado tras el último visible.
  *
- * Toda la lógica de recorte por ancho vive en {@link TagsOverflowDirective}, aplicada como `hostDirective`
- * (el propio host del componente es el contenedor/root del observer — sin `<div>` wrapper). El componente
- * solo proyecta el contenido, renderiza el contador y expone `maxVisible` (vía la hostDirective). El
- * `variant` aplica al contador (los tags proyectados llevan el suyo).
+ * La lógica de recorte vive en `TagsOverflowDirective`, aplicada como `hostDirective` (el host del
+ * componente es el contenedor — sin `<div>` wrapper). El componente proyecta el contenido, renderiza el
+ * contador (toma la variante de los tags proyectados) y le mide el ancho a la directiva para que reserve
+ * su espacio. `maxVisible` se expone vía la hostDirective.
  *
  * Uso:
  * ```html
@@ -37,39 +39,40 @@ import { TagsOverflowDirective } from './tags-overflow.directive';
 	template: `
 		<ng-content />
 		@if (overflow.hiddenCount() > 0) {
-			<!-- Un tag más, in-flow: la directiva ordena (flex order) los ocultos después, así cae justo
-				 a la derecha del último visible, con el gap natural de la fila. -->
 			<cuentoneta-tag
 				[label]="'+' + overflow.hiddenCount()"
-				[variant]="variant()"
+				[variant]="counterVariant()"
+				[attr.aria-label]="overflow.hiddenCount() + ' etiquetas más'"
 				#counter
 				data-testid="tags-overflow"
 			/>
 		}
 	`,
-	host: { class: 'relative flex items-center gap-1.5 overflow-hidden' },
+	host: { class: 'flex items-center gap-1.5 overflow-hidden' },
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TagsListComponent {
-	/** Variante del contador "+N" (los tags proyectados llevan la suya). */
-	readonly variant = input<TagVariant>('filled');
-
 	protected readonly overflow = inject(TagsOverflowDirective);
 	private readonly hostRef = inject<ElementRef<HTMLElement>>(ElementRef);
-	private readonly counterRef = viewChild('counter', { read: ElementRef });
+	private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
-	// Mide el ancho real del contador "+N" (tras el render, browser-only) y le pasa su huella —ancho + el
-	// gap de la fila— a la directiva como reserva: así el espacio reservado es exacto, sin tamaño
-	// hardcodeado. Se re-mide cuando el contador aparece/desaparece o cambia su "+N" (su ancho varía con
-	// los dígitos). El feedback reserva → recorte → "+N" se separa por el callback asíncrono del observer.
-	private readonly measureReserve = afterRenderEffect(() => {
-		const counter = this.counterRef()?.nativeElement as HTMLElement | undefined;
+	private readonly projectedTags = contentChildren(TagComponent);
+	private readonly counter = viewChild('counter', { read: ElementRef });
+
+	/** El contador "+N" toma la variante de los tags proyectados (todos suelen compartirla). */
+	protected readonly counterVariant = computed(() => this.projectedTags()[0]?.variant() ?? 'filled');
+
+	// Mide el ancho real del contador (más el gap de la fila) y se lo pasa a la directiva como reserva (se
+	// re-mide al aparecer el contador o cambiar su "+N"). El feedback reserva → recorte → "+N" se rompe por
+	// el callback asíncrono del observer, y un `set` con el mismo valor no recrea el observer.
+	private readonly measureReserveSpace = effect(() => {
+		const counter = this.counter()?.nativeElement as HTMLElement | undefined;
 		this.overflow.hiddenCount();
-		if (!counter) {
-			this.overflow.groupedTagsSlotReservedSpace.set(0);
+		if (!this.isBrowser || !counter) {
+			this.overflow.reserveTrailingSpace(0);
 			return;
 		}
 		const gap = parseFloat(getComputedStyle(this.hostRef.nativeElement).columnGap) || 0;
-		this.overflow.groupedTagsSlotReservedSpace.set(counter.offsetWidth + gap);
+		this.overflow.reserveTrailingSpace(counter.offsetWidth + gap);
 	});
 }

--- a/src/app/components/tags-list/tags-list.component.ts
+++ b/src/app/components/tags-list/tags-list.component.ts
@@ -29,14 +29,9 @@ import { TagsOverflowDirective } from './tags-overflow.directive';
 	template: `
 		<ng-content />
 		@if (overflow.hiddenCount() > 0) {
-			<!-- Ancho fijo (de su contenido), ubicado justo después del último tag visible (left medido). -->
-			<cuentoneta-tag
-				[style.left.px]="overflow.counterLeft()"
-				[label]="'+' + overflow.hiddenCount()"
-				[variant]="variant()"
-				class="absolute top-1/2 -translate-y-1/2"
-				data-testid="tags-overflow"
-			/>
+			<!-- Un tag más, in-flow: la directiva ordena (flex order) los ocultos después, así cae justo
+				 a la derecha del último visible, con el gap natural de la fila. -->
+			<cuentoneta-tag [label]="'+' + overflow.hiddenCount()" [variant]="variant()" data-testid="tags-overflow" />
 		}
 	`,
 	host: { class: 'relative flex items-center gap-1.5 overflow-hidden' },

--- a/src/app/components/tags-list/tags-overflow.directive.spec.ts
+++ b/src/app/components/tags-list/tags-overflow.directive.spec.ts
@@ -1,0 +1,137 @@
+import { Component, inject } from '@angular/core';
+import { render, screen } from '@testing-library/angular';
+
+import { TagsOverflowDirective } from './tags-overflow.directive';
+import { TagComponent } from '../tag/tag.component';
+
+// jsdom no implementa IntersectionObserver. El stub captura el callback para simular, en los tests,
+// que ciertos tags no entran en el contenedor (intersectionRatio < 1).
+let intersectionCallback: IntersectionObserverCallback | undefined;
+class IntersectionObserverStub {
+	constructor(callback: IntersectionObserverCallback) {
+		intersectionCallback = callback;
+	}
+	observe(): void {
+		return;
+	}
+	disconnect(): void {
+		return;
+	}
+}
+
+/** Simula que los tags dados quedaron fuera del contenedor (overflow). */
+const markOverflowing = (...elements: Element[]) =>
+	intersectionCallback?.(
+		elements.map((target) => ({ target, intersectionRatio: 0 }) as IntersectionObserverEntry),
+		{} as IntersectionObserver,
+	);
+
+// Host de prueba que usa la directiva como hostDirective y proyecta tags, tal como TagsListComponent.
+@Component({
+	selector: 'cuentoneta-test-overflow-host',
+	imports: [TagComponent],
+	hostDirectives: [{ directive: TagsOverflowDirective, inputs: ['maxVisible'] }],
+	template: `
+		<ng-content />
+		@if (overflow.hiddenCount() > 0) {
+			<span [style.left.px]="overflow.counterLeft()" data-testid="counter">+{{ overflow.hiddenCount() }}</span>
+		}
+	`,
+	host: { class: 'relative flex overflow-hidden' },
+})
+class TestOverflowHostComponent {
+	protected readonly overflow = inject(TagsOverflowDirective);
+}
+
+const renderHost = (labels: string[], maxVisible?: number) =>
+	render(
+		`<cuentoneta-test-overflow-host [maxVisible]="maxVisible">
+			@for (label of labels; track label) {
+				<cuentoneta-tag [label]="label" />
+			}
+		</cuentoneta-test-overflow-host>`,
+		{
+			imports: [TestOverflowHostComponent, TagComponent],
+			componentProperties: { labels, maxVisible },
+		},
+	);
+
+describe('TagsOverflowDirective', () => {
+	beforeAll(() => {
+		(globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver = IntersectionObserverStub;
+	});
+
+	beforeEach(() => (intersectionCallback = undefined));
+
+	it('descubre los tags proyectados y los muestra todos cuando entran', async () => {
+		await renderHost(['A', 'B', 'C']);
+		for (const label of ['A', 'B', 'C']) {
+			expect(screen.getByText(label)).not.toHaveStyle({ visibility: 'hidden' });
+		}
+		expect(screen.queryByTestId('counter')).not.toBeInTheDocument();
+	});
+
+	it('expone hiddenCount y oculta los tags que el observer reporta fuera del contenedor', async () => {
+		const { fixture } = await renderHost(['A', 'B', 'C', 'D', 'E']);
+
+		markOverflowing(screen.getByText('D'), screen.getByText('E'));
+		await fixture.whenStable();
+
+		expect(screen.getByTestId('counter')).toHaveTextContent('+2');
+		expect(screen.getByText('C')).not.toHaveStyle({ visibility: 'hidden' });
+		expect(screen.getByText('D')).toHaveStyle({ visibility: 'hidden' });
+		expect(screen.getByText('E')).toHaveStyle({ visibility: 'hidden' });
+	});
+
+	it('vuelve a mostrar los tags si el observer reporta que entran de nuevo', async () => {
+		const { fixture } = await renderHost(['A', 'B', 'C', 'D', 'E']);
+
+		markOverflowing(screen.getByText('D'), screen.getByText('E'));
+		await fixture.whenStable();
+		expect(screen.getByTestId('counter')).toHaveTextContent('+2');
+
+		intersectionCallback?.(
+			[
+				{ target: screen.getByText('D'), intersectionRatio: 1 } as IntersectionObserverEntry,
+				{ target: screen.getByText('E'), intersectionRatio: 1 } as IntersectionObserverEntry,
+			],
+			{} as IntersectionObserver,
+		);
+		await fixture.whenStable();
+		expect(screen.queryByTestId('counter')).not.toBeInTheDocument();
+		expect(screen.getByText('E')).not.toHaveStyle({ visibility: 'hidden' });
+	});
+
+	it('respeta maxVisible como tope duro aunque haya ancho de sobra', async () => {
+		await renderHost(['A', 'B', 'C', 'D', 'E'], 2);
+
+		expect(screen.getByTestId('counter')).toHaveTextContent('+3');
+		expect(screen.getByText('B')).not.toHaveStyle({ visibility: 'hidden' });
+		expect(screen.getByText('C')).toHaveStyle({ visibility: 'hidden' });
+	});
+
+	it('el ancho manda cuando es más restrictivo que maxVisible', async () => {
+		const { fixture } = await renderHost(['A', 'B', 'C', 'D', 'E'], 4);
+
+		markOverflowing(screen.getByText('C'), screen.getByText('D'), screen.getByText('E'));
+		await fixture.whenStable();
+
+		expect(screen.getByTestId('counter')).toHaveTextContent('+3');
+		expect(screen.getByText('B')).not.toHaveStyle({ visibility: 'hidden' });
+		expect(screen.getByText('C')).toHaveStyle({ visibility: 'hidden' });
+	});
+
+	it('posiciona el contador al final del último tag visible (counterLeft)', async () => {
+		const { fixture } = await renderHost(['A', 'B', 'C']);
+		// jsdom no hace layout: simulamos la geometría del último tag visible (B, tras ocultar C).
+		const b = screen.getByText('B');
+		Object.defineProperty(b, 'offsetLeft', { configurable: true, value: 40 });
+		Object.defineProperty(b, 'offsetWidth', { configurable: true, value: 30 });
+
+		markOverflowing(screen.getByText('C'));
+		await fixture.whenStable();
+
+		// counterLeft = offsetLeft(40) + offsetWidth(30) + gap(6) = 76
+		expect(screen.getByTestId('counter')).toHaveStyle({ left: '76px' });
+	});
+});

--- a/src/app/components/tags-list/tags-overflow.directive.spec.ts
+++ b/src/app/components/tags-list/tags-overflow.directive.spec.ts
@@ -34,7 +34,7 @@ const markOverflowing = (...elements: Element[]) =>
 	template: `
 		<ng-content />
 		@if (overflow.hiddenCount() > 0) {
-			<span [style.left.px]="overflow.counterLeft()" data-testid="counter">+{{ overflow.hiddenCount() }}</span>
+			<span data-testid="counter">+{{ overflow.hiddenCount() }}</span>
 		}
 	`,
 	host: { class: 'relative flex overflow-hidden' },
@@ -119,19 +119,5 @@ describe('TagsOverflowDirective', () => {
 		expect(screen.getByTestId('counter')).toHaveTextContent('+3');
 		expect(screen.getByText('B')).not.toHaveStyle({ visibility: 'hidden' });
 		expect(screen.getByText('C')).toHaveStyle({ visibility: 'hidden' });
-	});
-
-	it('posiciona el contador al final del último tag visible (counterLeft)', async () => {
-		const { fixture } = await renderHost(['A', 'B', 'C']);
-		// jsdom no hace layout: simulamos la geometría del último tag visible (B, tras ocultar C).
-		const b = screen.getByText('B');
-		Object.defineProperty(b, 'offsetLeft', { configurable: true, value: 40 });
-		Object.defineProperty(b, 'offsetWidth', { configurable: true, value: 30 });
-
-		markOverflowing(screen.getByText('C'));
-		await fixture.whenStable();
-
-		// counterLeft = offsetLeft(40) + offsetWidth(30) + gap(6) = 76
-		expect(screen.getByTestId('counter')).toHaveStyle({ left: '76px' });
 	});
 });

--- a/src/app/components/tags-list/tags-overflow.directive.spec.ts
+++ b/src/app/components/tags-list/tags-overflow.directive.spec.ts
@@ -3,28 +3,7 @@ import { render, screen } from '@testing-library/angular';
 
 import { TagsOverflowDirective } from './tags-overflow.directive';
 import { TagComponent } from '../tag/tag.component';
-
-// jsdom no implementa IntersectionObserver. El stub captura el callback para simular, en los tests,
-// que ciertos tags no entran en el contenedor (intersectionRatio < 1).
-let intersectionCallback: IntersectionObserverCallback | undefined;
-class IntersectionObserverStub {
-	constructor(callback: IntersectionObserverCallback) {
-		intersectionCallback = callback;
-	}
-	observe(): void {
-		return;
-	}
-	disconnect(): void {
-		return;
-	}
-}
-
-/** Simula que los tags dados quedaron fuera del contenedor (overflow). */
-const markOverflowing = (...elements: Element[]) =>
-	intersectionCallback?.(
-		elements.map((target) => ({ target, intersectionRatio: 0 }) as IntersectionObserverEntry),
-		{} as IntersectionObserver,
-	);
+import { installIntersectionObserverStub, markInsideViewport, markOutsideViewport } from './intersection-observer.stub';
 
 // Host de prueba que usa la directiva como hostDirective y proyecta tags, tal como TagsListComponent.
 @Component({
@@ -37,7 +16,7 @@ const markOverflowing = (...elements: Element[]) =>
 			<span data-testid="counter">+{{ overflow.hiddenCount() }}</span>
 		}
 	`,
-	host: { class: 'relative flex overflow-hidden' },
+	host: { class: 'flex overflow-hidden' },
 })
 class TestOverflowHostComponent {
 	protected readonly overflow = inject(TagsOverflowDirective);
@@ -57,13 +36,9 @@ const renderHost = (labels: string[], maxVisible?: number) =>
 	);
 
 describe('TagsOverflowDirective', () => {
-	beforeAll(() => {
-		(globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver = IntersectionObserverStub;
-	});
+	beforeEach(() => installIntersectionObserverStub());
 
-	beforeEach(() => (intersectionCallback = undefined));
-
-	it('descubre los tags proyectados y los muestra todos cuando entran', async () => {
+	it('should discover the projected tags and show them all when they fit', async () => {
 		await renderHost(['A', 'B', 'C']);
 		for (const label of ['A', 'B', 'C']) {
 			expect(screen.getByText(label)).not.toHaveStyle({ visibility: 'hidden' });
@@ -71,10 +46,10 @@ describe('TagsOverflowDirective', () => {
 		expect(screen.queryByTestId('counter')).not.toBeInTheDocument();
 	});
 
-	it('expone hiddenCount y oculta los tags que el observer reporta fuera del contenedor', async () => {
+	it('should expose hiddenCount and hide the tags the observer reports outside the container', async () => {
 		const { fixture } = await renderHost(['A', 'B', 'C', 'D', 'E']);
 
-		markOverflowing(screen.getByText('D'), screen.getByText('E'));
+		markOutsideViewport(screen.getByText('D'), screen.getByText('E'));
 		await fixture.whenStable();
 
 		expect(screen.getByTestId('counter')).toHaveTextContent('+2');
@@ -83,26 +58,20 @@ describe('TagsOverflowDirective', () => {
 		expect(screen.getByText('E')).toHaveStyle({ visibility: 'hidden' });
 	});
 
-	it('vuelve a mostrar los tags si el observer reporta que entran de nuevo', async () => {
+	it('should show the tags again when the observer reports them back inside', async () => {
 		const { fixture } = await renderHost(['A', 'B', 'C', 'D', 'E']);
 
-		markOverflowing(screen.getByText('D'), screen.getByText('E'));
+		markOutsideViewport(screen.getByText('D'), screen.getByText('E'));
 		await fixture.whenStable();
 		expect(screen.getByTestId('counter')).toHaveTextContent('+2');
 
-		intersectionCallback?.(
-			[
-				{ target: screen.getByText('D'), intersectionRatio: 1 } as IntersectionObserverEntry,
-				{ target: screen.getByText('E'), intersectionRatio: 1 } as IntersectionObserverEntry,
-			],
-			{} as IntersectionObserver,
-		);
+		markInsideViewport(screen.getByText('D'), screen.getByText('E'));
 		await fixture.whenStable();
 		expect(screen.queryByTestId('counter')).not.toBeInTheDocument();
 		expect(screen.getByText('E')).not.toHaveStyle({ visibility: 'hidden' });
 	});
 
-	it('respeta maxVisible como tope duro aunque haya ancho de sobra', async () => {
+	it('should respect maxVisible as a hard cap even with spare width', async () => {
 		await renderHost(['A', 'B', 'C', 'D', 'E'], 2);
 
 		expect(screen.getByTestId('counter')).toHaveTextContent('+3');
@@ -110,10 +79,10 @@ describe('TagsOverflowDirective', () => {
 		expect(screen.getByText('C')).toHaveStyle({ visibility: 'hidden' });
 	});
 
-	it('el ancho manda cuando es más restrictivo que maxVisible', async () => {
+	it('should let width win when it is more restrictive than maxVisible', async () => {
 		const { fixture } = await renderHost(['A', 'B', 'C', 'D', 'E'], 4);
 
-		markOverflowing(screen.getByText('C'), screen.getByText('D'), screen.getByText('E'));
+		markOutsideViewport(screen.getByText('C'), screen.getByText('D'), screen.getByText('E'));
 		await fixture.whenStable();
 
 		expect(screen.getByTestId('counter')).toHaveTextContent('+3');

--- a/src/app/components/tags-list/tags-overflow.directive.ts
+++ b/src/app/components/tags-list/tags-overflow.directive.ts
@@ -14,16 +14,10 @@ import {
 
 import { TagComponent } from '../tag/tag.component';
 
-/** Espacio (px) reservado a la derecha para el contador "+N" al decidir qué ítems entran. */
-const COUNTER_RESERVE_PX = 44;
-
-/** Separación entre ítems (px); debe coincidir con el `gap` de la fila contenedora. */
-const GAP_PX = 6;
-
 /**
  * Recorta una fila de tags **proyectados** por el ancho real de su contenedor: descubre los tags vía
- * `contentChildren`, oculta los que no entran (`visibility:hidden`) y expone cuántos quedan visibles
- * (`visibleCount`), cuántos se colapsan (`hiddenCount`) y dónde ubicar el contador "+N" (`counterLeft`).
+ * `contentChildren`, oculta los que no entran (`visibility:hidden`) y los empuja *después* del contador
+ * con flex `order`; expone cuántos quedan visibles (`visibleCount`) y cuántos se colapsan (`hiddenCount`).
  *
  * Pensada como `hostDirective` del contenedor (que debe ser `position: relative; overflow: hidden`): su
  * host es el contenedor y el root del observer. Usa `IntersectionObserver` (con un margen derecho que
@@ -46,17 +40,16 @@ export class TagsOverflowDirective {
 	private readonly items = contentChildren(TagComponent, { read: ElementRef });
 
 	// Elementos que NO entran completos en el contenedor (reservando el contador), según el observer.
-	private readonly overflowing = new WeakSet<Element>();
-	private readonly overflowVersion = signal(0);
+	private readonly overflowing = signal<ReadonlySet<Element>>(new Set());
 	private readonly observer = signal<IntersectionObserver | undefined>(undefined);
 
 	/** Cantidad de tags visibles: prefijo que entra, acotado por `maxVisible`. */
 	readonly visibleCount = computed(() => {
-		this.overflowVersion(); // dependencia: recalcula cuando el observer reporta cambios
+		const overflowing = this.overflowing();
 		const cap = this.maxVisible() ?? Infinity;
 		let count = 0;
 		for (const ref of this.items()) {
-			if (count >= cap || this.overflowing.has(ref.nativeElement)) {
+			if (count >= cap || overflowing.has(ref.nativeElement)) {
 				break;
 			}
 			count++;
@@ -67,25 +60,19 @@ export class TagsOverflowDirective {
 	/** Cantidad de tags colapsados detrás del contador "+N". */
 	readonly hiddenCount = computed(() => Math.max(0, this.items().length - this.visibleCount()));
 
-	/**
-	 * Posición izquierda (px, relativa al host) del contador: borde derecho del último tag visible más el
-	 * gap. Lo ubica justo después del último tag, con ancho fijo (su contenido), sin estirarse al borde.
-	 */
-	readonly counterLeft = signal(0);
-	private readonly counterPositionEffect = effect(() => {
-		const count = this.visibleCount();
-		const items = this.items();
-		const last = count > 0 ? items[count - 1]?.nativeElement : undefined;
-		this.counterLeft.set(last ? last.offsetLeft + last.offsetWidth + GAP_PX : 0);
-	});
-
-	// Oculta/muestra los tags proyectados según el recorte (la directiva es dueña de su visibilidad).
-	private readonly applyVisibilityEffect = effect(() => {
+	// La directiva es dueña del layout de overflow de los tags proyectados:
+	// - los ocultos se esconden (`visibility:hidden`; quedan en el flujo y observables) y se empujan
+	//   *después* del contador con flex `order` = cantidad de visibles a su izquierda + 1, de modo que el
+	//   contador "+N" —un tag más, in-flow— caiga justo a la derecha del último visible sin medir nada.
+	// - los visibles vuelven a su estado por defecto (`order` 0, visible).
+	private readonly applyOverflowEffect = effect(() => {
 		const count = this.visibleCount();
 		this.items().forEach((ref, i) => {
 			if (i >= count) {
+				this.renderer.setStyle(ref.nativeElement, 'order', `${count + 1}`);
 				this.renderer.setStyle(ref.nativeElement, 'visibility', 'hidden');
 			} else {
+				this.renderer.removeStyle(ref.nativeElement, 'order');
 				this.renderer.removeStyle(ref.nativeElement, 'visibility');
 			}
 		});
@@ -105,16 +92,21 @@ export class TagsOverflowDirective {
 
 	constructor() {
 		afterNextRender(() => {
+			/** Espacio (px) reservado a la derecha para el contador "+N" al decidir qué ítems entran. */
+			const COUNTER_RESERVE_PX = 44;
 			const observer = new IntersectionObserver(
 				(entries) => {
-					for (const entry of entries) {
-						if (entry.intersectionRatio >= 0.99) {
-							this.overflowing.delete(entry.target);
-						} else {
-							this.overflowing.add(entry.target);
+					this.overflowing.update((prev) => {
+						const next = new Set(prev);
+						for (const entry of entries) {
+							if (entry.intersectionRatio >= 0.99) {
+								next.delete(entry.target);
+							} else {
+								next.add(entry.target);
+							}
 						}
-					}
-					this.overflowVersion.update((v) => v + 1);
+						return next;
+					});
 				},
 				{
 					root: this.host.nativeElement,

--- a/src/app/components/tags-list/tags-overflow.directive.ts
+++ b/src/app/components/tags-list/tags-overflow.directive.ts
@@ -13,36 +13,34 @@ import {
 
 import { TagComponent } from '../tag/tag.component';
 
+// Ratio de intersección a partir del cual se considera que un tag entra completo (tolerancia sub-pixel).
+const FULLY_VISIBLE_RATIO = 0.99;
+
 /**
- * Recorta una fila de tags **proyectados** por el ancho real de su contenedor: descubre los tags vía
- * `contentChildren`, oculta los que no entran (`visibility:hidden`) y los empuja *después* del contador
- * con flex `order`; expone cuántos quedan visibles (`visibleCount`) y cuántos se colapsan (`hiddenCount`).
+ * Recorta una fila de tags proyectados según el ancho de su contenedor: descubre los tags vía
+ * `contentChildren`, oculta los que no entran (`visibility:hidden`) y los empuja después del contador con
+ * flex `order`. Expone `visibleCount` y `hiddenCount`, y recibe vía `reserveTrailingSpace()` cuánto
+ * espacio guardar a la derecha (el ancho del contador "+N", que mide el host).
  *
- * Pensada como `hostDirective` del contenedor (que debe ser `position: relative; overflow: hidden`): su
- * host es el contenedor y el root del observer. Usa `IntersectionObserver` (en lugar de `ResizeObserver`,
- * por restricción de diseño) y reacciona a cualquier cambio de ancho del contenedor. El espacio a reservar
- * a la derecha (p. ej. para un contador "+N") es configurable vía `groupedTagsSlotReservedSpace`: la directiva **no fija
- * ningún tamaño**; quien la usa le pasa la huella real. Los tags ocultos quedan en el flujo con
- * `visibility:hidden` (no `display:none`): no alteran el layout y siguen siendo observables (bidireccional).
- *
- * Sin layout (SSR/jsdom) el observer no se crea y se consideran todos visibles (acotados por `maxVisible`).
+ * Se aplica como `hostDirective` del contenedor (que debe tener `overflow: hidden`): su host es el root del
+ * `IntersectionObserver` (se usa IO, no `ResizeObserver`, por restricción de diseño). Los tags ocultos
+ * quedan en el flujo con `visibility:hidden` para seguir siendo observables, así el recorte reacciona en
+ * ambos sentidos al cambiar el ancho. Sin layout (SSR/jsdom) no se crea el observer y entran todos.
  */
 @Directive({})
 export class TagsOverflowDirective {
 	/** Tope duro opcional de tags visibles; sin valor, el único límite es el ancho. */
 	readonly maxVisible = input<number>();
-	/** Espacio (px) a reservar a la derecha (p. ej. para un contador). Lo setea quien usa la directiva. */
-	readonly groupedTagsSlotReservedSpace = signal(0);
 
 	private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
 	private readonly renderer = inject(Renderer2);
 
-	/** Tags proyectados a recortar, en orden de render. */
 	private readonly items = contentChildren(TagComponent, { read: ElementRef });
 
-	// Elementos que NO entran completos en el contenedor (reservando `groupedTagsSlotReservedSpace`), según el observer.
+	// Tags que NO entran completos en el contenedor (según el observer) y espacio reservado para el contador.
 	private readonly overflowing = signal<ReadonlySet<Element>>(new Set());
-	// Habilita la creación del observer recién tras el primer render (browser-only).
+	private readonly reservedSpace = signal(0);
+	// El observer recién se crea tras el primer render (browser-only).
 	private readonly ready = signal(false);
 
 	/** Cantidad de tags visibles: prefijo que entra, acotado por `maxVisible`. */
@@ -62,27 +60,23 @@ export class TagsOverflowDirective {
 	/** Cantidad de tags colapsados detrás del contador "+N". */
 	readonly hiddenCount = computed(() => Math.max(0, this.items().length - this.visibleCount()));
 
-	// La directiva es dueña del layout de overflow de los tags proyectados:
-	// - los ocultos se esconden (`visibility:hidden`; quedan en el flujo y observables) y se empujan
-	//   *después* del contador con flex `order` = cantidad de visibles a su izquierda + 1, de modo que el
-	//   contador "+N" —un tag más, in-flow— caiga justo a la derecha del último visible sin medir nada.
-	// - los visibles vuelven a su estado por defecto (`order` 0, visible).
+	/** El host informa el ancho (px) a reservar a la derecha para el contador "+N". */
+	reserveTrailingSpace(px: number): void {
+		this.reservedSpace.set(px);
+	}
+
+	// Oculta los tags que no entran y los manda (flex `order`) después del contador, que es in-flow `order 0`.
 	private readonly applyOverflowEffect = effect(() => {
 		const visibleCount = this.visibleCount();
 		this.items().forEach((ref, i) => {
-			if (i >= visibleCount) {
-				this.renderer.setStyle(ref.nativeElement, 'order', `${visibleCount + 1}`);
-				this.renderer.setStyle(ref.nativeElement, 'visibility', 'hidden');
-			} else {
-				this.renderer.removeStyle(ref.nativeElement, 'order');
-				this.renderer.removeStyle(ref.nativeElement, 'visibility');
-			}
+			const hidden = i >= visibleCount;
+			this.renderer.setStyle(ref.nativeElement, 'order', hidden ? '1' : '0');
+			this.renderer.setStyle(ref.nativeElement, 'visibility', hidden ? 'hidden' : 'visible');
 		});
 	});
 
-	// Crea el IntersectionObserver y observa los tags. Se recrea cuando cambia `groupedTagsSlotReservedSpace` (el
-	// `rootMargin` es inmutable por observer) o la lista proyectada; `onCleanup` desconecta el observer
-	// anterior en cada recreación y al destruir la directiva.
+	// (Re)crea el observer cuando cambia el espacio reservado (el `rootMargin` es inmutable por observer) o
+	// la lista; `onCleanup` desconecta el anterior y limpia al destruir.
 	private readonly observerEffect = effect((onCleanup) => {
 		if (!this.ready()) {
 			return;
@@ -92,7 +86,7 @@ export class TagsOverflowDirective {
 				this.overflowing.update((prev) => {
 					const next = new Set(prev);
 					for (const entry of entries) {
-						if (entry.intersectionRatio >= 0.99) {
+						if (entry.intersectionRatio >= FULLY_VISIBLE_RATIO) {
 							next.delete(entry.target);
 						} else {
 							next.add(entry.target);
@@ -103,7 +97,7 @@ export class TagsOverflowDirective {
 			{
 				root: this.host.nativeElement,
 				threshold: 1,
-				rootMargin: `0px -${this.groupedTagsSlotReservedSpace()}px 0px 0px`,
+				rootMargin: `0px -${this.reservedSpace()}px 0px 0px`,
 			},
 		);
 		for (const ref of this.items()) {

--- a/src/app/components/tags-list/tags-overflow.directive.ts
+++ b/src/app/components/tags-list/tags-overflow.directive.ts
@@ -2,7 +2,6 @@ import {
 	afterNextRender,
 	computed,
 	contentChildren,
-	DestroyRef,
 	Directive,
 	effect,
 	ElementRef,
@@ -20,28 +19,31 @@ import { TagComponent } from '../tag/tag.component';
  * con flex `order`; expone cuántos quedan visibles (`visibleCount`) y cuántos se colapsan (`hiddenCount`).
  *
  * Pensada como `hostDirective` del contenedor (que debe ser `position: relative; overflow: hidden`): su
- * host es el contenedor y el root del observer. Usa `IntersectionObserver` (con un margen derecho que
- * reserva el contador) en lugar de `ResizeObserver` por restricción de diseño; reacciona a cualquier
- * cambio de ancho del contenedor. Los tags ocultos quedan en el flujo con `visibility:hidden` (no
- * `display:none`): así no alteran el layout y siguen siendo observables (recorte bidireccional).
+ * host es el contenedor y el root del observer. Usa `IntersectionObserver` (en lugar de `ResizeObserver`,
+ * por restricción de diseño) y reacciona a cualquier cambio de ancho del contenedor. El espacio a reservar
+ * a la derecha (p. ej. para un contador "+N") es configurable vía `groupedTagsSlotReservedSpace`: la directiva **no fija
+ * ningún tamaño**; quien la usa le pasa la huella real. Los tags ocultos quedan en el flujo con
+ * `visibility:hidden` (no `display:none`): no alteran el layout y siguen siendo observables (bidireccional).
  *
- * Sin layout (SSR/jsdom) el observer no reporta y se consideran todos visibles (acotados por `maxVisible`).
+ * Sin layout (SSR/jsdom) el observer no se crea y se consideran todos visibles (acotados por `maxVisible`).
  */
 @Directive({})
 export class TagsOverflowDirective {
 	/** Tope duro opcional de tags visibles; sin valor, el único límite es el ancho. */
 	readonly maxVisible = input<number>();
+	/** Espacio (px) a reservar a la derecha (p. ej. para un contador). Lo setea quien usa la directiva. */
+	readonly groupedTagsSlotReservedSpace = signal(0);
 
 	private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
 	private readonly renderer = inject(Renderer2);
-	private readonly destroyRef = inject(DestroyRef);
 
 	/** Tags proyectados a recortar, en orden de render. */
 	private readonly items = contentChildren(TagComponent, { read: ElementRef });
 
-	// Elementos que NO entran completos en el contenedor (reservando el contador), según el observer.
+	// Elementos que NO entran completos en el contenedor (reservando `groupedTagsSlotReservedSpace`), según el observer.
 	private readonly overflowing = signal<ReadonlySet<Element>>(new Set());
-	private readonly observer = signal<IntersectionObserver | undefined>(undefined);
+	// Habilita la creación del observer recién tras el primer render (browser-only).
+	private readonly ready = signal(false);
 
 	/** Cantidad de tags visibles: prefijo que entra, acotado por `maxVisible`. */
 	readonly visibleCount = computed(() => {
@@ -66,10 +68,10 @@ export class TagsOverflowDirective {
 	//   contador "+N" —un tag más, in-flow— caiga justo a la derecha del último visible sin medir nada.
 	// - los visibles vuelven a su estado por defecto (`order` 0, visible).
 	private readonly applyOverflowEffect = effect(() => {
-		const count = this.visibleCount();
+		const visibleCount = this.visibleCount();
 		this.items().forEach((ref, i) => {
-			if (i >= count) {
-				this.renderer.setStyle(ref.nativeElement, 'order', `${count + 1}`);
+			if (i >= visibleCount) {
+				this.renderer.setStyle(ref.nativeElement, 'order', `${visibleCount + 1}`);
 				this.renderer.setStyle(ref.nativeElement, 'visibility', 'hidden');
 			} else {
 				this.renderer.removeStyle(ref.nativeElement, 'order');
@@ -78,44 +80,39 @@ export class TagsOverflowDirective {
 		});
 	});
 
-	// (Re)observa los tags cuando el observer está listo o cambia la lista proyectada.
-	private readonly observeEffect = effect(() => {
-		const observer = this.observer();
-		if (!observer) {
+	// Crea el IntersectionObserver y observa los tags. Se recrea cuando cambia `groupedTagsSlotReservedSpace` (el
+	// `rootMargin` es inmutable por observer) o la lista proyectada; `onCleanup` desconecta el observer
+	// anterior en cada recreación y al destruir la directiva.
+	private readonly observerEffect = effect((onCleanup) => {
+		if (!this.ready()) {
 			return;
 		}
-		observer.disconnect();
+		const observer = new IntersectionObserver(
+			(entries) =>
+				this.overflowing.update((prev) => {
+					const next = new Set(prev);
+					for (const entry of entries) {
+						if (entry.intersectionRatio >= 0.99) {
+							next.delete(entry.target);
+						} else {
+							next.add(entry.target);
+						}
+					}
+					return next;
+				}),
+			{
+				root: this.host.nativeElement,
+				threshold: 1,
+				rootMargin: `0px -${this.groupedTagsSlotReservedSpace()}px 0px 0px`,
+			},
+		);
 		for (const ref of this.items()) {
 			observer.observe(ref.nativeElement);
 		}
+		onCleanup(() => observer.disconnect());
 	});
 
 	constructor() {
-		afterNextRender(() => {
-			/** Espacio (px) reservado a la derecha para el contador "+N" al decidir qué ítems entran. */
-			const COUNTER_RESERVE_PX = 44;
-			const observer = new IntersectionObserver(
-				(entries) => {
-					this.overflowing.update((prev) => {
-						const next = new Set(prev);
-						for (const entry of entries) {
-							if (entry.intersectionRatio >= 0.99) {
-								next.delete(entry.target);
-							} else {
-								next.add(entry.target);
-							}
-						}
-						return next;
-					});
-				},
-				{
-					root: this.host.nativeElement,
-					threshold: 1,
-					rootMargin: `0px -${COUNTER_RESERVE_PX}px 0px 0px`,
-				},
-			);
-			this.observer.set(observer);
-			this.destroyRef.onDestroy(() => observer.disconnect());
-		});
+		afterNextRender(() => this.ready.set(true));
 	}
 }

--- a/src/app/components/tags-list/tags-overflow.directive.ts
+++ b/src/app/components/tags-list/tags-overflow.directive.ts
@@ -1,0 +1,129 @@
+import {
+	afterNextRender,
+	computed,
+	contentChildren,
+	DestroyRef,
+	Directive,
+	effect,
+	ElementRef,
+	inject,
+	input,
+	Renderer2,
+	signal,
+} from '@angular/core';
+
+import { TagComponent } from '../tag/tag.component';
+
+/** Espacio (px) reservado a la derecha para el contador "+N" al decidir qué ítems entran. */
+const COUNTER_RESERVE_PX = 44;
+
+/** Separación entre ítems (px); debe coincidir con el `gap` de la fila contenedora. */
+const GAP_PX = 6;
+
+/**
+ * Recorta una fila de tags **proyectados** por el ancho real de su contenedor: descubre los tags vía
+ * `contentChildren`, oculta los que no entran (`visibility:hidden`) y expone cuántos quedan visibles
+ * (`visibleCount`), cuántos se colapsan (`hiddenCount`) y dónde ubicar el contador "+N" (`counterLeft`).
+ *
+ * Pensada como `hostDirective` del contenedor (que debe ser `position: relative; overflow: hidden`): su
+ * host es el contenedor y el root del observer. Usa `IntersectionObserver` (con un margen derecho que
+ * reserva el contador) en lugar de `ResizeObserver` por restricción de diseño; reacciona a cualquier
+ * cambio de ancho del contenedor. Los tags ocultos quedan en el flujo con `visibility:hidden` (no
+ * `display:none`): así no alteran el layout y siguen siendo observables (recorte bidireccional).
+ *
+ * Sin layout (SSR/jsdom) el observer no reporta y se consideran todos visibles (acotados por `maxVisible`).
+ */
+@Directive({})
+export class TagsOverflowDirective {
+	/** Tope duro opcional de tags visibles; sin valor, el único límite es el ancho. */
+	readonly maxVisible = input<number>();
+
+	private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+	private readonly renderer = inject(Renderer2);
+	private readonly destroyRef = inject(DestroyRef);
+
+	/** Tags proyectados a recortar, en orden de render. */
+	private readonly items = contentChildren(TagComponent, { read: ElementRef });
+
+	// Elementos que NO entran completos en el contenedor (reservando el contador), según el observer.
+	private readonly overflowing = new WeakSet<Element>();
+	private readonly overflowVersion = signal(0);
+	private readonly observer = signal<IntersectionObserver | undefined>(undefined);
+
+	/** Cantidad de tags visibles: prefijo que entra, acotado por `maxVisible`. */
+	readonly visibleCount = computed(() => {
+		this.overflowVersion(); // dependencia: recalcula cuando el observer reporta cambios
+		const cap = this.maxVisible() ?? Infinity;
+		let count = 0;
+		for (const ref of this.items()) {
+			if (count >= cap || this.overflowing.has(ref.nativeElement)) {
+				break;
+			}
+			count++;
+		}
+		return count;
+	});
+
+	/** Cantidad de tags colapsados detrás del contador "+N". */
+	readonly hiddenCount = computed(() => Math.max(0, this.items().length - this.visibleCount()));
+
+	/**
+	 * Posición izquierda (px, relativa al host) del contador: borde derecho del último tag visible más el
+	 * gap. Lo ubica justo después del último tag, con ancho fijo (su contenido), sin estirarse al borde.
+	 */
+	readonly counterLeft = signal(0);
+	private readonly counterPositionEffect = effect(() => {
+		const count = this.visibleCount();
+		const items = this.items();
+		const last = count > 0 ? items[count - 1]?.nativeElement : undefined;
+		this.counterLeft.set(last ? last.offsetLeft + last.offsetWidth + GAP_PX : 0);
+	});
+
+	// Oculta/muestra los tags proyectados según el recorte (la directiva es dueña de su visibilidad).
+	private readonly applyVisibilityEffect = effect(() => {
+		const count = this.visibleCount();
+		this.items().forEach((ref, i) => {
+			if (i >= count) {
+				this.renderer.setStyle(ref.nativeElement, 'visibility', 'hidden');
+			} else {
+				this.renderer.removeStyle(ref.nativeElement, 'visibility');
+			}
+		});
+	});
+
+	// (Re)observa los tags cuando el observer está listo o cambia la lista proyectada.
+	private readonly observeEffect = effect(() => {
+		const observer = this.observer();
+		if (!observer) {
+			return;
+		}
+		observer.disconnect();
+		for (const ref of this.items()) {
+			observer.observe(ref.nativeElement);
+		}
+	});
+
+	constructor() {
+		afterNextRender(() => {
+			const observer = new IntersectionObserver(
+				(entries) => {
+					for (const entry of entries) {
+						if (entry.intersectionRatio >= 0.99) {
+							this.overflowing.delete(entry.target);
+						} else {
+							this.overflowing.add(entry.target);
+						}
+					}
+					this.overflowVersion.update((v) => v + 1);
+				},
+				{
+					root: this.host.nativeElement,
+					threshold: 1,
+					rootMargin: `0px -${COUNTER_RESERVE_PX}px 0px 0px`,
+				},
+			);
+			this.observer.set(observer);
+			this.destroyRef.onDestroy(() => observer.disconnect());
+		});
+	}
+}


### PR DESCRIPTION
## Resumen

Implementa, para el Design System v3 (issue #1515):

- **`TagComponent`** (`cuentoneta-tag`): etiqueta de presentación con variantes `soft` / `filled` / `gray`. Reemplaza progresivamente a `BadgeComponent` (su eliminación es parte de #1472).
- **`TagsListComponent`** (`cuentoneta-tags-list`): recibe los tags por **content projection** (`<ng-content>`) y, **cuando no entran en el ancho del contenedor**, colapsa el excedente detrás de un contador **"+N"** ubicado justo después del último tag visible.

## Recorte por ancho (sin ResizeObserver)

La lógica de overflow vive en **`TagsOverflowDirective`**, aplicada como **`hostDirective`** del componente:

- El **propio host es el contenedor** (`flex … overflow-hidden`) y el `root` del observer — sin `<div>` wrapper.
- Descubre los tags proyectados con **`contentChildren`** y es **dueña de su layout**: oculta los que no entran (`visibility:hidden` vía `Renderer2`) y los empuja después del contador con flex **`order`**.
- Usa **`IntersectionObserver`** (no `ResizeObserver`, por restricción de diseño). Los ocultos quedan en el flujo con `visibility:hidden` (no `display:none`): no alteran el layout y siguen siendo observables, logrando un recorte **bidireccional** (reaparecen al agrandar el contenedor).
- El espacio reservado para el "+N" **se mide del contador real** (sin tamaño hardcodeado): el componente mide el ancho del contador y se lo pasa a la directiva vía `reserveTrailingSpace()`.
- El contador "+N" es un `<cuentoneta-tag>` más in-flow que **toma su variante de los tags proyectados** y lleva `aria-label`.
- **`maxVisible`** (tope duro opcional) se expone vía la `hostDirective`.

El componente queda **declarativo**: proyecta el contenido y renderiza el contador; el estado de overflow es un signal (`overflowing`) del que derivan `visibleCount`/`hiddenCount`.

## Tests y verificación

- **Specs**: `tag.component.spec`; `tags-list.component.spec` (integración: proyección, variante del contador, wiring de la reserva); `tags-overflow.directive.spec` (la directiva en aislamiento con un host de prueba). El stub de `IntersectionObserver` está extraído a un helper compartido, **marcado para eliminarse al migrar a Vitest** (#1494).
- **Stories**: `Default`, `WidthOverflow`, `NarrowWidth`, `MaxVisibleCap`, `Variants` y un `Playground` redimensionable.
- Verificado visualmente en **Storybook** (recorte, posición y variante del contador, exclusión del contador del conteo, y comportamiento bidireccional al cambiar el ancho).
- `lint` y la suite de tests en verde.

## Commits

1. `[#1515] - Implementa el componente Tag del Design System v3`
2. `[#1515] - Implementa TagsList con recorte por ancho (content projection + hostDirective)`
3. `[#1515] - Posiciona el contador "+N" con flex order en vez de medir`
4. `[#1515] - Mide el contador "+N" para reservar su espacio (sin tamaño hardcodeado)`
5. `[#1515] - Aplica hallazgos del code review en TagsList (reduce complejidad y smells)`