### PR TITLE
[#1519] - Jerarquía de headings: un único H1 por página

### DIFF
--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -1,8 +1,14 @@
 import { test, expect } from '@playwright/test';
 
-test('has title', async ({ page }) => {
+test('home: único H1 de contenido y marca en el header', async ({ page }) => {
 	await page.goto('/');
 
-	// Expect h1 to contain a substring.
-	expect(await page.locator('header').locator('h1').innerText()).toContain('La Cuentoneta');
+	// La home debe tener exactamente un <h1> de contenido (sr-only). La marca del header
+	// dejó de ser <h1> (ahora es un <span>), por lo que ya no duplica el encabezado.
+	await expect(page.locator('h1')).toHaveCount(1);
+	await expect(page.locator('h1')).toHaveText('Cuentos y relatos breves para leer en línea');
+
+	// La marca sigue presente en el header y el <title> SEO contiene la marca.
+	await expect(page.locator('header').getByText('La Cuentoneta').first()).toBeVisible();
+	await expect(page).toHaveTitle(/La Cuentoneta/);
 });

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -23,7 +23,7 @@ enum VisibilityState {
 			<section class="flex items-center">
 				<a [routerLink]="['/', 'home']" class="flex">
 					<img [ngSrc]="'./assets/svg/logo.svg'" class="mr-3" width="59" height="32" alt="Logo de 'La Cuentoneta'" />
-					<h1 class="flex items-center font-inter text-lg font-bold">La Cuentoneta</h1>
+					<span class="flex items-center font-inter text-lg font-bold">La Cuentoneta</span>
 				</a>
 			</section>
 

--- a/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
+++ b/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
@@ -32,7 +32,7 @@ import { RouterLink } from '@angular/router';
 						<cuentoneta-story-edition-date-label [label]="story().originalPublication" />
 					}
 
-					<h1 class="mb-2 font-inter text-sm font-bold">{{ story().title }}</h1>
+					<h3 class="mb-2 font-inter text-sm font-bold">{{ story().title }}</h3>
 					<div class="flex items-center justify-between">
 						<time class="font-inter text-xs font-semibold text-neutral-600">
 							{{ story().approximateReadingTime }} minutos de lectura

--- a/src/app/components/navigable-storylist-story-teaser/navigable-storylist-story-teaser.component.ts
+++ b/src/app/components/navigable-storylist-story-teaser/navigable-storylist-story-teaser.component.ts
@@ -32,11 +32,11 @@ import { StorylistStoriesNavigationTeasers } from '@models/storylist.model';
 					<cuentoneta-story-edition-date-label [label]="story().originalPublication" />
 				}
 
-				<h1 class="mb-2 font-inter text-sm font-bold">{{ story().title }}</h1>
+				<h3 class="mb-2 font-inter text-sm font-bold">{{ story().title }}</h3>
 				<div class="flex items-center justify-between">
-					<h2 class="font-inter text-sm font-normal">
+					<span class="font-inter text-sm font-normal">
 						{{ story().author.name }}
-					</h2>
+					</span>
 					<cuentoneta-media-resource-tags [resources]="story().media" />
 				</div>
 			</article>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,5 +1,11 @@
 <main class="content horizontal-layout-spacing vertical-layout-spacing">
 	<!--
+        H1 de contenido de la home, oculto visualmente (sr-only) para mantener un único H1 por
+        página sin alterar el diseño. #1523 lo reemplazará por una intro visible.
+    -->
+	<h1 class="sr-only">Cuentos y relatos breves para leer en línea</h1>
+
+	<!--
         Las alturas fijadas para los elementos hijos de <main> tienen la finalidad de evitar
         el rebote vertical que puede observarse en el momento de la carga inicial de la página
     -->


### PR DESCRIPTION
## Resumen

Segundo issue del epic de SEO/AEO #1525. Corrige la jerarquía de encabezados para tener **un único `<h1>` de contenido por página**.

La auditoría detectó "2 H1" en la home: la causa era doble — el **logo del header** estaba marcado como `<h1>` (y se duplicaba vía `withAppShell`), y además la home **no tenía `<h1>` de contenido propio**. Por otro lado, los **teasers de la barra de navegación** de cuentos también usaban `<h1>`, generando múltiples H1 en las páginas de detalle.

## Cambios

- **`header.component.ts`**: la marca "La Cuentoneta" pasa de `<h1>` a `<span>` (mismas clases). El enlace al home conserva su nombre accesible (logo con `alt`). Elimina el H1 duplicado por el app-shell en **todas** las páginas.
- **`navigable-story-teaser.component.ts`** y **`navigable-storylist-story-teaser.component.ts`**: el título del cuento pasa de `<h1>` a `<h3>` (queda bajo el `<h2>` de sección de la `story-navigation-bar`). En el teaser de storylist, el nombre del autor pasa de `<h2>` a `<span>` (es metadato de la tarjeta, no un encabezado).
- **`home.component.html`**: se agrega un `<h1 class="sr-only">Cuentos y relatos breves para leer en línea</h1>` para mantener un único H1 de contenido sin alterar el diseño. **#1523** lo reemplazará por una intro visible.

## Verificación

- `nx lint @cuentoneta/app` ✅
- Suite Vitest completa: **424 passed | 3 skipped** ✅ (incluye los specs de header y de ambos teasers).
- Build de producción SSR + `curl` del HTML server-rendered:
  - `/home` → **1** `<h1>` (antes 2): `Cuentos y relatos breves para leer en línea` (sr-only). El header ya no aporta `<h1>` (es `<span>`). ✅
  - `/about` → **1** `<h1>` (el propio), confirmando que el header no agrega encabezados sitewide. ✅

> Las páginas de detalle (story/author/storylist) mantienen su `<h1>` de página y ahora los teasers son `<h3>`; verificado por los specs y la revisión de código (no se pudieron renderizar contra datos reales de Sanity en local por falta de credenciales).

Parte del epic #1525 · Closes #1519
