### PR TITLE
[#1509] - Componente AuthorTeaser V3 (DS v3) con avatar, tags recortables y skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,11 @@ Thumbs.db
 .github/instructions/nx.instructions.md
 .claude
 
+# Artefactos de Playwright MCP (snapshots/logs de inspección). No versionar: además, al
+# vivir dentro del repo, el escaneo de contenido de Tailwind v4 los vigila y su escritura
+# en vivo dispara rebuilds en bucle del dev server (HMR) si no se ignoran.
+.playwright-mcp/
+
 # Generated reference material (re-create with `pnpm exec tsx --env-file=.env scripts/audit/export-authors-bios.ts`)
 /tools/author-bios/
 

--- a/src/app/components/author-teaser-v3/author-teaser-v3-skeleton.component.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3-skeleton.component.ts
@@ -20,20 +20,20 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 			<div class="flex min-w-0 flex-1 flex-col gap-1 pt-1">
 				<div class="flex flex-wrap items-center gap-1.5">
 					<ngx-skeleton-loader
-						[theme]="{ height: '24px', width: '72px', 'margin-bottom': 0, 'border-radius': '4px' }"
+						[theme]="{ height: '22px', width: '72px', 'margin-bottom': 0, 'border-radius': '4px' }"
 						count="1"
 						appearance="line"
 						class="tag-skeleton"
 					/>
 					<ngx-skeleton-loader
-						[theme]="{ height: '24px', width: '72px', 'margin-bottom': 0, 'border-radius': '4px' }"
+						[theme]="{ height: '22px', width: '72px', 'margin-bottom': 0, 'border-radius': '4px' }"
 						count="1"
 						appearance="line"
 						class="tag-skeleton"
 					/>
 				</div>
 				<ngx-skeleton-loader
-					[theme]="{ height: '24px', width: '160px', 'margin-bottom': 0 }"
+					[theme]="{ height: '28px', width: '160px', 'margin-bottom': 0 }"
 					count="1"
 					appearance="line"
 					class="name-skeleton"

--- a/src/app/components/author-teaser-v3/author-teaser-v3-skeleton.component.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3-skeleton.component.ts
@@ -1,0 +1,69 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+
+/**
+ * Skeleton de carga de `AuthorTeaserV3`: reproduce su layout (avatar circular de 80px + columna con
+ * tags, nombre y cantidad de historias) mientras se cargan los datos del autor.
+ */
+@Component({
+	selector: 'cuentoneta-author-teaser-v3-skeleton',
+	imports: [NgxSkeletonLoaderModule],
+	template: `
+		<article class="flex items-start gap-4">
+			<ngx-skeleton-loader
+				[theme]="{ height: '80px', width: '80px', margin: 0 }"
+				count="1"
+				appearance="circle"
+				class="avatar-skeleton flex shrink-0"
+			/>
+			<div class="flex min-w-0 flex-1 flex-col gap-1 pt-1">
+				<div class="flex flex-wrap items-center gap-1.5">
+					<ngx-skeleton-loader
+						[theme]="{ height: '24px', width: '72px', 'margin-bottom': 0, 'border-radius': '4px' }"
+						count="1"
+						appearance="line"
+						class="tag-skeleton"
+					/>
+					<ngx-skeleton-loader
+						[theme]="{ height: '24px', width: '72px', 'margin-bottom': 0, 'border-radius': '4px' }"
+						count="1"
+						appearance="line"
+						class="tag-skeleton"
+					/>
+				</div>
+				<ngx-skeleton-loader
+					[theme]="{ height: '24px', width: '160px', 'margin-bottom': 0 }"
+					count="1"
+					appearance="line"
+					class="name-skeleton"
+				/>
+				<ngx-skeleton-loader
+					[theme]="{ height: '16px', width: '80px', 'margin-bottom': 0 }"
+					count="1"
+					appearance="line"
+					class="count-skeleton"
+				/>
+			</div>
+		</article>
+	`,
+	styles: `
+		@reference '#tailwind-theme';
+
+		:host {
+			@apply block w-full;
+		}
+
+		:host ::ng-deep .avatar-skeleton .skeleton-loader,
+		:host ::ng-deep .name-skeleton .skeleton-loader,
+		:host ::ng-deep .count-skeleton .skeleton-loader {
+			@apply bg-neutral-300;
+		}
+
+		:host ::ng-deep .tag-skeleton .skeleton-loader {
+			@apply bg-brand-100;
+		}
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AuthorTeaserV3SkeletonComponent {}

--- a/src/app/components/author-teaser-v3/author-teaser-v3.component.spec.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3.component.spec.ts
@@ -1,0 +1,78 @@
+import { AuthorTeaserV3Component } from './author-teaser-v3.component';
+import { render, screen } from '@testing-library/angular';
+import { authorTeaserMock } from '../../mocks/author.mock';
+import { Tag } from '@models/tag.model';
+
+describe('AuthorTeaserV3Component', () => {
+	const tags: Tag[] = [
+		{ title: 'Surrealismo', slug: 'surrealismo', shortDescription: '', description: [] },
+		{ title: 'Fantástico', slug: 'fantastico', shortDescription: '', description: [] },
+	];
+	const avatarName = `Retrato de ${authorTeaserMock.name}`;
+
+	it('should link to the author profile', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock } });
+		expect(screen.getByRole('link')).toHaveAttribute(
+			'href',
+			expect.stringContaining(`/author/${authorTeaserMock.slug}`),
+		);
+	});
+
+	it('should render the author name and avatar', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock } });
+		expect(screen.getByText(authorTeaserMock.name)).toBeInTheDocument();
+		expect(screen.getByRole('img', { name: avatarName })).toBeInTheDocument();
+	});
+
+	it('should render a placeholder when the author has no image', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: { ...authorTeaserMock, imageUrl: '' } } });
+		expect(screen.queryByRole('img', { name: avatarName })).not.toBeInTheDocument();
+		expect(screen.getByTestId('author')).toBeInTheDocument();
+	});
+
+	it('should request the avatar at 2x of 80px (HiDPI)', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock } });
+		expect(screen.getByRole('img', { name: avatarName })).toHaveAttribute(
+			'src',
+			expect.stringContaining('h=160&w=160'),
+		);
+	});
+
+	it('should render the nationality flag', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock } });
+		expect(screen.getByRole('img', { name: authorTeaserMock.nationality.country })).toBeInTheDocument();
+	});
+
+	it('should render the tags', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock, tags } });
+		expect(screen.getByTestId('tags')).toBeInTheDocument();
+		expect(screen.getByText('Surrealismo')).toBeInTheDocument();
+		expect(screen.getByText('Fantástico')).toBeInTheDocument();
+	});
+
+	it('should render more than two tags', async () => {
+		const manyTags: Tag[] = [
+			...tags,
+			{ title: 'Memoria', slug: 'memoria', shortDescription: '', description: [] },
+			{ title: 'Histórico', slug: 'historico', shortDescription: '', description: [] },
+		];
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock, tags: manyTags } });
+		manyTags.forEach((tag) => expect(screen.getByText(tag.title)).toBeInTheDocument());
+	});
+
+	it('should render the story count (plural)', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock, storyCount: 21 } });
+		expect(screen.getByTestId('story-count')).toHaveTextContent('21 historias');
+	});
+
+	it('should use the singular for a single story', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock, storyCount: 1 } });
+		expect(screen.getByTestId('story-count')).toHaveTextContent('1 historia');
+	});
+
+	it('should not render tags or story count when not provided', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock } });
+		expect(screen.queryByTestId('tags')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('story-count')).not.toBeInTheDocument();
+	});
+});

--- a/src/app/components/author-teaser-v3/author-teaser-v3.component.spec.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3.component.spec.ts
@@ -12,10 +12,29 @@ describe('AuthorTeaserV3Component', () => {
 
 	it('should link to the author profile', async () => {
 		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock } });
-		expect(screen.getByRole('link')).toHaveAttribute(
+		expect(screen.getByRole('link', { name: authorTeaserMock.name })).toHaveAttribute(
 			'href',
 			expect.stringContaining(`/author/${authorTeaserMock.slug}`),
 		);
+	});
+
+	it('should render the teaser as an article', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock } });
+		expect(screen.getByRole('article')).toBeInTheDocument();
+	});
+
+	it('should expose a single link whose accessible name is just the author name', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock, tags, storyCount: 21 } });
+		// Pese al avatar, los tags y el contador, el único enlace es el del nombre (nombre accesible conciso).
+		expect(screen.getAllByRole('link')).toHaveLength(1);
+		expect(screen.getByRole('link', { name: authorTeaserMock.name })).toBeInTheDocument();
+	});
+
+	it('should stretch the author-name link to cover the whole card', async () => {
+		await render(AuthorTeaserV3Component, { inputs: { author: authorTeaserMock } });
+		// El contenedor posicionado + el ::after del link es lo que hace clickeable toda la tarjeta.
+		expect(screen.getByRole('article')).toHaveClass('relative');
+		expect(screen.getByRole('link', { name: authorTeaserMock.name })).toHaveClass('after:absolute', 'after:inset-0');
 	});
 
 	it('should render the author name and avatar', async () => {
@@ -26,8 +45,10 @@ describe('AuthorTeaserV3Component', () => {
 
 	it('should render a placeholder when the author has no image', async () => {
 		await render(AuthorTeaserV3Component, { inputs: { author: { ...authorTeaserMock, imageUrl: '' } } });
-		expect(screen.queryByRole('img', { name: avatarName })).not.toBeInTheDocument();
-		expect(screen.getByTestId('author')).toBeInTheDocument();
+		expect(screen.getByRole('img', { name: avatarName })).toHaveAttribute(
+			'src',
+			expect.stringContaining('profile-placeholder.svg'),
+		);
 	});
 
 	it('should request the avatar at 2x of 80px (HiDPI)', async () => {

--- a/src/app/components/author-teaser-v3/author-teaser-v3.component.stories.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3.component.stories.ts
@@ -1,0 +1,87 @@
+import { applicationConfig, argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { provideRouter } from '@angular/router';
+
+import { AuthorTeaserV3Component } from './author-teaser-v3.component';
+import { AuthorTeaserV3SkeletonComponent } from './author-teaser-v3-skeleton.component';
+import { authorTeaserMock } from '../../mocks/author.mock';
+import { Tag } from '@models/tag.model';
+
+const tags: Tag[] = [
+	{ title: 'Surrealismo', slug: 'surrealismo', shortDescription: '', description: [] },
+	{ title: 'Fantástico', slug: 'fantastico', shortDescription: '', description: [] },
+];
+
+// Autor con más de 2 tags (ejemplo de Eduardo Galeano en el diseño v3).
+const galeanoMock = { ...authorTeaserMock, name: 'Eduardo Galeano' };
+const galeanoTags: Tag[] = [
+	{ title: 'Crónica', slug: 'cronica', shortDescription: '', description: [] },
+	{ title: 'Ensayo', slug: 'ensayo', shortDescription: '', description: [] },
+	{ title: 'Memoria', slug: 'memoria', shortDescription: '', description: [] },
+	{ title: 'Histórico', slug: 'historico', shortDescription: '', description: [] },
+];
+
+const meta: Meta<AuthorTeaserV3Component> = {
+	component: AuthorTeaserV3Component,
+	title: 'Componentes/AuthorTeaserV3',
+	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
+	],
+	parameters: {
+		docs: {
+			description: {
+				component: `<div>
+					<p>El componente **AuthorTeaserV3Component** muestra una vista previa de un autor enlazada a su perfil,
+					según el Design System v3. Está pensado para listar y visualizar perfiles de autores, mostrando el
+					avatar (80px), los tags, el nombre + bandera de nacionalidad y la cantidad de historias.</p>
+				</div>`,
+			},
+		},
+		layout: 'padded',
+	},
+	argTypes: {
+		author: { control: { type: 'object' }, description: 'Datos del autor (slug, nombre, imageUrl, nacionalidad)' },
+		tags: { control: { type: 'object' }, description: 'Tags asociados al autor' },
+		storyCount: { control: { type: 'number' }, description: 'Cantidad de historias del autor' },
+	},
+};
+
+export default meta;
+type Story = StoryObj<AuthorTeaserV3Component>;
+
+// Teaser completo: avatar, tags, nombre + bandera y cantidad de historias.
+export const Default: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-author-teaser-v3 ${argsToTemplate(args)} />` }),
+	args: { author: authorTeaserMock, tags, storyCount: 21 },
+	parameters: {
+		docs: { description: { story: 'Teaser completo del autor.' } },
+	},
+};
+
+// Más de 2 tags: la fila de tags se acomoda en varias líneas (ejemplo: Eduardo Galeano).
+export const ManyTags: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-author-teaser-v3 ${argsToTemplate(args)} />` }),
+	args: { author: galeanoMock, tags: galeanoTags, storyCount: 35 },
+	parameters: {
+		docs: { description: { story: 'Autor con más de 2 tags asignados, que se distribuyen en varias líneas.' } },
+	},
+};
+
+// Sin imagen: el avatar cae al placeholder circular.
+export const WithoutImage: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-author-teaser-v3 ${argsToTemplate(args)} />` }),
+	args: { author: { ...authorTeaserMock, imageUrl: '' }, tags, storyCount: 21 },
+	parameters: {
+		docs: { description: { story: 'Autor sin imagen: avatar con placeholder.' } },
+	},
+};
+
+// Estado de carga (skeleton) del teaser.
+export const Skeleton: StoryObj = {
+	decorators: [moduleMetadata({ imports: [AuthorTeaserV3SkeletonComponent] })],
+	render: () => ({ template: `<cuentoneta-author-teaser-v3-skeleton />` }),
+	parameters: {
+		docs: { description: { story: 'Skeleton de carga del teaser.' } },
+	},
+};

--- a/src/app/components/author-teaser-v3/author-teaser-v3.component.stories.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3.component.stories.ts
@@ -1,4 +1,11 @@
-import { applicationConfig, argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import {
+	applicationConfig,
+	argsToTemplate,
+	componentWrapperDecorator,
+	Meta,
+	moduleMetadata,
+	StoryObj,
+} from '@storybook/angular';
 import { provideRouter } from '@angular/router';
 
 import { AuthorTeaserV3Component } from './author-teaser-v3.component';
@@ -59,12 +66,18 @@ export const Default: Story = {
 	},
 };
 
-// Más de 2 tags: la fila de tags se acomoda en varias líneas (ejemplo: Eduardo Galeano).
+// Más de 2 tags en un contenedor acotado: la fila de tags se recorta por ancho y colapsa el excedente
+// tras un contador "+N" (ejemplo: Eduardo Galeano).
 export const ManyTags: Story = {
 	render: (args) => ({ props: args, template: `<cuentoneta-author-teaser-v3 ${argsToTemplate(args)} />` }),
 	args: { author: galeanoMock, tags: galeanoTags, storyCount: 35 },
+	decorators: [componentWrapperDecorator((story) => `<div style="width:320px">${story}</div>`)],
 	parameters: {
-		docs: { description: { story: 'Autor con más de 2 tags asignados, que se distribuyen en varias líneas.' } },
+		docs: {
+			description: {
+				story: 'Autor con varios tags en un contenedor de 320px: los que no entran se colapsan tras un contador "+N".',
+			},
+		},
 	},
 };
 

--- a/src/app/components/author-teaser-v3/author-teaser-v3.component.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3.component.ts
@@ -1,51 +1,51 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
 import { RouterLink } from '@angular/router';
 
 import { AuthorTeaser } from '@models/author.model';
 import { Tag } from '@models/tag.model';
 import { AppRoutes } from '../../app.routes';
-
-// Tamaño del avatar en px (Design System v3). La imagen se solicita al CDN a 2x (HiDPI).
-const AVATAR_PX = 80;
+import { ImageProfileComponent } from '../image-profile/image-profile.component';
+import { TagsListComponent } from '../tags-list/tags-list.component';
+import { TagComponent } from '../tag/tag.component';
 
 /**
  * Vista previa de un autor enlazada a su perfil, según el Design System v3. Componente de
  * presentación reutilizable para listar y visualizar perfiles de autores: avatar, tags,
- * nombre + bandera de nacionalidad y cantidad de historias. Encapsula el enlace, el avatar con
- * su placeholder y el redimensionado de la imagen.
+ * nombre + bandera de nacionalidad y cantidad de historias.
+ *
+ * Se modela como un `<article>` (unidad autocontenida) con un único enlace real sobre el nombre del autor,
+ * estirado con un pseudo-elemento (`after:absolute after:inset-0`) para que toda la tarjeta sea clickeable
+ * sin inflar el nombre accesible del link. El avatar lo resuelve `ImageProfile` y los tags `TagsList`.
  */
 @Component({
 	selector: 'cuentoneta-author-teaser-v3',
-	imports: [NgOptimizedImage, RouterLink],
+	imports: [NgOptimizedImage, RouterLink, ImageProfileComponent, TagsListComponent, TagComponent],
 	template: `
-		<a [routerLink]="['/', appRoutes.Author, author().slug]" class="flex items-start gap-4" data-testid="author">
-			<!-- Avatar del autor (o placeholder cuando no hay imagen). -->
-			@if (imageUrl(); as url) {
-				<img
-					[ngSrc]="url"
-					[alt]="'Retrato de ' + author().name"
-					width="80"
-					height="80"
-					class="size-20 shrink-0 rounded-full object-cover"
-				/>
-			} @else {
-				<div class="size-20 shrink-0 rounded-full bg-neutral-300"></div>
-			}
+		<article class="relative flex items-start gap-4" data-testid="author">
+			<cuentoneta-image-profile
+				[src]="author().imageUrl"
+				[alt]="'Retrato de ' + author().name"
+				size="lg"
+				class="shrink-0"
+			/>
 			<div class="flex min-w-0 flex-1 flex-col gap-1 pt-1">
 				@if (tags().length > 0) {
-					<div class="flex flex-wrap items-center gap-1.5" data-testid="tags">
+					<cuentoneta-tags-list data-testid="tags">
 						@for (tag of tags(); track tag.slug) {
-							<span class="rounded-sm bg-brand-50 px-2 py-1 font-inter text-xxs font-bold text-brand-500 uppercase">
-								{{ tag.title }}
-							</span>
+							<cuentoneta-tag [label]="tag.title" variant="filled" />
 						}
-					</div>
+					</cuentoneta-tags-list>
 				}
-				<div class="flex items-center gap-2">
-					<span class="overflow-hidden font-inter text-lg font-bold text-ellipsis whitespace-nowrap text-neutral-900">
-						{{ author().name }}
-					</span>
+				<div class="flex min-w-0 items-center gap-2">
+					<!-- Enlace real (nombre del autor) estirado con ::after para cubrir toda la tarjeta. -->
+					<a
+						[routerLink]="['/', appRoutes.Author, author().slug]"
+						class="min-w-0 after:absolute after:inset-0 after:content-['']"
+						data-testid="author-link"
+					>
+						<span class="block truncate font-inter text-lg font-bold text-neutral-900">{{ author().name }}</span>
+					</a>
 					@if (author().nationality.flag) {
 						<img
 							[ngSrc]="author().nationality.flag"
@@ -62,7 +62,7 @@ const AVATAR_PX = 80;
 					</span>
 				}
 			</div>
-		</a>
+		</article>
 	`,
 	host: {
 		class: 'block',
@@ -76,15 +76,4 @@ export class AuthorTeaserV3Component {
 	readonly author = input.required<AuthorTeaser>();
 	readonly tags = input<Tag[]>([]);
 	readonly storyCount = input<number>();
-
-	// El avatar se solicita al CDN de Sanity a 2x (HiDPI) del tamaño de display.
-	// Idealmente esto lo resolvería un loader de imágenes en lugar del resize manual.
-	readonly imageUrl = computed(() => {
-		const author = this.author();
-		if (!author.imageUrl) {
-			return '';
-		}
-		const size = AVATAR_PX * 2;
-		return `${author.imageUrl}?h=${size}&w=${size}`;
-	});
 }

--- a/src/app/components/author-teaser-v3/author-teaser-v3.component.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3.component.ts
@@ -1,0 +1,90 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { NgOptimizedImage } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+import { AuthorTeaser } from '@models/author.model';
+import { Tag } from '@models/tag.model';
+import { AppRoutes } from '../../app.routes';
+
+// Tamaño del avatar en px (Design System v3). La imagen se solicita al CDN a 2x (HiDPI).
+const AVATAR_PX = 80;
+
+/**
+ * Vista previa de un autor enlazada a su perfil, según el Design System v3. Componente de
+ * presentación reutilizable para listar y visualizar perfiles de autores: avatar, tags,
+ * nombre + bandera de nacionalidad y cantidad de historias. Encapsula el enlace, el avatar con
+ * su placeholder y el redimensionado de la imagen.
+ */
+@Component({
+	selector: 'cuentoneta-author-teaser-v3',
+	imports: [NgOptimizedImage, RouterLink],
+	template: `
+		<a [routerLink]="['/', appRoutes.Author, author().slug]" class="flex items-start gap-4" data-testid="author">
+			<!-- Avatar del autor (o placeholder cuando no hay imagen). -->
+			@if (imageUrl(); as url) {
+				<img
+					[ngSrc]="url"
+					[alt]="'Retrato de ' + author().name"
+					width="80"
+					height="80"
+					class="size-20 shrink-0 rounded-full object-cover"
+				/>
+			} @else {
+				<div class="size-20 shrink-0 rounded-full bg-neutral-300"></div>
+			}
+			<div class="flex min-w-0 flex-1 flex-col gap-1 pt-1">
+				@if (tags().length > 0) {
+					<div class="flex flex-wrap items-center gap-1.5" data-testid="tags">
+						@for (tag of tags(); track tag.slug) {
+							<span class="rounded-sm bg-brand-50 px-2 py-1 font-inter text-xxs font-bold text-brand-500 uppercase">
+								{{ tag.title }}
+							</span>
+						}
+					</div>
+				}
+				<div class="flex items-center gap-2">
+					<span class="overflow-hidden font-inter text-lg font-bold text-ellipsis whitespace-nowrap text-neutral-900">
+						{{ author().name }}
+					</span>
+					@if (author().nationality.flag) {
+						<img
+							[ngSrc]="author().nationality.flag"
+							[alt]="author().nationality.country"
+							width="21"
+							height="16"
+							class="h-4 w-5.25 shrink-0 rounded-[2px] object-cover"
+						/>
+					}
+				</div>
+				@if (storyCount() !== undefined) {
+					<span class="font-inter text-xs font-medium text-neutral-600" data-testid="story-count">
+						{{ storyCount() }} {{ storyCount() === 1 ? 'historia' : 'historias' }}
+					</span>
+				}
+			</div>
+		</a>
+	`,
+	host: {
+		class: 'block',
+	},
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AuthorTeaserV3Component {
+	protected readonly appRoutes = AppRoutes;
+
+	// Inputs
+	readonly author = input.required<AuthorTeaser>();
+	readonly tags = input<Tag[]>([]);
+	readonly storyCount = input<number>();
+
+	// El avatar se solicita al CDN de Sanity a 2x (HiDPI) del tamaño de display.
+	// Idealmente esto lo resolvería un loader de imágenes en lugar del resize manual.
+	readonly imageUrl = computed(() => {
+		const author = this.author();
+		if (!author.imageUrl) {
+			return '';
+		}
+		const size = AVATAR_PX * 2;
+		return `${author.imageUrl}?h=${size}&w=${size}`;
+	});
+}

--- a/src/app/components/image-profile/image-profile.component.spec.ts
+++ b/src/app/components/image-profile/image-profile.component.spec.ts
@@ -38,8 +38,13 @@ describe('ImageProfileComponent', () => {
 			expect(screen.getByRole('img', { name: alt })).toHaveAttribute('src', expect.stringContaining('h=80&w=80'));
 		});
 
-		it('should request large at 240px', async () => {
-			await render(ImageProfileComponent, { inputs: { src, alt, size: 'large' } });
+		it('should request lg at 160px', async () => {
+			await render(ImageProfileComponent, { inputs: { src, alt, size: 'lg' } });
+			expect(screen.getByRole('img', { name: alt })).toHaveAttribute('src', expect.stringContaining('h=160&w=160'));
+		});
+
+		it('should request xl at 240px', async () => {
+			await render(ImageProfileComponent, { inputs: { src, alt, size: 'xl' } });
 			expect(screen.getByRole('img', { name: alt })).toHaveAttribute('src', expect.stringContaining('h=240&w=240'));
 		});
 	});

--- a/src/app/components/image-profile/image-profile.component.stories.ts
+++ b/src/app/components/image-profile/image-profile.component.stories.ts
@@ -19,7 +19,7 @@ const meta: Meta<ImageProfileComponent> = {
 					mostrar la imagen de autores (y, a futuro, de usuarios logueados). Es el componente más anidado del árbol
 					de teasers v3.</p>
 					<ul>
-						<li><code>size</code>: small (24px), medium (40px), large (120px).</li>
+						<li><code>size</code>: small (24px), medium (40px), lg (80px), xl (120px).</li>
 						<li><code>src</code>/<code>alt</code>: foto del perfil. Sin <code>src</code> se muestra el placeholder de persona.</li>
 						<li><code>variant</code>: <code>profile</code> (default) o <code>collection</code> (fondo brand-100 + ícono de biblioteca).</li>
 					</ul>
@@ -32,7 +32,7 @@ const meta: Meta<ImageProfileComponent> = {
 	argTypes: {
 		size: {
 			control: { type: 'inline-radio' },
-			options: ['small', 'medium', 'large'],
+			options: ['small', 'medium', 'lg', 'xl'],
 			table: { defaultValue: { summary: 'medium' } },
 		},
 		variant: {
@@ -75,27 +75,30 @@ export const Showcase: Story = {
 		template: `
 			<div class="flex flex-col gap-8">
 				<div class="space-y-2">
-					<h3 class="text-sm font-semibold text-neutral-600">Foto — small / medium / large</h3>
+					<h3 class="text-sm font-semibold text-neutral-600">Foto — small / medium / lg / xl</h3>
 					<div class="flex items-end gap-4">
 						<cuentoneta-image-profile [src]="src" [alt]="alt" size="small" />
 						<cuentoneta-image-profile [src]="src" [alt]="alt" size="medium" />
-						<cuentoneta-image-profile [src]="src" [alt]="alt" size="large" />
+						<cuentoneta-image-profile [src]="src" [alt]="alt" size="lg" />
+						<cuentoneta-image-profile [src]="src" [alt]="alt" size="xl" />
 					</div>
 				</div>
 				<div class="space-y-2">
-					<h3 class="text-sm font-semibold text-neutral-600">Placeholder — small / medium / large</h3>
+					<h3 class="text-sm font-semibold text-neutral-600">Placeholder — small / medium / lg / xl</h3>
 					<div class="flex items-end gap-4">
 						<cuentoneta-image-profile size="small" />
 						<cuentoneta-image-profile size="medium" />
-						<cuentoneta-image-profile size="large" />
+						<cuentoneta-image-profile size="lg" />
+						<cuentoneta-image-profile size="xl" />
 					</div>
 				</div>
 				<div class="space-y-2">
-					<h3 class="text-sm font-semibold text-neutral-600">Collection — small / medium / large</h3>
+					<h3 class="text-sm font-semibold text-neutral-600">Collection — small / medium / lg / xl</h3>
 					<div class="flex items-end gap-4">
 						<cuentoneta-image-profile variant="collection" size="small" />
 						<cuentoneta-image-profile variant="collection" size="medium" />
-						<cuentoneta-image-profile variant="collection" size="large" />
+						<cuentoneta-image-profile variant="collection" size="lg" />
+						<cuentoneta-image-profile variant="collection" size="xl" />
 					</div>
 				</div>
 			</div>

--- a/src/app/components/image-profile/image-profile.component.ts
+++ b/src/app/components/image-profile/image-profile.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
 
-/** Tamaños del avatar (Design System v3): small=24px, medium=40px, large=120px. */
-export type ImageProfileSize = 'small' | 'medium' | 'large';
+/** Tamaños del avatar (Design System v3): small=24px, medium=40px, lg=80px, xl=120px. */
+export type ImageProfileSize = 'small' | 'medium' | 'lg' | 'xl';
 
 /**
  * Variante pública del componente (elección del consumidor):
@@ -49,7 +49,8 @@ export class ImageProfileComponent {
 	private readonly sizeMap: Record<ImageProfileSize, { px: number; circle: string; icon: string }> = {
 		small: { px: 24, circle: 'size-6', icon: 'size-3' },
 		medium: { px: 40, circle: 'size-10', icon: 'size-5' },
-		large: { px: 120, circle: 'size-30', icon: 'size-15' },
+		lg: { px: 80, circle: 'size-20', icon: 'size-10' },
+		xl: { px: 120, circle: 'size-30', icon: 'size-15' },
 	};
 
 	// Estado de render efectivo: única fuente de verdad de "qué se dibuja", derivada de variant + src.

--- a/src/app/components/tags-list/tags-list.component.spec.ts
+++ b/src/app/components/tags-list/tags-list.component.spec.ts
@@ -5,7 +5,7 @@ import {
 	installIntersectionObserverStub,
 	lastObserverOptions,
 	markOutsideViewport,
-} from './intersection-observer.stub';
+} from '../../testing/intersection-observer.stub';
 
 // Los tags se proyectan: la API del componente es por content projection. Se les da variant 'gray'
 // para verificar que el contador toma la variante de los tags proyectados.

--- a/src/app/components/tags-list/tags-overflow.directive.spec.ts
+++ b/src/app/components/tags-list/tags-overflow.directive.spec.ts
@@ -3,7 +3,11 @@ import { render, screen } from '@testing-library/angular';
 
 import { TagsOverflowDirective } from './tags-overflow.directive';
 import { TagComponent } from '../tag/tag.component';
-import { installIntersectionObserverStub, markInsideViewport, markOutsideViewport } from './intersection-observer.stub';
+import {
+	installIntersectionObserverStub,
+	markInsideViewport,
+	markOutsideViewport,
+} from '../../testing/intersection-observer.stub';
 
 // Host de prueba que usa la directiva como hostDirective y proyecta tags, tal como TagsListComponent.
 @Component({

--- a/src/app/testing/intersection-observer.stub.ts
+++ b/src/app/testing/intersection-observer.stub.ts
@@ -1,8 +1,9 @@
 // TODO(#1494): eliminar este stub al migrar a Vitest. Su browser mode provee un IntersectionObserver
-// real, lo que permitiría testear el recorte con layout real en vez de simular el callback a mano.
+// real, lo que permitiría testear con layout real en vez de simular el callback a mano.
 //
-// Stub de IntersectionObserver para tests (jsdom no lo implementa). Captura el callback del observer y
-// las opciones con que se creó, y permite simular que ciertos elementos entran o no en el contenedor.
+// Stub global de IntersectionObserver para tests (jsdom no lo implementa). Se instala en test-setup para
+// que cualquier componente que use IO se pueda renderizar. Captura el callback y las opciones del último
+// observer creado, y expone helpers para simular que ciertos elementos entran o no en el contenedor.
 let callback: IntersectionObserverCallback | undefined;
 let options: IntersectionObserverInit | undefined;
 
@@ -14,12 +15,18 @@ class IntersectionObserverStub {
 	observe(): void {
 		return;
 	}
+	unobserve(): void {
+		return;
+	}
 	disconnect(): void {
 		return;
 	}
+	takeRecords(): IntersectionObserverEntry[] {
+		return [];
+	}
 }
 
-/** Instala el stub como `IntersectionObserver` global y resetea el estado. Llamar en `beforeEach`. */
+/** Instala el stub como `IntersectionObserver` global y resetea el estado capturado. */
 export function installIntersectionObserverStub(): void {
 	(globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver = IntersectionObserverStub;
 	callback = undefined;

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,4 +1,9 @@
 import { setupZonelessTestEnv } from 'jest-preset-angular/setup-env/zoneless';
 import '@testing-library/jest-dom';
+import { installIntersectionObserverStub } from './app/testing/intersection-observer.stub';
 
 setupZonelessTestEnv();
+
+// jsdom no implementa IntersectionObserver: se instala un stub global para todos los tests. Los specs que
+// necesitan controlar el observer (simular overflow) reutilizan los helpers del mismo stub.
+installIntersectionObserverStub();


### PR DESCRIPTION
## Resumen

Implementa el componente **`AuthorTeaserV3`** (`cuentoneta-author-teaser-v3`) del Design System v3 (issue #1509): la vista previa de un autor enlazada a su perfil, pensada para listados/grillas de autores. Muestra avatar, tags, nombre + bandera de nacionalidad y cantidad de historias, e incluye su skeleton de carga.

Closes #1509

## Detalle de la implementación

- **Avatar vía `ImageProfile` (#1512).** Delega recorte circular, placeholder y redimensionado. Para soportar el avatar de 80px del diseño se agregó el tamaño **`lg` (80px)** a `ImageProfile` y se renombró el `large` previo a **`xl`** (cambio sobre componente compartido).
- **Tags vía `Tag` + `TagsList` v3 (#1515).** Los tags se proyectan en `TagsList`, que **recorta por ancho** y colapsa el excedente tras un contador **"+N"**, en lugar de spans inline que se desbordarían.
- **Un único enlace real (accesibilidad).** Se modela como `<article>` con un solo `<a>` sobre el nombre del autor, estirado con un pseudo-elemento (`after:absolute after:inset-0`) para que **toda la tarjeta sea clickeable** sin generar enlaces redundantes ni sin nombre accesible. Reutiliza patrones del code review de #1510.
- **Skeleton (`AuthorTeaserV3Skeleton`).** Reproduce el layout durante la carga. Los tamaños de los sub-skeletons se **midieron en Storybook** y se alinearon a la versión cargada: nombre 28px (line-height de `text-lg`), tags 22px (alto del `Tag` filled); avatar 80px y contador 16px ya coincidían.

## Cambios de soporte

- **Stub compartido de `IntersectionObserver`.** Como `TagsList` lo requiere (jsdom no lo implementa), el stub se movió de `tags-list/` a `src/app/testing/` y se instala globalmente en `test-setup.ts`. Marcado para eliminarse al migrar a Vitest (#1494).
- **`.gitignore`: `.playwright-mcp/`.** Tailwind v4 escanea todo el repo no gitignoreado; los artefactos de Playwright MCP, al vivir dentro del repo y escribirse en vivo, realimentaban el watcher y provocaban un **bucle infinito de rebuilds (HMR)** en el dev server de Storybook. Ignorarlos corta la realimentación.

## Tests y verificación

- **Specs** (`author-teaser-v3.component.spec`): enlace único con nombre accesible = nombre del autor, render como `article`, link estirado (`after:absolute after:inset-0`), avatar y placeholder (`profile-placeholder.svg`), solicitud del avatar en HiDPI, tags y contador.
- **Stories**: `Default`, `ManyTags` (recorte por ancho en contenedor de 320px), `WithoutImage` y `Skeleton`.
- Verificado visualmente en **Storybook**; `lint` y la suite de tests en verde.

> Nota: el alcance excedió el issue original en varios puntos (tamaño `lg`/rename de `ImageProfile`, integración con `TagsList`, refactor de accesibilidad, stub compartido y fix de `.gitignore`). El cuerpo del issue #1509 fue actualizado para documentarlos.

## Commits

1. `[#1509] - Implementa el componente AuthorTeaserV3 con su skeleton`
2. `[#1509] - Agrega el tamaño lg (80px) a ImageProfile y renombra large→xl`
3. `[#1509] - Comparte el stub de IntersectionObserver y lo instala global en los tests`
4. `[#1509] - Refactoriza AuthorTeaserV3 con ImageProfile, TagsList y un único enlace accesible`
5. `[#1509] - Ajusta los tamaños de los sub-skeletons a la versión cargada`
6. `[#1509] - Ignora .playwright-mcp/ para cortar el bucle de rebuilds de Storybook`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
