### PR TITLE
[#1495] - Crea CLAUDE.md y los archivos de referencia de Claude

### DIFF
--- a/.claude/references/angular-components.md
+++ b/.claude/references/angular-components.md
@@ -1,0 +1,248 @@
+# Componentes Angular — convenciones de cuentoneta
+
+> Detalle de componentes referenciado desde [`CLAUDE.md`](../../CLAUDE.md) (sección "Arquitectura de código (Angular)").
+> Para el manejo de **estado** (servicios + signals/RxJS, signals-first), ver [`angular-state.md`](./angular-state.md).
+>
+> **Idioma:** la documentación va en español; el **código y los identificadores siempre en inglés**. Los comentarios pueden ir en español.
+
+Esta referencia describe cómo se escriben los **componentes de presentación y de página** en cuentoneta. Los ejemplos buenos se anclan en componentes reales del repo (p. ej. `src/app/components/author-teaser-v3/`, alineado con el Design System v3). Algunos componentes antiguos del repo (p. ej. `badge`, `header`) todavía violan estas reglas: **son deuda técnica, no el patrón a imitar** — al tocarlos, migrarlos.
+
+---
+
+## Base de todo componente
+
+- **Standalone** (sin `NgModule`). No se declara `standalone: true` porque ya es el default de Angular.
+- **`ChangeDetectionStrategy.OnPush`** siempre.
+- App **zoneless** (sin Zone.js): la detección de cambios se dispara por signals, no por callbacks async. No depender de change detection automática post-evento.
+- **Selector con prefijo `cuentoneta-`** (kebab-case, selector de elemento) para componentes; `cuentoneta` (camelCase, selector de atributo) para directivas.
+- **`imports` explícitos** en el decorador con los componentes/directivas/pipes que usa la plantilla.
+
+```typescript
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { NgOptimizedImage } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+import { AuthorTeaser } from '@models/author.model';
+import { Tag } from '@models/tag.model';
+import { ImageProfileComponent } from '../image-profile/image-profile.component';
+import { TagsListComponent } from '../tags-list/tags-list.component';
+
+@Component({
+	selector: 'cuentoneta-author-teaser-v3',
+	imports: [NgOptimizedImage, RouterLink, ImageProfileComponent, TagsListComponent],
+	template: `
+		<article class="relative flex items-start gap-4" data-testid="author">
+			<!-- ... -->
+		</article>
+	`,
+	host: {
+		class: 'block',
+	},
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AuthorTeaserV3Component {
+	// Inputs
+	readonly author = input.required<AuthorTeaser>();
+	readonly tags = input<Tag[]>([]);
+	readonly storyCount = input<number>();
+}
+```
+
+---
+
+## Visibilidad de campos
+
+Regla central: **un campo de componente nunca es `public` por defecto.** Las plantillas de Angular pueden acceder a miembros `protected`, así que no hay razón para exponer nada como `public` solo para usarlo en la plantilla.
+
+| Visibilidad | Cuándo                                                                                                                                                                               |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `protected` | Campos/métodos usados **solo en la plantilla** del propio componente (rutas de navegación, helpers de formato, flags de UI).                                                         |
+| `private`   | Internos no referenciados en ninguna plantilla (servicios inyectados, effects, estado interno).                                                                                      |
+| `public`    | **Solo** inputs/outputs/models de signals (`input()`, `output()`, `model()`), **API imperativa** llamada por padres (`open()`, `close()`), y miembros **requeridos por interfaces**. |
+
+```typescript
+export class AuthorTeaserV3Component {
+	// public: input de signal → parte de la API del componente
+	readonly author = input.required<AuthorTeaser>();
+
+	// protected: solo lo consume la plantilla
+	protected readonly appRoutes = AppRoutes;
+
+	// private: interno, no aparece en la plantilla
+	private readonly store = inject(StoryService);
+}
+```
+
+> Los `input()`/`output()`/`model()` no llevan modificador (son `public` implícito): son la API del componente. El resto, decidir entre `protected` y `private` según se use o no en la plantilla.
+
+---
+
+## Inputs / outputs / queries con signals
+
+Nunca usar decoradores `@Input()`/`@Output()`/`@ViewChild()`/`@ContentChild()`. Usar las APIs de signals:
+
+| API                                    | Uso                                                    |
+| -------------------------------------- | ------------------------------------------------------ |
+| `input<T>(default)`                    | Input opcional con valor por defecto.                  |
+| `input.required<T>()`                  | Input obligatorio (sin default).                       |
+| `input(default, { transform })`        | Input con transformación de entrada.                   |
+| `output<T>()`                          | Evento de salida (reemplaza `@Output() EventEmitter`). |
+| `model<T>()`                           | Two-way binding (`[(x)]`).                             |
+| `viewChild()` / `viewChildren()`       | Referencias a la vista propia.                         |
+| `contentChild()` / `contentChildren()` | Referencias a contenido proyectado.                    |
+
+```typescript
+// Inputs
+readonly author = input.required<AuthorTeaser>();
+readonly tags = input<Tag[]>([]);
+readonly storyCount = input<number>();
+
+// Input con transform
+readonly isVisible = input(VisibilityState.Visible, {
+	transform: (value) => (value ? VisibilityState.Visible : VisibilityState.Hidden),
+});
+
+// Output / model / queries
+readonly selected = output<string>();
+readonly value = model<string>('');
+readonly listItems = contentChildren(TagComponent);
+```
+
+Los valores **derivados** son `computed()`, nunca estado duplicado guardado a mano:
+
+```typescript
+readonly icon = computed(() => {
+	if (!this.tag().slug) {
+		return null;
+	}
+	return iconMappers.find((m) => m.name === this.tag().slug)?.ngIconsName ?? null;
+});
+```
+
+---
+
+## Prohibido: lifecycle hooks
+
+**No usar lifecycle hooks** (`OnInit`/`ngOnInit`, `OnChanges`, `AfterViewInit`, `OnDestroy`, etc.). Reemplazar por las primitivas reactivas:
+
+| En vez de…                                       | Usar…                                                                     |
+| ------------------------------------------------ | ------------------------------------------------------------------------- |
+| `ngOnInit` / `ngOnChanges` reaccionando a inputs | `computed()` (derivación pura) o `effect()` (efecto colateral)            |
+| `ngAfterViewInit` para tocar el DOM              | `viewChild()` / `afterNextRender()` / `afterRenderEffect()`               |
+| `ngAfterContentInit`                             | `contentChild()` / `contentChildren()`                                    |
+| `ngOnDestroy` para limpieza                      | `takeUntilDestroyed()`, o el cleanup que retorna `effect()` (`onCleanup`) |
+
+> Componentes antiguos como `badge.component.ts` aún usan `implements OnInit`; al modificarlos, migrar el `ngOnInit` a un `effect()` nombrado o a `computed()`.
+
+---
+
+## `effect()` como field initializers nombrados
+
+Todo `effect()` / `afterRenderEffect()` / `afterNextRender()` se declara como **field initializer nombrado**, **nunca dentro del `constructor`**. Los field initializers de clases decoradas corren en contexto de inyección, así que `effect()` funciona ahí.
+
+```typescript
+// ✅ Correcto — effect nombrado como field, después de lo que referencia
+export class StoryComponent {
+	private readonly store = inject(StoryService);
+	readonly slug = input.required<string>();
+
+	private readonly syncSlugEffect = effect(() => {
+		const slug = this.slug();
+		untracked(() => this.store.load(slug));
+	});
+}
+
+// ❌ Incorrecto — effect anónimo dentro del constructor
+export class StoryComponent {
+	constructor() {
+		effect(() => {
+			/* ... */
+		});
+	}
+}
+```
+
+Reglas:
+
+- **Nombre descriptivo** del efecto (`syncSlugEffect`, `closeOnSuccessEffect`, `hideMenuOnNavigationEffect`).
+- Los campos que el effect **referencia se declaran antes** que el effect en el orden del cuerpo de la clase (los field initializers corren de arriba hacia abajo).
+- Para escribir señales dentro del effect sin crear dependencias, envolver con `untracked()`.
+
+---
+
+## Inyección de dependencias
+
+- **Siempre `inject()`**, nunca inyección por constructor.
+- Marcar las dependencias `private readonly` (o `protected readonly` si la plantilla las usa).
+
+```typescript
+private readonly store = inject(StoryService);
+private readonly injector = inject(EnvironmentInjector);
+```
+
+### App initializers
+
+`provideAppInitializer` usa una **factory nombrada** en un archivo `<nombre>.initializer.ts` que devuelve un closure async. **Nunca** lógica inline en `app.config.ts`.
+
+```typescript
+// foo.initializer.ts
+export function provideFooInitializer() {
+	return provideAppInitializer(() => {
+		const service = inject(FooService);
+		return service.preload();
+	});
+}
+```
+
+---
+
+## Control flow en plantillas
+
+- **`@if` / `@for` / `@switch`** — nunca `*ngIf` / `*ngFor` / `*ngSwitch`.
+- `@for` **requiere `track`**.
+- **Self-closing tags** para elementos sin contenido proyectado (`<cuentoneta-tag ... />`).
+- **`ngSrc`** (de `NgOptimizedImage`) para imágenes, no `src` crudo; declarar `width`/`height`.
+- Vincular clases de host vía la propiedad `host` del decorador, no `@HostBinding`.
+
+```html
+<article class="relative flex items-start gap-4" data-testid="author">
+	<cuentoneta-image-profile [src]="author().imageUrl" [alt]="'Retrato de ' + author().name" size="lg" />
+
+	@if (tags().length > 0) {
+	<cuentoneta-tags-list>
+		@for (tag of tags(); track tag.slug) {
+		<cuentoneta-tag [label]="tag.title" variant="filled" />
+		}
+	</cuentoneta-tags-list>
+	} @if (author().nationality.flag) {
+	<img [ngSrc]="author().nationality.flag" [alt]="author().nationality.country" width="21" height="16" />
+	} @if (storyCount() !== undefined) {
+	<span data-testid="story-count"> {{ storyCount() }} {{ storyCount() === 1 ? 'historia' : 'historias' }} </span>
+	}
+</article>
+```
+
+> Las signals se **invocan** en la plantilla: `author()`, `tags()`, `storyCount()`.
+
+---
+
+## Prohibiciones adicionales
+
+- **Propiedades estáticas** en componentes/servicios → usar un servicio singleton (`providedIn: 'root'`).
+- **`enum` de TypeScript** → usar `Object.freeze({...} as const)` con su `type` derivado (ver `CLAUDE.md`).
+- **Non-null assertion (`!`)** → estrechar con `@if`/guards o tipar correctamente.
+- En el frontend: **`firstValueFrom`/`lastValueFrom`/`toPromise`** prohibidos → componer con `computed()`/`toSignal()`/operadores RxJS (ver [`angular-state.md`](./angular-state.md)).
+
+---
+
+## Checklist al crear/modificar un componente
+
+- [ ] `ChangeDetectionStrategy.OnPush` y selector `cuentoneta-…`.
+- [ ] Inputs/outputs con `input()`/`input.required()`/`output()`/`model()`; queries con `viewChild()`/`contentChild()`.
+- [ ] Campos `protected` (plantilla) / `private` (interno); `public` solo para API (inputs/outputs/imperativa/interfaces).
+- [ ] Sin lifecycle hooks: derivar con `computed()`, efectos como `effect()` nombrados (no en el constructor).
+- [ ] DI con `inject()`.
+- [ ] Plantilla con `@if`/`@for` (con `track`)/`@switch`, self-closing tags y `ngSrc`.
+- [ ] Sin `enum`, sin propiedades estáticas, sin `!`.
+- [ ] Acompañar con su `*.stories.ts` (Storybook) y tests con Angular Testing Library (ver [`testing.md`](./testing.md)).
+- [ ] El estado vive en servicios + signals (ver [`angular-state.md`](./angular-state.md)).

--- a/.claude/references/angular-state.md
+++ b/.claude/references/angular-state.md
@@ -1,0 +1,156 @@
+# Estado: signals-first (sin NgRx)
+
+> **Alcance:** cómo se modela y muta el **estado** en el frontend de La Cuentoneta. Complementa la sección [_"Estado: signals-first (sin NgRx)"_ de `CLAUDE.md`](../../CLAUDE.md) con ejemplos anclados en el código real.
+>
+> **Idioma:** explicación en español, **código/identificadores en inglés**.
+>
+> Ver también: [`angular-components.md`](angular-components.md) (effects, DI/providers, control flow) · [`guiding-principles.md`](guiding-principles.md) (YAGNI/KISS + disciplina de operadores RxJS).
+
+---
+
+## Principio: servicios + signals + RxJS, sin NgRx
+
+Cuentoneta **no usa NgRx**. El estado vive en **servicios**, se expone como **signals** y se compone/orquesta con **RxJS**. Las reglas "signals-first" se adoptan como **principio de diseño**, no a través del mecanismo `rxMethod` / Signal Store (eso es la dirección futura — ver la sección final).
+
+Dónde viven los servicios de estado:
+
+- **`@Injectable({ providedIn: 'root' })`** para estado/acceso a datos de aplicación (singleton). Ej.: `LayoutService`, `StoryService`, `StorylistService`, `ContentService` en [`src/app/providers/`](../../src/app/providers/).
+- **`@Injectable()` provisto en un componente** cuando el estado es local a un subárbol y debe morir con él. Ej.: `CarouselStateService`, provisto en el `providers` del componente de carousel.
+
+> Los servicios de acceso a datos del frontend viven en `src/app/providers/` _(en migración al patrón `provideX()` / `*.provider.ts` — ver #1499)_.
+
+---
+
+## Reglas (con anclajes en el código)
+
+### 1. Sin promesas sobre observables
+
+**Prohibido** `firstValueFrom`, `lastValueFrom`, `toPromise` y `async/await` sobre observables en el frontend (restricción dura de `CLAUDE.md`). Se compone con **operadores RxJS** y se cruza a signals con `rxResource` / `toSignal`.
+
+```typescript
+// ✅ Correcto — el HTTP queda como Observable y se consume vía rxResource (story.component.ts)
+readonly storyResource = rxResource({
+	params: this.slug,
+	stream: ({ params }) =>
+		this.storyService.getBySlug(params).pipe(tap((story) => this.updateMetaTags(story))),
+	defaultValue: undefined,
+});
+
+// ❌ Incorrecto — convierte el observable en promesa
+const story = await firstValueFrom(this.storyService.getBySlug(slug));
+```
+
+El servicio de datos devuelve **siempre `Observable<T>`**, nunca `Promise<T>`:
+
+```typescript
+// story.service.ts
+public getBySlug(slug: string): Observable<Story> {
+	return this.http.get<Story>(`${this.url}/${slug}`);
+}
+```
+
+### 2. Derivar con `computed()` / `toSignal()` — nunca duplicar estado
+
+Los valores derivados son **`computed`** (o `toSignal` para fuentes observables), **jamás** estado guardado que haya que sincronizar a mano.
+
+```typescript
+// ✅ Correcto — todo lo derivado cuelga de un único origen (story.component.ts)
+readonly story = computed(() => this.storyResource.value());
+readonly sharingRoute = computed(() => `${AppRoutes.Story}/${this.story()?.slug}`);
+readonly shareMessage = computed(
+	() => `Leí "${this.story()?.title}" de ${this.story()?.author.name} en La Cuentoneta ...`,
+);
+
+// ❌ Incorrecto — segundo signal que hay que mantener en sync a mano
+readonly sharingRoute = signal('');
+// ...y luego un effect/set por cada cambio de story → estado duplicado
+```
+
+### 3. Mutaciones con `signal.set()` / `signal.update()` en servicios
+
+El estado mutable vive como `signal(...)` **privado** dentro del servicio; se muta solo con `set()` / `update()` y se expone **de solo lectura** con `asReadonly()`.
+
+```typescript
+// ✅ Correcto — patrón writable-privado / readonly-público (carousel-state.service.ts)
+@Injectable()
+export class CarouselStateService {
+	private readonly _activeIndex = signal(0);
+	private readonly _isTransitioning = signal(false);
+
+	// Signals públicas de solo lectura
+	readonly activeIndex: Signal<number> = this._activeIndex.asReadonly();
+	readonly isTransitioning: Signal<boolean> = this._isTransitioning.asReadonly();
+
+	selectSlide(index: number, direction: 'left' | 'right'): void {
+		if (this._isTransitioning() || index === this._activeIndex()) return;
+		this._isTransitioning.set(true);
+		this._activeIndex.set(index);
+	}
+}
+```
+
+Esto mantiene el control de las transiciones de estado dentro del servicio: los componentes **leen** la signal de solo lectura y **piden** mutaciones vía métodos (`next()`, `prev()`, `selectSlide()`), nunca escribiendo el estado directamente.
+
+### 4. `switchMap` como aplanado por defecto
+
+Para encadenar una emisión (un input, un cambio de ruta) a un request, el **operador de aplanado por defecto es `switchMap`**: cancela el request en vuelo cuando llega una emisión nueva, evitando respuestas obsoletas pisando estado más reciente.
+
+```typescript
+// ✅ Correcto — switchMap cancela el fetch anterior cuando cambia el slug
+slug$.pipe(switchMap((slug) => this.storyService.getBySlug(slug)));
+
+// ❌ Incorrecto — mergeMap deja correr todos: una respuesta vieja puede ganar la carrera
+slug$.pipe(mergeMap((slug) => this.storyService.getBySlug(slug)));
+```
+
+Usar `concatMap` / `exhaustMap` solo cuando la semántica lo exija (preservar orden, ignorar mientras hay uno en curso) y dejarlo justificado. Ver la disciplina de operadores en [`guiding-principles.md`](guiding-principles.md).
+
+### 5. Debounce / coordinación centralizados en servicios
+
+El throttle/debounce, el merge de fuentes de eventos y la coordinación de estado viven **en el servicio**, no esparcidos por los componentes. El componente solo consume el resultado ya coordinado.
+
+```typescript
+// ✅ Correcto — LayoutService centraliza el throttle y el merge de eventos (layout.service.ts)
+private _userHasScrolled$ = fromEvent(this.window, 'scroll').pipe(
+	takeUntilDestroyed(),
+	throttleTime(25),
+	map(() => this.window?.scrollY),
+	filter((scrollAmount) => scrollAmount > 400),
+	pairwise(),
+	map(([y1, y2]) => (y2 < y1 ? Direction.Up : Direction.Down)),
+	distinctUntilChanged(),
+);
+
+private _viewportHasChanged$ = merge(
+	fromEvent(this.window, 'resize').pipe(startWith(null)),
+	fromEvent(this.window, 'orientationchange').pipe(startWith(null)),
+).pipe(takeUntilDestroyed(), throttleTime(100));
+```
+
+El componente que lo consume no repite el `throttleTime` ni el `merge`: inyecta `LayoutService` y se suscribe (con `takeUntilDestroyed`) o lo lleva a signal.
+
+### 6. Errores tipados por operación
+
+Preferir un estado de error **por operación** a un único `string | null` compartido entre todas las operaciones del servicio. Cada lectura/mutación expone su propio estado de error/carga, de modo que la UI distingue qué falló. Con `rxResource` esto sale del propio recurso (`.status()` / `.error()` por recurso); con observables crudos, modelar un signal de error por operación, no un campo global del servicio.
+
+> El detalle de **manejo de errores** (preservar la causa, loguear con contexto) está en `CLAUDE.md` → _Manejo de errores_ y en [`maintainability.md`](maintainability.md).
+
+---
+
+## Checklist rápido
+
+- [ ] ¿El estado vive en un **servicio** (`providedIn: 'root'` o provisto en el componente), no en propiedades estáticas?
+- [ ] ¿Lo derivado es `computed()` / `toSignal()` y **no** un signal duplicado sincronizado a mano?
+- [ ] ¿El estado mutable es un signal **privado** expuesto con `asReadonly()` y mutado solo con `set()`/`update()`?
+- [ ] ¿Cero `firstValueFrom` / `lastValueFrom` / `toPromise` / `async-await` sobre observables?
+- [ ] ¿El aplanado por defecto es `switchMap` (y cualquier otro está justificado)?
+- [ ] ¿El debounce/throttle/coordinación está en el servicio, no en el componente?
+- [ ] ¿Los errores están tipados por operación, no en un `string | null` global?
+
+---
+
+## Dirección futura: NgRx Signal Store (no adoptado)
+
+La paridad con el starter contempla adoptar **NgRx Signal Store** (`@ngrx/signals` + `rxMethod`) para encapsular estado, mutaciones y efectos de forma declarativa. Esa adopción es el issue **#1530**.
+
+**Hasta que #1530 se implemente, rige todo lo de arriba** (servicios + signals + RxJS) y **no se genera código NgRx** (`signalStore`, `withState`, `withMethods`, `rxMethod`, etc.) salvo que el propio issue lo indique. No introducir `@ngrx/signals` como dependencia ni anticipar su API en código nuevo.

--- a/.claude/references/clean-architecture.md
+++ b/.claude/references/clean-architecture.md
@@ -1,0 +1,137 @@
+<!-- Fuente: CLAUDE.md | Adaptado para La Cuentoneta -->
+
+# Principios de Clean Architecture
+
+Construir sistemas **mantenibles, testeables e independientes** de los detalles externos (Sanity, Hono, Angular, el navegador). En cuentoneta esto se traduce en una sola idea operativa: **el modelo de dominio (`Story`, `Author`, `Storylist`, …) no conoce ni a GROQ ni al cliente HTTP**; los detalles externos se traducen en los bordes vía la **ACL de mappers**.
+
+## Principios arquitectónicos centrales
+
+### La regla de dependencia
+
+- Las dependencias del código fuente apuntan **solo hacia adentro**, hacia las políticas de más alto nivel (el dominio).
+- Nada de un círculo interno puede saber algo de un círculo externo.
+- Los formatos de datos de los círculos externos (p. ej. el shape crudo de una query GROQ, los tipos generados de Sanity) **no deben usarse** en los círculos internos.
+- Es la regla que prevalece sobre todas las demás y la que hace que la arquitectura funcione.
+
+### Las capas en cuentoneta (de adentro hacia afuera)
+
+| Capa                        | Contenido                                                        | Ejemplo en cuentoneta                                                           |
+| --------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| **Modelo de dominio**       | Tipos de negocio y datos críticos, sin dependencias de framework | `Story`, `Author`, `Storylist`, `Resource` (`@models/*`)                        |
+| **Casos de uso / lógica**   | Reglas de aplicación: leer, mapear, coordinar                    | `getStoryBySlug`, `getStories`, `getAuthorBySlug` (services)                    |
+| **Adaptadores de interfaz** | Traducen datos entre la lógica y los formatos externos           | Controllers Hono, **mappers / ACL** (`src/api/_utils/`), API services del front |
+| **Frameworks y drivers**    | Detalles externos                                                | Sanity/GROQ, Hono, `@sanity/client`, Angular, el navegador                      |
+
+### Principios de independencia
+
+- **Independencia del framework** — Hono, Angular y Sanity son herramientas, no restricciones que dicten el modelo de dominio.
+- **Independencia de la UI** — los componentes Angular signals-first pueden cambiar sin tocar las reglas de negocio.
+- **Independencia de la persistencia** — el dominio no está atado a Sanity; cambiar de CMS afectaría solo a repositories y mappers.
+- **Independencia de agencias externas** — el dominio no sabe nada del mundo exterior (Clarity, OG, etc.).
+
+### Testabilidad por diseño
+
+- Las reglas de negocio se testean sin UI, sin Sanity y sin servidor web.
+- Los tipos de dominio son objetos planos sin dependencias de framework.
+- Los services se testean sustituyendo el repository por un doble en memoria (`InMemory*`, ver más abajo): ver los `*.service.spec.ts` existentes (`content.service.spec.ts`, `sitemap.service.spec.ts`).
+
+### Cruce de fronteras
+
+- Definir fronteras claras entre componentes con distintas tasas de cambio (la query GROQ cambia más seguido que el tipo de dominio).
+- Cruzar fronteras vía **inversión de dependencias**: las capas internas definen la forma del dato; las externas se adaptan a ella.
+- Lo que cruza la frontera hacia el frontend es siempre **modelo de dominio mapeado**, nunca el resultado crudo de Sanity.
+
+---
+
+## La regla de dependencia aplicada al backend
+
+El backend es **Hono plano** (no OpenAPIHono). Cada módulo en `src/api/modules/<dominio>/` sigue **controller → service → repository**, con los **mappers (ACL)** traduciendo Sanity/GROQ al dominio.
+
+```
+HTTP → controller → service → repository → Sanity (GROQ)
+                       │            │
+                       │            └─ fetch*()   devuelve el resultado CRUDO de Sanity
+                       └─ get*()    llama al repository y MAPEA al dominio vía la ACL (_utils)
+```
+
+- **Controller** (`<dominio>.controller.ts`): rutas Hono, validación con `zValidator('param'|'query', schema)`, delega en el service. No conoce GROQ.
+- **Service** (`<dominio>.service.ts`): lógica de aplicación. `get*()` para lecturas; envuelve al repository y mapea al dominio.
+- **Repository** (`<dominio>.repository.ts`): acceso a datos. `fetch*()` ejecuta `client.fetch(query, params)` (GROQ) y devuelve el shape **crudo**. El cliente se importa de `_helpers/sanity-connector`.
+- **ACL / mappers** (`src/api/_utils/functions.ts` y `*.functions.ts` vecinos): funciones puras (`mapAuthor`, `mapAuthorTeaser`, `mapResources`, …) que traducen Sanity → dominio. Es el punto donde el shape externo **deja de propagarse hacia adentro**.
+
+> Las queries GROQ viven en `src/api/_queries/`, los schemas Zod del módulo en `<dominio>.schema.ts`. Detalle completo del flujo: [`sanity-acl.md`](sanity-acl.md).
+
+La dirección de las dependencias respeta la regla: el **service** (lógica) depende de la **abstracción** del repository, no del cliente de Sanity; el **dominio** no depende de nadie.
+
+---
+
+## La regla de dependencia aplicada al frontend
+
+Angular **signals-first** (sin NgRx). Los componentes y servicios consumen **modelo de dominio**, nunca el shape de la API cruda. Los servicios de acceso a datos viven en `src/app/providers/` y exponen estado como signals; los componentes son `OnPush`, zoneless, con `@if`/`@for`.
+
+- Los componentes no conocen URLs ni el shape de transporte: dependen de la abstracción del servicio de datos.
+- Los valores derivados son `computed()` / `toSignal()`, nunca estado duplicado.
+
+> Detalle: [`domain-model.md`](domain-model.md) (qué es el dominio compartido entre back y front).
+
+---
+
+## Qualified Implementation (convención de nombres)
+
+La interfaz lleva el **nombre limpio** (la responsabilidad), y la **implementación** lleva un **prefijo de tecnología/propósito**. El doble de test es siempre `InMemory*` — **nunca `Mock*`**.
+
+**Regla del prefijo `I`:** la interfaz **no** lleva prefijo `I` (no `IStoryRepository`). La única excepción es una **colisión** con una clase del mismo nombre que deba coexistir; recién ahí se admite `I` para desambiguar.
+
+### Backend
+
+| Rol                      | Interfaz (nombre limpio) | Implementación real           | Doble de test                 |
+| ------------------------ | ------------------------ | ----------------------------- | ----------------------------- |
+| Repository de stories    | `StoryRepository`        | `SanityStoryRepository`       | `InMemoryStoryRepository`     |
+| Repository de autores    | `AuthorRepository`       | `SanityAuthorRepository`      | `InMemoryAuthorRepository`    |
+| Repository de storylists | `StorylistRepository`    | `SanityStorylistRepository`   | `InMemoryStorylistRepository` |
+| Service (impl. única)    | `StoryService`           | `StoryService` (mismo nombre) | `InMemoryStoryService`        |
+
+- Prefijo **`Sanity*`** para implementaciones de repository respaldadas por Sanity/GROQ.
+- Prefijo **`InMemory*`** para **todos** los dobles de test (jamás `Mock*`).
+- Los services de implementación única **conservan el nombre de la interfaz** (sin prefijo, sin sufijo `Impl`).
+
+> Nota sobre el estado actual: hoy los módulos backend exponen funciones (`getStoryBySlug`, `fetchStories`) más que clases con interfaz explícita. La convención de arriba rige al introducir abstracciones de repository/service o sus dobles de test, y es la dirección a la que tienden los `*.service.spec.ts`.
+
+### Frontend
+
+| Rol               | Interfaz + token (`InjectionToken`) | Implementación     | Doble de test          |
+| ----------------- | ----------------------------------- | ------------------ | ---------------------- |
+| API de stories    | `StoryApi`                          | `HttpStoryApi`     | `InMemoryStoryApi`     |
+| API de autores    | `AuthorApi`                         | `HttpAuthorApi`    | `InMemoryAuthorApi`    |
+| API de storylists | `StorylistApi`                      | `HttpStorylistApi` | `InMemoryStorylistApi` |
+
+- Prefijo **`Http*`** para implementaciones de servicios de API basadas en HTTP.
+- Los tokens son `InjectionToken` planos (sin `providedIn`/`factory`), cableados vía funciones `provideX()` (en migración — ver #1499).
+
+**Resumen de reglas:**
+
+- Interfaz sin prefijo `I` (salvo colisión con clase homónima).
+- `Sanity*` para repositories sobre Sanity/GROQ; `Http*` para API services del front.
+- `InMemory*` para todo doble de test — nunca `Mock*`.
+- Servicio de implementación única → conserva el nombre de la interfaz.
+
+---
+
+## Guías prácticas
+
+1. **Empezar por el caso de uso** (`get*` del service) — define la intención del sistema.
+2. **Diferir decisiones** — el shape de Sanity y el de transporte HTTP se deciden en los bordes, no en el dominio.
+3. **Arquitectura que grita** — la estructura de `src/api/modules/<dominio>/` revela el dominio (story, author, storylist), no el framework.
+4. **Objetos humildes** — lo difícil de testear (cliente Sanity, HTTP) queda en wrappers mínimos (repository / API service).
+5. **El borde es sucio** — controllers y mappers absorben el formato externo para que el dominio quede limpio.
+
+_Basado en Robert C. Martin, "Clean Architecture" (2018), adaptado al stack de La Cuentoneta._
+
+---
+
+## Referencias relacionadas
+
+- [`sanity-acl.md`](sanity-acl.md) — el ACL central: GROQ → repository → mapper → modelo de dominio.
+- [`domain-model.md`](domain-model.md) — DDD estratégico: agregados e invariantes (Story / Author / Storylist).
+- [`solid.md`](solid.md) — principios SOLID (la inversión de dependencias subyace a "Qualified Implementation").
+- [`cupid.md`](cupid.md) — propiedades CUPID.

--- a/.claude/references/coding-agent-policies.md
+++ b/.claude/references/coding-agent-policies.md
@@ -1,0 +1,160 @@
+# Políticas de colaboración de agentes de código
+
+> **Audiencia:** cualquier agente de IA que opere sobre este repositorio (Claude Code, Cursor, Aider, GitHub Copilot Chat, etc.) y cualquier persona revisora que evalúe un PR producido por un agente.
+>
+> **Autoridad:** estas políticas son una restricción dura, al mismo nivel que las convenciones de [`CLAUDE.md`](../../CLAUDE.md). Las violaciones son **bloqueantes para la review**.
+>
+> **Carga:** este archivo se carga **siempre, al inicio de cada sesión**, antes de generar cualquier recomendación.
+
+---
+
+## Por qué existe este documento
+
+La Cuentoneta es un proyecto **colaborativo y de referencia**: las decisiones de cómo se estructura el trabajo acá sientan precedente para todo lo que viene después. Recomendaciones que cambian rigor por ceremonia —aun con buena intención— marcan el precedente equivocado para quienes copien patrones de este repo y para la cultura de desarrollo del equipo.
+
+Los agentes de código tienen un modo de falla particular: cuando sopesan alternativas, tienden a optimizar el costo percibido por el agente (tiempo, ventana de contexto, llamadas a la API) en vez de la salud del codebase a largo plazo. Este documento codifica las reglas que previenen ese modo de falla.
+
+---
+
+## Sección 1 — La regla "no-solo-maintainer"
+
+### Regla
+
+Cuando recomiendes entre alternativas que cambian rigor por ceremonia —por ejemplo:
+
+- Un PR grande vs. varios PRs chicos
+- Un solo commit vs. varios commits atómicos
+- Doc inline vs. archivo aparte
+- Saltear tests vs. escribirlos
+- Saltear la code review vs. correrla
+- Hand-wavear un edge case vs. cubrirlo
+
+— **nunca** uses ninguno de estos framings como desempate, pregunta lateral o justificación para ahorrar costo:
+
+- "Si sos el único que mantiene esto..."
+- "Si es trabajo en solitario..."
+- "Si nadie más va a revisar..."
+- "Como sos el contribuidor principal..."
+- "Si esto es solo para vos..."
+- Cualquier framing equivalente que asuma un mantenedor único.
+
+Tampoco incluyas esas frases como **cláusulas condicionales** en recomendaciones ("si X es verdad entonces esto está bien, si no aquello").
+
+### Por qué
+
+1. **El agente no está en posición de evaluar el contexto de mantenimiento.** Ve el repo en un momento puntual; no ve quién va a leer el código en seis meses, qué review de compliance lo va a tocar, ni qué historia de onboarding le importa al equipo.
+2. **Aunque el usuario fuera el único mantenedor**, el precedente existe para futuros contribuidores que copien patrones de este repo a su propio trabajo. La escapatoria del "solo-maintainer" envenena el pozo para todos aguas abajo.
+3. **Este es un proyecto colaborativo y de referencia.** Sugerir atajos sobre supuestos de mantenimiento en solitario malinterpreta el contexto real.
+
+### Cómo aplicarla
+
+- **Defaulteá a la opción rigurosa / amigable con la colaboración** y presentala como la recomendación, no como la rama "si son N personas".
+- Si una opción más liviana realmente vale la pena mencionarla, framéala como "la opción de menor costo, asumiendo que aceptamos X pérdida de rigor" —nunca como "está bien si sos solo vos".
+- Aplicá esto en code reviews, estructuración de planes, estrategia de PRs, decisiones de refactor, decisiones de cobertura de tests, decisiones de documentación y cualquier otro lugar donde el agente pueda tentarse de optimizar para el flujo en solitario.
+- Esta política es una regla dura, no una preferencia. Las personas revisoras pueden citar esta sección para bloquear un PR.
+- Las convenciones específicas de commits y PRs están en [`CLAUDE.md`](../../CLAUDE.md) (sección "Convenciones de Git"); esta sección gobierna el **framing** de las recomendaciones que tocan esas convenciones, no las convenciones en sí.
+
+### Framing bueno vs. malo
+
+**Malo** (prohibido):
+
+> "La opción A junta todos los cambios en un solo PR. La opción B los separa en varios PRs chicos. **Si sos el único que revisa, A está bien** —es más rápido y te ahorrás la ceremonia del merge. Si no, B es más limpia."
+
+**Bueno** (preferido):
+
+> "La opción A junta todos los cambios en un solo PR. La opción B los separa en varios PRs chicos. **B es la recomendación**: cada PR es revisable, revertible y trazable a su propio issue de forma independiente. A es la opción de menor rigor —se saltea la historia de review por área y concentra el riesgo de merge en un solo evento. Elegí A solo si aceptaste explícitamente esas pérdidas."
+
+---
+
+## Sección 2 — Otros anti-patrones de atajo
+
+Las siguientes recomendaciones están prohibidas. La lista crece con el tiempo a medida que se descubren nuevos modos de falla. **Las adiciones siguen el mismo proceso de enmienda que cualquier cambio:** propuesta vía issue en `cuentoneta/cuentoneta`, con aprobación explícita del usuario.
+
+### "Podemos saltear el test porque es un cambio chico"
+
+Prohibido. Los tests existen por algo; "chico" no es una medida de riesgo. Hasta un bugfix de una línea debe aterrizar con un test de regresión que hubiera atrapado el bug original. El trabajo del agente es escribir el test, no argumentar en contra de escribirlo.
+
+**Alcance:** esta regla aplica a cualquier cambio que modifique comportamiento en runtime —lógica, valores de configuración que la app lee en runtime, schemas (Sanity/Zod) o contratos de API. **Cambios solo de documentación** (Markdown, comentarios sin cambios de código) **y cambios solo de configuración de tooling** (reglas de ESLint/Stylelint, settings de Prettier, YAML de workflows de CI, etc., sin efecto en runtime sobre la app) están **exentos** del requisito de test.
+
+### "Borremos el archivo total está gitignoreado"
+
+Prohibido para artefactos intencionalmente autorados aunque estén gitignoreados —por ejemplo salidas regenerables bajo `tools/` (como `tools/author-bios/` o `tools/story-summaries/`), planes, notas de review o mapas de issues. No borres ese tipo de archivos sin instrucción explícita del usuario, sin importar su estado de gitignore. Antes de borrar/sobrescribir un artefacto generado, verificá que sea **re-generable** (ver "Convenciones de Git" en `CLAUDE.md`). Para archivos fuera de esas rutas, usá criterio: si la existencia del archivo fue pedida o referenciada explícitamente por el usuario en algún archivo commiteado (`CLAUDE.md`, `docs/`, etc.), no lo borres sin confirmar.
+
+### "La code review puede esperar hasta después de abrir el PR"
+
+Prohibido. La review local del agente (p. ej. el agente `code-reviewer` / skill de code review) corre **antes de abrir el PR**, para que quienes revisen el PR vean código ya pulido. Pushear la rama está bien; abrir el PR antes de la review local, no.
+
+### "Documentemos el edge case en un comentario y listo"
+
+Prohibido. Si un edge case se puede enumerar en un comentario, se puede enumerar en un test. Los comentarios documentan la intención; los tests la hacen cumplir. El agente debe escribir el test.
+
+### "El componente es simple, no hace falta la story de Storybook"
+
+Prohibido. Todo componente nuevo en `src/app/components/` lleva su `*.stories.ts` (ver "Testing" en `CLAUDE.md`). La respuesta siempre es escribir la story.
+
+---
+
+## Sección 3 — Preguntas aclaratorias
+
+Los agentes pueden hacer preguntas aclaratorias cuando la instrucción del usuario es genuinamente ambigua. No pueden hacer preguntas cuya respuesta cambiaría qué opción recomienda el agente sobre el eje rigor / ceremonia. En concreto:
+
+- ✅ "¿El nuevo input del componente debería ser `required`?" — ambigüedad sustantiva, preguntá.
+- ✅ "¿La entrada del changelog va bajo Added o Changed?" — ambigüedad sustantiva, preguntá.
+- ✅ "¿El componente nuevo soporta light y dark desde el día uno, o aterriza solo light y el dark va en un follow-up?" — pregunta de producto sustantiva, preguntá.
+- ❌ "¿Sos la única persona que va a revisar esto?" — prohibida, nunca preguntar.
+- ❌ "¿Qué tan importante es que los tests cubran este edge case?" — prohibida **como forma de pedir permiso para saltear el test**. La pregunta solo es aceptable si aclara _qué_ debe afirmar el test, no _si_ escribirlo. Si te encontrás queriendo preguntar esto para evitar escribir el test, escribí el test.
+- ❌ "¿Está bien si me salteo la code review para este PR chico?" — prohibida, nunca preguntar.
+- ❌ "¿Está bien saltear la story de Storybook porque el componente es simple?" — prohibida, nunca preguntar. La respuesta siempre es escribir la story.
+
+---
+
+## Sección 4 — Repos externos: política de issues
+
+Cuando trabajés contra repos donde el usuario **no es contribuidor** (p. ej. dependencias upstream, el starter de referencia, librerías de terceros):
+
+- **No crees issues, PRs ni comentarios** en esos repos en nombre del usuario.
+- Si detectás algo que ameritaría un issue upstream, **informalo al usuario** con el detalle suficiente (repo, descripción, reproducción) y dejá que **él lo cree** si decide hacerlo.
+- Está bien **leer** esos repos (vía `gh api`, clonado, etc.) para inspirarse o portar patrones, siempre que el resultado aterrice en `cuentoneta/cuentoneta`.
+
+El repo propio donde sí se crean issues/PRs es `cuentoneta/cuentoneta` (usar `gh`).
+
+---
+
+## Sección 5 — Retención de memoria
+
+Este agente usa el **sistema de memoria de Claude Code** (archivos en `.claude/projects/<project-id>/memory/` indexados desde `MEMORY.md`). Debe guardar un registro de feedback que codifique estas reglas, para que sobrevivan a la pérdida de contexto entre sesiones.
+
+La memoria local **no reemplaza** este documento: el documento es la versión autoritativa que las personas revisoras y otros agentes pueden citar, y es portable entre proveedores de agentes. La memoria local es el refuerzo táctico para el comportamiento de un agente entre sus propias sesiones.
+
+El principio: **el documento es canónico; la memoria es refuerzo**. Si los dos alguna vez se contradicen, gana el documento y se actualiza la memoria.
+
+> **Específico de Claude Code:** la memoria de este proyecto vive en `.claude/projects/C--Users-ramir-WebstormProjects-cuentoneta/memory/` y se indexa desde `MEMORY.md`. Otros agentes (Cursor, Aider, Copilot Chat, etc.) deberían usar su mecanismo de persistencia equivalente o —si no tienen ninguno— cargar este documento al inicio de cada sesión vía el mecanismo de inclusión de contexto del proyecto (`.cursorrules`, `.aiderrules`, etc.).
+
+---
+
+## Sección 6 — Enforcement
+
+### Para agentes
+
+- Leé este documento al inicio de sesión, **cada** sesión, sin condiciones.
+- Si una recomendación violaría cualquier regla de arriba, **revisá la recomendación antes de presentarla** en vez de presentar la violación con un caveat.
+- Si una instrucción del usuario forzaría una violación (p. ej. "salteá los tests para este"), explicitá el conflicto: "Esto violaría `coding-agent-policies.md` Sección 2. Confirmá que querés que avance igual."
+
+### Para personas revisoras
+
+- Una descripción de PR que contenga cualquiera de los framings prohibidos es bloqueante. Pedí cambios citando este documento por sección.
+- Un PR que omite tests sobre la base de "es chico" es bloqueante. Pedí los tests faltantes.
+- Un PR abierto sin la pasada de review local (cuando el flujo la especifica) es bloqueante. Pedí la pasada antes de mergear.
+- Un componente nuevo sin su `*.stories.ts` es bloqueante. Pedí la story.
+
+### Gates de CI
+
+Independientemente de lo anterior, todo PR debe dejar verdes los gates de CI definidos en `CLAUDE.md`: `test`, `lint`, `stylelint`, `e2e`, `build`, `storybook`. Que un gate sea "molesto" o "lento" no es justificación para saltearlo o deshabilitarlo.
+
+### Enmiendas
+
+Proponé cambios vía issue en `cuentoneta/cuentoneta`. Las enmiendas requieren aprobación explícita del usuario antes de mergear al documento. Cada PR que modifique este archivo debe actualizar la fecha de "Última actualización" del pie de página.
+
+---
+
+_Última actualización: 2026-06-15. Versión inicial creada como parte del issue #1495 (CLAUDE.md + archivos de referencia)._

--- a/.claude/references/cross-reference.md
+++ b/.claude/references/cross-reference.md
@@ -1,0 +1,101 @@
+<!-- Fuente: CLAUDE.md | Última actualización: 2026-06-15 -->
+
+# Cruce de principios (Cross-Reference)
+
+Varios cuerpos de principios refuerzan las mismas ideas centrales. Este archivo es la **matriz** que las relaciona: **SOLID** (diseño de clases), **CUPID** (propiedades de código), **Clean Architecture** (capas y regla de dependencia) y **DDD** (modelo de dominio). Usá el encuadre que mejor encaje con tu contexto — todos apuntan a lo mismo.
+
+> Referencias relacionadas: [`solid.md`](solid.md) · [`cupid.md`](cupid.md) · [`guiding-principles.md`](guiding-principles.md) · [`clean-architecture.md`](clean-architecture.md) · [`domain-model.md`](domain-model.md)
+
+---
+
+## 1. Misma idea, distinto encuadre
+
+Una misma idea central aparece bajo distintos nombres según hablemos de clases, de propiedades de código o de código general. Elegí el vocabulario que comunique mejor en cada caso.
+
+| Idea central                             | Diseño de clases (SOLID) | Propiedades de código (CUPID) | Código general       |
+| ---------------------------------------- | ------------------------ | ----------------------------- | -------------------- |
+| **Un único foco**                        | SRP                      | Composable, Unix Philosophy   | Filosofía Unix       |
+| **Depender de abstracciones**            | DIP                      | —                             | —                    |
+| **No depender de lo que no se usa**      | ISP                      | Composable                    | —                    |
+| **Extender sin modificar**               | OCP                      | —                             | —                    |
+| **Cumplir las expectativas (sustituir)** | LSP                      | Predictable                   | —                    |
+| **Seguir convenciones**                  | —                        | Idiomatic                     | Idiomático           |
+| **Usar lenguaje de dominio**             | —                        | Domain-Based                  | Basado en el dominio |
+| **Construir solo lo necesario**          | —                        | —                             | YAGNI                |
+| **Preferir la simplicidad**              | —                        | —                             | KISS                 |
+
+> En cuentoneta el sesgo es **signals-first sin NgRx** y **backend Hono plano**: la "composición" se expresa con servicios + signals/RxJS en el frontend y con `controller → service → repository` en el backend, no con abstracciones extra que no aportan valor (YAGNI/KISS).
+
+---
+
+## 2. SOLID ↔ CUPID
+
+SOLID describe **cómo diseñar clases**; CUPID describe **qué propiedades** debería exhibir el código bueno. Se solapan, pero CUPID es más amplio (aplica a funciones, módulos y componentes, no solo a clases).
+
+| Principio SOLID                     | Propiedad(es) CUPID que refuerza | Cómo se relacionan                                                                                      |
+| ----------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **SRP** (responsabilidad única)     | Composable, Unix Philosophy      | Una sola razón para cambiar ⇒ piezas pequeñas que se componen ("hacer una cosa bien").                  |
+| **OCP** (abierto/cerrado)           | Composable                       | Extender combinando piezas en vez de editar las existentes.                                             |
+| **LSP** (sustitución de Liskov)     | Predictable                      | Una implementación que respeta el contrato es sustituible y se comporta como se espera.                 |
+| **ISP** (segregación de interfaces) | Composable                       | Interfaces chicas y enfocadas ⇒ se combinan sin arrastrar dependencias inútiles.                        |
+| **DIP** (inversión de dependencias) | Composable, Domain-Based         | Depender de abstracciones del dominio permite intercambiar implementaciones (p. ej. Sanity / InMemory). |
+
+> CUPID añade dos propiedades sin equivalente directo en SOLID: **Idiomatic** (seguir las convenciones del lenguaje/framework — en cuentoneta: Angular zoneless + signals, `@if`/`@for`, `inject()`) y **Domain-Based** (modelar con el lenguaje del dominio — `Story`, `Author`, `Storylist`).
+
+---
+
+## 3. SOLID/CUPID ↔ Clean Architecture
+
+Clean Architecture aporta la **dimensión estructural** que SOLID/CUPID no fijan por sí solos: la **regla de dependencia** (las dependencias apuntan hacia adentro, hacia el dominio) y las **capas**.
+
+| Concepto                        | Encuadre en cuentoneta                                                                                                                                                                     |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **DIP** + regla de dependencia  | El dominio (`Story`, `Author`, `Storylist`, `Resource`) no conoce a Sanity. Los detalles dependen del dominio, nunca al revés.                                                             |
+| **Qualified Implementation**    | Una misma operación de dominio admite varias implementaciones (p. ej. Sanity vs. InMemory) detrás del mismo contrato.                                                                      |
+| **Anti-Corruption Layer (ACL)** | El **patrón central** del repo: los **mappers** (`mapAuthor`, `mapResources`, …) traducen el shape crudo de GROQ al modelo de dominio. Lo crudo de Sanity **nunca** se filtra al frontend. |
+| **SRP por capa** (backend)      | `controller → service → repository`: rutas/validación, lógica/mapeo de dominio, acceso a datos. Cada capa con una única razón para cambiar.                                                |
+| **Composable** (frontend)       | Estado modelado con **servicios + signals + RxJS** (sin NgRx); derivados con `computed()`/`toSignal()`, no estado duplicado.                                                               |
+
+```
+GROQ query → repository.fetch*()  →  service.get*()  →  mapX(rawResult): DomainType  →  controller
+            (resultado crudo Sanity)                    (mapper / ACL en _utils)
+```
+
+> Backend **Hono plano** (no OpenAPIHono): la regla de dependencia se respeta con la convención de capas, no con un framework de inversión adicional. Ver [`clean-architecture.md`](clean-architecture.md) y [`sanity-acl.md`](sanity-acl.md).
+
+---
+
+## 4. Clean Architecture ↔ DDD
+
+Clean Architecture dice **dónde** vive cada cosa (capas); DDD dice **qué** vive en el centro (el modelo de dominio) y **cómo** se expresa.
+
+| DDD                                | Cómo aterriza en cuentoneta                                                                                                            |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lenguaje ubicuo / Domain-Based** | Los tipos de dominio (`Story`, `Author`, `Storylist`, `Resource`) usan el vocabulario del negocio, en el código y en la documentación. |
+| **Agregados e invariantes**        | El modelo de dominio concentra las invariantes; los mappers garantizan que solo entren shapes válidos del dominio.                     |
+| **Anti-Corruption Layer**          | Frontera explícita entre el modelo de Sanity (externo) y el modelo de dominio (interno): los **mappers** del ACL.                      |
+| **Bounded contexts**               | Cada módulo de `src/api/modules/<dominio>/` acota un contexto con su propio controller/service/repository/schema.                      |
+
+> Detalle de DDD estratégico (agregados, invariantes, bounded contexts) en [`domain-model.md`](domain-model.md).
+
+---
+
+## 5. Resolución de tensiones
+
+Cuando dos principios parecen empujar en direcciones opuestas, esta es la prioridad en cuentoneta:
+
+1. **YAGNI / KISS ganan sobre la abstracción especulativa.** No introducir interfaces, capas o indirecciones "por si acaso". Sin NgRx ni OpenAPIHono hasta que un issue lo indique (ver #1530 / #1531 en `CLAUDE.md`).
+2. **El ACL no es negociable.** Aunque "sea más simple" pasar el resultado crudo de GROQ, los mappers se mantienen: es la frontera de dominio del repo.
+3. **Idiomatic gana sobre la preferencia personal.** Seguir las convenciones de Angular zoneless + signals y de Hono plano, aunque exista otra forma "válida".
+4. **Predictable sobre clever.** Código sustituible y testeable (Angular Testing Library, comportamiento de usuario) antes que soluciones ingeniosas difíciles de razonar.
+
+---
+
+## 6. Cómo usar esta matriz
+
+- Al **diseñar una clase/servicio** → encuadre **SOLID** (columna "Diseño de clases").
+- Al **revisar un módulo/componente** → encuadre **CUPID** (¿es Composable, Predictable, Idiomatic, Domain-Based?).
+- Al **ubicar lógica** (¿controller, service, repository, mapper?) → **Clean Architecture** + el ACL.
+- Al **nombrar y modelar** → **DDD** (lenguaje ubicuo, tipos de dominio).
+
+Las cuatro vistas describen el mismo código bueno desde ángulos distintos; ninguna sustituye a las otras.

--- a/.claude/references/cupid.md
+++ b/.claude/references/cupid.md
@@ -1,0 +1,86 @@
+<!-- Fuente: CLAUDE.md | Última actualización: 2026-06-15 -->
+
+# Principios CUPID
+
+Escribí código que dé gusto trabajar haciéndolo:
+
+## Componible (Composable)
+
+- Diseñá unidades que se combinen fácilmente con otras
+- Mantené las dependencias mínimas y explícitas (`inject()`, no estado global oculto)
+- Favorecé piezas pequeñas y enfocadas que funcionen bien juntas
+- Habilitá el plug-and-play mediante interfaces claras
+
+```typescript
+// ✅ Componible: el mapper es una función pura que se compone con cualquier query
+export function mapAuthorTeaser(raw: SanityAuthor): AuthorTeaser {
+	return {
+		slug: raw.slug.current,
+		name: raw.name,
+		imageUrl: urlForWithAutoFormat(raw.image),
+	};
+}
+```
+
+## Filosofía Unix (Unix Philosophy)
+
+- Hacé una sola cosa, y hacela bien (un `fetchStoryBySlug` lee; no mapea ni valida)
+- Trabajá con interfaces simples y bien definidas entre capas (`repository` → `service` → `controller`)
+- Diseñá para componer con otras herramientas
+- Evitá la complejidad innecesaria (respetá los límites de función ≤ 50 líneas y complejidad ≤ 10)
+
+```typescript
+// ✅ Cada capa hace una cosa
+// repository: solo trae el resultado crudo de Sanity
+export const fetchStoryBySlug = (slug: string) => client.fetch(storyBySlugQuery, { slug });
+
+// service: envuelve al repository y mapea al dominio vía la ACL
+export const getStoryBySlug = async (slug: string): Promise<Story> => mapStory(await fetchStoryBySlug(slug));
+```
+
+## Predecible (Predictable)
+
+- El código hace lo que parece que hace
+- Comportate de forma consistente y determinística
+- Minimizá las sorpresas; seguí el principio de la menor sorpresa
+- Usá nombres que revelen la intención (`getStories`, `closeOnSuccessEffect`)
+- Manejá los casos límite de forma explícita y visible (errores tipados por operación, no un `string | null` compartido)
+
+```typescript
+// ✅ El nombre del effect revela qué hace y cuándo
+private readonly syncSlugEffect = effect(() => {
+	const slug = this.slug();
+	untracked(() => this.load(slug));
+});
+```
+
+## Idiomático (Idiomatic)
+
+- Seguí las convenciones del lenguaje, del framework y del propio repo
+- Escribí código que se sienta natural para quien conoce el ecosistema
+- Usá patrones estándar — no reinventes la rueda
+- Respetá el estilo y la estructura existentes en cuentoneta:
+  - Componentes standalone, `OnPush`, app **zoneless**: signals / `computed` / `effect` en vez de lifecycle hooks
+  - `@if` / `@for` / `@switch` en plantillas (nunca `*ngIf`/`*ngFor`), self-closing tags, `ngSrc`
+  - `Object.freeze({...} as const)` en vez de `enum`
+  - Tests con Angular Testing Library + wrappers de `@test-utils` (nunca `vi.*` directo)
+
+```typescript
+// ✅ Idiomático en cuentoneta: derivar con computed, no estado duplicado
+protected readonly hasStories = computed(() => this.stories().length > 0);
+```
+
+## Basado en el dominio (Domain-Based)
+
+- Usá el lenguaje del dominio del problema, no detalles de implementación técnica
+- Estructurá el código alrededor de conceptos de negocio (`Story`, `Author`, `Storylist`, `Resource`)
+- Hacé que el código cuente la historia de lo que el sistema hace
+- Mantené la lógica de dominio separada de la infraestructura: el **ACL (mappers)** traduce el shape crudo de Sanity al modelo de dominio, y los resultados crudos de GROQ **nunca** se filtran al frontend
+
+```typescript
+// ✅ El dominio habla: lecturas de Storylist, no "documents con _type"
+export const getStorylistBySlug = async (slug: string): Promise<Storylist> =>
+	mapStorylist(await fetchStorylistBySlug(slug));
+```
+
+_Fuente: Dan North, "CUPID—for joyful coding"_

--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -1,0 +1,366 @@
+<!-- Fuente: adaptado de ResetShop/angular-nx-standalone-starter · .claude/references/domain-model.md -->
+
+# Modelo de Dominio — Guía estratégica (DDD)
+
+> **Propósito:** esta referencia es la **guía conceptual/objetivo** de Domain-Driven Design para La Cuentoneta. Documenta los patrones **estratégicos** de DDD (agregados + invariantes, bounded contexts, lenguaje ubicuo, domain events, policies puras, decisiones de consistencia, value objects) re-ejemplificados con el dominio real: **Story, Author, Storylist, Resource**.
+>
+> **Idioma:** la guía va en **español**; el **código siempre en inglés**.
+>
+> **Estado del proyecto — leer primero.** Hoy cuentoneta es **DDD-lite**: módulos organizados en capas (`controller → service → repository`) con un **ACL de mappers** sólido, pero los **repositorios están acoplados a Sanity** y no existen todavía clases de agregado, value objects, specification ni domain events como código. La implementación profunda de estos patrones es un **ROADMAP**, no el estado actual:
+>
+> - El **modelo de dominio descriptivo** (agregados, vistas polimórficas, value objects, lenguaje ubicuo) vive en [`docs/DOMAIN_MODEL.md`](../../docs/DOMAIN_MODEL.md).
+> - Las **mejoras propuestas** (repository pattern desacoplado, domain events, specification) viven en [`docs/DDD_IMPROVEMENTS.md`](../../docs/DDD_IMPROVEMENTS.md).
+> - El **issue de implementación** es **#1503**.
+>
+> Esta referencia es el **norte conceptual**; donde un patrón aún no esté implementado, se marca explícitamente como roadmap.
+
+---
+
+## Índice
+
+1. [Estructura por bounded context](#estructura-por-bounded-context)
+2. [Diseño orientado a interfaces](#diseño-orientado-a-interfaces)
+3. [Vistas polimórficas (projection pattern)](#vistas-polimórficas-projection-pattern)
+4. [Inmutabilidad](#inmutabilidad)
+5. [Value Objects (Slug, ReadingTime, DateString)](#value-objects-slug-readingtime-datestring)
+6. [Validación en runtime (Zod)](#validación-en-runtime-zod)
+7. [El ACL como frontera (mappers)](#el-acl-como-frontera-mappers)
+8. [Binding en componentes: solo dominio](#binding-en-componentes-solo-dominio)
+9. [Patrones estratégicos](#patrones-estratégicos)
+   - [Diseño de agregados](#diseño-de-agregados)
+   - [Domain events](#domain-events)
+   - [Type-state pattern](#type-state-pattern)
+   - [Policies como funciones puras](#policies-como-funciones-puras)
+   - [Principios de bounded context](#principios-de-bounded-context)
+   - [Lenguaje ubicuo](#lenguaje-ubicuo)
+   - [Decisiones de consistencia](#decisiones-de-consistencia)
+
+---
+
+## Estructura por bounded context
+
+Organizá el modelo de dominio por **contexto acotado**. Cuentoneta define cuatro (ver `docs/DOMAIN_MODEL.md`): **Catálogo de Contenido** (`Story`, `Author`, `Resource`, `Media`, `Epigraph`), **Curación y Colecciones** (`Storylist`), **Administración del Proyecto** (`Contributor`) y **Página de Inicio** (`LandingPageContent`, `ContentCampaign`).
+
+Hoy los tipos de dominio viven en `src/app/models/` (frontend) y la ACL/dominio del backend en `src/api/`. La estructura **objetivo** por contexto (roadmap #1503) agrupa, por agregado, el contrato + el modelo + el mapper + su spec:
+
+```
+<contexto>/                 # p. ej. content-catalog/, curation/
+├── <entidad>.interface.ts   # contrato de dominio (IStory, IAuthor, …)
+├── <entidad>.model.ts       # implementación con invariantes
+├── <entidad>.mapper.ts      # factory + traducción desde Sanity
+└── <entidad>.model.spec.ts
+```
+
+> **Roadmap:** la separación física por carpeta de contexto es objetivo. No inventar estos archivos al implementar features actuales; seguir la organización vigente (`src/app/models/`, `src/api/_utils/`) hasta que #1503 la migre.
+
+---
+
+## Diseño orientado a interfaces
+
+Definí **interfaces** para las entidades de dominio. Los componentes dependen de interfaces, no de clases concretas. Esto ya rige hoy: el frontend consume `Story`, `Author`, `Storylist`, `Resource` como contratos, nunca el shape crudo de Sanity.
+
+```typescript
+// story.interface.ts (objetivo: contrato explícito separado de la implementación)
+export interface IStory {
+	readonly slug: string; // business key, invariante única
+	readonly title: string;
+	readonly author: IAuthor; // un Story siempre tiene autor
+	readonly approximateReadingTime: number; // minutos, >= 1
+	hasMedia(): boolean;
+}
+```
+
+**Convención `I`:** usar el prefijo `I` **solo** cuando coexista una clase concreta con el mismo nombre (`IStory`/`Story`), para distinguir contrato de implementación. Donde hoy hay solo una `interface Story` (sin clase), no hace falta el prefijo.
+
+### Factory functions
+
+Usá factories para abstraer la instanciación y **devolver la interfaz**, no la clase concreta. Esto encaja con el rol actual de los mappers del ACL (`mapAuthor`, `mapStoryContent`):
+
+```typescript
+// story.mapper.ts
+interface CreateStoryOptions {
+	slug: string;
+	title: string;
+	author: IAuthor;
+	paragraphs: TextBlockContent[];
+	approximateReadingTime: number;
+}
+
+export function createStory(options: CreateStoryOptions): IStory {
+	return new Story(options);
+}
+```
+
+**Reglas:**
+
+- **Options object** para funciones con 3+ parámetros.
+- Mantené las interfaces de options **privadas** (no exportadas) — TS infiere el tipo en el call site.
+- Devolvé el **tipo interfaz**, no la clase concreta.
+
+---
+
+## Vistas polimórficas (projection pattern)
+
+Un agregado expone **múltiples interfaces** para distintos casos de uso, optimizando la transferencia de datos. Este patrón **ya está implementado** y es central en cuentoneta:
+
+```typescript
+Story; // vista completa: párrafos, epígrafes, autor completo
+StoryTeaser; // sin contenido pesado, para listados
+StoryNavigationTeaser; // mínima, para navegación
+StoryNavigationTeaserWithAuthor; // mínima + autor resumido
+
+Author; // completa: biografía + recursos
+AuthorTeaser; // resumida, para tarjetas
+
+Storylist; // completa: stories con autor
+StorylistTeaser; // sin stories
+```
+
+Cada vista es una proyección coherente del mismo agregado; el mapper correspondiente del ACL produce exactamente la vista que la query GROQ pidió.
+
+---
+
+## Inmutabilidad
+
+Los objetos de dominio deben ser **inmutables** tras su construcción:
+
+```typescript
+export class Story implements IStory {
+	readonly slug: string;
+	readonly title: string;
+	readonly author: IAuthor;
+	readonly resources: readonly IResource[];
+	// …
+}
+```
+
+- Marcá todas las propiedades `readonly`.
+- Usá `readonly T[]` para arrays.
+- Calculá los valores derivados en el constructor y guardalos en campos privados.
+
+El contenido enriquecido (`TextBlockContent` / Portable Text) **se trata como inmutable**: una vez producido por Sanity, no se modifica en la aplicación.
+
+---
+
+## Value Objects (Slug, ReadingTime, DateString)
+
+Un **Value Object** no tiene identidad propia: representa un concepto del dominio, es inmutable y se compara por su contenido. Hoy cuentoneta usa **tipos primitivos** para estos conceptos (`slug: string`, `approximateReadingTime: number`, `bornOn?: DateString`). Promoverlos a value objects con auto-validación es **roadmap (#1503)**; abajo va el objetivo.
+
+### Slug — clave de negocio
+
+`slug` es el patrón **Business Key** del proyecto: identificador amigable, único e **inmutable** que reemplaza al `_id` técnico de Sanity en URLs y rutas (`/story/el-aleph`, `/author/jorge-luis-borges`). El `_id` se reserva para GROQ y manipulación en la capa de datos.
+
+```typescript
+// objetivo (roadmap): brandear el slug y validar formato al construir
+export type Slug = string & { readonly __brand: 'Slug' };
+
+export function slug(value: string): Slug {
+	if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
+		throw new Error(`Slug inválido: "${value}"`);
+	}
+	return value as Slug;
+}
+```
+
+### ReadingTime — minutos de lectura
+
+Invariante: el tiempo de lectura es un **número positivo** (`>= 1`). Como value object encapsula esa invariante en un solo lugar:
+
+```typescript
+// objetivo (roadmap)
+export type ReadingTime = number & { readonly __brand: 'ReadingTime' };
+
+export function readingTime(minutes: number): ReadingTime {
+	if (!Number.isInteger(minutes) || minutes < 1) {
+		throw new Error(`ReadingTime inválido: ${minutes}`);
+	}
+	return minutes as ReadingTime;
+}
+```
+
+### DateString — fechas de autor (`YYYY-MM-DD`)
+
+`bornOn` / `diedOn` de `Author` usan el formato `YYYY-MM-DD`. La invariante de dominio — _si `diedOn` está definida, debe ser posterior a `bornOn`_ — se valida al construir el agregado `Author`, no en el value object aislado (es una regla entre dos campos del agregado).
+
+```typescript
+// objetivo (roadmap)
+export type DateString = string & { readonly __brand: 'DateString' };
+
+export function dateString(value: string): DateString {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+		throw new Error(`DateString inválida: "${value}"`);
+	}
+	return value as DateString;
+}
+```
+
+> **Nota de estilo (CLAUDE.md):** para conjuntos cerrados de literales **nunca** usar `enum` de TS — usar `Object.freeze({...} as const)`. Esto aplica a `ResourceType.slug`, `MediaType`, `ContributorAreaType`, etc.
+
+---
+
+## Validación en runtime (Zod)
+
+Usá **Zod** para validar **datos externos** en la frontera (respuestas de API, contenido crudo de Sanity, params/query del backend con `@hono/zod-validator`). La validación protege el dominio de shapes inesperados antes de mapear:
+
+```typescript
+import { z } from 'zod';
+
+const storySlugParamSchema = z.object({ slug: z.string().min(1) });
+
+// en el controller Hono:
+// zValidator('param', storySlugParamSchema)
+```
+
+La validación cruza la frontera una sola vez; pasada esa frontera, el dominio confía en sus tipos.
+
+---
+
+## El ACL como frontera (mappers)
+
+El **Anti-Corruption Layer es el patrón central** de cuentoneta y **ya está implementado**. Los resultados crudos de GROQ **nunca** se filtran al frontend: los mappers traducen el shape de Sanity al modelo de dominio.
+
+```
+GROQ → repository.fetch*()  →  service.get*()  →  mapX(raw): DomainType  →  controller
+       (resultado crudo)                         (mapper / ACL en _utils)
+```
+
+- Mappers como **funciones puras**: `mapAuthor`, `mapAuthorTeaser`, `mapStoryContent`, `mapResources`, …
+- Los helpers de imágenes (`urlFor`, `urlForWithAutoFormat`) también viven en la capa de mappers.
+- Al cambiar una query GROQ o un tipo generado de Sanity, actualizá el **mapper** y los tipos de dominio en el **mismo** PR.
+
+El ACL es la frontera explícita entre la infraestructura (Sanity) y el dominio: un cambio en el CMS no afecta al dominio mientras se mantengan los contratos. Detalle en [`sanity-acl.md`](sanity-acl.md).
+
+---
+
+## Binding en componentes: solo dominio
+
+Los componentes deben hacer binding **exclusivamente** a interfaces de dominio (`IStory`, `IAuthor`, `IStorylist`, `IResource`) o sus modelos. El **shape crudo de Sanity** y cualquier DTO de contrato pertenecen a la capa de API/provider — **nunca** se importan ni se referencian en componentes ni plantillas.
+
+La frontera es clara: los repositories/services de Sanity manejan el shape crudo; desde la superficie pública del provider/store hacia arriba (componentes, plantillas), **solo** interfaces de dominio. Los modelos de dominio exponen propiedades computadas y métodos que encierran las reglas de negocio en un único lugar.
+
+**Patrón:** el mapeo crudo → dominio se hace en la ACL (backend) y/o en el provider (frontend), de modo que las señales públicas ya exponen interfaces de dominio. El componente solo las consume.
+
+---
+
+# Patrones estratégicos
+
+Las secciones de arriba son **tácticas** (_cómo_ construir bien un modelo). Las de abajo son **estratégicas**: _cuándo_ y _por qué_ aplicar esas tácticas y cómo se relacionan los modelos en el sistema. Son conceptos DDD framework-agnósticos adaptados al dominio TypeScript de cuentoneta.
+
+## Diseño de agregados
+
+Un **agregado** es un cluster de objetos de dominio tratado como una unidad para cambios de datos. Un objeto es la **raíz de agregado** — el único punto de entrada, responsable de hacer cumplir cada invariante del cluster. Los callers tienen referencia a la raíz, nunca a sus internos.
+
+**Cómo identificar la raíz:** buscá la entidad que **posee más invariantes de negocio**; esa entidad es la raíz, porque las invariantes solo se garantizan si toda mutación pasa por ella.
+
+En cuentoneta, **`Story` es la raíz** del agregado de contenido. Posee `author: IAuthor`, `paragraphs`, `epigraphs`, `resources: IResource[]` y `media: Media[]`. Sus invariantes (de `docs/DOMAIN_MODEL.md`):
+
+- El `slug` es único e inmutable una vez creado.
+- Toda historia **debe tener un autor**.
+- Debe tener **al menos un párrafo** de contenido.
+- El tiempo de lectura es un número positivo (`>= 1`).
+
+El objetivo (roadmap #1503) es hacer cumplir esas invariantes **en construcción**, de modo que ningún caller pueda crear un `Story` inconsistente:
+
+```typescript
+// story.model.ts — objetivo: invariantes en tiempo de construcción
+constructor(options: CreateStoryOptions) {
+	if (!options.author) throw new Error('Story requiere autor');
+	if (options.paragraphs.length === 0) throw new Error('Story requiere al menos un párrafo');
+	this.slug = slug(options.slug);
+	this.approximateReadingTime = readingTime(options.approximateReadingTime);
+	// …
+}
+```
+
+`Author` y `Storylist` son raíces de sus propios agregados. **`Storylist`** posee la invariante _`count` coincide con el número real de `stories`_; **`Author`** posee _`diedOn` (si existe) es posterior a `bornOn`_ y _`nationality` siempre presente_.
+
+> **Nota:** la frontera del agregado es también la frontera de consistencia — ver [Decisiones de consistencia](#decisiones-de-consistencia).
+>
+> **Estado:** hoy estas invariantes están **descritas** en `docs/DOMAIN_MODEL.md` y garantizadas de hecho por el contenido curado en Sanity; su **enforcement en código** (constructores que lanzan) es roadmap.
+
+## Domain events
+
+Un **domain event** es un hecho en pasado sobre algo que **ya ocurrió**: `StoryPublished`, `StoryCreated`, `AuthorPublished`, `StorylistPublished`. Nombralos como hechos, nunca como comandos (`PublishStory` es un comando; `StoryPublished` es el evento).
+
+Los eventos permiten que un bounded context reaccione a otro sin llamada directa: el contexto productor registra el hecho y los consumidores se suscriben. Esto **desacopla** contextos.
+
+**Estado — roadmap (#1503).** Los domain events **no están implementados** todavía. La comunicación entre contextos hoy pasa por los **mappers del ACL** y llamadas directas a services. Esta sección documenta el patrón para el momento en que ese acoplamiento directo se vuelva una carga — por ejemplo, cuando publicar un `Story` deba propagarse a varios contextos (Página de Inicio: `mostRead`/`latestReads`; perfil de `Author`; notificaciones) que no conviene cablear en un único service. El diseño detallado (incluyendo `StoryPublished`, `StoryCreated`, `AuthorAssigned`) vive en `docs/DDD_IMPROVEMENTS.md` §2. Los nombres son ilustrativos; los autoritativos se acordarán al introducir los eventos.
+
+## Type-state pattern
+
+Modelá los estados del ciclo de vida de una entidad como **tipos distintos** en vez de un único tipo con un campo `status`, para que el compilador rechace operaciones inválidas en un estado dado.
+
+El ciclo de vida de `Story` hoy es: `Borrador en Sanity → Publicación en contexto (Storylist / perfil de Author) → Accesible para lectura`. El enfoque vigente es implícito: el contenido publicado es el que las queries GROQ recuperan.
+
+**Dirección futura:** cuando las reglas de negocio diverjan lo bastante entre estados como para que un método deba existir solo en uno, promover los estados a tipos distintos (p. ej. `DraftStory` vs `PublishedStory`), de modo que una operación como "agregar a una Storylist" exista solo sobre `PublishedStory` y sea un **error de compilación** sobre un borrador, en vez de un guard en runtime. Para conjuntos de literales de estado, usar `Object.freeze({...} as const)` (nunca `enum`).
+
+## Policies como funciones puras
+
+Una **policy** es una regla de negocio extraída a una función pura — sin efectos secundarios, sin services inyectados — con la forma `(entity, context) → decision`. Al ser pura es testeable de forma aislada, componible y reutilizable.
+
+En cuentoneta, candidatas naturales a policy:
+
+```typescript
+// policy pura: ¿esta Storylist debe mostrar info de autores en sus tarjetas?
+function shouldShowAuthors(storylist: IStorylist): boolean {
+	return storylist.config.showAuthors;
+}
+
+// policy pura: ¿este Story lleva advertencia de lenguaje explícito?
+function requiresLanguageWarning(story: IStory): boolean {
+	return story.badLanguage === true;
+}
+
+// composición de predicados pequeños con && / ||
+function isReadyForLanding(story: IStory): boolean {
+	return story.approximateReadingTime >= 1 && Boolean(story.author);
+}
+```
+
+**Reglas:**
+
+- Mantené las policies **libres de I/O** — pasá los datos por parámetro, devolvé una decisión.
+- Componé policies pequeñas con `&&` / `||` en vez de una función con mucho branching (recordá: complejidad ciclomática ≤ 10, anidamiento ≤ 3).
+- Devolvé `boolean` para predicados simples; un tipo de resultado estructurado cuando el caller necesite el **motivo** del rechazo.
+
+## Principios de bounded context
+
+Un **bounded context** es un ámbito dentro del cual aplican consistentemente un lenguaje ubicuo y un modelo. El mismo concepto del mundo real puede — y debe — modelarse distinto en contextos distintos. Cuentoneta separa cuatro:
+
+| Contexto                   | Agregados raíz                          | Perspectiva                                        |
+| -------------------------- | --------------------------------------- | -------------------------------------------------- |
+| **Catálogo de Contenido**  | `Story`, `Author`                       | Inventario completo de historias y autores         |
+| **Curación y Colecciones** | `Storylist`                             | Agrupar y ordenar historias en colecciones         |
+| **Administración**         | `Contributor`                           | Colaboradores del proyecto por área                |
+| **Página de Inicio**       | `LandingPageContent`, `ContentCampaign` | Agregar contenido de varios contextos para el home |
+
+La idea clave: un mismo `Story` se modela distinto según el contexto. En **Catálogo** es la vista completa (`Story` con párrafos, epígrafes, autor completo). En **Curación**, dentro de una `Storylist`, es una proyección `StoryTeaserWithAuthor` — solo lo esencial para listar. En **Página de Inicio** es `StoryNavigationTeaserWithAuthor` dentro de `mostRead`/`latestReads`. Las **vistas polimórficas + los mappers del ACL** son las fronteras explícitas entre estos modelos.
+
+### Lenguaje ubicuo
+
+Cada contexto **posee las definiciones** de sus términos, co-localizadas con sus interfaces. Una misma palabra puede tener un matiz distinto por contexto, y esa divergencia es esperada. Términos clave (de `docs/DOMAIN_MODEL.md`):
+
+| Término       | Definición                                                    | Contexto              |
+| ------------- | ------------------------------------------------------------- | --------------------- |
+| **Historia**  | Obra literaria curada y publicada                             | Catálogo de Contenido |
+| **Slug**      | Identificador amigable, único e inmutable basado en el título | Todos                 |
+| **Epígrafe**  | Cita literaria que precede al texto principal                 | Catálogo de Contenido |
+| **Teaser**    | Vista reducida de una entidad para listados y navegación      | Todos                 |
+| **Colección** | Agrupación temática u editorial de historias (`Storylist`)    | Curación              |
+| **Recurso**   | Enlace externo a información complementaria (`Resource`)      | Catálogo de Contenido |
+| **Curaduría** | Proceso de seleccionar, ordenar y presentar historias         | Curación              |
+
+**Convención para contextos nuevos:** al introducir un bounded context, definí su vocabulario junto a sus interfaces y aclará, por cada término, a qué términos existentes mapea o de cuáles diverge deliberadamente.
+
+## Decisiones de consistencia
+
+Elegí el modelo de consistencia **por frontera**, no por proyecto:
+
+| Modelo       | Cuándo aplicarlo                                        | Ejemplo en cuentoneta                                                               |
+| ------------ | ------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **Fuerte**   | Invariantes que deben valer de inmediato, en una unidad | Agregado `Story`: autor presente y `>= 1` párrafo siempre consistentes al construir |
+| **Eventual** | Estado best-effort donde un lag breve es aceptable      | _Futuro:_ un `StoryPublished` que actualice `mostRead`/`latestReads` del home       |
+
+**Regla:** consistencia **fuerte** _dentro_ de la frontera de un agregado; consistencia **eventual** _entre_ agregados o contextos (propagada por [domain events](#domain-events)). El pivote de la decisión es la invariante: si _debe_ ser siempre verdadera, mantenela dentro de un agregado bajo consistencia fuerte; si tolera una ventana breve de staleness, dejá que converja.
+
+> **Estado:** la implementación actual es fuertemente consistente de hecho (el contenido se cura y publica en Sanity, y las queries leen el estado publicado). La consistencia eventual cruzando contextos se documenta como guía futura, en tándem con los domain events del roadmap (#1503).

--- a/.claude/references/guiding-principles.md
+++ b/.claude/references/guiding-principles.md
@@ -1,0 +1,141 @@
+<!-- Fuente: CLAUDE.md | Última actualización: 2026-06-15 -->
+
+# Principios rectores
+
+> Adaptación para **La Cuentoneta** de los principios rectores del starter de referencia.
+> La documentación va en **español**; el **código y los identificadores en inglés** (los comentarios pueden ir en español).
+
+---
+
+## YAGNI (You Aren't Gonna Need It)
+
+**Agregá funcionalidad solo cuando se necesite de verdad, no para un uso futuro hipotético.**
+
+**Hacer:**
+
+- Implementar exactamente lo que pide el requerimiento actual
+- Borrar código, parámetros y abstracciones que no se usan
+- Cuestionar cada agregado del tipo "¿y si más adelante lo necesitamos?"
+
+**No hacer:**
+
+- Agregar parámetros "por flexibilidad"
+- Crear clases abstractas para una única implementación
+- Construir opciones de configuración que nadie pidió
+- Agregar puntos de extensión "por las dudas"
+
+**Test práctico:** si no podés nombrar un caso de uso concreto y actual para algo, no lo construyas.
+
+---
+
+## KISS (Keep It Simple, Stupid)
+
+**Preferí soluciones simples antes que ingeniosas. La complejidad es un costo, no una funcionalidad.**
+
+**Hacer:**
+
+- Elegir primero el enfoque directo
+- Usar funciones de la librería estándar antes que implementaciones propias
+- Escribir código que una persona junior pueda entender
+- Refactorizar cuando la complejidad crece
+
+**No hacer:**
+
+- Sobre-abstraer de forma prematura
+- Usar patrones de diseño solo por usarlos
+- Optimizar antes de medir
+- Agregar capas sin un propósito claro
+
+**Test práctico:** ¿podés explicar qué hace este código en una sola oración? Si no, simplificalo.
+
+---
+
+## Disciplina de operadores RxJS
+
+**Usá cada operador para lo que está pensado. Los efectos colaterales van en `tap`; las transformaciones van en `map`.**
+
+`map` es un operador de transformación pura: recibe un valor y devuelve un valor nuevo. Poner efectos colaterales (mutaciones de estado, logging, manipulación del DOM) dentro de `map` crea una dependencia oculta del momento de la suscripción. Si después el stream se multicastea, se reproduce (replay) o se compone con un operador que no se suscribe, el efecto colateral se dispara de más o no se dispara.
+
+**Hacer:**
+
+- Usar `tap` para efectos colaterales: actualizaciones de estado en un servicio (p. ej. `signal.set()` / `signal.update()`), logging, analytics
+- Usar `map` exclusivamente para transformar valores: reformar datos, mapear DTOs/resultados de API al modelo de dominio
+- Cuando hagan falta ambos, encadenarlos por separado: `map(transform)` y luego `tap(sideEffect)`
+
+**No hacer:**
+
+- Meter `signal.set()`, `signal.update()` u otra mutación dentro de `map`
+- Hacer logging o tracking de analytics dentro de `map`
+- Llamar métodos con efectos colaterales (HTTP, navegación) dentro de `map`
+
+```typescript
+// ✅ Correcto — transformación y efecto colateral separados
+return this.storyService.getStoryBySlug(slug).pipe(
+	map((response) => mapStory(response)),
+	tap((story) => this.story.set(story)), // efecto colateral en tap
+);
+
+// ❌ Incorrecto — efecto colateral escondido en un operador puro
+return this.storyService.getStoryBySlug(slug).pipe(
+	map((response) => {
+		const story = mapStory(response);
+		this.story.set(story); // ¡efecto colateral dentro de map!
+		return story;
+	}),
+);
+```
+
+**Test práctico:** si sacaras el `subscribe()`, ¿el operador seguiría teniendo sentido? `map` sí debería: es solo una transformación de datos. `tap` no debería: así sabés que el efecto colateral está en el lugar correcto.
+
+---
+
+## Operaciones async signals-first (sin promesas)
+
+**El frontend es signals-first. Componé con operadores RxJS y no conviertas observables a promesas.**
+
+El frontend de cuentoneta modela el estado con **servicios + signals + RxJS** (ver [`angular-state.md`](angular-state.md)). No hay NgRx Signal Store ni `rxMethod`: la coordinación async vive en **servicios Angular** (`providedIn: 'root'` o providers en `src/app/providers/`) que exponen observables y signals a los componentes.
+
+**Hacer:**
+
+- Componer las llamadas a la API en métodos de servicio con un pipe declarativo: `service.getX(params).pipe(map(mapper), tap(sideEffect), catchError(...))`
+- Derivar valores con `computed()` / `toSignal()` en vez de mantener estado duplicado (p. ej. `totalPages` se deriva, no se guarda)
+- Usar `switchMap` como operador de aplanado por defecto (cancela los requests en vuelo obsoletos); `concatMap` cuando el orden importa, `mergeMap` para concurrencia, `exhaustMap` para ignorar disparos mientras hay uno en curso
+- Centralizar debounce/coordinación en servicios (p. ej. `LayoutService`), no esparcidos en los componentes
+- Usar errores tipados por operación (p. ej. una signal de error por operación) en vez de un único `string | null` compartido
+- Loguear los errores con contexto suficiente en cada handler (`catchError`)
+
+**No hacer:**
+
+- Usar `firstValueFrom`, `lastValueFrom` o `toPromise` para convertir observables a promesas (prohibido en el frontend — ver Restricciones duras en `CLAUDE.md`)
+- Usar `async/await` sobre observables en métodos de servicio que llaman a la API
+- Anidar `subscribe()` dentro de otro `subscribe()` — componer con operadores de orden superior (`switchMap`, `mergeMap`, `concatMap`, `exhaustMap`)
+- Suscribirse manualmente cuando alcanza con `toSignal()` / el `async` pipe en la plantilla; cuando una suscripción manual es inevitable, atarla a `takeUntilDestroyed()`
+- Mantener estado derivado como estado guardado: derivarlo con `computed()`
+- Inventar signals contador/trigger (`reloadCounter`, `_reload`, `forceRefresh`) para forzar re-evaluación — son workarounds innecesarios que ensucian el estado; usá una llamada imperativa al método del servicio con el valor actual
+
+```typescript
+// ✅ Correcto — composición declarativa con switchMap, derivación con computed,
+//              efectos colaterales en tap y sin promesas
+@Injectable({ providedIn: 'root' })
+export class StorylistService {
+	private readonly api = inject(StorylistApiService);
+	private readonly stories = signal<Story[]>([]);
+
+	readonly storyCount = computed(() => this.stories().length); // derivado, no guardado
+
+	load(slug: string): Observable<Story[]> {
+		return this.api.getStorylistBySlug(slug).pipe(
+			map((raw) => raw.stories.map(mapStory)),
+			tap((stories) => this.stories.set(stories)), // efecto colateral en tap
+			catchError((err) => {
+				this.logError('load', err);
+				return of([]);
+			}),
+		);
+	}
+}
+```
+
+**Test práctico:** si un método de servicio tiene `async` en su firma o importa `firstValueFrom`/`toPromise`, hay que refactorizarlo a un pipe declarativo con operadores RxJS.
+
+> **Dirección futura (paridad con el starter):** adoptar **NgRx Signal Store** (`@ngrx/signals` + `rxMethod` de `@ngrx/signals/rxjs-interop`) — ver **#1530**. Hasta esa adopción rige lo de arriba (servicios + signals/RxJS); **no** generar código NgRx (`rxMethod`/`patchState`/Signal Store) salvo que el issue lo indique.

--- a/.claude/references/maintainability.md
+++ b/.claude/references/maintainability.md
@@ -1,0 +1,48 @@
+# Mantenibilidad y simplificación estructural
+
+Una **lente ambiciosa** para reviews y refactors: no te quedes en "esto podría estar un poco más prolijo". Buscá activamente reestructuraciones que hagan un cambio _dramáticamente más simple_ sin alterar el comportamiento — y **preferí borrar complejidad antes que reordenarla**.
+
+Este archivo complementa, y nunca anula, las restricciones duras de [`CLAUDE.md`](../../CLAUDE.md) ni los principios de [`solid.md`](solid.md), [`cupid.md`](cupid.md), [`clean-architecture.md`](clean-architecture.md) y [`guiding-principles.md`](guiding-principles.md). La idea es re-expresada en la voz de este proyecto para que aplique con contexto completo de cuentoneta.
+
+## Postura central
+
+- Buscá el **"movimiento de judo de código"** — una reorganización que aprovecha mejor la arquitectura existente y hace que el cambio se sienta inevitable en retrospectiva, de modo que ramas enteras, helpers, modos, condicionales o capas desaparezcan por completo.
+- Premiá implementaciones que **eliminan piezas móviles**, no refactors que apenas reparten la misma complejidad.
+- Inclinate por código **directo, aburrido y legible** antes que mecanismos ingeniosos/mágicos. "Funciona" no alcanza si deja el codebase más desordenado.
+
+## Smells a marcar
+
+A propósito son los que nuestras otras referencias subestiman (los smells de tamaño/tipado/naming/test/seguridad ya viven en `CLAUDE.md` y las demás refs — no los re-litigues acá):
+
+- **Crecimiento espagueti.** Nuevos condicionales ad-hoc, booleanos de un solo uso, "modos" nullable, o ramas de caso especial atornilladas sobre un flujo existente y no relacionado. Tratalo como un problema de _diseño_, no como un detalle de estilo — empujá la lógica hacia una abstracción dedicada, un helper, una máquina de estados o un objeto de política.
+- **Wrappers finos / de identidad / pasamanos.** Abstracciones que agregan una capa de indirección sin comprar claridad. Marcá la "magia" genérica que esconde una simple suposición sobre la forma de los datos.
+- **Inflado de archivos por el diff.** Aunque `CLAUDE.md` topa los archivos en **≤ 500 líneas** (el límite absoluto — ese siempre gana), preguntate también si _este PR_ hizo crecer un archivo de forma significativa: si el código nuevo podría partirse en un módulo/subcomponente enfocado, preferí descomponer antes que dejar el archivo derramarse hacia el tope.
+- **Orquestación evitable.** Trabajo independiente serializado sin razón (preferí paralelo), o actualizaciones relacionadas que pueden quedar a medio aplicar (preferí una estructura más atómica). No micro-optimices, pero sí marcá la fragilidad. En el backend, esto aplica a coordinar lecturas de Sanity independientes; en el frontend, a componer streams con los operadores RxJS adecuados.
+- **Ramas "temporales"** que probablemente se vuelvan deuda permanente.
+
+## Preguntas primarias para cada cambio relevante
+
+- ¿Hay un reencuadre que necesite **menos conceptos, ramas o capas de helpers**?
+- ¿El diff agregó ramificación donde debería existir una **mejor abstracción**, o volvió un módulo antes cohesivo más acoplado / más stateful / más difícil de escanear?
+- ¿Esta abstracción **se gana su lugar**, o es un wrapper alrededor de un único call site?
+- ¿Podrían **borrarse** categorías enteras de complejidad en vez de pulirlas?
+
+## Remedios preferidos (en orden de preferencia)
+
+1. **Borrar una capa** de indirección en vez de refinarla.
+2. **Reencuadrar el modelo de estado** para que los condicionales desaparezcan en vez de centralizarse (p. ej. derivar con `computed()` / `toSignal()` en vez de mantener estado duplicado y sincronizarlo a mano).
+3. **Mover el límite de propiedad** para que la feature sea una extensión natural de una abstracción existente.
+4. Convertir la lógica de caso especial en un **flujo por defecto más simple** con menos excepciones.
+5. Extraer un helper puro, o partir un archivo grande en módulos enfocados.
+
+## Guardrails — mantené conciencia del proyecto
+
+Aplicá esta lente **dentro** de las convenciones del proyecto; un instinto genérico de "simplificar" nunca debe contradecir un patrón mandatorio. En particular, **no** recomiendes cambios que peleen con `CLAUDE.md`, por ejemplo:
+
+- el patrón de capas **controller → service → repository** en `src/api/modules/<dominio>/` (es mandatorio; no es "indirección para colapsar");
+- el naming `fetch*()` en repositorios y `get*()`/`update*()` en servicios — no los aplanes en una sola función "para ahorrar una capa";
+- el **ACL central**: los resultados crudos de GROQ se traducen al modelo de dominio (`Story`, `Author`, `Storylist`, `Resource`, …) vía **mappers puros** (`mapAuthor`, `mapAuthorTeaser`, …); no filtres el shape crudo de Sanity al frontend "porque es más corto";
+- el estilo **signals-first** en `src/app/`: derivar con `computed()`/`toSignal()`, `effect()` como field initializers nombrados, sin promesas sobre observables (`firstValueFrom`/`lastValueFrom`/`toPromise` prohibidos) y `switchMap` como aplanado por defecto;
+- `Object.freeze({...} as const)` en vez de `enum`; campos de componente `protected`/`private` (no `public` implícito); plantillas con `@if`/`@for`, self-closing tags y `ngSrc`.
+
+Cuando una simplificación violaría una restricción dura o una convención establecida, **descartala** — la restricción gana. Mostrá solo reestructuraciones que sean a la vez más simples **y** compatibles con las convenciones.

--- a/.claude/references/sanity-acl.md
+++ b/.claude/references/sanity-acl.md
@@ -1,0 +1,255 @@
+# Anti-Corruption Layer (ACL): GROQ → repository → mapper → modelo de dominio
+
+> **Carga esta referencia** al trabajar sobre el backend (`src/api/`): cualquier lectura/escritura
+> de Sanity, queries GROQ, mappers o tipos de dominio. Es el **patrón central** de cuentoneta.
+>
+> Relacionadas: [`clean-architecture.md`](clean-architecture.md) (capas y regla de dependencia) ·
+> [`domain-model.md`](domain-model.md) (Story / Author / Storylist / Resource).
+
+---
+
+## Por qué existe el ACL
+
+Sanity expone su contenido vía **GROQ**, y el typegen (`pnpm sanity:run-typegen-generator`) genera
+tipos a partir del schema y de cada query (`StoryBySlugQueryResult`, `AuthorBySlugQueryResult`,
+`StoriesByAuthorSlugQueryResult`, …). Esos tipos describen el **shape crudo de Sanity**: campos
+opcionales/nullables, referencias sin resolver, imágenes como `SanityImageSource`, bloques
+`BlockContent`, `coalesce(...)` con defaults, etc.
+
+**Regla dura:** el resultado crudo de GROQ (los tipos `*QueryResult`) **nunca** se filtra al
+frontend. El frontend consume únicamente el **modelo de dominio** (`Story`, `Author`, `Storylist`,
+`Resource`, `Tag`, …, definidos en `@models/*`), que es **independiente del shape de Sanity**.
+
+El **Anti-Corruption Layer** son los **mappers**: funciones puras que traducen el resultado crudo de
+Sanity al modelo de dominio. Si mañana se cambia el CMS o se reorganiza una query, el blast radius
+queda contenido en el mapper; el dominio y el frontend no se enteran.
+
+---
+
+## El flujo central
+
+```
+                 GROQ query                 client.fetch(query, params)
+   _queries/story.query.ts  ───────────────▶  repository.fetch*()
+                                                   │  (resultado CRUDO de Sanity:
+                                                   │   tipos generados *QueryResult)
+                                                   ▼
+                                              service.get*()
+                                                   │  invoca el mapper (ACL)
+                                                   ▼
+                                  mapX(rawResult): DomainType
+                              (mapper / ACL en _utils/functions.ts)
+                                                   │  (modelo de dominio: Story, Author, …)
+                                                   ▼
+                                            controller (Hono)
+                                                   │  c.json(result)
+                                                   ▼
+                                              frontend
+```
+
+| Capa           | Archivo                       | Devuelve / responsabilidad                                              |
+| -------------- | ----------------------------- | ----------------------------------------------------------------------- |
+| **GROQ**       | `_queries/<dominio>.query.ts` | Query con `defineQuery(...)`; los `*QueryResult` salen del typegen      |
+| **Repository** | `<dominio>.repository.ts`     | `fetch*()` → `client.fetch(query, params)`; **resultado CRUDO** Sanity  |
+| **Mapper/ACL** | `_utils/functions.ts`         | `mapX(raw): DomainType`; funciones **puras**; helpers de imagen         |
+| **Service**    | `<dominio>.service.ts`        | `get*()`: llama al repository y **mapea** al dominio; lógica de negocio |
+| **Controller** | `<dominio>.controller.ts`     | Rutas Hono + `zValidator`; llama al service y responde `c.json(...)`    |
+
+El módulo **story** (`src/api/modules/story/`) es el ejemplo canónico. Todos los demás módulos
+(`author`, `storylist`, `content`, `contributor`, `sitemap`) siguen la misma forma.
+
+---
+
+## Naming de capas (no negociable)
+
+- **Repository → `fetch*()`** para todas las lecturas. Devuelve el resultado **crudo** de la query
+  de Sanity, sin mapear. Una función `fetch*` = una query GROQ con sus params.
+- **Service → `get*()`** (y `update*()` para escrituras). Envuelve al repository y **mapea** al
+  modelo de dominio vía la ACL. Acá vive la lógica de negocio (validación de existencia, paginación,
+  composición de varias fuentes).
+- El cliente de Sanity se importa siempre desde **`_helpers/sanity-connector`**
+  (`import { client } from '../../_helpers/sanity-connector'`). No instanciar `client` ad-hoc.
+
+### Repository — `fetch*()` (crudo)
+
+```typescript
+// story.repository.ts
+import { client } from '../../_helpers/sanity-connector';
+import { storyBySlugQuery, allStoriesQuery /* … */ } from '../../_queries/story.query';
+
+export async function fetchStoryBySlug(slug: string) {
+	return client.fetch(storyBySlugQuery, { slug });
+}
+
+export async function fetchStories(start: number, end: number) {
+	return client.fetch(allStoriesQuery, { start, end });
+}
+```
+
+Notá que `fetch*` **no anota** un tipo de retorno: el tipo lo infiere el typegen a partir de la
+query (`StoryBySlugQueryResult`, etc.). Ese tipo crudo es justo lo que el mapper recibe como entrada.
+
+### Service — `get*()` (mapea al dominio)
+
+```typescript
+// story.service.ts
+export async function getStoryBySlug(slug: string): Promise<Story> {
+	const result = await fetchStoryBySlug(slug);
+
+	if (!result) {
+		throw new Error(`Story with slug ${slug} not found`);
+	}
+
+	return await mapStoryContent(result); // ← ACL: crudo → dominio (Story)
+}
+```
+
+El service es el **único** lugar donde el resultado crudo y el modelo de dominio coexisten. A partir
+de su `return`, solo circula dominio.
+
+### Controller — Hono + zValidator
+
+```typescript
+// story.controller.ts
+const storyController = new Hono();
+
+storyController.get('/:slug', zValidator('param', slugSchema), async (c) => {
+	const { slug } = c.req.valid('param');
+	const result = await getStoryBySlug(slug);
+	return c.json(result);
+});
+```
+
+- Validación de path params / query con **`@hono/zod-validator`** (`zValidator('param', …)`,
+  `zValidator('query', …)`). Los path params usan `:slug` (estilo Hono).
+- **Orden de rutas:** las rutas específicas van **antes** del wildcard `/:slug` (p. ej.
+  `/most-read`, `/author/:slug/navigation`, `/author/:slug`, luego `/`, y al final `/:slug`).
+- El controller no conoce Sanity ni los mappers: solo valida, llama al service y serializa.
+
+---
+
+## Los mappers (la ACL en sí)
+
+Viven en **`src/api/_utils/functions.ts`** (y archivos `*.functions.ts` vecinos como
+`media-sources.functions.ts`). Son **funciones puras**: misma entrada → misma salida, sin efectos
+secundarios ni I/O.
+
+```typescript
+// _utils/functions.ts
+export function mapAuthor(rawAuthorData: NonNullable<AuthorBySlugQueryResult>): Author {
+	const resources = mapResources(rawAuthorData.resources);
+	const biography = mapAuthorBiography(rawAuthorData.biography);
+
+	return {
+		_id: rawAuthorData._id,
+		slug: rawAuthorData.slug,
+		nationality: {
+			country: rawAuthorData.nationality?.country,
+			flag: urlFor(rawAuthorData.nationality.flag),
+		},
+		resources,
+		imageUrl: urlFor(rawAuthorData.image),
+		name: rawAuthorData.name,
+		biography,
+		bornOnYear: rawAuthorData.bornOnYear ?? undefined,
+		diedOnYear: rawAuthorData.diedOnYear ?? undefined,
+		// …
+	};
+}
+```
+
+Patrones que se repiten:
+
+- **Entrada tipada con el resultado crudo de Sanity** (`NonNullable<AuthorBySlugQueryResult>`,
+  `StorylistTeasersQueryResult`, sub-queries derivadas como
+  `NonNullable<StorylistQueryResult>['stories'][0]['author']`). **Salida = tipo de dominio**
+  (`Author`, `AuthorTeaser`, `Resource`, `Tag`, …).
+- **Normalización de nullables:** `?? undefined`, `?? ''`, `?? []` para colapsar los opcionales de
+  Sanity a la forma que el dominio espera.
+- **Composición:** un mapper grande delega en otros (`mapStoryContent` usa `mapAuthor`,
+  `mapResources`, `mapBlockContentToTextParagraphs`, `mapMediaSources`).
+- **`BlockContent` → texto de dominio:** `mapBlockContentToTextParagraphs(content)` filtra los
+  bloques `_type === 'block'` a `TextBlockContent[]`.
+
+Mappers principales (no exhaustivo): `mapAuthor`, `mapAuthorTeaser`, `mapAuthorBiography`,
+`mapResources`, `mapTags`, `mapStoryContent`, `mapStoryTeaser`, `mapStoryTeaserWithAuthor`,
+`mapStoryNavigationTeaser`, `mapStoryNavigationTeaserWithAuthor`, `mapLandingPageContent`,
+`mapContentCampaigns`.
+
+### Helpers de imagen (también parte de la capa de mappers)
+
+La conversión de imágenes de Sanity a URLs es traducción de shape → dominio, así que vive **en la
+capa de mappers**, no en componentes ni en el repository:
+
+```typescript
+export function urlFor(source: SanityImageSource): string {
+	if (!source) {
+		console.warn('urlFor: Se recibió source vacío o nulo');
+		return '';
+	}
+	try {
+		return createImageUrlBuilder(client).image(source).url();
+	} catch (error) {
+		console.error('urlFor: Error al construir URL de imagen', { error, source: JSON.stringify(source) });
+		return '';
+	}
+}
+
+export function urlForWithAutoFormat(source: SanityImageSource): string {
+	// idéntico, pero .auto('format').url() para servir el formato óptimo (WebP/AVIF)
+}
+```
+
+Los mappers invocan `urlFor` / `urlForWithAutoFormat` y exponen al dominio un `imageUrl: string`,
+nunca el `SanityImageSource` crudo.
+
+---
+
+## Regla de mantenimiento (mismo PR)
+
+> Al cambiar una **query GROQ** o un **tipo generado de Sanity**, actualizar el **mapper**
+> correspondiente y el **tipo de dominio** en el **MISMO PR**.
+
+Secuencia típica al tocar una query:
+
+1. Editar la query en `_queries/<dominio>.query.ts`.
+2. Re-extraer schema y regenerar tipos: `pnpm sanity:extract-schema` →
+   `pnpm sanity:run-typegen-generator` (cambian los `*QueryResult`).
+3. Ajustar el/los `mapX(...)` en `_utils/functions.ts` para consumir el nuevo shape crudo.
+4. Si cambió la forma del dominio, actualizar el modelo en `@models/*`.
+5. Correr el [scan de impacto en documentación](../../CLAUDE.md#scan-de-impacto-en-documentación):
+   actualizar `docs/`, `CLAUDE.md` y `.claude/references/` que referencien esos contratos.
+
+Como los mappers son puros y tienen tipos de dominio explícitos en su firma, TypeScript marca de
+inmediato dónde el nuevo shape crudo dejó de encajar.
+
+---
+
+## Dirección DDD: repositorio como puerto + DI (#1503)
+
+Hoy el repository es un **módulo de funciones** (`fetch*()`) acoplado directamente al `client` de
+Sanity. La dirección objetivo (ver [`clean-architecture.md`](clean-architecture.md), "Qualified
+Implementation") es invertir esa dependencia con un **puerto de repositorio** y dos
+implementaciones intercambiables:
+
+- **`SanityStoryRepository`** — implementación real contra GROQ/`@sanity/client` (lo que hoy hacen
+  las funciones `fetch*`).
+- **`InMemoryStoryRepository`** — implementación de prueba con datos en memoria, para tests rápidos y
+  deterministas sin tocar Sanity.
+
+El service dependería del **puerto** (interfaz), no de la implementación concreta, y la elección se
+resolvería vía un **contenedor de DI**. El directorio **`src/api/di/`** ya existe **vacío** como
+placeholder de esa dirección (#1503). Mientras tanto, rige el patrón de funciones `fetch*()` /
+`get*()` descripto arriba; **no** introducir clases de repositorio ni DI salvo que el issue lo pida.
+
+---
+
+## Dirección futura: OpenAPIHono (no adoptado)
+
+El backend es hoy **Hono plano** (`new Hono()` + `@hono/zod-validator`). La dirección objetivo, para
+paridad con el starter, es migrar a **OpenAPIHono** (`@hono/zod-openapi`: `createRoute` /
+`registerRoute` + spec servida en `/api/openapi.json`) — ver **#1531**.
+
+Hasta su adopción, rige el patrón Hono plano descripto en esta referencia y en
+[`CLAUDE.md` → Backend API](../../CLAUDE.md#backend-api-hono--sanity). **No** generar código
+OpenAPIHono salvo que el issue lo indique.

--- a/.claude/references/solid.md
+++ b/.claude/references/solid.md
@@ -1,0 +1,163 @@
+<!-- Fuente: CLAUDE.md | Última actualización: 2026-06-15 -->
+
+# Principios SOLID
+
+Diseñá clases, módulos y sus relaciones para que sean flexibles, mantenibles y resilientes al cambio. En cuentoneta estos principios guían tanto los componentes Angular (servicios + signals) como las capas del backend (controller → service → repository) y los mappers del ACL.
+
+> El código y los identificadores van **siempre en inglés**; los comentarios pueden ir en español.
+
+## S — Principio de Responsabilidad Única (SRP)
+
+**Una clase debe tener una, y solo una, razón para cambiar.**
+
+- Cada clase o módulo es dueño de una sola parte de la funcionalidad.
+- "Razón para cambiar" = un actor o stakeholder cuyas necesidades podrían motivar modificaciones.
+- Si para describir lo que hace una clase necesitás un "y", considerá dividirla.
+
+**Síntomas de violación:** clases enormes, métodos no relacionados agrupados, cambios que se propagan a funcionalidad ajena.
+
+**Guía:**
+
+- Separá persistencia, validación, formateo y lógica de negocio en clases distintas. En el backend esto ya está reflejado en las capas: el `repository` (`fetch*()`) solo accede a datos, el `service` (`get*()`) aplica lógica de negocio y mapea al dominio, y el `controller` solo arma rutas y valida.
+- Preferí muchas clases chicas y enfocadas antes que pocas grandes y multipropósito.
+
+```typescript
+// ✅ Responsabilidades separadas: el repository solo trae datos crudos de Sanity,
+// el service mapea al dominio vía el ACL.
+async function fetchStoryBySlug(slug: string) {
+	return client.fetch(storyBySlugQuery, { slug }); // resultado crudo de Sanity
+}
+
+async function getStoryBySlug(slug: string): Promise<Story> {
+	const raw = await fetchStoryBySlug(slug);
+	return mapStory(raw); // mapper / ACL
+}
+
+// ❌ Una sola función que consulta, mapea, valida y formatea para la UI:
+// demasiadas razones para cambiar.
+```
+
+---
+
+## O — Principio Abierto/Cerrado (OCP)
+
+**Las entidades de software deben estar abiertas a la extensión pero cerradas a la modificación.**
+
+- Agregá comportamiento nuevo sin tocar el código existente.
+- Se logra mediante abstracción: dependé de interfaces, no de implementaciones concretas.
+- Funcionalidad nueva = clases nuevas que implementan interfaces existentes.
+
+**Síntomas de violación:** agregar `if/else` o `switch` cada vez que aparece un tipo nuevo.
+
+**Guía:**
+
+- Usá polimorfismo y composición estratégicamente como puntos de extensión.
+- Favorecé la composición sobre la herencia al extender comportamiento.
+
+```typescript
+// ❌ Cerrado a la extensión: cada nuevo tipo de recurso obliga a tocar este switch.
+function renderResource(resource: Resource) {
+	switch (resource.mediaType) {
+		case 'audio':
+			return renderAudio(resource);
+		case 'video':
+			return renderVideo(resource);
+		// ...y a editar esta función cada vez que se agrega un mediaType
+	}
+}
+
+// ✅ Abierto a la extensión vía abstracción: un nuevo renderer implementa la interfaz
+// sin modificar el código que la consume.
+interface ResourceRenderer {
+	canRender(resource: Resource): boolean;
+	render(resource: Resource): string;
+}
+```
+
+---
+
+## L — Principio de Sustitución de Liskov (LSP)
+
+**Los subtipos deben poder sustituir a sus tipos base sin alterar la correctitud del programa.**
+
+- Si S es subtipo de T, los objetos de tipo T pueden reemplazarse por objetos de tipo S.
+- Las clases derivadas deben respetar los contratos de la base (precondiciones, postcondiciones, invariantes).
+
+**Síntomas de violación:** chequeos `instanceof`, condicionales por tipo en el código cliente.
+
+**Guía:**
+
+- No sobreescribas métodos de forma que viole las expectativas de la clase base.
+- Si una subclase no puede soportar plenamente un método de la base, la jerarquía está mal.
+- En cuentoneta esto aplica a las implementaciones intercambiables de un repositorio: un `SanityStoryRepository` y un `InMemoryStoryRepository` (usado en tests) deben honrar el mismo contrato — mismas garantías de retorno y de error — para ser sustituibles sin que el `service` lo note.
+
+---
+
+## I — Principio de Segregación de Interfaces (ISP)
+
+**Los clientes no deberían verse forzados a depender de interfaces que no usan.**
+
+- Preferí muchas interfaces chicas y específicas antes que una grande y de propósito general.
+- Cada interfaz representa un conjunto cohesivo de comportamientos para un cliente específico.
+
+**Síntomas de violación:** implementadores que lanzan errores de "no implementado", clases que implementan interfaces con métodos sin usar.
+
+**Guía:**
+
+- Diseñá las interfaces desde la perspectiva del cliente.
+- Interfaces de rol (`StoryReader`, `StoryListProvider`) antes que interfaces "cabezal" que lo abarcan todo.
+
+```typescript
+// ✅ Interfaces de rol segregadas: un consumidor que solo lista no depende de la lectura por slug.
+interface StoryReader {
+	getStoryBySlug(slug: string): Promise<Story>;
+}
+
+interface StoryListProvider {
+	getStories(): Promise<Story[]>;
+}
+
+// ❌ Una interfaz monolítica que obliga a todo cliente a conocer lectura, listado,
+// escritura, búsqueda, etc., aunque solo use una de esas operaciones.
+```
+
+---
+
+## D — Principio de Inversión de Dependencias (DIP)
+
+**Los módulos de alto nivel no deben depender de los de bajo nivel. Ambos deben depender de abstracciones.**
+
+- Invertí las dependencias tradicionales: alto y bajo nivel dependen de interfaces.
+- La política de alto nivel define las interfaces; los detalles de bajo nivel las implementan.
+
+**Guía:**
+
+- Inyectá dependencias en vez de instanciarlas directamente. En Angular, usá `inject()` (no inyección por constructor); en el backend, pasá las dependencias como parámetros en vez de importar clientes concretos ad-hoc.
+- Definí las interfaces junto al código que las usa, no junto al que las implementa.
+- Evitá referencias directas a clases concretas para dependencias volátiles (Sanity, servicios externos). El cliente de Sanity se importa desde `_helpers/sanity-connector`, nunca instanciando `client` en cada módulo.
+
+```typescript
+// ✅ El componente (alto nivel) depende de una abstracción inyectada, no de Sanity directo.
+export class StoryComponent {
+	private readonly stories = inject(StoryService);
+	private readonly slug = input.required<string>();
+	protected readonly story = toSignal(/* derivado del slug vía el service */);
+}
+
+// ❌ El componente conoce GROQ y el cliente de Sanity directamente: alto nivel
+// acoplado a un detalle de bajo nivel.
+```
+
+---
+
+## Relaciones entre los principios SOLID
+
+| Principio | Habilita                                                                            |
+| --------- | ----------------------------------------------------------------------------------- |
+| SRP       | Facilita OCP — las clases enfocadas son más simples de extender                     |
+| OCP       | Se apoya en DIP — las extensiones funcionan a través de abstracciones               |
+| LSP       | Garantiza que OCP funcione — los subtipos sustituibles permiten polimorfismo seguro |
+| ISP       | Sostiene SRP — las interfaces segregadas reflejan responsabilidades únicas          |
+| DIP       | Habilita a todos — las abstracciones son el cimiento del diseño flexible            |
+
+_Fuente: Robert C. Martin, "Clean Code" (2008)_

--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -1,0 +1,306 @@
+# Testing — La Cuentoneta
+
+> Referencia detallada de testing. La síntesis vive en [`CLAUDE.md` → Testing](../../CLAUDE.md); este archivo profundiza en patrones y ejemplos.
+>
+> **Idioma:** documentación en español; **código e identificadores en inglés**.
+
+---
+
+## Stack y configuración
+
+| Aspecto          | Valor                                                                                    |
+| ---------------- | ---------------------------------------------------------------------------------------- |
+| **Runner**       | **Vitest** (`pnpm test` / `pnpm test:watch`)                                             |
+| **Entorno**      | `happy-dom`, Angular **zoneless** (sin `zone.js`)                                        |
+| **Componentes**  | **Angular Testing Library** (`@testing-library/angular`) + `@testing-library/user-event` |
+| **Mocks/timers** | Wrappers de **`@test-utils`** (`src/test-utils.ts`)                                      |
+| **Compilación**  | `@analogjs/vite-plugin-angular` (JIT en tests)                                           |
+
+Archivos clave:
+
+- **`vitest.config.ts`** — `globals: true`, `environment: 'happy-dom'`, `setupFiles: ['src/test-setup.ts']`, `include: ['src/**/*.{test,spec}.ts']`. Inlina `@sanity` y bundles `fesm` para que Vite los transforme. Coverage solo en CI (`CI=true`/`COVERAGE=true`).
+- **`src/test-setup.ts`** — inicializa el `TestBed` zoneless (Angular 21 corre zoneless por defecto cuando `zone.js` no está presente; no se llama a `provideZonelessChangeDetection()`). El `ErrorHandler` **relanza** cualquier error no manejado para que falle el test. Instala el stub global de `IntersectionObserver`.
+- **`src/test-utils.ts`** — los wrappers obligatorios (ver abajo).
+
+---
+
+## Regla dura: nada de `vi.*` directo
+
+ESLint (`viRestrictedSyntax` en `eslint.config.js`) **prohíbe** usar `vi.fn()`, `vi.spyOn()`, `vi.useFakeTimers()`, `vi.clearAllMocks()`, etc. directamente en los specs. **`src/test-utils.ts` es la única excepción** (es el wrapper que el resto del repo consume).
+
+Importá siempre desde `@test-utils`:
+
+| Export                           | Reemplaza a                       |
+| -------------------------------- | --------------------------------- |
+| `fn`                             | `vi.fn`                           |
+| `spyOn`                          | `vi.spyOn`                        |
+| `clearAllMocks()`                | `vi.clearAllMocks()`              |
+| `resetAllMocks()`                | `vi.resetAllMocks()`              |
+| `restoreAllMocks()`              | `vi.restoreAllMocks()`            |
+| `useFakeTimers()`                | `vi.useFakeTimers()`              |
+| `useRealTimers()`                | `vi.useRealTimers()`              |
+| `advanceTimersByTime(ms)`        | `vi.advanceTimersByTime(ms)`      |
+| `advanceTimersByTimeAsync(ms)`   | `vi.advanceTimersByTimeAsync(ms)` |
+| `runOnlyPendingTimers()`         | `vi.runOnlyPendingTimers()`       |
+| `setSystemTime(t)`               | `vi.setSystemTime(t)`             |
+| `type Mock`, `type MockInstance` | tipos del runner                  |
+
+`fn()` es genérico: `fn<[number], Promise<User>>()`. Para castear una función auto-mockeada por `vi.mock` usá `as Mock` importado de `@test-utils` (nunca `vi.mocked()`, también prohibido).
+
+```typescript
+import { clearAllMocks } from '@test-utils';
+
+beforeEach(() => {
+	clearAllMocks(); // resetea el historial de llamadas entre tests
+});
+```
+
+---
+
+## Componentes: Angular Testing Library
+
+### Reglas core
+
+1. **Siempre ATL.** `render()` + queries de `screen`. **Nunca** `ComponentFixture`, `TestBed.createComponent()`, ni acceso por `querySelector` / `container`.
+2. **Testear comportamiento de usuario, no implementación.** Buscá por rol/texto/label como lo haría una persona; no por clases CSS ni estructura interna.
+3. **`clearAllMocks()` en `beforeEach`.**
+4. Interacciones con `userEvent` (`@testing-library/user-event`), no con eventos sintéticos crudos.
+
+### Patrón básico
+
+```typescript
+import { render, screen } from '@testing-library/angular';
+import { BadgeComponent } from './badge.component';
+import { tagMock } from '../../mocks/tag.mocks';
+
+describe('BadgeComponent', () => {
+	it('should display the badge title', async () => {
+		await render(BadgeComponent, {
+			inputs: { tag: tagMock, showIcon: true },
+		});
+
+		expect(screen.getByText(tagMock.title)).toBeInTheDocument();
+	});
+});
+```
+
+Para inputs se usa `inputs: { ... }`; para proyectar plantilla con bindings, la sobrecarga string de `render('<cuentoneta-... />', { imports, componentProperties })`.
+
+### Interacciones de usuario
+
+```typescript
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
+it('should react to a click', async () => {
+	const user = userEvent.setup();
+	await render(MyComponent);
+
+	await user.click(screen.getByRole('button', { name: /enviar/i }));
+
+	expect(screen.getByText('Enviado')).toBeInTheDocument();
+});
+```
+
+### Asíncrono
+
+`findBy*` y `waitFor` tienen espera incorporada; preferilos a esperas manuales.
+
+```typescript
+const heading = await screen.findByRole('heading', { name: /bienvenida/i });
+expect(heading).toBeInTheDocument();
+```
+
+### Servicios inyectados (mock con `fn()`)
+
+```typescript
+import { fn } from '@test-utils';
+
+const getStory = fn<[string], Promise<Story>>();
+getStory.mockResolvedValue(storyMock);
+
+await render(StoryComponent, {
+	providers: [{ provide: StoryService, useValue: { getStory } }],
+});
+
+expect(await screen.findByText(storyMock.title)).toBeInTheDocument();
+```
+
+---
+
+## Prioridad de queries
+
+Elegí la query **más alta** de la tabla que aplique. `getByTestId` es el último recurso (no es accesible para usuarios reales).
+
+| Prioridad | Query                  | Cuándo                                           |
+| --------- | ---------------------- | ------------------------------------------------ |
+| 1         | `getByRole`            | Casi siempre (botones, links, headings, inputs)  |
+| 2         | `getByLabelText`       | Campos de formulario con label                   |
+| 3         | `getByPlaceholderText` | Inputs sin label (preferí dar label)             |
+| 4         | `getByText`            | Texto no interactivo                             |
+| 5         | `getByDisplayValue`    | Valor actual de un input                         |
+| 6         | `getByAltText`         | Imágenes / `area` / `input[type=image]`          |
+| 7         | `getByTitle`           | Elementos con `title`                            |
+| 8         | `getByTestId`          | Último recurso, cuando nada de lo anterior sirve |
+
+Variantes: `queryBy*` (cuando se espera ausencia, no lanza), `findBy*` (async, espera).
+
+---
+
+## `IntersectionObserver` en tests
+
+`happy-dom` no implementa `IntersectionObserver`. `src/test-setup.ts` instala un **stub global** (`src/app/testing/intersection-observer.stub.ts`) para que cualquier componente que use IO se pueda renderizar.
+
+Los specs que necesitan **simular overflow** (p. ej. `TagsListComponent` / `TagsOverflowDirective`, que recorta tags por ancho con `IntersectionObserver`) reutilizan los helpers del mismo stub:
+
+| Helper                              | Efecto                                                                 |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| `installIntersectionObserverStub()` | (Re)instala el stub y resetea el callback capturado                    |
+| `markOutsideViewport(...els)`       | Simula que esos elementos quedaron fuera del contenedor                |
+| `markInsideViewport(...els)`        | Simula que volvieron a entrar completos                                |
+| `lastObserverOptions()`             | Opciones del último observer creado (p. ej. inspeccionar `rootMargin`) |
+
+```typescript
+import { render, screen } from '@testing-library/angular';
+import { installIntersectionObserverStub, markOutsideViewport } from '../../testing/intersection-observer.stub';
+
+describe('TagsOverflowDirective', () => {
+	beforeEach(() => installIntersectionObserverStub());
+
+	it('should hide the tags the observer reports outside the container', async () => {
+		const { fixture } = await renderHost(['A', 'B', 'C', 'D', 'E']);
+
+		markOutsideViewport(screen.getByText('D'), screen.getByText('E'));
+		await fixture.whenStable();
+
+		expect(screen.getByTestId('counter')).toHaveTextContent('+2');
+		expect(screen.getByText('E')).toHaveStyle({ visibility: 'hidden' });
+	});
+});
+```
+
+> Nota (#1494): el stub es temporal. El browser mode de Vitest provee un `IntersectionObserver` real, lo que permitiría testear con layout real en vez de simular el callback a mano.
+
+---
+
+## Timers
+
+Usá siempre los wrappers de `@test-utils`, nunca `vi.useFakeTimers()` directo.
+
+```typescript
+import { advanceTimersByTime, useFakeTimers, useRealTimers } from '@test-utils';
+
+beforeEach(() => useFakeTimers());
+afterEach(() => useRealTimers());
+
+it('should debounce', () => {
+	triggerAction();
+	advanceTimersByTime(300);
+	expect(result).toBe(expected);
+});
+```
+
+Para flujos asíncronos junto a timers, `advanceTimersByTimeAsync(ms)`.
+
+---
+
+## Backend (Hono): tests funcionales con module mocking
+
+El backend (`src/api/modules/<dominio>/`) sigue **controller → service → repository** con **Hono plano** y **todavía no tiene inyección de dependencias**. Por eso, los specs de service/repository mockean el módulo del repository con **`vi.mock`**, que normalmente está prohibido.
+
+**Patrón actual** (autorizado mediante `eslint-disable` puntual y comentado):
+
+```typescript
+import { clearAllMocks, type Mock } from '@test-utils';
+import * as sitemapRepository from './sitemap.repository';
+import { getSitemapUrls } from './sitemap.service';
+
+/* eslint-disable no-restricted-syntax -- vi.mock/vi.fn: mock de módulo del repository; se migra a inyección de dependencias en #1503 */
+vi.mock('./sitemap.repository', () => ({
+	fetchSitemapSlugs: vi.fn(),
+}));
+/* eslint-enable no-restricted-syntax */
+
+describe('SitemapService', () => {
+	beforeEach(() => {
+		clearAllMocks();
+		process.env['BASE_URL'] = 'https://test.cuentoneta.ar';
+	});
+
+	it('should include story URLs', async () => {
+		(sitemapRepository.fetchSitemapSlugs as Mock).mockResolvedValue({
+			stories: [{ slug: 'el-aleph', lastmod: '2025-01-01' }],
+			authors: [],
+			storylists: [],
+		});
+
+		const urls = await getSitemapUrls();
+		expect(urls).toContainEqual(expect.objectContaining({ loc: 'https://test.cuentoneta.ar/story/el-aleph' }));
+	});
+});
+```
+
+Reglas del patrón:
+
+- El `vi.mock(...)` va envuelto en un bloque `/* eslint-disable no-restricted-syntax -- ... */` … `/* eslint-enable ... */` con **justificación y referencia a #1503**.
+- La función auto-mockeada se castea con `as Mock` importado de `@test-utils` (no `vi.mocked()`).
+- `clearAllMocks()` en `beforeEach`; limpiar `process.env` en `afterEach` si se setea.
+- Testear **comportamiento de la función** (entrada → salida), agrupando por función en `describe` anidados.
+
+> **Nota (deuda técnica #1503):** este es un patrón _transitorio_. El module mocking es necesario solo porque el backend carece de DI. Cuando se migre a inyección de dependencias, estos `vi.mock` + `eslint-disable` desaparecen a favor de dobles inyectados. **No** extender este patrón a código frontend.
+
+---
+
+## Storybook
+
+Todo componente nuevo en **`src/app/components/`** lleva su `*.stories.ts` (documentación viva + catálogo visual). Los componentes de página (`src/app/pages/`) están exentos.
+
+### Convenciones (según las stories existentes)
+
+- `title` en español bajo `Componentes/...` (p. ej. `'Componentes/Tag'`).
+- `parameters.docs.description.component` con descripción en español (markdown/HTML).
+- `argTypes` para cada `input()` público, con `control`, `options` y `table.defaultValue`.
+- Una **story por estado/variante** (`Soft`, `Filled`, `Gray`, …) y opcionalmente un `Showcase`.
+- Render con `argsToTemplate(args)` y el selector real del componente (`cuentoneta-...`).
+
+```typescript
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular';
+import { TagComponent } from './tag.component';
+
+const meta: Meta<TagComponent> = {
+	component: TagComponent,
+	title: 'Componentes/Tag',
+	parameters: {
+		docs: { description: { component: `El **TagComponent** del Design System v3...` } },
+		layout: 'padded',
+	},
+	argTypes: {
+		label: { control: { type: 'text' } },
+		variant: {
+			control: { type: 'inline-radio' },
+			options: ['soft', 'filled', 'gray'],
+			table: { defaultValue: { summary: 'soft' } },
+		},
+	},
+};
+export default meta;
+type Story = StoryObj<TagComponent>;
+
+export const Soft: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-tag ${argsToTemplate(args)} />` }),
+	args: { label: 'Crónica', variant: 'soft' },
+};
+```
+
+Para dependencias de DI usá los decoradores `moduleMetadata({ imports, providers })` (imports/iconos por story) o `applicationConfig({ providers })` (servicios globales: Router, etc.).
+
+**Siempre** actualizá las stories cuando cambien inputs, estados visuales o la API pública del componente.
+
+---
+
+## Checklist por tipo de cambio
+
+- **Componente nuevo/modificado en `src/app/components/`** → spec con ATL (comportamiento) **y** `*.stories.ts`.
+- **Service/repository de backend** → spec funcional; si necesita aislar el repository, module mocking con el bloque `eslint-disable` + nota #1503.
+- **Mocks/timers** → siempre desde `@test-utils`; `clearAllMocks()` en `beforeEach`.
+- **Componente que usa `IntersectionObserver`** → `installIntersectionObserverStub()` en `beforeEach`; simular overflow con `markOutsideViewport` / `markInsideViewport`.

--- a/.claude/references/typescript.md
+++ b/.claude/references/typescript.md
@@ -1,0 +1,94 @@
+# Convenciones de TypeScript / JavaScript
+
+> Las **reglas terse** viven en la tabla de Hard Constraints de [`CLAUDE.md`](../../CLAUDE.md). Acá está el **rationale y los ejemplos** de las micro-convenciones de TS/JS transversales (no atadas a Angular ni al backend). Cargá esta referencia en tareas con foco en tipos, modelado de constantes o imports.
+
+---
+
+## `Object.freeze()` en vez de `enum`
+
+Los `enum` de TypeScript están **prohibidos**. Para referencias clave/valor usar `Object.freeze({...} as const)` + un tipo derivado.
+
+```typescript
+// ✅ Correcto
+export const MediaType = Object.freeze({
+	AUDIO: 'audio',
+	VIDEO: 'video',
+} as const);
+export type MediaType = (typeof MediaType)[keyof typeof MediaType];
+// type MediaType = 'audio' | 'video'
+
+// ❌ Incorrecto
+export enum MediaType {
+	AUDIO = 'audio',
+	VIDEO = 'video',
+}
+```
+
+**Por qué:**
+
+- Idiomático en JS (objetos planos), sin runtime overhead específico de TS.
+- Mejor tree-shaking por los bundlers.
+- Más flexible: se puede extender, mergear o computar.
+- Funciona naturalmente con `typeof` / `keyof` para derivar el tipo.
+
+**Uso con seguridad de tipos:**
+
+```typescript
+function describe(type: MediaType): string {
+	return type === MediaType.AUDIO ? 'Audio' : 'Video';
+}
+```
+
+> **Deuda existente:** todavía hay `enum` en el repo (p. ej. `src/app/app.routes.ts`, `src/app/components/header/header.component.ts`, `src/app/providers/endpoints.ts`). Son **deuda a migrar** al tocarlos; el enforcement por ESLint llega en #1500. El patrón `Object.freeze` ya se usa en `src/app/models/content-campaign.model.ts` y `src/app/providers/layout.service.ts`.
+
+---
+
+## Imports type-only
+
+Usar la palabra clave `type` cuando un import se use **solo** como anotación de tipo. Es requisito de `isolatedModules` (activo en el repo) y reduce el bundle (los type imports se eliminan del output).
+
+```typescript
+// ✅ Correcto
+import type { Story } from '@models/story.model';
+import { type Mock } from '@test-utils';
+import { StoryService } from '../../providers/story.service'; // se usa en runtime → sin `type`
+
+// ❌ Incorrecto — falta `type` en imports solo-de-tipo
+import { Story } from '@models/story.model';
+```
+
+**Cuándo usar `type`:** interfaces, type aliases, o clases usadas solo como tipo (`story: Story` pero nunca `new Story()`).
+
+**Cuándo NO usar `type`:** clases usadas en runtime (constructores, métodos estáticos), funciones, constantes, o cualquier cosa usada en una expresión.
+
+---
+
+## Literales de tiempo / duration strings
+
+No usar números "mágicos" de milisegundos en el código (`60000`, `24 * 60 * 60 * 1000`). Para constantes de tiempo, usar **duration strings** (`'15m'`, `'1h'`, `'7d'`) como fuente de verdad y resolverlas a número **en el punto de uso**.
+
+```typescript
+// ✅ Correcto — la duración es legible y la unidad no se codifica en el nombre
+const REFRESH_INTERVAL = '15m';
+
+// ❌ Incorrecto — literal de ms crudo / expresión computada / sufijo de unidad en el nombre
+const REFRESH_INTERVAL_MS = 900000;
+const DEFAULT_INTERVAL = 24 * 60 * 60 * 1000;
+```
+
+**Reglas:**
+
+- Sin sufijos `_MS` / `_SECONDS` en el nombre de la constante: la unidad es un detalle de la expresión que la consume, no del nombre.
+- Extraer a una constante nombrada los duration strings repetidos (producción o tests).
+
+> **Nota:** hoy el repo **no** tiene un helper `parseDurationToMs()` / `parseDurationToSeconds()` (la convención viene del starter). Si aparece la necesidad real de resolver duration strings a número, introducir ese helper en `@utils` en ese momento; hasta entonces, alcanza con evitar literales de ms crudos y mantener las constantes de tiempo legibles.
+
+---
+
+## Scope de constantes y variables
+
+- **Local por defecto:** declarar `const` dentro del scope de la función cuando la usa una sola función, lo más cerca posible del punto de uso. No subir una constante al tope del archivo si su único consumo está adentro de una sola función.
+- **Módulo:** promover a nivel de módulo solo cuando se comparte entre varias funciones del mismo archivo.
+- **Global:** solo tras confirmar reuso entre varios archivos.
+
+**Rationale:** una constante declarada 50 líneas lejos de su único uso obliga al lector a saltar entre dos lugares. Co-locarla con su uso (cuando es único) hace el código autocontenido.

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,11 @@ Thumbs.db
 .vercel
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
-.claude
+
+# Claude — se versiona la config de equipo (.claude/{references,agents,skills,settings.json}).
+# Quedan fuera los datos personales/locales y el almacenamiento interno de git worktrees.
+.claude/settings.local.json
+.claude/worktrees/
 
 # Artefactos de Playwright MCP (snapshots/logs de inspección). No versionar: además, al
 # vivir dentro del repo, el escaneo de contenido de Tailwind v4 los vigila y su escritura

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # Guía del proyecto — La Cuentoneta
 
-> **Propósito:** este documento define estándares de código, principios de arquitectura y convenciones de tooling para **La Cuentoneta**. Claude Code debe seguir estas reglas al generar, revisar o modificar código.
+> **Propósito:** este documento define estándares de código, principios de arquitectura y convenciones de tooling para **La Cuentoneta**. Claude Code debe seguir estas reglas al generar, revisar o modificar código. Es la guía **siempre presente**; el detalle del "cómo" vive en [`.claude/references/`](.claude/references/) y se carga **según la tarea** (ver [Carga estratificada de referencias](#carga-estratificada-de-referencias)).
 
-> **Idioma:** la documentación y las reviews van en **español**; el **código siempre en inglés** (los comentarios pueden ir en español). Los identificadores, nombres de archivo, ramas y mensajes de commit siguen las convenciones de abajo.
+> **Idioma:** la documentación y las reviews van en **español**; el **código siempre en inglés** (los comentarios pueden ir en español). Identificadores, nombres de archivo, ramas y mensajes de commit siguen las convenciones de abajo.
 
 > **Políticas de agentes de IA:** todo agente que opere sobre este repo debe seguir además [`.claude/references/coding-agent-policies.md`](.claude/references/coding-agent-policies.md) y **cargarlo al inicio de cada sesión, antes de generar recomendaciones**. Es una restricción dura, al mismo nivel que las de este archivo.
 
@@ -13,14 +13,8 @@
 1. [Resumen del proyecto](#resumen-del-proyecto)
 2. [Comandos comunes](#comandos-comunes)
 3. [Restricciones duras (Hard Constraints)](#restricciones-duras-hard-constraints)
-4. [Arquitectura de código (Angular)](#arquitectura-de-código-angular)
-5. [Estado: signals-first (sin NgRx)](#estado-signals-first-sin-ngrx)
-6. [Backend API (Hono + Sanity)](#backend-api-hono--sanity)
-7. [Anti-Corruption Layer (mappers)](#anti-corruption-layer-mappers)
-8. [Testing](#testing)
-9. [Manejo de errores](#manejo-de-errores)
-10. [Convenciones de Git](#convenciones-de-git)
-11. [Archivos de referencia](#archivos-de-referencia)
+4. [Convenciones del repo](#convenciones-del-repo)
+5. [Carga estratificada de referencias](#carga-estratificada-de-referencias)
 
 ---
 
@@ -71,186 +65,52 @@ Usar **siempre `pnpm`** para instalar y ejecutar scripts. Los scripts envuelven 
 
 Reglas no negociables. Una violación requiere justificación explícita.
 
-| Restricción                                  | Límite / regla                                                                                  |
-| -------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Largo de función                             | ≤ 50 líneas                                                                                     |
-| Largo de archivo                             | ≤ 500 líneas (los `*.spec.ts` quedan exentos)                                                   |
-| Complejidad ciclomática                      | ≤ 10                                                                                            |
-| Profundidad de anidamiento                   | ≤ 3 niveles                                                                                     |
-| Barrels (`index.ts` re-export)               | **Prohibidos** en todo el proyecto (ESLint `no-barrel-files`)                                   |
-| Tipo `any`                                   | Prohibido sin un comentario `// REASON:` (ESLint `no-explicit-any`)                             |
-| `// @ts-ignore`                              | Prohibido sin issue enlazado                                                                    |
-| `console.log`                                | Quitar antes de commitear                                                                       |
-| `enum` de TypeScript                         | **Prohibidos** — usar `Object.freeze({...} as const)` (ver abajo)                               |
-| Lifecycle hooks (`OnInit`, etc.)             | **Prohibidos** — usar signals / `computed` / `effect` / `viewChild` / `contentChild`            |
-| Propiedades estáticas                        | **Prohibidas** — usar un servicio singleton (`providedIn: 'root'`)                              |
-| Imports type-only                            | Usar `type` cuando un import se use solo como anotación de tipo (`isolatedModules`)             |
-| Literales de tiempo crudos                   | Usar duration strings (`'15m'`, `'1h'`, `'7d'`) resueltas en el punto de uso, no `60000`        |
-| `vi.fn()` / `vi.mock()` / `vi.*`             | **Prohibido** el uso directo — usar los wrappers de `@test-utils` (ESLint `viRestrictedSyntax`) |
-| `firstValueFrom`/`lastValueFrom`/`toPromise` | **Prohibidos** en el frontend — usar `computed()`/`toSignal()`/operadores RxJS                  |
-| Non-null assertion (`!`)                     | Prohibido (ESLint `no-non-null-assertion`)                                                      |
-| Non-self-closing / control flow viejo        | Plantillas: `@if`/`@for` (no `*ngIf`/`*ngFor`), self-closing tags, `ngSrc`                      |
+| Restricción                                  | Límite / regla                                                                                                    |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Largo de función                             | ≤ 50 líneas                                                                                                       |
+| Largo de archivo                             | ≤ 500 líneas (los `*.spec.ts` quedan exentos)                                                                     |
+| Complejidad ciclomática                      | ≤ 10                                                                                                              |
+| Profundidad de anidamiento                   | ≤ 3 niveles                                                                                                       |
+| Barrels (`index.ts` re-export)               | **Prohibidos** en todo el proyecto (ESLint `no-barrel-files`)                                                     |
+| Tipo `any`                                   | Prohibido sin un comentario `// REASON:` (ESLint `no-explicit-any`)                                               |
+| `// @ts-ignore`                              | Prohibido sin issue enlazado                                                                                      |
+| `console.log`                                | Quitar antes de commitear                                                                                         |
+| `enum` de TypeScript                         | **Prohibidos** — usar `Object.freeze({...} as const)` → [`typescript.md`](.claude/references/typescript.md)       |
+| Lifecycle hooks (`OnInit`, etc.)             | **Prohibidos** — usar signals / `computed` / `effect` / `viewChild` / `contentChild`                              |
+| Propiedades estáticas                        | **Prohibidas** — usar un servicio singleton (`providedIn: 'root'`)                                                |
+| Imports type-only                            | Usar `type` cuando un import se use solo como anotación de tipo (`isolatedModules`)                               |
+| Literales de tiempo crudos                   | Usar duration strings (`'15m'`, `'1h'`, `'7d'`), no `60000` → [`typescript.md`](.claude/references/typescript.md) |
+| `vi.fn()` / `vi.mock()` / `vi.*`             | **Prohibido** el uso directo — usar los wrappers de `@test-utils` (ESLint `viRestrictedSyntax`)                   |
+| `firstValueFrom`/`lastValueFrom`/`toPromise` | **Prohibidos** en el frontend — usar `computed()`/`toSignal()`/operadores RxJS                                    |
+| Non-null assertion (`!`)                     | Prohibido (ESLint `no-non-null-assertion`)                                                                        |
+| Errores atrapados                            | Preservar la causa (ESLint `preserve-caught-error`); errores tipados por operación                                |
+| Plantillas: control flow / tags              | `@if`/`@for` (no `*ngIf`/`*ngFor`), self-closing tags, `ngSrc`                                                    |
 
-### `Object.freeze()` en vez de `enum`
-
-```typescript
-// ✅ Correcto
-export const MediaType = Object.freeze({
-	AUDIO: 'audio',
-	VIDEO: 'video',
-} as const);
-export type MediaType = (typeof MediaType)[keyof typeof MediaType];
-
-// ❌ Incorrecto
-export enum MediaType {
-	AUDIO = 'audio',
-	VIDEO = 'video',
-}
-```
-
-Beneficios: idiomático en JS, mejor tree-shaking, sin runtime overhead de TS, funciona con `typeof`/`keyof`.
+> El **rationale y los ejemplos** de las micro-convenciones de TS/JS (`Object.freeze`, imports type-only, duration strings, scope de constantes) están en [`typescript.md`](.claude/references/typescript.md).
 
 ---
 
-## Arquitectura de código (Angular)
+## Convenciones del repo
 
-> Principios: [`solid.md`](.claude/references/solid.md) · [`cupid.md`](.claude/references/cupid.md) · [`guiding-principles.md`](.claude/references/guiding-principles.md) · [`clean-architecture.md`](.claude/references/clean-architecture.md)
->
-> Detalle de componentes: [`angular-components.md`](.claude/references/angular-components.md)
-
-### Visibilidad de campos
-
-Los campos de clase de un componente usan `protected` — nunca `public` implícito. Las plantillas de Angular acceden a miembros `protected`, así que no hay razón para exponerlos. Lo que no se usa en la plantilla va `private`.
-
-- `protected` → campos/métodos usados solo en la plantilla del propio componente.
-- `private` → internos, no referenciados en ninguna plantilla.
-- `public` → **solo** inputs/outputs/models de signals (`input()`, `output()`, `model()`), API imperativa llamada por padres (`open()`, `close()`), y miembros requeridos por interfaces.
-
-### `effect()` como field initializers nombrados
-
-Todo `effect()` / `afterRenderEffect()` / `afterNextRender()` se declara como **field initializer nombrado**, nunca dentro del `constructor`. Los field initializers de clases decoradas corren en contexto de inyección.
-
-```typescript
-// ✅ Correcto
-export class StoryComponent {
-	private readonly store = inject(StoryService);
-	private readonly syncEffect = effect(() => {
-		const slug = this.slug();
-		untracked(() => this.load(slug));
-	});
-}
-
-// ❌ Incorrecto — effect dentro del constructor
-```
-
-- Nombres descriptivos (`syncSlugEffect`, `closeOnSuccessEffect`).
-- Los campos referenciados por el effect se declaran **antes** que el effect en el orden del cuerpo de la clase.
-
-### App initializers
-
-`provideAppInitializer` usa una factory nombrada en un archivo `<nombre>.initializer.ts` que devuelve un closure async; nunca lógica inline en `app.config.ts`.
-
-### Control flow y change detection
-
-- Componentes standalone, `ChangeDetectionStrategy.OnPush`, app **zoneless**.
-- Plantillas con `@if` / `@for` / `@switch` (nunca `*ngIf`/`*ngFor`), self-closing tags y `ngSrc` para imágenes.
-- Inyección con `inject()` (no inyección por constructor).
-
----
-
-## Estado: signals-first (sin NgRx)
-
-> Detalle: [`angular-state.md`](.claude/references/angular-state.md)
-
-Cuentoneta **no usa NgRx**. El estado se modela con **servicios + signals + RxJS**. Las reglas "signals-first" se adoptan como **principio**, no como mecanismo `rxMethod`/Signal Store.
-
-**Reglas:**
-
-1. **Sin promesas sobre observables:** prohibido `firstValueFrom`, `lastValueFrom`, `toPromise`, y `async/await` sobre observables en el frontend. Componer con operadores RxJS.
-2. **Derivar con `computed()` / `toSignal()`** en vez de mantener estado duplicado. Los valores derivados son `computed`, nunca estado guardado.
-3. **Debounce / coordinación centralizados en servicios** (p. ej. `LayoutService`), no esparcidos en componentes.
-4. **Errores tipados por operación** — preferir un estado de error por operación a un único `string | null` compartido.
-5. **`switchMap` como operador de aplanado por defecto** para cancelar requests en vuelo obsoletos.
-6. Los servicios de acceso a datos del frontend viven en `src/app/providers/` _(en migración al patrón `provideX()` / `_.provider.ts` — ver #1499)\*.
-
-> **Dirección futura (paridad con el starter):** adoptar **NgRx Signal Store** (`@ngrx/signals` + `rxMethod`) — ver **#1530**. Hasta su adopción, rige lo de arriba; **no** generar código NgRx salvo que el issue lo indique.
-
----
-
-## Backend API (Hono + Sanity)
-
-> Detalle: [`sanity-acl.md`](.claude/references/sanity-acl.md)
-
-El backend es **Hono plano** (no OpenAPIHono). Cada módulo en `src/api/modules/<dominio>/` sigue el patrón **controller → service → repository**, con **mappers (ACL)** traduciendo los resultados crudos de Sanity al modelo de dominio.
-
-### Convención de capas
-
-| Capa           | Archivo                   | Responsabilidad                                                                                    |
-| -------------- | ------------------------- | -------------------------------------------------------------------------------------------------- |
-| **Controller** | `<dominio>.controller.ts` | Rutas Hono (`new Hono()`), validación con `zValidator('param'\|'query', schema)`, llama al service |
-| **Service**    | `<dominio>.service.ts`    | Lógica de negocio. Funciones `get*()`/`update*()`. Llama al repository y mapea al dominio          |
-| **Repository** | `<dominio>.repository.ts` | Acceso a datos. Funciones `fetch*()` que ejecutan `client.fetch(query, params)` (GROQ)             |
-| **Schemas**    | `<dominio>.schema.ts`     | Schemas Zod locales del módulo                                                                     |
-
-### Naming de capas
-
-- **Repository → `fetch*()`** para todas las lecturas (`fetchStoryBySlug`, `fetchStories`). Devuelve el resultado **crudo** de la query de Sanity.
-- **Service → `get*()`** para lecturas (`getStoryBySlug`, `getStories`). Envuelve al repository y **mapea** al modelo de dominio vía la ACL.
-- Validación de params/query con `@hono/zod-validator`; los path params usan `:slug` (estilo Hono).
-- El cliente de Sanity se importa desde `_helpers/sanity-connector` (no instanciar `client` ad-hoc).
-
-> **Dirección futura (paridad con el starter):** adoptar **OpenAPIHono** (`@hono/zod-openapi`: `createRoute`/`registerRoute` + spec en `/api/openapi.json`) — ver **#1531**. Hasta su adopción, rige el patrón Hono plano de arriba.
-
----
-
-## Anti-Corruption Layer (mappers)
-
-> Detalle: [`sanity-acl.md`](.claude/references/sanity-acl.md) · [`domain-model.md`](.claude/references/domain-model.md)
-
-El **ACL es el patrón central** de cuentoneta: los resultados crudos de GROQ **nunca** se filtran al frontend. Los **mappers** en `src/api/_utils/functions.ts` (y `*.functions.ts` vecinos) traducen el shape de Sanity al **modelo de dominio** (`Story`, `Author`, `Storylist`, `Resource`, …).
-
-```
-GROQ query → repository.fetch*()  →  service.get*()  →  mapX(rawResult): DomainType  →  controller
-            (resultado crudo Sanity)                    (mapper / ACL en _utils)
-```
-
-- Los mappers son funciones puras (`mapAuthor`, `mapAuthorTeaser`, `mapResources`, …).
-- Helpers de imágenes (`urlFor`, `urlForWithAutoFormat`) también viven en la capa de mappers.
-- Al cambiar una query GROQ o un tipo generado de Sanity, actualizar el mapper correspondiente y los tipos de dominio en el **mismo** PR.
-
----
-
-## Testing
-
-> Detalle: [`testing.md`](.claude/references/testing.md)
-
-- **Runner:** Vitest (`pnpm test`). Setup zoneless en `src/test-setup.ts`.
-- **Componentes:** **siempre** Angular Testing Library (`@testing-library/angular`). **Nunca** `ComponentFixture`, `TestBed.createComponent()`, ni queries por `querySelector`/`container`. Testear **comportamiento de usuario**, no implementación.
-- **Mocks/timers:** usar los wrappers de **`@test-utils`** (`fn()`, `spyOn()`, `clearAllMocks()`, `useFakeTimers()`, …). **Prohibido** `vi.fn()`/`vi.mock()`/`vi.spyOn()` directo (ESLint `viRestrictedSyntax`). `src/test-utils.ts` es la única excepción.
-- **`clearAllMocks()` de `@test-utils` en `beforeEach`** para resetear estado entre tests.
-- **Prioridad de queries:** `getByRole` > `getByLabelText` > `getByPlaceholderText` > `getByText` > `getByDisplayValue` > `getByAltText` > `getByTitle` > `getByTestId` (último recurso).
-- **Storybook:** todo componente nuevo en `src/app/components/` lleva su `*.stories.ts`.
-
----
-
-## Manejo de errores
-
-> Detalle: [`maintainability.md`](.claude/references/maintainability.md)
-
-- Manejar errores en el nivel adecuado — no atrapar e ignorar. Preservar la causa (`preserve-caught-error`).
-- Errores tipados por operación; loguear con contexto suficiente.
-- Backend: propagar errores con mensajes accionables; el controller traduce a la respuesta HTTP.
-- Frontend: errores tipados por operación expuestos como signals para la UI.
-
----
-
-## Convenciones de Git
+### Git
 
 - **Ramas:** `feat/<id_issue>-<descripcion-en-kebab-case>` desde `develop` actualizado (p. ej. `feat/1495-claude-md-and-references`).
-- **Commits:** `[#<id_issue>] - <mensaje>` (p. ej. `[#1495] - Crea CLAUDE.md y archivos de referencia`).
-- **PRs:** título `[#<id_issue>] - <título>`; cuerpo en español con `Closes #<id_issue>`; base `develop`; milestone correspondiente.
-- **Reviews:** en **español**.
-- Antes de borrar/sobrescribir archivos generados (p. ej. `tools/author-bios/`), verificar que sean re-generables.
+- **Commits:** `[#<id_issue>] - <mensaje>`.
+- **PRs:** título `[#<id_issue>] - <título>`; cuerpo en español con `Closes #<id_issue>`; base `develop`; milestone correspondiente. **Reviews en español.**
+
+### Naming
+
+- Archivos `kebab-case`; clases `PascalCase`; funciones/métodos `camelCase`; constantes globales `SCREAMING_SNAKE_CASE`, locales `camelCase`.
+- Interfaces **sin** prefijo `I` (salvo que coexista con una clase homónima). Convención **Qualified Implementation**: la interfaz tiene el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test son `InMemory*` (**nunca** `Mock*`).
+
+### Arquitectura (resumen)
+
+- **Frontend:** Angular standalone, **zoneless**, OnPush; estado **signals-first sin NgRx** (servicios + signals/RxJS). Sin `firstValueFrom`/`toPromise`; derivar con `computed()`/`toSignal()`. Detalle: [`angular-components.md`](.claude/references/angular-components.md) · [`angular-state.md`](.claude/references/angular-state.md).
+- **Backend:** **Hono plano** (`src/api/modules/<dominio>/`) con el patrón **controller → service → repository** y un **Anti-Corruption Layer de mappers** (`src/api/_utils/`) que traduce los resultados crudos de Sanity/GROQ al modelo de dominio. Repos `fetch*()` (crudo), services `get*()` (mapean a dominio). Detalle: [`sanity-acl.md`](.claude/references/sanity-acl.md) · [`clean-architecture.md`](.claude/references/clean-architecture.md).
+
+### Dirección futura (paridad con el starter)
+
+Como dirección objetivo —**no adoptada**— se evalúa **NgRx Signal Store** (#1530) y **OpenAPIHono** (#1531). Hasta que esos issues cambien de estado, **no** se genera código NgRx ni OpenAPIHono salvo que el issue lo pida. Detalle en [`angular-state.md`](.claude/references/angular-state.md) y [`sanity-acl.md`](.claude/references/sanity-acl.md).
 
 ### Scan de impacto en documentación
 
@@ -258,9 +118,24 @@ Si un cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología
 
 ---
 
-## Archivos de referencia
+## Carga estratificada de referencias
 
-`CLAUDE.md` es la guía base; el conocimiento detallado se estratifica en [`.claude/references/`](.claude/references/) y se carga **según el tipo de tarea** (los subagentes de `.claude/agents/` los consumen — ver #1501). `coding-agent-policies.md` se carga **siempre**, al inicio de cada sesión.
+`CLAUDE.md` (este archivo) se carga **siempre**. El conocimiento detallado vive en [`.claude/references/`](.claude/references/) y se carga **según el tipo de tarea** (los subagentes de `.claude/agents/` lo consumen — ver #1501). `coding-agent-policies.md` se carga **siempre**, al inicio de cada sesión.
+
+**Qué cargar según la tarea:**
+
+| Cuando trabajes en…                  | Cargá                                                                                              |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| Cualquier sesión (siempre)           | `coding-agent-policies`                                                                            |
+| Componentes / plantillas Angular     | `angular-components`, `angular-state`                                                              |
+| Estado / servicios / RxJS            | `angular-state`, `guiding-principles`                                                              |
+| Backend / Sanity / GROQ / mappers    | `sanity-acl`, `clean-architecture`, `domain-model`                                                 |
+| Modelo de dominio / DDD              | `domain-model`, `clean-architecture`                                                               |
+| Tests (Vitest / Storybook)           | `testing`                                                                                          |
+| Tipos / constantes / imports (TS/JS) | `typescript`                                                                                       |
+| Decisiones de diseño / arquitectura  | `solid`, `cupid`, `guiding-principles`, `cross-reference`, `clean-architecture`, `maintainability` |
+
+**Catálogo completo (`.claude/references/`):**
 
 | Referencia                 | Contenido                                                                           |
 | -------------------------- | ----------------------------------------------------------------------------------- |
@@ -275,4 +150,5 @@ Si un cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología
 | `angular-state.md`         | Estado signals-first sin NgRx (servicios + signals/RxJS)                            |
 | `testing.md`               | Vitest + Angular Testing Library + `@test-utils` + Storybook                        |
 | `sanity-acl.md`            | GROQ → repository → mapper → modelo de dominio (el ACL central)                     |
+| `typescript.md`            | Micro-convenciones TS/JS (`Object.freeze`, type-only, duration strings)             |
 | `maintainability.md`       | Mantenibilidad y simplificación estructural                                         |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,278 @@
+# Guía del proyecto — La Cuentoneta
+
+> **Propósito:** este documento define estándares de código, principios de arquitectura y convenciones de tooling para **La Cuentoneta**. Claude Code debe seguir estas reglas al generar, revisar o modificar código.
+
+> **Idioma:** la documentación y las reviews van en **español**; el **código siempre en inglés** (los comentarios pueden ir en español). Los identificadores, nombres de archivo, ramas y mensajes de commit siguen las convenciones de abajo.
+
+> **Políticas de agentes de IA:** todo agente que opere sobre este repo debe seguir además [`.claude/references/coding-agent-policies.md`](.claude/references/coding-agent-policies.md) y **cargarlo al inicio de cada sesión, antes de generar recomendaciones**. Es una restricción dura, al mismo nivel que las de este archivo.
+
+---
+
+## Índice
+
+1. [Resumen del proyecto](#resumen-del-proyecto)
+2. [Comandos comunes](#comandos-comunes)
+3. [Restricciones duras (Hard Constraints)](#restricciones-duras-hard-constraints)
+4. [Arquitectura de código (Angular)](#arquitectura-de-código-angular)
+5. [Estado: signals-first (sin NgRx)](#estado-signals-first-sin-ngrx)
+6. [Backend API (Hono + Sanity)](#backend-api-hono--sanity)
+7. [Anti-Corruption Layer (mappers)](#anti-corruption-layer-mappers)
+8. [Testing](#testing)
+9. [Manejo de errores](#manejo-de-errores)
+10. [Convenciones de Git](#convenciones-de-git)
+11. [Archivos de referencia](#archivos-de-referencia)
+
+---
+
+## Resumen del proyecto
+
+| Aspecto                | Valor                                                           |
+| ---------------------- | --------------------------------------------------------------- |
+| **Framework**          | Angular 21 (standalone, **zoneless**, OnPush, SSR/hidratación)  |
+| **Lenguaje**           | TypeScript (modo estricto)                                      |
+| **Monorepo**           | Nx 22 (single-project `@cuentoneta/app`) — builder vite/esbuild |
+| **Gestor de paquetes** | **pnpm** (10.x). `npm`/`yarn` están bloqueados (`only-allow`)   |
+| **Backend**            | **Hono** (`src/api/`) + `@hono/zod-validator`                   |
+| **Persistencia/CMS**   | **Sanity** (GROQ) vía `@sanity/client`. Studio en `/cms`        |
+| **Testing**            | **Vitest** + Angular Testing Library + `@test-utils`            |
+| **Estilos**            | Tailwind v4 + Stylelint                                         |
+| **Componentes**        | Storybook 10                                                    |
+
+**Aliases de paths** (ver `tsconfig.json`): `@components/*`, `@mocks/*`, `@models/*`, `@utils/*`, `@test-utils`.
+
+**Prefijo de selectores:** componentes `cuentoneta-` (kebab-case, elemento); directivas `cuentoneta` (camelCase, atributo).
+
+---
+
+## Comandos comunes
+
+Usar **siempre `pnpm`** para instalar y ejecutar scripts. Los scripts envuelven targets de Nx del proyecto `@cuentoneta/app`.
+
+| Comando                                   | Descripción                          |
+| ----------------------------------------- | ------------------------------------ |
+| `pnpm install`                            | Instala dependencias                 |
+| `pnpm dev`                                | Dev server (SSR) en desarrollo       |
+| `pnpm build`                              | Build de producción                  |
+| `pnpm lint`                               | ESLint sobre `src/**/*.{ts,html}`    |
+| `pnpm stylelint`                          | Stylelint sobre CSS                  |
+| `pnpm test`                               | Tests unitarios (Vitest)             |
+| `pnpm test:watch`                         | Tests en watch                       |
+| `pnpm test:e2e`                           | E2E (Playwright)                     |
+| `pnpm storybook` / `pnpm storybook:build` | Storybook dev / build                |
+| `pnpm sanity:dev`                         | Studio de Sanity (`@cuentoneta/cms`) |
+| `pnpm sanity:extract-schema`              | Extrae el schema de Sanity           |
+| `pnpm sanity:run-typegen-generator`       | Genera tipos a partir del schema     |
+
+**Gates de CI** (deben quedar verdes en cada PR): `test`, `lint`, `stylelint`, `e2e`, `build`, `storybook`.
+
+---
+
+## Restricciones duras (Hard Constraints)
+
+Reglas no negociables. Una violación requiere justificación explícita.
+
+| Restricción                                  | Límite / regla                                                                                  |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Largo de función                             | ≤ 50 líneas                                                                                     |
+| Largo de archivo                             | ≤ 500 líneas (los `*.spec.ts` quedan exentos)                                                   |
+| Complejidad ciclomática                      | ≤ 10                                                                                            |
+| Profundidad de anidamiento                   | ≤ 3 niveles                                                                                     |
+| Barrels (`index.ts` re-export)               | **Prohibidos** en todo el proyecto (ESLint `no-barrel-files`)                                   |
+| Tipo `any`                                   | Prohibido sin un comentario `// REASON:` (ESLint `no-explicit-any`)                             |
+| `// @ts-ignore`                              | Prohibido sin issue enlazado                                                                    |
+| `console.log`                                | Quitar antes de commitear                                                                       |
+| `enum` de TypeScript                         | **Prohibidos** — usar `Object.freeze({...} as const)` (ver abajo)                               |
+| Lifecycle hooks (`OnInit`, etc.)             | **Prohibidos** — usar signals / `computed` / `effect` / `viewChild` / `contentChild`            |
+| Propiedades estáticas                        | **Prohibidas** — usar un servicio singleton (`providedIn: 'root'`)                              |
+| Imports type-only                            | Usar `type` cuando un import se use solo como anotación de tipo (`isolatedModules`)             |
+| Literales de tiempo crudos                   | Usar duration strings (`'15m'`, `'1h'`, `'7d'`) resueltas en el punto de uso, no `60000`        |
+| `vi.fn()` / `vi.mock()` / `vi.*`             | **Prohibido** el uso directo — usar los wrappers de `@test-utils` (ESLint `viRestrictedSyntax`) |
+| `firstValueFrom`/`lastValueFrom`/`toPromise` | **Prohibidos** en el frontend — usar `computed()`/`toSignal()`/operadores RxJS                  |
+| Non-null assertion (`!`)                     | Prohibido (ESLint `no-non-null-assertion`)                                                      |
+| Non-self-closing / control flow viejo        | Plantillas: `@if`/`@for` (no `*ngIf`/`*ngFor`), self-closing tags, `ngSrc`                      |
+
+### `Object.freeze()` en vez de `enum`
+
+```typescript
+// ✅ Correcto
+export const MediaType = Object.freeze({
+	AUDIO: 'audio',
+	VIDEO: 'video',
+} as const);
+export type MediaType = (typeof MediaType)[keyof typeof MediaType];
+
+// ❌ Incorrecto
+export enum MediaType {
+	AUDIO = 'audio',
+	VIDEO = 'video',
+}
+```
+
+Beneficios: idiomático en JS, mejor tree-shaking, sin runtime overhead de TS, funciona con `typeof`/`keyof`.
+
+---
+
+## Arquitectura de código (Angular)
+
+> Principios: [`solid.md`](.claude/references/solid.md) · [`cupid.md`](.claude/references/cupid.md) · [`guiding-principles.md`](.claude/references/guiding-principles.md) · [`clean-architecture.md`](.claude/references/clean-architecture.md)
+>
+> Detalle de componentes: [`angular-components.md`](.claude/references/angular-components.md)
+
+### Visibilidad de campos
+
+Los campos de clase de un componente usan `protected` — nunca `public` implícito. Las plantillas de Angular acceden a miembros `protected`, así que no hay razón para exponerlos. Lo que no se usa en la plantilla va `private`.
+
+- `protected` → campos/métodos usados solo en la plantilla del propio componente.
+- `private` → internos, no referenciados en ninguna plantilla.
+- `public` → **solo** inputs/outputs/models de signals (`input()`, `output()`, `model()`), API imperativa llamada por padres (`open()`, `close()`), y miembros requeridos por interfaces.
+
+### `effect()` como field initializers nombrados
+
+Todo `effect()` / `afterRenderEffect()` / `afterNextRender()` se declara como **field initializer nombrado**, nunca dentro del `constructor`. Los field initializers de clases decoradas corren en contexto de inyección.
+
+```typescript
+// ✅ Correcto
+export class StoryComponent {
+	private readonly store = inject(StoryService);
+	private readonly syncEffect = effect(() => {
+		const slug = this.slug();
+		untracked(() => this.load(slug));
+	});
+}
+
+// ❌ Incorrecto — effect dentro del constructor
+```
+
+- Nombres descriptivos (`syncSlugEffect`, `closeOnSuccessEffect`).
+- Los campos referenciados por el effect se declaran **antes** que el effect en el orden del cuerpo de la clase.
+
+### App initializers
+
+`provideAppInitializer` usa una factory nombrada en un archivo `<nombre>.initializer.ts` que devuelve un closure async; nunca lógica inline en `app.config.ts`.
+
+### Control flow y change detection
+
+- Componentes standalone, `ChangeDetectionStrategy.OnPush`, app **zoneless**.
+- Plantillas con `@if` / `@for` / `@switch` (nunca `*ngIf`/`*ngFor`), self-closing tags y `ngSrc` para imágenes.
+- Inyección con `inject()` (no inyección por constructor).
+
+---
+
+## Estado: signals-first (sin NgRx)
+
+> Detalle: [`angular-state.md`](.claude/references/angular-state.md)
+
+Cuentoneta **no usa NgRx**. El estado se modela con **servicios + signals + RxJS**. Las reglas "signals-first" se adoptan como **principio**, no como mecanismo `rxMethod`/Signal Store.
+
+**Reglas:**
+
+1. **Sin promesas sobre observables:** prohibido `firstValueFrom`, `lastValueFrom`, `toPromise`, y `async/await` sobre observables en el frontend. Componer con operadores RxJS.
+2. **Derivar con `computed()` / `toSignal()`** en vez de mantener estado duplicado. Los valores derivados son `computed`, nunca estado guardado.
+3. **Debounce / coordinación centralizados en servicios** (p. ej. `LayoutService`), no esparcidos en componentes.
+4. **Errores tipados por operación** — preferir un estado de error por operación a un único `string | null` compartido.
+5. **`switchMap` como operador de aplanado por defecto** para cancelar requests en vuelo obsoletos.
+6. Los servicios de acceso a datos del frontend viven en `src/app/providers/` _(en migración al patrón `provideX()` / `_.provider.ts` — ver #1499)\*.
+
+> **Dirección futura (paridad con el starter):** adoptar **NgRx Signal Store** (`@ngrx/signals` + `rxMethod`) — ver **#1530**. Hasta su adopción, rige lo de arriba; **no** generar código NgRx salvo que el issue lo indique.
+
+---
+
+## Backend API (Hono + Sanity)
+
+> Detalle: [`sanity-acl.md`](.claude/references/sanity-acl.md)
+
+El backend es **Hono plano** (no OpenAPIHono). Cada módulo en `src/api/modules/<dominio>/` sigue el patrón **controller → service → repository**, con **mappers (ACL)** traduciendo los resultados crudos de Sanity al modelo de dominio.
+
+### Convención de capas
+
+| Capa           | Archivo                   | Responsabilidad                                                                                    |
+| -------------- | ------------------------- | -------------------------------------------------------------------------------------------------- |
+| **Controller** | `<dominio>.controller.ts` | Rutas Hono (`new Hono()`), validación con `zValidator('param'\|'query', schema)`, llama al service |
+| **Service**    | `<dominio>.service.ts`    | Lógica de negocio. Funciones `get*()`/`update*()`. Llama al repository y mapea al dominio          |
+| **Repository** | `<dominio>.repository.ts` | Acceso a datos. Funciones `fetch*()` que ejecutan `client.fetch(query, params)` (GROQ)             |
+| **Schemas**    | `<dominio>.schema.ts`     | Schemas Zod locales del módulo                                                                     |
+
+### Naming de capas
+
+- **Repository → `fetch*()`** para todas las lecturas (`fetchStoryBySlug`, `fetchStories`). Devuelve el resultado **crudo** de la query de Sanity.
+- **Service → `get*()`** para lecturas (`getStoryBySlug`, `getStories`). Envuelve al repository y **mapea** al modelo de dominio vía la ACL.
+- Validación de params/query con `@hono/zod-validator`; los path params usan `:slug` (estilo Hono).
+- El cliente de Sanity se importa desde `_helpers/sanity-connector` (no instanciar `client` ad-hoc).
+
+> **Dirección futura (paridad con el starter):** adoptar **OpenAPIHono** (`@hono/zod-openapi`: `createRoute`/`registerRoute` + spec en `/api/openapi.json`) — ver **#1531**. Hasta su adopción, rige el patrón Hono plano de arriba.
+
+---
+
+## Anti-Corruption Layer (mappers)
+
+> Detalle: [`sanity-acl.md`](.claude/references/sanity-acl.md) · [`domain-model.md`](.claude/references/domain-model.md)
+
+El **ACL es el patrón central** de cuentoneta: los resultados crudos de GROQ **nunca** se filtran al frontend. Los **mappers** en `src/api/_utils/functions.ts` (y `*.functions.ts` vecinos) traducen el shape de Sanity al **modelo de dominio** (`Story`, `Author`, `Storylist`, `Resource`, …).
+
+```
+GROQ query → repository.fetch*()  →  service.get*()  →  mapX(rawResult): DomainType  →  controller
+            (resultado crudo Sanity)                    (mapper / ACL en _utils)
+```
+
+- Los mappers son funciones puras (`mapAuthor`, `mapAuthorTeaser`, `mapResources`, …).
+- Helpers de imágenes (`urlFor`, `urlForWithAutoFormat`) también viven en la capa de mappers.
+- Al cambiar una query GROQ o un tipo generado de Sanity, actualizar el mapper correspondiente y los tipos de dominio en el **mismo** PR.
+
+---
+
+## Testing
+
+> Detalle: [`testing.md`](.claude/references/testing.md)
+
+- **Runner:** Vitest (`pnpm test`). Setup zoneless en `src/test-setup.ts`.
+- **Componentes:** **siempre** Angular Testing Library (`@testing-library/angular`). **Nunca** `ComponentFixture`, `TestBed.createComponent()`, ni queries por `querySelector`/`container`. Testear **comportamiento de usuario**, no implementación.
+- **Mocks/timers:** usar los wrappers de **`@test-utils`** (`fn()`, `spyOn()`, `clearAllMocks()`, `useFakeTimers()`, …). **Prohibido** `vi.fn()`/`vi.mock()`/`vi.spyOn()` directo (ESLint `viRestrictedSyntax`). `src/test-utils.ts` es la única excepción.
+- **`clearAllMocks()` de `@test-utils` en `beforeEach`** para resetear estado entre tests.
+- **Prioridad de queries:** `getByRole` > `getByLabelText` > `getByPlaceholderText` > `getByText` > `getByDisplayValue` > `getByAltText` > `getByTitle` > `getByTestId` (último recurso).
+- **Storybook:** todo componente nuevo en `src/app/components/` lleva su `*.stories.ts`.
+
+---
+
+## Manejo de errores
+
+> Detalle: [`maintainability.md`](.claude/references/maintainability.md)
+
+- Manejar errores en el nivel adecuado — no atrapar e ignorar. Preservar la causa (`preserve-caught-error`).
+- Errores tipados por operación; loguear con contexto suficiente.
+- Backend: propagar errores con mensajes accionables; el controller traduce a la respuesta HTTP.
+- Frontend: errores tipados por operación expuestos como signals para la UI.
+
+---
+
+## Convenciones de Git
+
+- **Ramas:** `feat/<id_issue>-<descripcion-en-kebab-case>` desde `develop` actualizado (p. ej. `feat/1495-claude-md-and-references`).
+- **Commits:** `[#<id_issue>] - <mensaje>` (p. ej. `[#1495] - Crea CLAUDE.md y archivos de referencia`).
+- **PRs:** título `[#<id_issue>] - <título>`; cuerpo en español con `Closes #<id_issue>`; base `develop`; milestone correspondiente.
+- **Reviews:** en **español**.
+- Antes de borrar/sobrescribir archivos generados (p. ej. `tools/author-bios/`), verificar que sean re-generables.
+
+### Scan de impacto en documentación
+
+Si un cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología de dominio, actualizar en el **mismo** commit/PR toda la documentación que los referencie: `docs/`, este `CLAUDE.md`, y `.claude/references/`.
+
+---
+
+## Archivos de referencia
+
+`CLAUDE.md` es la guía base; el conocimiento detallado se estratifica en [`.claude/references/`](.claude/references/) y se carga **según el tipo de tarea** (los subagentes de `.claude/agents/` los consumen — ver #1501). `coding-agent-policies.md` se carga **siempre**, al inicio de cada sesión.
+
+| Referencia                 | Contenido                                                                           |
+| -------------------------- | ----------------------------------------------------------------------------------- |
+| `coding-agent-policies.md` | Políticas de colaboración de agentes (carga obligatoria al inicio)                  |
+| `solid.md`                 | Principios SOLID                                                                    |
+| `cupid.md`                 | Propiedades CUPID                                                                   |
+| `guiding-principles.md`    | YAGNI / KISS + disciplina de operadores RxJS                                        |
+| `cross-reference.md`       | Cómo se relacionan SOLID / CUPID / Clean Architecture / DDD                         |
+| `clean-architecture.md`    | Capas, regla de dependencia, "Qualified Implementation" (Sanity/InMemory)           |
+| `domain-model.md`          | DDD estratégico (agregados, invariantes, bounded contexts) — Story/Author/Storylist |
+| `angular-components.md`    | Componentes, effects, DI/providers, control flow                                    |
+| `angular-state.md`         | Estado signals-first sin NgRx (servicios + signals/RxJS)                            |
+| `testing.md`               | Vitest + Angular Testing Library + `@test-utils` + Storybook                        |
+| `sanity-acl.md`            | GROQ → repository → mapper → modelo de dominio (el ACL central)                     |
+| `maintainability.md`       | Mantenibilidad y simplificación estructural                                         |


### PR DESCRIPTION
Closes #1495 · Parte de #1498

## Descripción

Crea la capa de **documentación y referencias de Claude** en cuentoneta, adaptada del starter [`ResetShop/angular-nx-standalone-starter`](https://github.com/ResetShop/angular-nx-standalone-starter). Documentación en **español**; código siempre en inglés.

> Depende de #1494 (Vitest), ya mergeado en `develop`.

## Cambios

**Versionado de `.claude` (config de equipo)**
- `.gitignore`: `.claude` deja de ignorarse; solo quedan fuera `.claude/settings.local.json` y `.claude/worktrees/`.

**`CLAUDE.md` (raíz)** — guía del proyecto en español adaptada al stack real:
- Resumen + comandos (`pnpm`), Hard Constraints, arquitectura Angular (visibilidad de campos, `effect()` como field initializers, `provideAppInitializer`, OnPush/zoneless, control flow `@if`/`@for`).
- **Estado signals-first sin NgRx**; **backend Hono plano → service → repository con ACL de mappers** (verificado contra el código: repos `fetch*` GROQ, services `get*`, mappers en `_utils/functions.ts`).
- Testing con `@test-utils`, convenciones de Git (ramas `feat/<id>-<kebab>`), e índice que delega a `.claude/references/`.
- Desbloquea la referencia de `.github/workflows/claude-code-review.yml` ("Use the repository's CLAUDE.md").

**`.claude/references/` — 12 archivos (español):**
- Genéricas: `solid`, `cupid`, `cross-reference`, `guiding-principles`, `maintainability`.
- Adaptadas: `clean-architecture` (Qualified Implementation `Sanity*`/`InMemory*`), `domain-model` (Story/Author/Storylist; roadmap DDD #1503), `testing` (Vitest + ATL + `@test-utils` + Storybook), `coding-agent-policies`.
- Nuevas de cuentoneta: `angular-components`, `angular-state`, `sanity-acl` (GROQ → repository → mapper → modelo de dominio).

## Paridad futura con el starter

Como dirección futura (patrón doc→issue, igual que `DDD_IMPROVEMENTS.md`→#1503) se crearon dos issues de tracking en milestone 3.1.0 (NO parte de este epic):
- **#1530** — NgRx Signal Store.
- **#1531** — OpenAPIHono.

Las referencias describen el **estado actual** (autoridad) y apuntan a esos issues. `CLAUDE.md` enlaza #1530 (estado) y #1531 (backend). **No** se genera código NgRx/OpenAPIHono hasta adoptarlos.

## Fuera de alcance (issues siguientes del epic)

Enforcement de ESLint (#1500), renombrado a `*.provider.ts` (#1499), subagentes + skill (#1501), `.mcp.json`/`settings.json` (#1502), implementación DDD en código (#1503).

## CI

Sin impacto: son markdown en `.claude/` + `CLAUDE.md` raíz. ESLint solo lintea `src/**`, así que test/lint/stylelint/e2e/build/storybook no se ven afectados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
