### PR TITLE
[#1524] - Keywords específicas y relevantes en el meta tag de la home

### DIFF
--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -15,4 +15,7 @@ test('home: único H1 de contenido y marca en el header', async ({ page }) => {
 	// La home expone contenido indexable: la sección "Sobre La Cuentoneta" con texto sustantivo.
 	await expect(page.getByRole('heading', { name: /Sobre La Cuentoneta/i })).toBeVisible();
 	await expect(page.getByText(/proyecto abierto, comunitario y sin fines de lucro/i)).toBeVisible();
+
+	// La home declara keywords relevantes en su meta tag.
+	await expect(page.locator('meta[name="keywords"]')).toHaveAttribute('content', /relatos breves/);
 });

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -59,7 +59,19 @@ export default class HomeComponent {
 		// —marca incluida— se emita tal cual en el SSR, donde el sufijo "| La Cuentoneta" no se agrega.
 		this.metaTagsDirective.setTitle('Cuentos y relatos breves para leer en línea | La Cuentoneta', false);
 		this.metaTagsDirective.setDefaultDescription();
-		this.metaTagsDirective.setDefaultKeywords();
+		// Keywords específicas de la home (relevantes y alineadas al título/posicionamiento).
+		this.metaTagsDirective.setKeywords([
+			'cuentos',
+			'relatos breves',
+			'literatura',
+			'poemas',
+			'narraciones',
+			'lectura digital',
+			'cuentos para leer',
+			'literatura breve',
+			'colecciones de cuentos',
+			'leer en línea',
+		]);
 		this.metaTagsDirective.setCanonicalUrl(`${environment.website}`);
 		this.metaTagsDirective.setRobots('index, follow');
 	}


### PR DESCRIPTION
## Resumen

> **PR stacked** sobre #1541 (#1523). Base: `feat/1523-home-indexable-content`. El diff muestra solo los cambios de #1524.

Séptimo y último issue del epic de SEO/AEO #1525 — **opcional / bajo impacto**. La home ya emitía un `<meta name="keywords">` (vía `setDefaultKeywords()`, desde #1518); este PR lo reemplaza por un set de **10 keywords específicas de la home**, más relevantes y alineadas al título "Cuentos y relatos breves para leer en línea".

> **Nota:** los meta keywords no influyen en el ranking de los buscadores modernos; este issue cierra el check de la auditoría con keywords orientadas a términos de búsqueda reales.

## Cambios

- **`home.component.ts`**: `setDefaultKeywords()` → `setKeywords([...10 keywords...])` (cuentos, relatos breves, literatura, poemas, narraciones, lectura digital, cuentos para leer, literatura breve, colecciones de cuentos, leer en línea).
- **`e2e/example.spec.ts`**: verifica que el meta keywords de la home contiene términos relevantes.

## Code review local (antes del PR)

Corrida con el agente code-reviewer (`coding-agent-policies.md`). Aprobado; se aplicó el fix recomendado: la keyword `'storylists'` (término interno del codebase, no de búsqueda de usuario) se reemplazó por `'colecciones de cuentos'` (alineado al lenguaje de dominio "Colección").

## Verificación

- `nx lint` ✅ · Vitest **457 passed | 3 skipped** ✅ · e2e **6 passed** ✅ · build SSR ✅.
- `curl` del SSR de `/home`: `<meta name="keywords">` con los 10 términos.

Parte del epic #1525 · Closes #1524
