### PR TITLE
[#1500] - Adopta el enforcement de ESLint estilo ResetShop

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -132,11 +132,10 @@ export default [
 				},
 			],
 			'@angular-eslint/prefer-signals': 'error',
-			// TODO(#1500): se habilita en el commit de visibilidad de miembros (298 clasificaciones).
-			// '@typescript-eslint/explicit-member-accessibility': [
-			// 	'error',
-			// 	{ accessibility: 'explicit', overrides: { constructors: 'no-public' } },
-			// ],
+			'@typescript-eslint/explicit-member-accessibility': [
+				'error',
+				{ accessibility: 'explicit', overrides: { constructors: 'no-public' } },
+			],
 			'@typescript-eslint/no-inferrable-types': 0,
 			'@typescript-eslint/no-unused-vars': 'error',
 			'@typescript-eslint/no-non-null-assertion': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,8 +5,20 @@ import storybook from 'eslint-plugin-storybook';
 import vitest from '@vitest/eslint-plugin';
 import testingLibrary from 'eslint-plugin-testing-library';
 import noBarrelFiles from 'eslint-plugin-no-barrel-files';
+import requireEnvironmentProviders from './tools/eslint/require-environment-providers.js';
+import storybookSourceState from './tools/eslint/storybook-source-state.js';
 
-// Reglas base de ES modules: prohíben CommonJS.
+// Restricciones de sintaxis comunes: CommonJS, enums, lifecycle hooks y propiedades estáticas.
+const lifecycleHooks = [
+	['OnInit', 'Usá inicialización en el constructor y signals en lugar de OnInit.'],
+	['OnChanges', 'Reaccioná a cambios de input con computed() o effect() en lugar de OnChanges.'],
+	['DoCheck', 'Usá computed() o effect() en lugar de DoCheck.'],
+	['AfterContentInit', 'Usá contentChild() y effect() en lugar de AfterContentInit.'],
+	['AfterContentChecked', 'Usá computed() o effect() en lugar de AfterContentChecked.'],
+	['AfterViewInit', 'Usá viewChild() y effect() en lugar de AfterViewInit.'],
+	['AfterViewChecked', 'Usá computed() o effect() en lugar de AfterViewChecked.'],
+];
+
 const commonRestrictedSyntax = [
 	{
 		selector: 'MemberExpression[object.name="module"][property.name="exports"]',
@@ -15,6 +27,18 @@ const commonRestrictedSyntax = [
 	{
 		selector: 'MemberExpression[object.name="exports"]',
 		message: 'Use ES modules (export) instead of CommonJS (exports)',
+	},
+	{
+		selector: 'TSEnumDeclaration',
+		message: 'Los enum están prohibidos. Usá Object.freeze({...} as const) — ver typescript.md.',
+	},
+	...lifecycleHooks.map(([hook, message]) => ({
+		selector: `TSClassImplements > Identifier[name="${hook}"]`,
+		message: `${hook} está prohibido. ${message}`,
+	})),
+	{
+		selector: 'PropertyDefinition[static=true]',
+		message: 'Las propiedades estáticas están prohibidas. Usá un servicio singleton (providedIn: root).',
 	},
 ];
 
@@ -53,7 +77,7 @@ const viRestrictedSyntax = [
 export default [
 	{
 		name: 'ignores',
-		ignores: ['!**/*', '.nx', 'dist'],
+		ignores: ['!**/*', '.nx', 'dist', 'tools/**'],
 	},
 	...nx.configs['flat/base'],
 	...nx.configs['flat/typescript'],
@@ -108,14 +132,13 @@ export default [
 				},
 			],
 			'@angular-eslint/prefer-signals': 'error',
+			// TODO(#1500): se habilita en el commit de visibilidad de miembros (298 clasificaciones).
+			// '@typescript-eslint/explicit-member-accessibility': [
+			// 	'error',
+			// 	{ accessibility: 'explicit', overrides: { constructors: 'no-public' } },
+			// ],
 			'@typescript-eslint/no-inferrable-types': 0,
-			'@typescript-eslint/no-unused-vars': [
-				'error',
-				{
-					argsIgnorePattern: '^_',
-					varsIgnorePattern: '^_',
-				},
-			],
+			'@typescript-eslint/no-unused-vars': 'error',
 			'@typescript-eslint/no-non-null-assertion': 'error',
 			'@typescript-eslint/no-explicit-any': 'error',
 			'@typescript-eslint/no-require-imports': 'error',
@@ -132,6 +155,26 @@ export default [
 		files: ['src/test-utils.ts'],
 		rules: {
 			'no-restricted-syntax': ['error', ...commonRestrictedSyntax],
+		},
+	},
+	{
+		name: 'require-environment-providers',
+		files: ['src/app/providers/**/*.provider.ts', 'src/app/providers/**/*.mock.ts'],
+		plugins: {
+			'custom-providers': { rules: { 'require-environment-providers': requireEnvironmentProviders } },
+		},
+		rules: {
+			'custom-providers/require-environment-providers': 'error',
+		},
+	},
+	{
+		name: 'storybook-source-state',
+		files: ['**/*.stories.ts'],
+		plugins: {
+			'custom-storybook': { rules: { 'storybook-source-state': storybookSourceState } },
+		},
+		rules: {
+			'custom-storybook/storybook-source-state': 'error',
 		},
 	},
 	{

--- a/nx.json
+++ b/nx.json
@@ -19,7 +19,7 @@
 			"inputs": ["default", "^production"]
 		},
 		"lint": {
-			"inputs": ["default", "{workspaceRoot}/eslint.config.js"]
+			"inputs": ["default", "{workspaceRoot}/eslint.config.mjs"]
 		},
 		"build-storybook": {
 			"inputs": ["default", "^production", "{projectRoot}/.storybook/**/*", "{projectRoot}/tsconfig.storybook.json"],
@@ -50,7 +50,7 @@
 			"!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
 			"!{projectRoot}/tsconfig.spec.json",
 			"!{projectRoot}/jest.config.[jt]s",
-			"!{projectRoot}/eslint.config.js",
+			"!{projectRoot}/eslint.config.mjs",
 			"!{projectRoot}/**/*.stories.@(js|jsx|ts|tsx|mdx)",
 			"!{projectRoot}/.storybook/**/*",
 			"!{projectRoot}/tsconfig.storybook.json",

--- a/src/api/modules/content/content.service.ts
+++ b/src/api/modules/content/content.service.ts
@@ -62,7 +62,8 @@ export async function addNextWeeksLandingPageContent(weeksInTheFuture: number = 
 	const notLoadedWeeks = slugs.filter((t) => !existingLandingPagesList.find((r) => r.config === t));
 
 	const landingPageObjects = notLoadedWeeks.map((weekYear) => {
-		const { _id: _, ...config } = latestLandingPageConfig;
+		const config = { ...latestLandingPageConfig };
+		delete (config as { _id?: string })._id;
 		return {
 			...config,
 			config: weekYear,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { afterNextRender, Component, inject, OnInit, signal } from '@angular/core';
+import { afterNextRender, Component, inject, signal } from '@angular/core';
 
 import { HeaderComponent } from '@components/header/header.component';
 import { FooterComponent } from '@components/footer/footer.component';
@@ -20,7 +20,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 	imports: [FooterComponent, HeaderComponent, RouterModule],
 	providers: [AnalyticsService],
 })
-export class AppComponent implements OnInit {
+export class AppComponent {
 	private readonly analytics = inject(AnalyticsService);
 	private readonly isHeaderVisible$ = inject(LayoutService).isHeaderVisible$.pipe(takeUntilDestroyed());
 
@@ -32,12 +32,9 @@ export class AppComponent implements OnInit {
 				this.isHeaderVisible.set(isVisible);
 			});
 		});
-	}
 
-	async ngOnInit() {
-		if (environment.environment !== 'production') {
-			return;
+		if (environment.environment === 'production') {
+			void this.analytics.init();
 		}
-		await this.analytics.init();
 	}
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,7 +24,7 @@ export class AppComponent {
 	private readonly analytics = inject(AnalyticsService);
 	private readonly isHeaderVisible$ = inject(LayoutService).isHeaderVisible$.pipe(takeUntilDestroyed());
 
-	readonly isHeaderVisible = signal(true);
+	protected readonly isHeaderVisible = signal(true);
 
 	constructor() {
 		afterNextRender(() => {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,14 +1,15 @@
 import { Routes } from '@angular/router';
 
-export enum AppRoutes {
-	Home = 'home',
-	Story = 'story',
-	StoryList = 'storylist',
-	Author = 'author',
-	Authors = 'authors',
-	About = 'about',
-	Dmca = 'dmca',
-}
+export const AppRoutes = Object.freeze({
+	Home: 'home',
+	Story: 'story',
+	StoryList: 'storylist',
+	Author: 'author',
+	Authors: 'authors',
+	About: 'about',
+	Dmca: 'dmca',
+} as const);
+export type AppRoutes = (typeof AppRoutes)[keyof typeof AppRoutes];
 
 export const appRoutes: Routes = [
 	{

--- a/src/app/components/audio-recording-widget/audio-recording-widget.component.ts
+++ b/src/app/components/audio-recording-widget/audio-recording-widget.component.ts
@@ -19,5 +19,5 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AudioRecordingWidgetComponent {
-	readonly media = input.required<AudioRecording>();
+	public readonly media = input.required<AudioRecording>();
 }

--- a/src/app/components/audio-recording-widget/audio-recording-widget.stories.ts
+++ b/src/app/components/audio-recording-widget/audio-recording-widget.stories.ts
@@ -5,6 +5,13 @@ import { audioRecordingMock } from '@mocks/audio-recording.mock';
 const meta: Meta<AudioRecordingWidgetComponent> = {
 	title: 'Widgets/AudioRecording',
 	component: AudioRecordingWidgetComponent,
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+		},
+	},
 	argTypes: {
 		media: {
 			description: 'Audio recording media object containing title, description, and audio URL',

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
@@ -29,7 +29,7 @@ import { rxResource } from '@angular/core/rxjs-interop';
 	}`,
 })
 export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
-	readonly appRoutes = AppRoutes;
+	private readonly appRoutes = AppRoutes;
 
 	// Providers
 	private storyService = inject(StoryApi);
@@ -42,8 +42,8 @@ export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
 	});
 
 	// Propiedades
-	readonly stories = computed(() => this.storiesResource.value());
-	readonly authorSlug = computed(() => this.navigationSlug() ?? '');
+	protected readonly stories = computed(() => this.storiesResource.value());
+	protected readonly authorSlug = computed(() => this.navigationSlug() ?? '');
 
 	constructor() {
 		super();

--- a/src/app/components/author-teaser-v3/author-teaser-v3.component.stories.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3.component.stories.ts
@@ -37,6 +37,9 @@ const meta: Meta<AuthorTeaserV3Component> = {
 	],
 	parameters: {
 		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
 			description: {
 				component: `<div>
 					<p>El componente **AuthorTeaserV3Component** muestra una vista previa de un autor enlazada a su perfil,

--- a/src/app/components/author-teaser-v3/author-teaser-v3.component.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3.component.ts
@@ -73,7 +73,7 @@ export class AuthorTeaserV3Component {
 	protected readonly appRoutes = AppRoutes;
 
 	// Inputs
-	readonly author = input.required<AuthorTeaser>();
-	readonly tags = input<Tag[]>([]);
-	readonly storyCount = input<number>();
+	public readonly author = input.required<AuthorTeaser>();
+	public readonly tags = input<Tag[]>([]);
+	public readonly storyCount = input<number>();
 }

--- a/src/app/components/author-teaser/author-teaser.component.ts
+++ b/src/app/components/author-teaser/author-teaser.component.ts
@@ -60,19 +60,19 @@ import { faSolidArrowRightLong } from '@ng-icons/font-awesome/solid';
 	</a>`,
 })
 export class AuthorTeaserComponent {
-	readonly author = input.required<Omit<Author, 'biography'>>();
-	readonly variant = input<'sm' | 'md'>('sm');
+	public readonly author = input.required<Omit<Author, 'biography'>>();
+	public readonly variant = input<'sm' | 'md'>('sm');
 
-	readonly imageSize = computed(() => (this.variant() === 'sm' ? 40 : 64));
+	protected readonly imageSize = computed(() => (this.variant() === 'sm' ? 40 : 64));
 
 	// Para un mejor scaling, a cargo del browser, se obtiene una imagen del 1.5x el tamaño final renderizado
-	readonly authorImageUrl = computed(() =>
+	protected readonly authorImageUrl = computed(() =>
 		this.author().imageUrl
 			? `${this.author().imageUrl}?h=${this.imageSize() * 1.5}&w=${this.imageSize() * 1.5}&auto=format`
 			: 'assets/img/default-avatar.jpg',
 	);
 
-	readonly authorFlagUrl = computed(
+	protected readonly authorFlagUrl = computed(
 		() => `${this.author().nationality.flag}?h=${this.flagImageSize.height}&w=${this.flagImageSize.width}&auto=format`,
 	);
 

--- a/src/app/components/badge/badge.component.stories.ts
+++ b/src/app/components/badge/badge.component.stories.ts
@@ -7,6 +7,11 @@ const meta: Meta<BadgeComponent> = {
 	component: BadgeComponent,
 	parameters: {
 		layout: 'centered',
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+		},
 	},
 	tags: ['autodocs'],
 	argTypes: {

--- a/src/app/components/badge/badge.component.ts
+++ b/src/app/components/badge/badge.component.ts
@@ -30,9 +30,9 @@ import { NgComponentOutlet } from '@angular/common';
 	},
 })
 export class BadgeComponent {
-	readonly tag = input.required<Tag>();
-	readonly showIcon = input(false);
-	readonly icon = computed(() => {
+	public readonly tag = input.required<Tag>();
+	public readonly showIcon = input(false);
+	protected readonly icon = computed(() => {
 		if (!this.tag().slug) {
 			return null;
 		}
@@ -49,7 +49,7 @@ export class BadgeComponent {
 		};
 	});
 
-	readonly NgIcon = NgIcon;
+	protected readonly NgIcon = NgIcon;
 
 	private injector = inject(EnvironmentInjector);
 	private tooltipDirective = inject(TooltipDirective);

--- a/src/app/components/badge/badge.component.ts
+++ b/src/app/components/badge/badge.component.ts
@@ -2,10 +2,10 @@ import {
 	Component,
 	computed,
 	createEnvironmentInjector,
+	effect,
 	EnvironmentInjector,
 	inject,
 	input,
-	OnInit,
 } from '@angular/core';
 import { Tag } from '@models/tag.model';
 import { TooltipDirective } from '../../directives/tooltip.directive';
@@ -29,7 +29,7 @@ import { NgComponentOutlet } from '@angular/common';
 		class: 'flex rounded bg-brand-200 px-4.5 py-0.5 uppercase hover:cursor-default',
 	},
 })
-export class BadgeComponent implements OnInit {
+export class BadgeComponent {
 	readonly tag = input.required<Tag>();
 	readonly showIcon = input(false);
 	readonly icon = computed(() => {
@@ -54,8 +54,8 @@ export class BadgeComponent implements OnInit {
 	private injector = inject(EnvironmentInjector);
 	private tooltipDirective = inject(TooltipDirective);
 
-	ngOnInit() {
+	private readonly syncTooltipEffect = effect(() => {
 		this.tooltipDirective.text.set(this.tag().shortDescription);
 		this.tooltipDirective.position.set('top');
-	}
+	});
 }

--- a/src/app/components/bio-summary-card/bio-summary-card.component.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.ts
@@ -33,6 +33,9 @@ import { ResourceComponent } from '../resource/resource.component';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BioSummaryCardComponent {
-	readonly story = input.required<Story>();
-	readonly resources = computed(() => [...(this.story().resources ?? []), ...(this.story().author.resources ?? [])]);
+	public readonly story = input.required<Story>();
+	protected readonly resources = computed(() => [
+		...(this.story().resources ?? []),
+		...(this.story().author.resources ?? []),
+	]);
 }

--- a/src/app/components/button/button.component.stories.ts
+++ b/src/app/components/button/button.component.stories.ts
@@ -9,6 +9,11 @@ const meta: Meta<ButtonComponent> = {
 	component: ButtonComponent,
 	parameters: {
 		layout: 'centered',
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+		},
 	},
 	tags: ['autodocs'],
 	argTypes: {

--- a/src/app/components/button/button.component.ts
+++ b/src/app/components/button/button.component.ts
@@ -41,10 +41,10 @@ export type ButtonType = 'filled' | 'outline' | 'share';
 })
 export class ButtonComponent {
 	/** Variante del tipo de botón - determina el estilo visual */
-	readonly type = input<ButtonType>('filled');
+	public readonly type = input<ButtonType>('filled');
 
 	/** Clases del host calculadas según el tipo de botón */
-	readonly hostClasses = computed(() => {
+	protected readonly hostClasses = computed(() => {
 		const baseClasses =
 			'inline-flex cursor-pointer items-center justify-center font-inter font-semibold no-underline transition-colors duration-200 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50';
 

--- a/src/app/components/carousel/carousel-controls.component.ts
+++ b/src/app/components/carousel/carousel-controls.component.ts
@@ -51,9 +51,9 @@ import { faSolidChevronLeft, faSolidChevronRight } from '@ng-icons/font-awesome/
 })
 export class CarouselControlsComponent {
 	// Entradas
-	readonly type = input.required<'left' | 'right'>();
-	readonly disabled = input<boolean>(false);
+	public readonly type = input.required<'left' | 'right'>();
+	public readonly disabled = input<boolean>(false);
 
 	// Salidas
-	readonly controlClick = output<void>();
+	public readonly controlClick = output<void>();
 }

--- a/src/app/components/carousel/carousel-gesture.service.spec.ts
+++ b/src/app/components/carousel/carousel-gesture.service.spec.ts
@@ -14,7 +14,7 @@ describe('CarouselGestureService', () => {
 		mockElement = document.createElement('div');
 		mockElementRef = { nativeElement: mockElement };
 		mockDestroyRef = {
-			onDestroy: fn((_callback: () => void) => {
+			onDestroy: fn(() => {
 				// Store callback for potential cleanup simulation
 			}),
 		} as unknown as DestroyRef;

--- a/src/app/components/carousel/carousel-gesture.service.ts
+++ b/src/app/components/carousel/carousel-gesture.service.ts
@@ -38,15 +38,15 @@ export class CarouselGestureService {
 	private readonly _swipeCurrentX = signal<number | null>(null);
 
 	// Signal de solo lectura para informar si un deslizamiento está en proceso
-	readonly isSwiping: Signal<boolean> = this._isSwiping.asReadonly();
+	public readonly isSwiping: Signal<boolean> = this._isSwiping.asReadonly();
 
 	// Subjects para eventos del ciclo de vida del deslizamiento
 	private readonly _swipeStart$ = new Subject<void>();
 	private readonly _swipeEnd$ = new Subject<void>();
 
 	// Observables públicos para coordinación con auto-play
-	readonly onSwipeStart$: Observable<void> = this._swipeStart$.asObservable();
-	readonly onSwipeEnd$: Observable<void> = this._swipeEnd$.asObservable();
+	public readonly onSwipeStart$: Observable<void> = this._swipeStart$.asObservable();
+	public readonly onSwipeEnd$: Observable<void> = this._swipeEnd$.asObservable();
 
 	// Subject para comandos de navegación
 	private readonly _navigationCommand$ = new Subject<NavigationCommand>();
@@ -57,7 +57,11 @@ export class CarouselGestureService {
 	 * @param destroyRef DestroyRef para limpieza automática
 	 * @param isTransitioning Signal que indica si hay una transición en curso
 	 */
-	attach(element: ElementRef, destroyRef: DestroyRef, isTransitioning: Signal<boolean>): Observable<NavigationCommand> {
+	public attach(
+		element: ElementRef,
+		destroyRef: DestroyRef,
+		isTransitioning: Signal<boolean>,
+	): Observable<NavigationCommand> {
 		// Flujos de eventos táctiles
 		const touchStart$ = fromEvent<TouchEvent>(element.nativeElement, 'touchstart').pipe(takeUntilDestroyed(destroyRef));
 

--- a/src/app/components/carousel/carousel-indicator.component.ts
+++ b/src/app/components/carousel/carousel-indicator.component.ts
@@ -68,13 +68,13 @@ import { ChangeDetectionStrategy, Component, computed, input, output } from '@an
 })
 export class CarouselIndicatorComponent {
 	// Entradas
-	readonly count = input.required<number>();
-	readonly activeIndex = input.required<number>();
-	readonly device = input<'Mobile' | 'Desktop'>('Desktop');
+	public readonly count = input.required<number>();
+	public readonly activeIndex = input.required<number>();
+	public readonly device = input<'Mobile' | 'Desktop'>('Desktop');
 
 	// Señales computadas
-	readonly indices = computed(() => Array.from({ length: this.count() }, (_, i) => i));
+	protected readonly indices = computed(() => Array.from({ length: this.count() }, (_, i) => i));
 
 	// Salidas
-	readonly indicatorClick = output<number>();
+	public readonly indicatorClick = output<number>();
 }

--- a/src/app/components/carousel/carousel-state.service.ts
+++ b/src/app/components/carousel/carousel-state.service.ts
@@ -20,20 +20,20 @@ export class CarouselStateService implements OnDestroy {
 	private transitionTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 	// Signals públicas de solo lectura
-	readonly activeIndex: Signal<number> = this._activeIndex.asReadonly();
-	readonly previousIndex: Signal<number | null> = this._previousIndex.asReadonly();
-	readonly isTransitioning: Signal<boolean> = this._isTransitioning.asReadonly();
-	readonly direction: Signal<'left' | 'right' | null> = this._direction.asReadonly();
-	readonly slideCount: Signal<number> = this._slideCount.asReadonly();
+	public readonly activeIndex: Signal<number> = this._activeIndex.asReadonly();
+	public readonly previousIndex: Signal<number | null> = this._previousIndex.asReadonly();
+	public readonly isTransitioning: Signal<boolean> = this._isTransitioning.asReadonly();
+	public readonly direction: Signal<'left' | 'right' | null> = this._direction.asReadonly();
+	public readonly slideCount: Signal<number> = this._slideCount.asReadonly();
 
-	ngOnDestroy(): void {
+	public ngOnDestroy(): void {
 		this.clearTransitionTimeout();
 	}
 
 	/**
 	 * Inicializa el servicio con la cantidad de diapositivas y duración de transición.
 	 */
-	initialize(slideCount: number, transitionDuration: number): void {
+	public initialize(slideCount: number, transitionDuration: number): void {
 		this._slideCount.set(slideCount);
 		this._transitionDuration.set(transitionDuration);
 	}
@@ -42,7 +42,7 @@ export class CarouselStateService implements OnDestroy {
 	 * Actualiza la cantidad de diapositivas (para cuando cambia el input).
 	 * Ajusta el índice activo si excede el nuevo conteo.
 	 */
-	updateSlideCount(count: number): void {
+	public updateSlideCount(count: number): void {
 		this._slideCount.set(count);
 		// Si el índice activo excede el nuevo conteo, ajustar al último índice válido
 		if (this._activeIndex() >= count && count > 0) {
@@ -53,7 +53,7 @@ export class CarouselStateService implements OnDestroy {
 	/**
 	 * Navega a la siguiente diapositiva.
 	 */
-	next(): void {
+	public next(): void {
 		if (this._isTransitioning()) return;
 
 		const nextIndex = this._activeIndex() + 1;
@@ -67,7 +67,7 @@ export class CarouselStateService implements OnDestroy {
 	/**
 	 * Navega a la diapositiva anterior.
 	 */
-	prev(): void {
+	public prev(): void {
 		if (this._isTransitioning()) return;
 
 		const prevIndex = this._activeIndex() - 1;
@@ -81,7 +81,7 @@ export class CarouselStateService implements OnDestroy {
 	/**
 	 * Selecciona una diapositiva específica con la dirección de animación indicada.
 	 */
-	selectSlide(index: number, direction: 'left' | 'right'): void {
+	public selectSlide(index: number, direction: 'left' | 'right'): void {
 		if (this._isTransitioning() || index === this._activeIndex()) return;
 
 		this._isTransitioning.set(true);
@@ -113,7 +113,7 @@ export class CarouselStateService implements OnDestroy {
 	/**
 	 * Maneja el clic en un indicador, determinando la dirección automáticamente.
 	 */
-	onIndicatorClick(index: number): void {
+	public onIndicatorClick(index: number): void {
 		const direction = index > this._activeIndex() ? 'left' : 'right';
 		this.selectSlide(index, direction);
 	}

--- a/src/app/components/carousel/carousel.component.spec.ts
+++ b/src/app/components/carousel/carousel.component.spec.ts
@@ -10,13 +10,13 @@ import { LayoutService } from '../../providers/layout.service';
 
 // Servicios mock
 class MockLayoutXsViewportService {
-	biggerThan(viewport: string) {
+	public biggerThan(viewport: string) {
 		return viewport !== 'xs';
 	}
 }
 
 class MockLayoutMdViewportService {
-	biggerThan(viewport: string) {
+	public biggerThan(viewport: string) {
 		return viewport === 'xs';
 	}
 }

--- a/src/app/components/carousel/carousel.component.stories.ts
+++ b/src/app/components/carousel/carousel.component.stories.ts
@@ -15,6 +15,9 @@ const meta: Meta<CarouselComponent> = {
 	],
 	parameters: {
 		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
 			description: {
 				component: `<div>
 					<p>El componente **CarouselComponent** es un carousel de contenido interactivo que permite mostrar campañas de contenido destacado con navegación automática y manual.</p>

--- a/src/app/components/carousel/carousel.component.ts
+++ b/src/app/components/carousel/carousel.component.ts
@@ -51,29 +51,29 @@ export class CarouselComponent {
 	private readonly destroyRef = inject(DestroyRef);
 
 	// Entradas
-	readonly slides = input<ContentCampaign[]>([]);
-	readonly transitionDuration = input<number>(600);
-	readonly autoPlayInterval = input<number>(5000);
+	public readonly slides = input<ContentCampaign[]>([]);
+	public readonly transitionDuration = input<number>(600);
+	public readonly autoPlayInterval = input<number>(5000);
 
 	// Signals de estado - Auto-reproducción
-	readonly isPaused = signal(false);
+	public readonly isPaused = signal(false);
 
 	// Exponer signals del servicio de estado para el template
-	readonly activeIndex = this.stateService.activeIndex;
-	readonly previousIndex = this.stateService.previousIndex;
-	readonly isTransitioning = this.stateService.isTransitioning;
-	readonly direction = this.stateService.direction;
+	public readonly activeIndex = this.stateService.activeIndex;
+	public readonly previousIndex = this.stateService.previousIndex;
+	public readonly isTransitioning = this.stateService.isTransitioning;
+	public readonly direction = this.stateService.direction;
 
 	// Signals computadas
-	readonly slideCount = computed(() => this.slides().length);
-	readonly viewport = computed(() => {
+	public readonly slideCount = computed(() => this.slides().length);
+	protected readonly viewport = computed(() => {
 		const isTabletOrDesktop = this.layoutService.biggerThan('xs');
 		return isTabletOrDesktop ? 'md' : 'xs';
 	});
-	readonly showControls = computed(() => this.layoutService.biggerThan('xs'));
+	public readonly showControls = computed(() => this.layoutService.biggerThan('xs'));
 
 	// Constantes
-	readonly viewportSpecificClasses: { [key in ContentCampaignViewport]: string } = {
+	protected readonly viewportSpecificClasses: { [key in ContentCampaignViewport]: string } = {
 		xs: 'sm:hidden',
 		md: 'max-sm:hidden',
 	};
@@ -126,24 +126,24 @@ export class CarouselComponent {
 	}
 
 	// Métodos de navegación (delegados al servicio)
-	next(): void {
+	public next(): void {
 		this.stateService.next();
 	}
 
-	prev(): void {
+	public prev(): void {
 		this.stateService.prev();
 	}
 
-	onIndicatorClick(index: number): void {
+	public onIndicatorClick(index: number): void {
 		this.stateService.onIndicatorClick(index);
 	}
 
 	// Métodos de control de auto-reproducción
-	pauseAutoPlay(): void {
+	public pauseAutoPlay(): void {
 		this.isPaused.set(true);
 	}
 
-	resumeAutoPlay(): void {
+	public resumeAutoPlay(): void {
 		this.isPaused.set(false);
 		this.restartAutoPlay$.next();
 	}

--- a/src/app/components/collection-teaser/collection-teaser.stories.ts
+++ b/src/app/components/collection-teaser/collection-teaser.stories.ts
@@ -16,6 +16,13 @@ const meta: Meta<CollectionTeaser> = {
 			imports: [NgOptimizedImage, CollectionTeaserSkeleton],
 		}),
 	],
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+		},
+	},
 };
 export default meta;
 

--- a/src/app/components/collection-teaser/collection-teaser.ts
+++ b/src/app/components/collection-teaser/collection-teaser.ts
@@ -40,7 +40,7 @@ import { NgOptimizedImage } from '@angular/common';
 						<cuentoneta-portable-text-parser
 							[classes]="'line-clamp-4 sm:line-clamp-3'"
 							[paragraphs]="[storylist.description[0]]"
-							class="text-ellipsis font-inter text-sm text-neutral-700"
+							class="font-inter text-sm text-ellipsis text-neutral-700"
 						/>
 						<footer class="flex flex-col gap-1 font-inter text-xs text-neutral-600 sm:flex-row">
 							@if (storylist.tags[0]) {
@@ -56,6 +56,6 @@ import { NgOptimizedImage } from '@angular/common';
 	`,
 })
 export class CollectionTeaser {
-	readonly collection = input<StorylistTeaser>();
+	public readonly collection = input<StorylistTeaser>();
 	protected readonly appRoutes = AppRoutes;
 }

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.ts
@@ -32,6 +32,6 @@ import { CollectionTeaserSkeleton } from '@components/collection-teaser/collecti
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CollectionTeasersDeck {
-	readonly SKELETON_COUNT = 4;
-	readonly teasers = input<StorylistTeaser[]>([]);
+	protected readonly SKELETON_COUNT = 4;
+	public readonly teasers = input<StorylistTeaser[]>([]);
 }

--- a/src/app/components/epigraph/epigraph.component.ts
+++ b/src/app/components/epigraph/epigraph.component.ts
@@ -23,5 +23,5 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EpigraphComponent {
-	readonly epigraph = input.required<Epigraph>();
+	public readonly epigraph = input.required<Epigraph>();
 }

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -94,13 +94,13 @@ import { NgIcon, provideIcons, provideNgIconsConfig } from '@ng-icons/core';
 	`,
 })
 export class FooterComponent {
-	readonly navLinks: InternalLink[] = [
+	protected readonly navLinks: InternalLink[] = [
 		{ path: '/', label: 'Inicio' },
 		{ path: '/about', label: 'Acerca de' },
 		{ path: '/dmca', label: 'DMCA' },
 	];
 
-	readonly socialLinks: UrlLink[] = [
+	protected readonly socialLinks: UrlLink[] = [
 		{
 			url: 'https://whatsapp.com/channel/0029VaC3aCSJuyAGTU2tC02F',
 			label: 'Whatsapp',

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -104,13 +104,13 @@ type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 	],
 })
 export class HeaderComponent {
-	readonly navLinks: InternalLink[] = [
+	protected readonly navLinks: InternalLink[] = [
 		{ label: 'Inicio', path: '/home' },
 		{ label: 'Nosotros', path: '/about' },
 	];
-	readonly displayMenu = signal(false);
+	protected readonly displayMenu = signal(false);
 
-	readonly isVisible = input(VisibilityState.Visible, {
+	public readonly isVisible = input(VisibilityState.Visible, {
 		transform: (value) => (value ? VisibilityState.Visible : VisibilityState.Hidden),
 	});
 
@@ -122,7 +122,7 @@ export class HeaderComponent {
 		});
 	}
 
-	onMenuTogglerClicked() {
+	protected onMenuTogglerClicked() {
 		this.displayMenu.set(!this.displayMenu());
 	}
 }

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -5,10 +5,11 @@ import { InternalLink } from '@models/link.model';
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { HEADER_HEIGHT_STRING_PX } from '@utils/spacing.utils';
 
-enum VisibilityState {
-	Visible = 'visible',
-	Hidden = 'hidden',
-}
+const VisibilityState = Object.freeze({
+	Visible: 'visible',
+	Hidden: 'hidden',
+} as const);
+type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 
 @Component({
 	selector: 'cuentoneta-header',

--- a/src/app/components/image-profile/image-profile.component.stories.ts
+++ b/src/app/components/image-profile/image-profile.component.stories.ts
@@ -13,6 +13,9 @@ const meta: Meta<ImageProfileComponent> = {
 	title: 'Componentes/ImageProfile',
 	parameters: {
 		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
 			description: {
 				component: `<div>
 					<p>El componente **ImageProfileComponent** es la foto de perfil circular del Design System v3, usada para

--- a/src/app/components/image-profile/image-profile.component.ts
+++ b/src/app/components/image-profile/image-profile.component.ts
@@ -40,10 +40,10 @@ const PROFILE_PLACEHOLDER = './assets/svg/profile-placeholder.svg';
 })
 export class ImageProfileComponent {
 	// Inputs
-	readonly src = input<string>();
-	readonly alt = input<string>('');
-	readonly size = input<ImageProfileSize>('medium');
-	readonly variant = input<ImageProfileVariant>('profile');
+	public readonly src = input<string>();
+	public readonly alt = input<string>('');
+	public readonly size = input<ImageProfileSize>('medium');
+	public readonly variant = input<ImageProfileVariant>('profile');
 
 	// Tamaño del círculo (px) y clases de Tailwind del círculo y del ícono interno, por tamaño.
 	private readonly sizeMap: Record<ImageProfileSize, { px: number; circle: string; icon: string }> = {
@@ -54,7 +54,7 @@ export class ImageProfileComponent {
 	};
 
 	// Estado de render efectivo: única fuente de verdad de "qué se dibuja", derivada de variant + src.
-	readonly renderMode = computed<RenderMode>(() => {
+	private readonly renderMode = computed<RenderMode>(() => {
 		if (this.variant() === 'collection') {
 			return 'collection';
 		}
@@ -62,7 +62,7 @@ export class ImageProfileComponent {
 	});
 
 	// Descriptor único por estado: centraliza url, tamaño, clases de la imagen y fondo del círculo.
-	readonly view = computed(() => {
+	protected readonly view = computed(() => {
 		const { px, icon } = this.sizeMap[this.size()];
 		switch (this.renderMode()) {
 			case 'collection':
@@ -80,7 +80,7 @@ export class ImageProfileComponent {
 		}
 	});
 
-	readonly containerClasses = computed(() => {
+	protected readonly containerClasses = computed(() => {
 		const { circle } = this.sizeMap[this.size()];
 		return `relative inline-flex items-center justify-center overflow-hidden rounded-full ${circle} ${this.view().background}`;
 	});

--- a/src/app/components/latest-stories-card-deck/latest-stories-card-deck.ts
+++ b/src/app/components/latest-stories-card-deck/latest-stories-card-deck.ts
@@ -39,5 +39,5 @@ import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LatestStoriesCardDeck {
-	readonly stories = input<StoryNavigationTeaserWithAuthor[]>([]);
+	public readonly stories = input<StoryNavigationTeaserWithAuthor[]>([]);
 }

--- a/src/app/components/media-resource-tag/media-resource-tag.component.ts
+++ b/src/app/components/media-resource-tag/media-resource-tag.component.ts
@@ -21,12 +21,12 @@ export interface MediaResourcePlatform {
 	</div>`,
 })
 export class MediaResourceTagComponent {
-	readonly platform = input.required<MediaResourcePlatform>();
-	readonly size = input<'md' | 'lg'>('md');
-	readonly iconSize = computed(() => (this.size() === 'md' ? '32px' : '24px'));
-	readonly sizeClasses = computed(() => (this.size() === 'md' ? 'h-6 w-6' : 'h-8 w-8'));
+	public readonly platform = input.required<MediaResourcePlatform>();
+	public readonly size = input<'md' | 'lg'>('md');
+	protected readonly iconSize = computed(() => (this.size() === 'md' ? '32px' : '24px'));
+	protected readonly sizeClasses = computed(() => (this.size() === 'md' ? 'h-6 w-6' : 'h-8 w-8'));
 
-	readonly iconName = computed(() => {
+	protected readonly iconName = computed(() => {
 		const icon = this.platform().icon;
 		return Object.keys(icon)[0]; // Get the key name
 	});

--- a/src/app/components/media-resource-tag/media-resource-tag.component.ts
+++ b/src/app/components/media-resource-tag/media-resource-tag.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, OnInit } from '@angular/core';
+import { Component, computed, effect, inject, input } from '@angular/core';
 import { TooltipDirective } from '../../directives/tooltip.directive';
 import { NgIcon } from '@ng-icons/core';
 
@@ -20,7 +20,7 @@ export interface MediaResourcePlatform {
 		/>
 	</div>`,
 })
-export class MediaResourceTagComponent implements OnInit {
+export class MediaResourceTagComponent {
 	readonly platform = input.required<MediaResourcePlatform>();
 	readonly size = input<'md' | 'lg'>('md');
 	readonly iconSize = computed(() => (this.size() === 'md' ? '32px' : '24px'));
@@ -33,8 +33,8 @@ export class MediaResourceTagComponent implements OnInit {
 
 	private tooltipDirective = inject(TooltipDirective);
 
-	ngOnInit() {
+	private readonly syncTooltipEffect = effect(() => {
 		this.tooltipDirective.text.set(this.platform().title);
 		this.tooltipDirective.position.set('bottom');
-	}
+	});
 }

--- a/src/app/components/media-resource-tags/media-resource-tags.component.ts
+++ b/src/app/components/media-resource-tags/media-resource-tags.component.ts
@@ -21,23 +21,23 @@ import { NgComponentOutlet } from '@angular/common';
 	}`,
 })
 export class MediaResourceTagsComponent {
-	readonly resources = input<Media[]>([]);
-	readonly size = input<'md' | 'lg'>('md');
-	readonly MediaResourceTagComponent = MediaResourceTagComponent;
+	public readonly resources = input<Media[]>([]);
+	public readonly size = input<'md' | 'lg'>('md');
+	protected readonly MediaResourceTagComponent = MediaResourceTagComponent;
 
 	private injector = inject(EnvironmentInjector);
 
 	// We use a custom injector for the nav items to load ng-icons on demand using lazy loading
 	// By providing the icon definitions in navigation.config.ts we're able to directly load the icons
 	// that are rendered on the sidebar
-	readonly parsedResources = computed(() =>
+	protected readonly parsedResources = computed(() =>
 		this.resources().map((resource) => ({
 			...resource,
 			injector: createEnvironmentInjector([provideIcons(this.platforms[resource.type].icon)], this.injector),
 		})),
 	);
 
-	readonly platforms: { [key in MediaTypeKey]: MediaResourcePlatform } = {
+	protected readonly platforms: { [key in MediaTypeKey]: MediaResourcePlatform } = {
 		audioRecording: {
 			title: 'Contiene narraciones en audio',
 			icon: { faSolidFileAudio },

--- a/src/app/components/media-resource/media-resource.component.ts
+++ b/src/app/components/media-resource/media-resource.component.ts
@@ -30,7 +30,7 @@ const MEDIA_WIDGET_MAP: Record<MediaTypeKey, Type<MediaTypeWidgetComponents>> = 
 	},
 })
 export class MediaResourceComponent {
-	readonly mediaResources = input.required({
+	public readonly mediaResources = input.required({
 		transform: (media: Media[]) => media.map((m) => this.mediaTypesAdapter(m)),
 	});
 

--- a/src/app/components/most-read-stories-card-deck/most-read-stories-card-deck.component.ts
+++ b/src/app/components/most-read-stories-card-deck/most-read-stories-card-deck.component.ts
@@ -39,5 +39,5 @@ import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MostReadStoriesCardDeckComponent {
-	readonly stories = input<StoryNavigationTeaserWithAuthor[]>([]);
+	public readonly stories = input<StoryNavigationTeaserWithAuthor[]>([]);
 }

--- a/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
+++ b/src/app/components/navigable-story-teaser/navigable-story-teaser.component.ts
@@ -45,8 +45,8 @@ import { RouterLink } from '@angular/router';
 	`,
 })
 export class NavigableStoryTeaserComponent {
-	readonly story = input.required<StoryNavigationTeaser>();
-	readonly selected = input<boolean>();
-	readonly authorSlug = input.required<string>();
+	public readonly story = input.required<StoryNavigationTeaser>();
+	public readonly selected = input<boolean>();
+	public readonly authorSlug = input.required<string>();
 	protected readonly appRoutes = AppRoutes;
 }

--- a/src/app/components/navigable-storylist-story-teaser/navigable-storylist-story-teaser.component.ts
+++ b/src/app/components/navigable-storylist-story-teaser/navigable-storylist-story-teaser.component.ts
@@ -44,8 +44,8 @@ import { StorylistStoriesNavigationTeasers } from '@models/storylist.model';
 	`,
 })
 export class NavigableStorylistStoryTeaserComponent {
-	readonly story = input.required<StoryNavigationTeaserWithAuthor>();
-	readonly selected = input<boolean>();
-	readonly storylist = input.required<StorylistStoriesNavigationTeasers>();
+	public readonly story = input.required<StoryNavigationTeaserWithAuthor>();
+	public readonly selected = input<boolean>();
+	public readonly storylist = input.required<StorylistStoriesNavigationTeasers>();
 	protected readonly appRoutes = AppRoutes;
 }

--- a/src/app/components/portable-text-parser/portable-text-parser.component.stories.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.stories.ts
@@ -4,6 +4,13 @@ import { PortableTextParserComponent } from './portable-text-parser.component';
 const meta: Meta<PortableTextParserComponent> = {
 	component: PortableTextParserComponent,
 	title: 'PortableTextParserComponent',
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+		},
+	},
 };
 export default meta;
 

--- a/src/app/components/portable-text-parser/portable-text-parser.component.ts
+++ b/src/app/components/portable-text-parser/portable-text-parser.component.ts
@@ -40,10 +40,10 @@ interface ParagraphGroup {
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PortableTextParserComponent {
-	readonly paragraphs = input.required<TextBlockContent[]>();
-	readonly classes = input<string>('classes');
+	public readonly paragraphs = input.required<TextBlockContent[]>();
+	public readonly classes = input<string>('classes');
 
-	readonly groups = computed(() => {
+	protected readonly groups = computed(() => {
 		let currentGroupIndex = 0;
 		const groups: ParagraphGroup[] = [];
 

--- a/src/app/components/resource/resource.component.ts
+++ b/src/app/components/resource/resource.component.ts
@@ -42,8 +42,8 @@ import { NgComponentOutlet } from '@angular/common';
 	},
 })
 export class ResourceComponent {
-	readonly resource = input.required<Resource>();
-	readonly icon = computed(() => {
+	public readonly resource = input.required<Resource>();
+	protected readonly icon = computed(() => {
 		if (!this.resource()?.resourceType?.slug) {
 			return null;
 		}
@@ -58,7 +58,7 @@ export class ResourceComponent {
 		};
 	});
 
-	readonly NgIcon = NgIcon;
+	protected readonly NgIcon = NgIcon;
 
 	private injector = inject(EnvironmentInjector);
 	private tooltipDirective = inject(TooltipDirective);

--- a/src/app/components/resource/resource.component.ts
+++ b/src/app/components/resource/resource.component.ts
@@ -3,10 +3,10 @@ import {
 	Component,
 	computed,
 	createEnvironmentInjector,
+	effect,
 	EnvironmentInjector,
 	inject,
 	input,
-	OnInit,
 } from '@angular/core';
 
 // Models
@@ -41,7 +41,7 @@ import { NgComponentOutlet } from '@angular/common';
 		class: 'flex items-center justify-center',
 	},
 })
-export class ResourceComponent implements OnInit {
+export class ResourceComponent {
 	readonly resource = input.required<Resource>();
 	readonly icon = computed(() => {
 		if (!this.resource()?.resourceType?.slug) {
@@ -63,8 +63,8 @@ export class ResourceComponent implements OnInit {
 	private injector = inject(EnvironmentInjector);
 	private tooltipDirective = inject(TooltipDirective);
 
-	ngOnInit() {
+	private readonly syncTooltipEffect = effect(() => {
 		this.tooltipDirective.text.set(this.resource().title);
 		this.tooltipDirective.position.set('bottom');
-	}
+	});
 }

--- a/src/app/components/share-button/share-button.component.spec.ts
+++ b/src/app/components/share-button/share-button.component.spec.ts
@@ -5,11 +5,11 @@ import { storyMock } from '../../mocks/story.mock';
 import { faBrandFacebook } from '@ng-icons/font-awesome/brands';
 
 class MockSharingPlatform implements SharingPlatform {
-	name = 'MySpace';
-	icon = { faBrandFacebook };
-	platformApiUrl = `https://www.facebook.com/share.php`;
+	public name = 'MySpace';
+	public icon = { faBrandFacebook };
+	public platformApiUrl = `https://www.facebook.com/share.php`;
 
-	generateSharingUrl(appRoute: string, urlParams: string): string {
+	public generateSharingUrl(appRoute: string, urlParams: string): string {
 		const url = encodeURIComponent(`http://localhost:4200/${appRoute}?${urlParams}`);
 		return `${this.platformApiUrl}?u=${url}`;
 	}

--- a/src/app/components/share-button/share-button.component.ts
+++ b/src/app/components/share-button/share-button.component.ts
@@ -30,12 +30,12 @@ import { NgComponentOutlet } from '@angular/common';
 	}`,
 })
 export class ShareButtonComponent {
-	readonly platform = input.required<SharingPlatform>();
-	readonly params = input<{ [key: string]: string }>({});
-	readonly message = input<string>('');
-	readonly route = input<string>('');
+	public readonly platform = input.required<SharingPlatform>();
+	public readonly params = input<{ [key: string]: string }>({});
+	public readonly message = input<string>('');
+	public readonly route = input<string>('');
 
-	readonly NgIcon = NgIcon;
+	protected readonly NgIcon = NgIcon;
 
 	private tooltipDirective = inject(TooltipDirective);
 	private injector = inject(EnvironmentInjector);
@@ -45,7 +45,7 @@ export class ShareButtonComponent {
 		this.tooltipDirective.position.set('bottom');
 	});
 
-	readonly icon = computed(() => {
+	protected readonly icon = computed(() => {
 		const platform = this.platform();
 
 		if (!platform) {
@@ -58,7 +58,7 @@ export class ShareButtonComponent {
 		};
 	});
 
-	onShareToPlatformClicked(event: MouseEvent | KeyboardEvent, platform: SharingPlatform) {
+	protected onShareToPlatformClicked(event: MouseEvent | KeyboardEvent, platform: SharingPlatform) {
 		const urlParams = Object.keys(this.params())
 			.map((key) => `${key}=${this.params()[key]}`)
 			.join('&');

--- a/src/app/components/share-button/share-button.component.ts
+++ b/src/app/components/share-button/share-button.component.ts
@@ -2,10 +2,10 @@ import {
 	Component,
 	computed,
 	createEnvironmentInjector,
+	effect,
 	EnvironmentInjector,
 	inject,
 	input,
-	OnInit,
 } from '@angular/core';
 import { SharingPlatform } from '@models/sharing-platform';
 import { TooltipDirective } from '../../directives/tooltip.directive';
@@ -29,7 +29,7 @@ import { NgComponentOutlet } from '@angular/common';
 		</button>
 	}`,
 })
-export class ShareButtonComponent implements OnInit {
+export class ShareButtonComponent {
 	readonly platform = input.required<SharingPlatform>();
 	readonly params = input<{ [key: string]: string }>({});
 	readonly message = input<string>('');
@@ -39,6 +39,11 @@ export class ShareButtonComponent implements OnInit {
 
 	private tooltipDirective = inject(TooltipDirective);
 	private injector = inject(EnvironmentInjector);
+
+	private readonly syncTooltipEffect = effect(() => {
+		this.tooltipDirective.text.set('Compartir en ' + this.platform().name);
+		this.tooltipDirective.position.set('bottom');
+	});
 
 	readonly icon = computed(() => {
 		const platform = this.platform();
@@ -62,10 +67,5 @@ export class ShareButtonComponent implements OnInit {
 			platform.target,
 			platform.features,
 		);
-	}
-
-	ngOnInit() {
-		this.tooltipDirective.text.set('Compartir en ' + this.platform().name);
-		this.tooltipDirective.position.set('bottom');
 	}
 }

--- a/src/app/components/share-content/share-content.component.ts
+++ b/src/app/components/share-content/share-content.component.ts
@@ -23,11 +23,11 @@ import { FacebookPlatform, SharingPlatform, TwitterPlatform, WhatsappPlatform } 
 	`,
 })
 export class ShareContentComponent {
-	readonly route = input<string>('');
-	readonly params = input<{ [key: string]: string }>({});
-	readonly message = input<string>('');
+	public readonly route = input<string>('');
+	public readonly params = input<{ [key: string]: string }>({});
+	public readonly message = input<string>('');
 
-	platforms: SharingPlatform[] = [
+	protected platforms: SharingPlatform[] = [
 		new FacebookPlatform(),
 		new WhatsappPlatform(),
 		new TwitterPlatform(),

--- a/src/app/components/space-recording-widget/space-recording-widget.component.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.component.ts
@@ -75,5 +75,5 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SpaceRecordingWidgetComponent {
-	readonly media = input.required<SpaceRecording>();
+	public readonly media = input.required<SpaceRecording>();
 }

--- a/src/app/components/space-recording-widget/space-recording-widget.stories.ts
+++ b/src/app/components/space-recording-widget/space-recording-widget.stories.ts
@@ -11,6 +11,13 @@ const meta: Meta<SpaceRecordingWidgetComponent> = {
 			imports: [CommonModule, NgOptimizedImage],
 		}),
 	],
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+		},
+	},
 	argTypes: {
 		media: {
 			description: 'Space recording media object containing Twitter/X Space data with metadata',

--- a/src/app/components/spotify-audio-widget/spotify-podcast-episode-widget.stories.ts
+++ b/src/app/components/spotify-audio-widget/spotify-podcast-episode-widget.stories.ts
@@ -5,6 +5,13 @@ import { spotifyPodcastEpisodeMock } from '@mocks/spotify-podcast-episode.mock';
 const meta: Meta<SpotifyPodcastEpisodeWidget> = {
 	title: 'Widgets/SpotifyPodcastEpisode',
 	component: SpotifyPodcastEpisodeWidget,
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+		},
+	},
 	argTypes: {
 		media: {
 			description: 'Spotify podcast episode media object containing title, description, and Spotify embed URL',

--- a/src/app/components/spotify-audio-widget/spotify-podcast-episode-widget.ts
+++ b/src/app/components/spotify-audio-widget/spotify-podcast-episode-widget.ts
@@ -30,10 +30,10 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SpotifyPodcastEpisodeWidget {
-	readonly media = input.required<SpotifyPodcastEpisode>();
+	public readonly media = input.required<SpotifyPodcastEpisode>();
 	private readonly sanitizer = inject(DomSanitizer);
 
-	readonly mediaUrl = computed((): SafeResourceUrl => {
+	protected readonly mediaUrl = computed((): SafeResourceUrl => {
 		const spotifyUrl = this.media().data.url;
 		// Transformar URL a formato embedded en caso de que sea necesario
 		// e.g., https://open.spotify.com/episode/xxx -> https://open.spotify.com/embed/episode/xxx

--- a/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser-skeleton.component.ts
@@ -115,11 +115,11 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 })
 export class StoryCardTeaserSkeletonComponent {
 	// Inputs
-	readonly order = input<number>();
-	readonly showAuthor = input<boolean>(false);
-	readonly showExcerpt = input<boolean>(false);
-	readonly excerptLines = input<number>(3);
+	public readonly order = input<number>();
+	public readonly showAuthor = input<boolean>(false);
+	public readonly showExcerpt = input<boolean>(false);
+	public readonly excerptLines = input<number>(3);
 
 	// Usado de auxiliar para iterar a través de la cantidad de líneas del extracto de texto
-	readonly excerptArrayLines = computed(() => Array(this.excerptLines()).fill(0));
+	protected readonly excerptArrayLines = computed(() => Array(this.excerptLines()).fill(0));
 }

--- a/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
@@ -20,6 +20,9 @@ const meta: Meta<StoryCardTeaserComponent> = {
 	],
 	parameters: {
 		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
 			description: {
 				component: `<div>
 					<p>El componente **StoryCardTeaserComponent** representa una vista previa de una entidad story del sistema. El componente posee inputs opcionales que permiten visualizar:</p>

--- a/src/app/components/story-card-teaser/story-card-teaser.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.ts
@@ -13,7 +13,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 		@if (story(); as story) {
 			<article class="flex gap-4">
 				@if (order()) {
-					<span class="source-serif-2-5xl font-bold leading-none text-brand-500">{{ formattedOrder() }}.</span>
+					<span class="source-serif-2-5xl leading-none font-bold text-brand-500">{{ formattedOrder() }}.</span>
 				}
 				<div class="flex flex-1 flex-col">
 					@if (showAuthor() && 'author' in story) {
@@ -42,7 +42,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 								[paragraphs]="story.paragraphs"
 								[class]="'line-clamp-' + excerptLines()"
 								data-testid="portable-text-parser"
-								class="source-serif-xl min-h-18 relative text-ellipsis text-justify font-normal"
+								class="source-serif-xl relative min-h-18 text-justify font-normal text-ellipsis"
 							/>
 						}
 						<footer class="flex gap-1 font-inter text-xs text-neutral-500">
@@ -70,13 +70,13 @@ export class StoryCardTeaserComponent {
 	protected readonly appRoutes = AppRoutes;
 
 	// Inputs
-	readonly story = input<StoryNavigationTeaserWithAuthor | StoryTeaserWithAuthor | StoryTeaser>();
-	readonly order = input<number>();
-	readonly showAuthor = input<boolean>(false);
-	readonly showExcerpt = input<boolean>(false);
-	readonly excerptLines = input<number>(3);
-	readonly navigationParams = input<{ navigation: string; navigationSlug: string }>();
-	readonly authorImageUrl = computed(() => {
+	public readonly story = input<StoryNavigationTeaserWithAuthor | StoryTeaserWithAuthor | StoryTeaser>();
+	public readonly order = input<number>();
+	public readonly showAuthor = input<boolean>(false);
+	public readonly showExcerpt = input<boolean>(false);
+	public readonly excerptLines = input<number>(3);
+	public readonly navigationParams = input<{ navigation: string; navigationSlug: string }>();
+	protected readonly authorImageUrl = computed(() => {
 		const story = this.story();
 		if (story && 'author' in story) {
 			return `${story.author.imageUrl}?h=64&w=64`;
@@ -85,7 +85,7 @@ export class StoryCardTeaserComponent {
 	});
 
 	// Propiedades
-	readonly formattedOrder = computed(() => {
+	protected readonly formattedOrder = computed(() => {
 		const order = this.order();
 		return order && order >= 10 ? order : `0${order}`;
 	});

--- a/src/app/components/story-edition-date-label/story-edition-date-label.component.ts
+++ b/src/app/components/story-edition-date-label/story-edition-date-label.component.ts
@@ -24,6 +24,6 @@ import { Component, input } from '@angular/core';
 	`,
 })
 export class StoryEditionDateLabelComponent {
-	readonly label = input<string>();
-	readonly markAsNew = input<boolean>(false);
+	public readonly label = input<string>();
+	public readonly markAsNew = input<boolean>(false);
 }

--- a/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
+++ b/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
@@ -23,6 +23,9 @@ const meta: Meta<StoryMediaSelectorsComponent> = {
 	title: 'Componentes/StoryMediaSelectors',
 	parameters: {
 		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
 			description: {
 				component: `<div>
 					<p>El componente **StoryMediaSelectorsComponent** renderiza los selectores de los recursos multimedia

--- a/src/app/components/story-media-selectors/story-media-selectors.component.ts
+++ b/src/app/components/story-media-selectors/story-media-selectors.component.ts
@@ -79,12 +79,12 @@ interface MediaSelectorItem {
 })
 export class StoryMediaSelectorsComponent {
 	// Inputs
-	readonly media = input<Media[]>([]);
-	readonly orientation = input<'horizontal' | 'vertical'>('horizontal');
-	readonly theme = input<StoryMediaSelectorsTheme>('subtle');
-	readonly selectable = input<boolean>(false);
+	public readonly media = input<Media[]>([]);
+	public readonly orientation = input<'horizontal' | 'vertical'>('horizontal');
+	public readonly theme = input<StoryMediaSelectorsTheme>('subtle');
+	public readonly selectable = input<boolean>(false);
 
-	readonly selected = output<Media>();
+	public readonly selected = output<Media>();
 
 	// Mapeo de cada tipo de media del dominio a su ícono y etiqueta accesible.
 	private readonly mediaPlatforms: Record<MediaTypeKey, { iconName: string; label: string }> = {
@@ -94,7 +94,7 @@ export class StoryMediaSelectorsComponent {
 		audioRecording: { iconName: 'faSolidFileAudio', label: 'Audio' },
 	};
 
-	readonly selectors = computed<MediaSelectorItem[]>(() => {
+	protected readonly selectors = computed<MediaSelectorItem[]>(() => {
 		const media = this.media();
 		if (this.selectable()) {
 			return media.map((item) => ({ ...this.mediaPlatforms[item.type], count: 1, media: item }));
@@ -106,7 +106,7 @@ export class StoryMediaSelectorsComponent {
 		return [...counts.entries()].map(([type, count]) => ({ ...this.mediaPlatforms[type], count }));
 	});
 
-	readonly containerClasses = computed(() =>
+	protected readonly containerClasses = computed(() =>
 		this.orientation() === 'vertical' ? 'flex flex-col items-center gap-2.5' : 'flex items-center gap-2.5',
 	);
 
@@ -114,7 +114,7 @@ export class StoryMediaSelectorsComponent {
 	private readonly selectorBaseClasses = 'relative flex items-center justify-center rounded-lg px-2.5 py-2';
 
 	// Estilos del recuadro de cada selector: clases base + las propias del tema.
-	readonly selectorClasses = computed(() => {
+	protected readonly selectorClasses = computed(() => {
 		const theme = (() => {
 			switch (this.theme()) {
 				case 'solid':
@@ -130,12 +130,12 @@ export class StoryMediaSelectorsComponent {
 
 	// Nombre accesible del selector: incluye el conteo cuando se agrupan varios recursos de la
 	// misma plataforma, de modo que el badge visual pueda marcarse como decorativo (aria-hidden).
-	ariaLabel(selector: MediaSelectorItem): string {
+	protected ariaLabel(selector: MediaSelectorItem): string {
 		return selector.count > 1 ? `${selector.label} (${selector.count})` : selector.label;
 	}
 
 	// Estilos del contador (badge) que se superpone al selector según el tema.
-	readonly badgeClasses = computed(() => {
+	protected readonly badgeClasses = computed(() => {
 		switch (this.theme()) {
 			case 'solid':
 				return 'border-2 border-neutral-100 bg-white';

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -57,21 +57,21 @@ import { NavigationFrameComponent } from '@models/navigation-frame.component';
 	imports: [CommonModule, NgxSkeletonLoaderModule, RouterLink],
 })
 export class StoryNavigationBarComponent {
-	readonly selectedStorySlug = input<string>();
-	readonly navigation = input.required<'author' | 'storylist'>();
-	readonly navigationSlug = input.required<string>();
+	public readonly selectedStorySlug = input<string>();
+	public readonly navigation = input.required<'author' | 'storylist'>();
+	public readonly navigationSlug = input.required<string>();
 
 	// Inyección de providers
 	private navigationFrameService = inject(NavigationFrameService);
 
-	readonly frame = computed(() => {
+	protected readonly frame = computed(() => {
 		const storySlug = this.selectedStorySlug() ?? '';
 		const navigation = this.navigation();
 
 		return this.setNavigationFrame(storySlug, navigation);
 	});
 
-	frameConfig = this.navigationFrameService.navigationBarConfig;
+	protected frameConfig = this.navigationFrameService.navigationBarConfig;
 
 	private setNavigationFrame(
 		storySlug: string,

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
@@ -49,7 +49,7 @@ export type NavigationBarConfig = {
 })
 export class StorylistNavigationFrameComponent extends NavigationFrameComponent {
 	// Routes
-	readonly appRoutes = AppRoutes;
+	private readonly appRoutes = AppRoutes;
 
 	// Providers
 	private storylistService = inject(StorylistApi);
@@ -62,9 +62,9 @@ export class StorylistNavigationFrameComponent extends NavigationFrameComponent 
 	});
 
 	// Propiedades
-	displayedStories: StoryNavigationTeaserWithAuthor[] = [];
-	dummyList: null[] = Array(9);
-	readonly storylist = computed(() => this.storylistResource.value());
+	protected displayedStories: StoryNavigationTeaserWithAuthor[] = [];
+	protected dummyList: null[] = Array(9);
+	protected readonly storylist = computed(() => this.storylistResource.value());
 
 	constructor() {
 		super();
@@ -93,7 +93,7 @@ export class StorylistNavigationFrameComponent extends NavigationFrameComponent 
 	 * caso de que la story actualmente en vista sea una de las primeras o de las últimas.
 	 * @author Ramiro Olivencia <ramiro@olivencia.com.ar>
 	 */
-	sliceDisplayedStories(stories: StoryNavigationTeaserWithAuthor[]): void {
+	private sliceDisplayedStories(stories: StoryNavigationTeaserWithAuthor[]): void {
 		if (!this.storylist) {
 			return;
 		}

--- a/src/app/components/tabs/tab.component.ts
+++ b/src/app/components/tabs/tab.component.ts
@@ -10,7 +10,7 @@ import { ChangeDetectionStrategy, Component, input, TemplateRef, viewChild } fro
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class Tab {
-	readonly title = input.required<string>();
-	readonly name = input.required<string>();
-	readonly content = viewChild.required(TemplateRef);
+	public readonly title = input.required<string>();
+	public readonly name = input.required<string>();
+	public readonly content = viewChild.required(TemplateRef);
 }

--- a/src/app/components/tabs/tabs.component.spec.ts
+++ b/src/app/components/tabs/tabs.component.spec.ts
@@ -22,7 +22,7 @@ import Tabs from './tabs.component';
 	`,
 })
 class TestHostComponent {
-	initialActiveTab = 'tab1';
+	public initialActiveTab = 'tab1';
 }
 
 describe('TabsComponent', () => {

--- a/src/app/components/tabs/tabs.component.stories.ts
+++ b/src/app/components/tabs/tabs.component.stories.ts
@@ -12,6 +12,11 @@ const meta: Meta<TabsComponent> = {
 	],
 	parameters: {
 		layout: 'centered',
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+		},
 	},
 	tags: ['autodocs'],
 	argTypes: {

--- a/src/app/components/tabs/tabs.component.ts
+++ b/src/app/components/tabs/tabs.component.ts
@@ -33,9 +33,9 @@ import { NgTemplateOutlet } from '@angular/common';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class Tabs {
-	readonly initialTab = input<string>();
-	readonly tabs = contentChildren(Tab);
-	readonly active = linkedSignal({
+	public readonly initialTab = input<string>();
+	public readonly tabs = contentChildren(Tab);
+	protected readonly active = linkedSignal({
 		source: this.tabs,
 		computation: (tabs) => {
 			if (tabs.length === 0) {
@@ -57,7 +57,7 @@ export default class Tabs {
 		},
 	});
 
-	setActive(tab: Tab) {
+	protected setActive(tab: Tab) {
 		this.active.set(tab);
 	}
 }

--- a/src/app/components/tag/tag.component.stories.ts
+++ b/src/app/components/tag/tag.component.stories.ts
@@ -7,6 +7,9 @@ const meta: Meta<TagComponent> = {
 	title: 'Componentes/Tag',
 	parameters: {
 		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
 			description: {
 				component: `<div>
 					<p>El componente **TagComponent** es la etiqueta (tag) del Design System v3. Reemplaza progresivamente

--- a/src/app/components/tag/tag.component.ts
+++ b/src/app/components/tag/tag.component.ts
@@ -23,8 +23,8 @@ export type TagVariant = 'soft' | 'filled' | 'gray';
 })
 export class TagComponent {
 	// Inputs
-	readonly label = input.required<string>();
-	readonly variant = input<TagVariant>('soft');
+	public readonly label = input.required<string>();
+	public readonly variant = input<TagVariant>('soft');
 
 	// Clases (chrome + tipografía) por variante. Las dimensiones/colores salen de tokens del DS v3.
 	private readonly variantClasses: Record<TagVariant, string> = {
@@ -33,7 +33,7 @@ export class TagComponent {
 		gray: 'rounded-sm bg-neutral-950-40 px-1.5 py-1 text-xxs text-neutral-50',
 	};
 
-	readonly hostClasses = computed(
+	protected readonly hostClasses = computed(
 		() => `inline-flex items-center font-inter font-bold whitespace-nowrap ${this.variantClasses[this.variant()]}`,
 	);
 }

--- a/src/app/components/tags-list/tags-list.component.stories.ts
+++ b/src/app/components/tags-list/tags-list.component.stories.ts
@@ -33,6 +33,9 @@ const meta: Meta<Args> = {
 	decorators: [moduleMetadata({ imports: [TagComponent] })],
 	parameters: {
 		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
 			description: {
 				component: `<div>
 					<p>El componente **TagsListComponent** recibe los tags por <strong>content projection</strong>

--- a/src/app/components/tags-list/tags-overflow.directive.ts
+++ b/src/app/components/tags-list/tags-overflow.directive.ts
@@ -30,7 +30,7 @@ const FULLY_VISIBLE_RATIO = 0.99;
 @Directive({})
 export class TagsOverflowDirective {
 	/** Tope duro opcional de tags visibles; sin valor, el único límite es el ancho. */
-	readonly maxVisible = input<number>();
+	public readonly maxVisible = input<number>();
 
 	private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
 	private readonly renderer = inject(Renderer2);
@@ -44,7 +44,7 @@ export class TagsOverflowDirective {
 	private readonly ready = signal(false);
 
 	/** Cantidad de tags visibles: prefijo que entra, acotado por `maxVisible`. */
-	readonly visibleCount = computed(() => {
+	public readonly visibleCount = computed(() => {
 		const overflowing = this.overflowing();
 		const cap = this.maxVisible() ?? Infinity;
 		let count = 0;
@@ -58,10 +58,10 @@ export class TagsOverflowDirective {
 	});
 
 	/** Cantidad de tags colapsados detrás del contador "+N". */
-	readonly hiddenCount = computed(() => Math.max(0, this.items().length - this.visibleCount()));
+	public readonly hiddenCount = computed(() => Math.max(0, this.items().length - this.visibleCount()));
 
 	/** El host informa el ancho (px) a reservar a la derecha para el contador "+N". */
-	reserveTrailingSpace(px: number): void {
+	public reserveTrailingSpace(px: number): void {
 		this.reservedSpace.set(px);
 	}
 

--- a/src/app/components/youtube-video-widget/youtube-video-widget.component.ts
+++ b/src/app/components/youtube-video-widget/youtube-video-widget.component.ts
@@ -31,5 +31,5 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 	`,
 })
 export class YoutubeVideoWidgetComponent {
-	readonly media = input.required<YouTubeVideo>();
+	public readonly media = input.required<YouTubeVideo>();
 }

--- a/src/app/components/youtube-video-widget/youtube-video-widget.stories.ts
+++ b/src/app/components/youtube-video-widget/youtube-video-widget.stories.ts
@@ -5,6 +5,13 @@ import { youtubeVideoMock } from '@mocks/youtube-video.mock';
 const meta: Meta<YoutubeVideoWidgetComponent> = {
 	title: 'Widgets/YoutubeVideo',
 	component: YoutubeVideoWidgetComponent,
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+		},
+	},
 	argTypes: {
 		media: {
 			description: 'YouTube video media object containing title, description, and video ID',

--- a/src/app/directives/meta-tags.directive.ts
+++ b/src/app/directives/meta-tags.directive.ts
@@ -12,7 +12,7 @@ export class MetaTagsDirective implements OnDestroy {
 	private platformId = inject(PLATFORM_ID);
 	private titleService = inject(Title);
 
-	setTitle(title: string, addPrefix: boolean = true) {
+	public setTitle(title: string, addPrefix: boolean = true) {
 		const platformTitle = isPlatformBrowser(this.platformId) && addPrefix ? `${title} | La Cuentoneta` : title;
 		this.titleService.setTitle(`${platformTitle}`);
 		this.metaTagService.updateTag({
@@ -26,7 +26,7 @@ export class MetaTagsDirective implements OnDestroy {
 		});
 	}
 
-	setDescription(content: string) {
+	public setDescription(content: string) {
 		this.metaTagService.updateTag({
 			name: 'description',
 			content: content,
@@ -41,7 +41,7 @@ export class MetaTagsDirective implements OnDestroy {
 		});
 	}
 
-	setKeywords(keywords: string | string[]) {
+	public setKeywords(keywords: string | string[]) {
 		const keywordsString = Array.isArray(keywords) ? keywords.join(', ') : keywords;
 		this.metaTagService.updateTag({
 			name: 'keywords',
@@ -49,25 +49,25 @@ export class MetaTagsDirective implements OnDestroy {
 		});
 	}
 
-	removeKeywords() {
+	public removeKeywords() {
 		this.metaTagService.removeTag('name="keywords"');
 	}
 
-	setDefault() {
+	public setDefault() {
 		this.setTitle('La Cuentoneta', false);
 		this.setDefaultDescription();
 		this.setDefaultKeywords();
 	}
 
-	setDefaultDescription() {
+	public setDefaultDescription() {
 		this.setDescription('Una iniciativa que busca fomentar y hacer accesible la lectura digital.');
 	}
 
-	setDefaultKeywords() {
+	public setDefaultKeywords() {
 		this.setKeywords(['cuentos', 'literatura', 'poemas', 'podcast', 'narraciones']);
 	}
 
-	setCanonicalUrl(url: string) {
+	public setCanonicalUrl(url: string) {
 		const head = this.document.getElementsByTagName('head')[0];
 		let element: HTMLLinkElement | null = this.document.querySelector(`link[rel='canonical']`) || null;
 		if (!element) {
@@ -78,7 +78,7 @@ export class MetaTagsDirective implements OnDestroy {
 		element.setAttribute('href', url);
 	}
 
-	removeCanonicalUrl() {
+	public removeCanonicalUrl() {
 		const element = this.document.querySelector(`link[rel='canonical']`);
 		if (element) {
 			element.remove();
@@ -90,7 +90,9 @@ export class MetaTagsDirective implements OnDestroy {
 	// buscadores y answer engines. Coincide con el fallback estático de indexFile.html.
 	private readonly indexableRobots = 'index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1';
 
-	setRobots(content: 'index, follow' | 'noindex, nofollow' | 'index, nofollow' | 'noindex, follow' | 'all' | 'none') {
+	public setRobots(
+		content: 'index, follow' | 'noindex, nofollow' | 'index, nofollow' | 'noindex, follow' | 'all' | 'none',
+	) {
 		const value = content === 'index, follow' || content === 'all' ? this.indexableRobots : content;
 		this.metaTagService.updateTag({
 			name: 'robots',
@@ -98,11 +100,11 @@ export class MetaTagsDirective implements OnDestroy {
 		});
 	}
 
-	removeRobots() {
+	public removeRobots() {
 		this.metaTagService.removeTag('name="robots"');
 	}
 
-	ngOnDestroy() {
+	public ngOnDestroy() {
 		this.removeKeywords();
 		this.removeCanonicalUrl();
 		this.removeRobots();

--- a/src/app/directives/portable-text-parser/portable-text-parser.directive.spec.ts
+++ b/src/app/directives/portable-text-parser/portable-text-parser.directive.spec.ts
@@ -13,8 +13,8 @@ import { PortableTextDirective } from './portable-text-parser.directive';
 	</article>`,
 })
 class TestComponent {
-	readonly content = signal(authorMock.biography);
-	readonly classes = signal('test-class');
+	public readonly content = signal(authorMock.biography);
+	public readonly classes = signal('test-class');
 }
 
 describe('PortableTextDirective', () => {

--- a/src/app/directives/portable-text-parser/portable-text-parser.directive.ts
+++ b/src/app/directives/portable-text-parser/portable-text-parser.directive.ts
@@ -9,8 +9,8 @@ export class PortableTextDirective {
 	private el = inject(ElementRef);
 	private renderer = inject(Renderer2);
 
-	readonly portableText = input.required<TextBlockContent>();
-	readonly classes = input<string>('');
+	public readonly portableText = input.required<TextBlockContent>();
+	public readonly classes = input<string>('');
 
 	constructor() {
 		effect(() => {

--- a/src/app/directives/tooltip.directive.spec.ts
+++ b/src/app/directives/tooltip.directive.spec.ts
@@ -17,8 +17,8 @@ const ELEMENT_HEIGHT = 500;
 	hostDirectives: [TooltipDirective],
 })
 class HostComponent {
-	width = ELEMENT_WIDTH;
-	height = ELEMENT_HEIGHT;
+	protected width = ELEMENT_WIDTH;
+	protected height = ELEMENT_HEIGHT;
 	private tooltipDirective = inject(TooltipDirective);
 
 	constructor() {

--- a/src/app/directives/tooltip.directive.spec.ts
+++ b/src/app/directives/tooltip.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { render, screen } from '@testing-library/angular';
 import { TooltipDirective } from './tooltip.directive';
 import userEvent from '@testing-library/user-event';
@@ -16,12 +16,12 @@ const ELEMENT_HEIGHT = 500;
 	imports: [TooltipDirective],
 	hostDirectives: [TooltipDirective],
 })
-class HostComponent implements OnInit {
+class HostComponent {
 	width = ELEMENT_WIDTH;
 	height = ELEMENT_HEIGHT;
 	private tooltipDirective = inject(TooltipDirective);
 
-	ngOnInit() {
+	constructor() {
 		this.tooltipDirective.text.set('Tooltip test');
 		this.tooltipDirective.position.set('bottom');
 	}

--- a/src/app/directives/tooltip.directive.ts
+++ b/src/app/directives/tooltip.directive.ts
@@ -8,24 +8,24 @@ type TooltipPosition = 'top' | 'right' | 'bottom' | 'left';
 	standalone: true,
 })
 export class TooltipDirective implements OnDestroy {
-	readonly text = signal<string>(''); // Texto para el Tooltip
-	readonly position = signal<TooltipPosition>('top'); // Posición del tooltip
-	readonly offset = signal<number>(6); // Offset del tooltip respecto al elemento
+	public readonly text = signal<string>(''); // Texto para el Tooltip
+	public readonly position = signal<TooltipPosition>('top'); // Posición del tooltip
+	public readonly offset = signal<number>(6); // Offset del tooltip respecto al elemento
 
 	private myPopup: HTMLElement | null = null;
 	private readonly el = inject(ElementRef);
 
-	ngOnDestroy(): void {
+	public ngOnDestroy(): void {
 		if (this.myPopup) {
 			this.myPopup.remove();
 		}
 	}
 
-	@HostListener('mouseenter') onMouseEnter() {
+	@HostListener('mouseenter') public onMouseEnter() {
 		this.createTooltipPopup();
 	}
 
-	@HostListener('mouseleave') onMouseLeave() {
+	@HostListener('mouseleave') public onMouseLeave() {
 		if (this.myPopup) {
 			this.myPopup.remove();
 		}

--- a/src/app/models/navigation-frame.component.ts
+++ b/src/app/models/navigation-frame.component.ts
@@ -15,9 +15,9 @@ export abstract class NavigationFrameComponent {
 	private navigationFrameService = inject(NavigationFrameService);
 
 	// Inputs
-	readonly selectedStorySlug = input<string>();
-	readonly navigationSlug = input<string>();
-	readonly config = signal<NavigationBarConfig>(this.navigationFrameService.navigationBarConfig());
+	public readonly selectedStorySlug = input<string>();
+	public readonly navigationSlug = input<string>();
+	protected readonly config = signal<NavigationBarConfig>(this.navigationFrameService.navigationBarConfig());
 
 	protected constructor() {
 		effect(() => {

--- a/src/app/models/sharing-platform.ts
+++ b/src/app/models/sharing-platform.ts
@@ -11,26 +11,26 @@ export interface SharingPlatform {
 }
 
 export class FacebookPlatform implements SharingPlatform {
-	name = 'Facebook';
-	icon = { faBrandFacebook };
-	platformApiUrl = `https://www.facebook.com/share.php`;
-	target = 'facebook-share-dialog';
-	features = 'width=626,height=436';
+	public name = 'Facebook';
+	public icon = { faBrandFacebook };
+	public platformApiUrl = `https://www.facebook.com/share.php`;
+	public target = 'facebook-share-dialog';
+	public features = 'width=626,height=436';
 
-	generateSharingUrl(appRoute: string, urlParams: string): string {
+	public generateSharingUrl(appRoute: string, urlParams: string): string {
 		const url = encodeURIComponent(`${environment.website}${appRoute}?${urlParams}`);
 		return `${this.platformApiUrl}?u=${url}`;
 	}
 }
 
 export class WhatsappPlatform implements SharingPlatform {
-	name = 'Whatsapp';
-	icon = { faBrandWhatsapp };
-	platformApiUrl = `whatsapp://send/`;
-	target = '_blank';
-	features = '';
+	public name = 'Whatsapp';
+	public icon = { faBrandWhatsapp };
+	public platformApiUrl = `whatsapp://send/`;
+	public target = '_blank';
+	public features = '';
 
-	generateSharingUrl(appRoute: string, urlParams: string, message: string): string {
+	public generateSharingUrl(appRoute: string, urlParams: string, message: string): string {
 		const sharedUrl = encodeURIComponent(`${environment.website}${appRoute}?${urlParams}`);
 		const queryParams: { [key: string]: string } = {
 			text: `${message}%0a%0a${sharedUrl}`,
@@ -42,13 +42,13 @@ export class WhatsappPlatform implements SharingPlatform {
 }
 
 export class TwitterPlatform implements SharingPlatform {
-	name = 'Twitter';
-	icon = { faBrandXTwitter };
-	platformApiUrl = `https://twitter.com/intent/tweet`;
-	target = '_blank';
-	features = '';
+	public name = 'Twitter';
+	public icon = { faBrandXTwitter };
+	public platformApiUrl = `https://twitter.com/intent/tweet`;
+	public target = '_blank';
+	public features = '';
 
-	generateSharingUrl(appRoute: string, urlParams: string, message: string): string {
+	public generateSharingUrl(appRoute: string, urlParams: string, message: string): string {
 		const queryParams: { [key: string]: string } = {
 			url: encodeURIComponent(`${environment.website}${appRoute}?${urlParams}`),
 			text: message + '%0a%0a',

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -14,7 +14,7 @@ import { ContributorApi } from '../../providers/contributor-api.interface';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class AboutComponent {
-	readonly links = {
+	protected readonly links = {
 		CONTRIBUTING: 'https://github.com/rolivencia/cuentoneta/blob/master/CONTRIBUTING.md',
 		GITHUB_REPO: 'https://github.com/rolivencia/cuentoneta',
 		FACEBOOK: 'https://facebook.com/cuentoneta',
@@ -29,12 +29,12 @@ export default class AboutComponent {
 	private metaTagsDirective = inject(MetaTagsDirective);
 	private contributorService = inject(ContributorApi);
 
-	readonly contributorsResource = rxResource({
+	private readonly contributorsResource = rxResource({
 		stream: () => this.contributorService.getAllByArea(),
 		defaultValue: [],
 	});
 
-	readonly contributorsPerArea = computed(() => this.contributorsResource.value());
+	protected readonly contributorsPerArea = computed(() => this.contributorsResource.value());
 
 	constructor() {
 		this.updateMetaTags();

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -210,8 +210,8 @@ export default class AuthorComponent {
 	private readonly appRoutes = AppRoutes;
 
 	// Route inputs
-	readonly slug = input.required<string>();
-	readonly activeTab = input<'stories' | 'about'>('stories');
+	public readonly slug = input.required<string>();
+	public readonly activeTab = input<'stories' | 'about'>('stories');
 
 	// Providers
 	private authorService = inject(AuthorApi);
@@ -222,7 +222,7 @@ export default class AuthorComponent {
 	private metaTagsDirective = inject(MetaTagsDirective);
 
 	// Recursos
-	readonly authorResource = rxResource({
+	protected readonly authorResource = rxResource({
 		params: this.slug,
 		stream: ({ params }) =>
 			this.author$(params).pipe(
@@ -232,19 +232,19 @@ export default class AuthorComponent {
 			),
 		defaultValue: undefined,
 	});
-	readonly storiesResource = rxResource({
+	protected readonly storiesResource = rxResource({
 		params: this.slug,
 		stream: ({ params }) => this.stories$(params),
 		defaultValue: [],
 	});
 
 	// Propiedades
-	readonly author = computed(() => this.authorResource.value());
-	readonly stories = computed(() => this.storiesResource.value());
-	readonly authorImageUrl = computed(() =>
+	protected readonly author = computed(() => this.authorResource.value());
+	protected readonly stories = computed(() => this.storiesResource.value());
+	protected readonly authorImageUrl = computed(() =>
 		this.author()?.imageUrl ? `${this.author()?.imageUrl}?auto=format` : 'assets/img/default-avatar.jpg',
 	);
-	readonly authorFlagUrl = computed(() => `${this.author()?.nationality.flag}?auto=format`);
+	protected readonly authorFlagUrl = computed(() => `${this.author()?.nationality.flag}?auto=format`);
 
 	private updateMetaTags(author: Author) {
 		this.metaTagsDirective.setTitle(`${author.name}`);

--- a/src/app/pages/authors/authors.component.ts
+++ b/src/app/pages/authors/authors.component.ts
@@ -31,7 +31,7 @@ export default class AuthorsComponent {
 		defaultValue: [],
 	});
 
-	readonly authors = computed(() => this.authorsResource.value());
+	protected readonly authors = computed(() => this.authorsResource.value());
 
 	constructor() {
 		this.updateMetaTags();

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -35,6 +35,6 @@ describe.skip('HomeComponent', () => {
 	template: '',
 })
 class MockStorylistCardDeckComponent {
-	readonly storylist = input<Storylist>();
-	readonly isLoading = input<boolean>(false);
+	public readonly storylist = input<Storylist>();
+	public readonly isLoading = input<boolean>(false);
 }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -38,17 +38,17 @@ export default class HomeComponent {
 	private metaTagsDirective = inject(MetaTagsDirective);
 
 	// Recursos
-	readonly landingPageResource = rxResource({
+	private readonly landingPageResource = rxResource({
 		stream: () => this.contentService.getLandingPageContent(),
 		defaultValue: undefined,
 	});
 
 	// Propiedades
-	readonly landingPageContent = computed(() => this.landingPageResource.value());
-	readonly collections = computed(() => this.landingPageContent()?.cards || []);
-	readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
-	readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
-	readonly latestReads = computed(() => this.landingPageContent()?.latestReads.slice(0, 6) || []);
+	private readonly landingPageContent = computed(() => this.landingPageResource.value());
+	protected readonly collections = computed(() => this.landingPageContent()?.cards || []);
+	protected readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
+	protected readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
+	protected readonly latestReads = computed(() => this.landingPageContent()?.latestReads.slice(0, 6) || []);
 
 	constructor() {
 		this.updateMetaTags();

--- a/src/app/pages/stories/stories.component.ts
+++ b/src/app/pages/stories/stories.component.ts
@@ -79,12 +79,12 @@ export default class StoriesComponent {
 	private metaTagsDirective = inject(MetaTagsDirective);
 
 	// TODO: Implementar tamaño de página variable
-	readonly storiesResource = rxResource({
+	private readonly storiesResource = rxResource({
 		stream: () => this.storyService.get(0, 2000),
 		defaultValue: [],
 	});
 
-	readonly stories = computed(() => this.storiesResource.value());
+	protected readonly stories = computed(() => this.storiesResource.value());
 
 	constructor() {
 		this.updateMetaTags();

--- a/src/app/pages/story/story.component.spec.ts
+++ b/src/app/pages/story/story.component.spec.ts
@@ -49,10 +49,10 @@ describe('StoryComponent', () => {
 	template: '',
 })
 class MockShareContentComponent {
-	readonly route = input('');
-	readonly params = input<{ [key: string]: string }>({});
-	readonly message = input('');
-	readonly isLoading = input(false);
+	public readonly route = input('');
+	public readonly params = input<{ [key: string]: string }>({});
+	public readonly message = input('');
+	public readonly isLoading = input(false);
 }
 
 @Component({
@@ -61,7 +61,7 @@ class MockShareContentComponent {
 	template: '',
 })
 class MockBioSummaryCardComponent {
-	readonly story = input.required<Story>();
+	public readonly story = input.required<Story>();
 }
 
 @Component({
@@ -70,6 +70,6 @@ class MockBioSummaryCardComponent {
 	template: '',
 })
 class MockStoryNavigationBarComponent {
-	readonly selectedStorySlug = input('');
-	readonly storylist = input<Storylist>();
+	public readonly selectedStorySlug = input('');
+	public readonly storylist = input<Storylist>();
 }

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -74,12 +74,12 @@ import { faSolidArrowRightLong } from '@ng-icons/font-awesome/solid';
 })
 export default class StoryComponent {
 	// Routes
-	readonly appRoutes = AppRoutes;
+	protected readonly appRoutes = AppRoutes;
 
 	// Providers
-	readonly slug = input.required<string>();
-	readonly navigation = input<'author' | 'storylist'>('author');
-	readonly navigationSlug = input<string>();
+	public readonly slug = input.required<string>();
+	public readonly navigation = input<'author' | 'storylist'>('author');
+	public readonly navigationSlug = input<string>();
 
 	private storyService = inject(StoryApi);
 	private layoutService = inject(LayoutService);
@@ -87,8 +87,8 @@ export default class StoryComponent {
 	private isHeaderVisible$ = inject(LayoutService).isHeaderVisible$.pipe(takeUntilDestroyed());
 
 	// Recursos
-	readonly dummyList = Array(10);
-	readonly storyResource = rxResource({
+	protected readonly dummyList = Array(10);
+	private readonly storyResource = rxResource({
 		params: this.slug,
 		stream: ({ params }) =>
 			this.storyService.getBySlug(params).pipe(
@@ -100,17 +100,17 @@ export default class StoryComponent {
 	});
 
 	// Propiedades
-	readonly story = computed(() => this.storyResource.value());
-	readonly sharingRoute = computed(() => `${AppRoutes.Story}/${this.story()?.slug}`);
-	readonly shareContentParams = computed(() => ({
+	protected readonly story = computed(() => this.storyResource.value());
+	protected readonly sharingRoute = computed(() => `${AppRoutes.Story}/${this.story()?.slug}`);
+	protected readonly shareContentParams = computed(() => ({
 		navigationSlug: this.story()?.author.slug ?? '',
 		navigation: this.navigation() ?? 'author',
 	}));
-	readonly shareMessage = computed(
+	protected readonly shareMessage = computed(
 		() =>
 			`Leí "${this.story()?.title}" de ${this.story()?.author.name} en La Cuentoneta y te lo comparto. Sumate a leer este y otros cuentos en este link:`,
 	);
-	readonly navigationParams = computed(() => {
+	protected readonly navigationParams = computed(() => {
 		const navigation = this.navigation() ?? 'author';
 		let navigationSlug = this.navigationSlug();
 
@@ -120,7 +120,7 @@ export default class StoryComponent {
 
 		return { navigation, navigationSlug };
 	});
-	readonly headerPosition = signal('top-header-height');
+	protected readonly headerPosition = signal('top-header-height');
 
 	constructor() {
 		this.isHeaderVisible$.subscribe((isVisible) => {

--- a/src/app/pages/storylist/storylist-title/storylist-title.ts
+++ b/src/app/pages/storylist/storylist-title/storylist-title.ts
@@ -28,5 +28,5 @@ import { StorylistTitleSkeleton } from './storylist-title-skeleton';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StorylistTitle {
-	readonly storylist = input<Storylist>();
+	public readonly storylist = input<Storylist>();
 }

--- a/src/app/pages/storylist/storylist.component.spec.ts
+++ b/src/app/pages/storylist/storylist.component.spec.ts
@@ -43,6 +43,6 @@ describe.skip('StorylistComponent', () => {
 	template: '',
 })
 class MockStorylistCardDeckComponent {
-	readonly storyList = input<Storylist>();
-	readonly isLoading = input(false);
+	public readonly storyList = input<Storylist>();
+	public readonly isLoading = input(false);
 }

--- a/src/app/pages/storylist/storylist.component.ts
+++ b/src/app/pages/storylist/storylist.component.ts
@@ -51,15 +51,15 @@ import { MediaResourceComponent } from '@components/media-resource/media-resourc
 })
 export default class StorylistComponent {
 	// Route inputs
-	readonly slug = input.required<string>();
-	readonly activeTab = input<'stories' | 'about' | string>('stories');
+	public readonly slug = input.required<string>();
+	public readonly activeTab = input<'stories' | 'about' | string>('stories');
 
 	// Providers
 	private metaTagsDirective = inject(MetaTagsDirective);
 	private storylistService = inject(StorylistApi);
 
 	// Recursos
-	readonly storylistResource = rxResource({
+	protected readonly storylistResource = rxResource({
 		params: this.slug,
 		stream: ({ params }) =>
 			this.storylistService.get(params, 60, 'asc').pipe(
@@ -72,16 +72,16 @@ export default class StorylistComponent {
 
 	// Propiedades
 	// TODO: Implementar uso de imagen alusiva/tapa de libro en la ficha técnica
-	readonly featuredImageUrl = computed(
+	private readonly featuredImageUrl = computed(
 		() => `${this.storylistResource.value()?.featuredImage}?h=${256 * 1.5}&w=${192 * 1.5}&auto=format`,
 	);
 	// TODO: Simplificar estructura de tipo Storylist para evitar estas transformaciones
-	readonly stories = computed(() => this.storylistResource.value()?.stories.map((story) => story) || []);
+	protected readonly stories = computed(() => this.storylistResource.value()?.stories.map((story) => story) || []);
 
 	// Computed properties for tabs and media
-	readonly tabs = computed(() => this.storylistResource.value()?.tabs || []);
-	readonly media = computed(() => this.storylistResource.value()?.media || []);
-	readonly hasMedia = computed(() => this.media().length > 0);
+	protected readonly tabs = computed(() => this.storylistResource.value()?.tabs || []);
+	protected readonly media = computed(() => this.storylistResource.value()?.media || []);
+	protected readonly hasMedia = computed(() => this.media().length > 0);
 
 	private updateMetaTags(storylist: Storylist) {
 		this.metaTagsDirective.setTitle(`${storylist.title}`);

--- a/src/app/pipes/bypass-html-sanitizer.pipe.ts
+++ b/src/app/pipes/bypass-html-sanitizer.pipe.ts
@@ -5,7 +5,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 export class BypassHtmlSanitizerPipe implements PipeTransform {
 	private readonly sanitizer = inject(DomSanitizer);
 
-	transform(html: string): SafeHtml {
+	public transform(html: string): SafeHtml {
 		return this.sanitizer.bypassSecurityTrustHtml(html);
 	}
 }

--- a/src/app/pipes/initials.pipe.ts
+++ b/src/app/pipes/initials.pipe.ts
@@ -5,7 +5,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 	standalone: true,
 })
 export class InitialsPipe implements PipeTransform {
-	transform(name: string): string {
+	public transform(name: string): string {
 		if (!name) return '';
 
 		if (name.length <= 22) {

--- a/src/app/pipes/repeat.pipe.ts
+++ b/src/app/pipes/repeat.pipe.ts
@@ -5,7 +5,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 	standalone: true,
 })
 export class RepeatPipe implements PipeTransform {
-	transform(value: number): number[] {
+	public transform(value: number): number[] {
 		return Array(value).fill(0);
 	}
 }

--- a/src/app/providers/analytics/analytics.mock.service.ts
+++ b/src/app/providers/analytics/analytics.mock.service.ts
@@ -6,5 +6,5 @@ import { AnalyticsService } from './analytics.service';
 })
 export class AnalyticsMockService extends AnalyticsService {
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	async init() {}
+	public async init() {}
 }

--- a/src/app/providers/analytics/analytics.service.ts
+++ b/src/app/providers/analytics/analytics.service.ts
@@ -5,7 +5,7 @@ import { environment } from '../../environments/environment';
 	providedIn: 'root',
 })
 export class AnalyticsService {
-	async init() {
+	public async init() {
 		if (!environment.clarityProjectId) {
 			return;
 		}

--- a/src/app/providers/author.mock.ts
+++ b/src/app/providers/author.mock.ts
@@ -12,7 +12,7 @@ export class InMemoryAuthorApi implements AuthorApi {
 		return of([authorTeaserMock]);
 	}
 
-	public getBySlug(_slug: string): Observable<Author> {
+	public getBySlug(): Observable<Author> {
 		return of(authorMock);
 	}
 }

--- a/src/app/providers/endpoints.ts
+++ b/src/app/providers/endpoints.ts
@@ -1,8 +1,9 @@
-export enum Endpoints {
-	Author = 'api/author',
-	Story = 'api/story',
-	StoryList = 'api/storylist',
-	Contributor = 'api/contributor',
-}
+export const Endpoints = Object.freeze({
+	Author: 'api/author',
+	Story: 'api/story',
+	StoryList: 'api/storylist',
+	Contributor: 'api/contributor',
+} as const);
+export type Endpoints = (typeof Endpoints)[keyof typeof Endpoints];
 
 export type ApiUrl = `${string}${Endpoints}`;

--- a/src/app/providers/layout.service.ts
+++ b/src/app/providers/layout.service.ts
@@ -49,15 +49,15 @@ export class LayoutService {
 		fromEvent(this.window, 'orientationchange').pipe(startWith(null)),
 	).pipe(takeUntilDestroyed(), throttleTime(100));
 
-	get userHasScrolled$() {
+	public get userHasScrolled$() {
 		return this._userHasScrolled$;
 	}
 
-	get viewportHasChanged$() {
+	public get viewportHasChanged$() {
 		return this._viewportHasChanged$;
 	}
 
-	get isHeaderVisible$() {
+	public get isHeaderVisible$() {
 		return combineLatest([this.viewportHasChanged$, this.userHasScrolled$]).pipe(
 			map(([hasChanged, direction]) => {
 				if (hasChanged) {
@@ -79,15 +79,15 @@ export class LayoutService {
 	 * Se usan estos wrappers en vez de las implementaciones nativas
 	 * a fin de permitir evaluar casos de pruebas unitarias variadas.
 	 */
-	isPlatformBrowser() {
+	public isPlatformBrowser() {
 		return isPlatformBrowser(this.platformId);
 	}
 
-	isPlatformServer() {
+	public isPlatformServer() {
 		return isPlatformServer(this.platformId);
 	}
 
-	setViewport() {
+	public setViewport() {
 		// Para SSR, siempre devolver md dado que no se puede acceder a window
 		if (this.isPlatformServer()) {
 			this.viewport.set('md');
@@ -114,7 +114,7 @@ export class LayoutService {
 	 * @param viewport
 	 * @param test
 	 */
-	biggerThan(test: Viewport): boolean {
+	public biggerThan(test: Viewport): boolean {
 		const currentWidth = VIEWPORT_WIDTHS_NUMERIC[this.viewport()];
 		const testWidth = VIEWPORT_WIDTHS_NUMERIC[test];
 
@@ -130,7 +130,7 @@ export class LayoutService {
 	 * @param viewport
 	 * @param test
 	 */
-	smallerThan(test: Viewport): boolean {
+	public smallerThan(test: Viewport): boolean {
 		const currentWidth = VIEWPORT_WIDTHS_NUMERIC[this.viewport()];
 		const testWidth = VIEWPORT_WIDTHS_NUMERIC[test];
 
@@ -141,7 +141,7 @@ export class LayoutService {
 		return currentWidth < testWidth;
 	}
 
-	isActual(test: Viewport): boolean {
+	public isActual(test: Viewport): boolean {
 		const currentWidth = VIEWPORT_WIDTHS_NUMERIC[this.viewport()];
 		const testWidth = VIEWPORT_WIDTHS_NUMERIC[test];
 

--- a/src/app/providers/navigation-frame.service.ts
+++ b/src/app/providers/navigation-frame.service.ts
@@ -5,14 +5,14 @@ import { NavigationBarConfig } from '../components/storylist-navigation-frame/st
 	providedIn: 'root',
 })
 export class NavigationFrameService {
-	readonly navigationBarConfig = signal<NavigationBarConfig>({
+	public readonly navigationBarConfig = signal<NavigationBarConfig>({
 		headerTitle: '',
 		footerTitle: '',
 		navigationRoute: '',
 		showFooter: false,
 	});
 
-	setNavigationBarConfig(config: NavigationBarConfig) {
+	public setNavigationBarConfig(config: NavigationBarConfig) {
 		this.navigationBarConfig.set(config);
 	}
 }

--- a/src/app/providers/story.mock.ts
+++ b/src/app/providers/story.mock.ts
@@ -8,23 +8,19 @@ import { storyMock, storyNavigationTeaserMock, storyTeaserMock, storyTeaserWithA
 import { StoryApi } from './story-api.interface';
 
 export class InMemoryStoryApi implements StoryApi {
-	public getBySlug(_slug: string): Observable<Story> {
+	public getBySlug(): Observable<Story> {
 		return of(storyMock);
 	}
 
-	public getByAuthorSlug(_slug: string, _offset?: number, _limit?: number): Observable<StoryTeaser[]> {
+	public getByAuthorSlug(): Observable<StoryTeaser[]> {
 		return of([storyTeaserMock]);
 	}
 
-	public getNavigationTeasersByAuthorSlug(
-		_slug: string,
-		_offset?: number,
-		_limit?: number,
-	): Observable<StoryNavigationTeaser[]> {
+	public getNavigationTeasersByAuthorSlug(): Observable<StoryNavigationTeaser[]> {
 		return of([storyNavigationTeaserMock]);
 	}
 
-	public get(_offset?: number, _limit?: number): Observable<StoryTeaserWithAuthor[]> {
+	public get(): Observable<StoryTeaserWithAuthor[]> {
 		return of([storyTeaserWithAuthorMock]);
 	}
 }

--- a/src/app/providers/storylist.mock.ts
+++ b/src/app/providers/storylist.mock.ts
@@ -8,15 +8,11 @@ import { storylistMock, storylistNavigationTeaserMock } from '@mocks/storylist.m
 import { StorylistApi } from './storylist-api.interface';
 
 export class InMemoryStorylistApi implements StorylistApi {
-	public get(_slug: string, _amount?: number, _ordering?: 'asc' | 'desc'): Observable<Storylist> {
+	public get(): Observable<Storylist> {
 		return of(storylistMock);
 	}
 
-	public getStorylistNavigationTeasers(
-		_slug: string,
-		_limit?: number,
-		_offset?: number,
-	): Observable<StorylistStoriesNavigationTeasers> {
+	public getStorylistNavigationTeasers(): Observable<StorylistStoriesNavigationTeasers> {
 		return of(storylistNavigationTeaserMock);
 	}
 }

--- a/src/app/testing/intersection-observer.stub.ts
+++ b/src/app/testing/intersection-observer.stub.ts
@@ -12,16 +12,16 @@ class IntersectionObserverStub {
 		callback = cb;
 		options = init;
 	}
-	observe(): void {
+	public observe(): void {
 		return;
 	}
-	unobserve(): void {
+	public unobserve(): void {
 		return;
 	}
-	disconnect(): void {
+	public disconnect(): void {
 		return;
 	}
-	takeRecords(): IntersectionObserverEntry[] {
+	public takeRecords(): IntersectionObserverEntry[] {
 		return [];
 	}
 }

--- a/tools/eslint/require-environment-providers.js
+++ b/tools/eslint/require-environment-providers.js
@@ -1,0 +1,76 @@
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Require exported provider functions in *.provider.ts and *.mock.ts files to use makeEnvironmentProviders',
+		},
+		schema: [],
+		messages: {
+			missingMakeEnvironmentProviders:
+				'Exported provider function "{{ name }}" must return EnvironmentProviders via makeEnvironmentProviders(). Do not return Provider[] directly.',
+		},
+	},
+	create(context) {
+		const filename = context.filename ?? context.getFilename();
+		const isProviderFile = filename.endsWith('.provider.ts');
+		const isMockFile = filename.endsWith('.mock.ts');
+
+		if (!isProviderFile && !isMockFile) {
+			return {};
+		}
+
+		function containsMakeEnvironmentProviders(node) {
+			if (!node) return false;
+			if (node.type === 'CallExpression') {
+				const callee = node.callee;
+				if (callee.type === 'Identifier' && callee.name === 'makeEnvironmentProviders') {
+					return true;
+				}
+			}
+			if (node.type === 'BlockStatement') {
+				return node.body.some((stmt) => containsMakeEnvironmentProviders(stmt));
+			}
+			if (node.type === 'ReturnStatement') {
+				return containsMakeEnvironmentProviders(node.argument);
+			}
+			return false;
+		}
+
+		function isProviderFunction(name) {
+			return name.startsWith('provide');
+		}
+
+		function checkFunction(node, name) {
+			if (!isProviderFunction(name)) return;
+			const body = node.body;
+			if (!body) return;
+			if (!containsMakeEnvironmentProviders(body)) {
+				context.report({
+					node,
+					messageId: 'missingMakeEnvironmentProviders',
+					data: { name },
+				});
+			}
+		}
+
+		return {
+			// export function provideX() { ... }
+			'ExportNamedDeclaration > FunctionDeclaration'(node) {
+				if (node.id) {
+					checkFunction(node, node.id.name);
+				}
+			},
+			// export const provideX = () => ...
+			'ExportNamedDeclaration > VariableDeclaration > VariableDeclarator'(node) {
+				if (
+					node.id.type === 'Identifier' &&
+					(node.init?.type === 'ArrowFunctionExpression' || node.init?.type === 'FunctionExpression')
+				) {
+					checkFunction(node.init, node.id.name);
+				}
+			},
+		};
+	},
+};

--- a/tools/eslint/storybook-source-state.js
+++ b/tools/eslint/storybook-source-state.js
@@ -1,0 +1,105 @@
+/**
+ * Require every Storybook `*.stories.ts` default-export meta to set
+ * parameters.docs.canvas.sourceState = 'shown'.
+ *
+ * Showing source by default keeps the docs canvas useful for consumers
+ * who want a runnable snippet alongside the rendered story.
+ */
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: "Require parameters.docs.canvas.sourceState: 'shown' in every Storybook meta",
+		},
+		schema: [],
+		messages: {
+			missingParameters:
+				"Storybook meta is missing `parameters`. Add `parameters: { docs: { canvas: { sourceState: 'shown' } } }`.",
+			missingDocs: "Storybook meta is missing `parameters.docs`. Add `docs: { canvas: { sourceState: 'shown' } }`.",
+			missingCanvas: "Storybook meta is missing `parameters.docs.canvas`. Add `canvas: { sourceState: 'shown' }`.",
+			missingSourceState: "Storybook meta is missing `parameters.docs.canvas.sourceState: 'shown'`.",
+			wrongSourceState: "Storybook meta sets `parameters.docs.canvas.sourceState` to {{ value }} — must be 'shown'.",
+		},
+	},
+	create(context) {
+		const filename = context.filename ?? context.getFilename();
+		if (!filename.endsWith('.stories.ts')) return {};
+
+		function findProperty(objectExpression, key) {
+			if (!objectExpression || objectExpression.type !== 'ObjectExpression') return undefined;
+			return objectExpression.properties.find(
+				(prop) =>
+					prop.type === 'Property' && !prop.computed && prop.key && (prop.key.name === key || prop.key.value === key),
+			);
+		}
+
+		function resolveToObjectExpression(node, scope) {
+			if (!node) return undefined;
+			if (node.type === 'ObjectExpression') return node;
+			if (node.type === 'Identifier' && scope) {
+				// Cross-module imports (e.g. `import meta from './meta.config'; export default meta`) are
+				// not resolved — the ImportBinding has no `init` value in the local file, so this returns
+				// undefined and the rule silently skips. Skipping is safer than false-positives.
+				const variable = scope.references.find((ref) => ref.identifier === node)?.resolved;
+				const definition = variable?.defs?.[0];
+				const init = definition?.node?.init;
+				if (init && init.type === 'ObjectExpression') return init;
+			}
+			return undefined;
+		}
+
+		// Each nested value below is checked for `type === 'ObjectExpression'` before recursing.
+		// A non-ObjectExpression value (e.g. a spread, a function call, a variable reference) is
+		// skipped silently to avoid false-positives on dynamically-built parameters. The trade-off
+		// is that those constructions also escape enforcement; see PLAN.md Risk #2.
+		function checkMeta(meta, reportNode) {
+			const parameters = findProperty(meta, 'parameters');
+			if (!parameters) {
+				context.report({ node: reportNode, messageId: 'missingParameters' });
+				return;
+			}
+			const parametersValue = parameters.value;
+			if (parametersValue.type !== 'ObjectExpression') return;
+
+			const docs = findProperty(parametersValue, 'docs');
+			if (!docs) {
+				context.report({ node: parameters, messageId: 'missingDocs' });
+				return;
+			}
+			const docsValue = docs.value;
+			if (docsValue.type !== 'ObjectExpression') return;
+
+			const canvas = findProperty(docsValue, 'canvas');
+			if (!canvas) {
+				context.report({ node: docs, messageId: 'missingCanvas' });
+				return;
+			}
+			const canvasValue = canvas.value;
+			if (canvasValue.type !== 'ObjectExpression') return;
+
+			const sourceState = findProperty(canvasValue, 'sourceState');
+			if (!sourceState) {
+				context.report({ node: canvas, messageId: 'missingSourceState' });
+				return;
+			}
+			const valueNode = sourceState.value;
+			if (valueNode.type === 'Literal' && valueNode.value !== 'shown') {
+				context.report({
+					node: sourceState,
+					messageId: 'wrongSourceState',
+					data: { value: JSON.stringify(valueNode.value) },
+				});
+			}
+		}
+
+		return {
+			ExportDefaultDeclaration(node) {
+				const scope = context.sourceCode?.getScope?.(node) ?? context.getScope?.();
+				const meta = resolveToObjectExpression(node.declaration, scope);
+				if (!meta) return;
+				checkMeta(meta, node);
+			},
+		};
+	},
+};

--- a/tools/eslint/tsconfig.json
+++ b/tools/eslint/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": false,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"module": "esnext",
+		"moduleResolution": "bundler"
+	},
+	"include": ["**/*.js"]
+}


### PR DESCRIPTION
Closes #1500 · Parte de #1498

## Descripción

Adopta el enforcement de **ESLint estilo ResetShop** para las reglas de Angular/TS que cuentoneta documentaba pero no forzaba. Depende de #1494 (Vitest) y #1499 (API providers) — ambos mergeados.

## Reglas activadas

- **`@typescript-eslint/explicit-member-accessibility`** (`accessibility: explicit`, `constructors: no-public`) — visibilidad explícita en cada miembro de clase.
- **`no-restricted-syntax`** ampliado (commonRestrictedSyntax): prohíbe `enum` (`TSEnumDeclaration`), lifecycle hooks (`OnInit`/`OnChanges`/`DoCheck`/`AfterContent*`/`AfterView*`) y propiedades estáticas.
- **`@typescript-eslint/no-unused-vars`** estricto (sin ignore de `^_`).
- **Reglas custom** en `tools/eslint/` (no `tools/eslint-rules/`, reservado por Nx): `require-environment-providers` (sobre `*.provider.ts`/`*.mock.ts`) y `storybook-source-state` (sobre `*.stories.ts`).
- `eslint.config.js` → **`eslint.config.mjs`** (+ refs en `nx.json`).

## Violaciones corregidas (~334)

| Categoría | Cantidad | Fix |
| --- | --- | --- |
| `explicit-member-accessibility` | ~292 (72 archivos) | `public`/`protected`/`private` por miembro según `angular-components.md` |
| `enum` → `Object.freeze` | 3 | `endpoints.ts`, `app.routes.ts`, `header.component.ts` |
| lifecycle (`ngOnInit`) | 6 | → `effect()`/constructor: app, badge, media-resource-tag, resource, share-button, host de tooltip.spec |
| `no-unused-vars` | 18 | params sin usar en `InMemory*Api`, content.service, carousel-gesture.spec |
| `storybook-source-state` | 16 stories | `parameters.docs.canvas.sourceState: 'shown'` |
| `require-environment-providers` | 0 | los providers de #1499 ya cumplen |
| propiedades estáticas | 0 | — |

## Commits

1. `[#1500] - Enforcement ESLint (sin member-accessibility)` — reglas + reglas custom + `.mjs` + fixes de enum/lifecycle/no-unused/storybook.
2. `[#1500] - Habilita explicit-member-accessibility y clasifica la visibilidad` — la regla + ~292 clasificaciones de visibilidad.

## Fuera de alcance

`@nx/enforce-module-boundaries`, `form-field-allowed-content` (N/A), y el guard de `process.env` (decisión: no adoptarlo en cuentoneta).

## Verificación local (CI)

| Gate | Resultado |
| --- | --- |
| `nx lint` | ✅ verde (todas las reglas nuevas) |
| `nx test` | ✅ verde |
| `nx build:production` | ✅ verde (AOT valida que ningún miembro de plantilla quedara `private`) |
| `nx build-storybook` | ✅ verde |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
