### PR TITLE
[#1523] - Contenido indexable en la home: sección Sobre La Cuentoneta

### DIFF
--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -11,4 +11,8 @@ test('home: único H1 de contenido y marca en el header', async ({ page }) => {
 	// La marca sigue presente en el header y el <title> SEO contiene la marca.
 	await expect(page.locator('header').getByText('La Cuentoneta').first()).toBeVisible();
 	await expect(page).toHaveTitle(/La Cuentoneta/);
+
+	// La home expone contenido indexable: la sección "Sobre La Cuentoneta" con texto sustantivo.
+	await expect(page.getByRole('heading', { name: /Sobre La Cuentoneta/i })).toBeVisible();
+	await expect(page.getByText(/proyecto abierto, comunitario y sin fines de lucro/i)).toBeVisible();
 });

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -34,18 +34,21 @@
         Intro descriptiva con texto sustantivo y citable, server-rendered (sin @defer), para que
         buscadores y answer engines tengan contenido indexable más allá de las imágenes del hero.
     -->
-	<section class="mb-8">
-		<h2 class="h2 mb-5 text-neutral-600">Sobre <em>La Cuentoneta</em></h2>
-		<p class="font-inter text-base font-normal">
-			La Cuentoneta es un proyecto abierto, comunitario y sin fines de lucro que busca fomentar y hacer accesible la
-			lectura digital. Publicamos cuentos, poemas y relatos breves organizados en
-			<em>storylists</em> temáticas —antologías pensadas como las playlists de Spotify o YouTube— para que descubrir y
-			disfrutar literatura breve sea simple y entretenido.
-		</p>
-		<br />
-		<p class="font-inter text-base font-normal">
-			Reunimos obras de autores y autoras de distintos géneros, estilos y épocas, con soporte multimedia y foco en la
-			accesibilidad. Sumate a leer, compartir y aprender con cada historia.
-		</p>
+	<section class="mb-8 flex flex-col gap-8">
+		<h2 class="font-inter text-2xl font-bold">Sobre <em>La Cuentoneta</em></h2>
+
+		<div class="flex flex-col gap-4">
+			<p class="font-inter text-base font-normal">
+				La Cuentoneta es un proyecto abierto, comunitario y sin fines de lucro que busca fomentar y hacer accesible la
+				lectura digital. Publicamos cuentos, poemas y relatos breves organizados en
+				<em>storylists</em> temáticas —antologías pensadas como las playlists de Spotify o YouTube— para que descubrir y
+				disfrutar literatura se transforme en un proceso simple y entretenido.
+			</p>
+			<p class="font-inter text-base font-normal">
+				Reunimos obras de autores y autoras de distintos géneros, estilos y épocas, con soporte multimedia y foco en la
+				captura de material literario editado con fines educativos y su adaptación a texto accesible. Te invitamos a
+				leer, compartir y aprender con cada historia.
+			</p>
+		</div>
 	</section>
 </main>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,7 +1,8 @@
 <main class="content horizontal-layout-spacing vertical-layout-spacing">
 	<!--
-        H1 de contenido de la home, oculto visualmente (sr-only) para mantener un único H1 por
-        página sin alterar el diseño. #1523 lo reemplazará por una intro visible.
+        H1 de contenido de la home, oculto visualmente (sr-only) para mantener un único H1 por página
+        sin desplazar el hero. El texto introductorio sustantivo va en la sección "Sobre La Cuentoneta"
+        al final del main (contenido indexable para buscadores y answer engines).
     -->
 	<h1 class="sr-only">Cuentos y relatos breves para leer en línea</h1>
 
@@ -27,5 +28,24 @@
 
 	<section class="mb-8">
 		<cuentoneta-collection-teasers-deck [teasers]="collections()" class="flex flex-col gap-8" />
+	</section>
+
+	<!--
+        Intro descriptiva con texto sustantivo y citable, server-rendered (sin @defer), para que
+        buscadores y answer engines tengan contenido indexable más allá de las imágenes del hero.
+    -->
+	<section class="mb-8">
+		<h2 class="h2 mb-5 text-neutral-600">Sobre <em>La Cuentoneta</em></h2>
+		<p class="font-inter text-base font-normal">
+			La Cuentoneta es un proyecto abierto, comunitario y sin fines de lucro que busca fomentar y hacer accesible la
+			lectura digital. Publicamos cuentos, poemas y relatos breves organizados en
+			<em>storylists</em> temáticas —antologías pensadas como las playlists de Spotify o YouTube— para que descubrir y
+			disfrutar literatura breve sea simple y entretenido.
+		</p>
+		<br />
+		<p class="font-inter text-base font-normal">
+			Reunimos obras de autores y autoras de distintos géneros, estilos y épocas, con soporte multimedia y foco en la
+			accesibilidad. Sumate a leer, compartir y aprender con cada historia.
+		</p>
 	</section>
 </main>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -40,9 +40,9 @@
 		<div class="flex flex-col gap-4">
 			<p class="font-inter text-base font-normal">
 				La Cuentoneta es un proyecto abierto, comunitario y sin fines de lucro que busca fomentar y hacer accesible la
-				lectura digital. Publicamos cuentos, poemas y relatos breves organizados en
-				<em>storylists</em> temáticas —antologías pensadas como las playlists de Spotify o YouTube— para que descubrir y
-				disfrutar literatura se transforme en un proceso simple y entretenido.
+				lectura digital. Publicamos cuentos, poemas y relatos breves organizados en colecciones temáticas —antologías
+				pensadas como las playlists de Spotify o YouTube— para que descubrir y disfrutar literatura se transforme en un
+				proceso simple y entretenido.
 			</p>
 			<p class="font-inter text-base font-normal">
 				Reunimos obras de autores y autoras de distintos géneros, estilos y épocas, con soporte multimedia y foco en la

--- a/src/app/providers/schema-org.initializer.ts
+++ b/src/app/providers/schema-org.initializer.ts
@@ -7,7 +7,7 @@ import { environment } from '../environments/environment';
 const ORGANIZATION_NAME = 'La Cuentoneta';
 const ORGANIZATION_DESCRIPTION =
 	'Proyecto abierto, comunitario y sin fines de lucro que fomenta y hace accesible la lectura digital, ' +
-	'publicando relatos breves en storylists temáticas.';
+	'publicando relatos breves en colecciones temáticas.';
 
 // URLs canónicas de los perfiles, alineadas con las que renderiza el footer (footer.component.ts).
 const SOCIAL_PROFILES = [


### PR DESCRIPTION
## Resumen

> **PR stacked** sobre #1539 (#1522). Base: `feat/1522-author-storylist-structured-data`. El diff muestra solo los cambios de #1523.

Sexto issue del epic de SEO/AEO #1525. Aumenta el **contenido indexable** de la home: la auditoría reportó solo ~92 caracteres de texto en el body (página muy visual: carrusel + cards de imágenes), lo que limita lo que buscadores y answer engines pueden leer y citar.

## Decisión (consultada)

Agregar una sección visible **"Sobre La Cuentoneta"** (H2 + 2 párrafos, copy estático server-rendered) **al final del `<main>`**, manteniendo el `<h1 class="sr-only">` arriba sin tocar el hero (carrusel). El copy se redactó a partir del MVV/README del proyecto y replica el patrón de la sección equivalente del About.

## Cambios

- **`home.component.html`**: nueva sección "Sobre La Cuentoneta" con texto sustantivo y citable (sin `@defer`, server-rendered). El H1 sigue siendo el sr-only (un único H1 por página); la sección usa H2.
- **`e2e/example.spec.ts`**: verifica que la sección y su texto se renderizan en la home.

## Verificación

- `nx lint` ✅ · Vitest **457 passed | 3 skipped** ✅ · e2e **6 passed** ✅ (incluye las nuevas aserciones) · build SSR ✅.
- `curl` del HTML server-rendered de `/home`: la sección "Sobre La Cuentoneta" aparece, el texto plano del `<main>` pasó de **~92 a ~712 caracteres**, y se mantiene **1 solo `<h1>`**.

## Code review local (antes del PR)

Corrida con el agente code-reviewer (`coding-agent-policies.md`). Sin bloqueantes ni importantes: confirma jerarquía de headings correcta (1 H1, sección con H2), consistencia con el About y cobertura e2e suficiente.

Parte del epic #1525 · Closes #1523

---

### Fuera de scope

- `schema-org.initializer.ts` (de #1520): se alineó la descripción del JSON-LD `Organization` de "storylists temáticas" → "colecciones temáticas", mismo criterio de lenguaje de dominio que el copy de la home.
