### PR TITLE
[#1548] - Colapsar wrappers de componentes a host: { class }

### DIFF
--- a/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
@@ -1,12 +1,22 @@
 import { render, screen } from '@testing-library/angular';
 import { BioSummaryCardComponent } from './bio-summary-card.component';
 import { storyMock } from '@mocks/story.mock';
+import type { Story } from '@models/story.model';
 
 const country = storyMock.author.nationality.country;
 const countryRegex = new RegExp(`\\b${country}\\b`, 'i');
 
 const name = storyMock.author.name;
 const nameRegex = new RegExp(`\\b${name}\\b`, 'iu');
+
+// Para los asserts del author-teaser se usa una historia sin recursos: los recursos del autor
+// también generan links que mencionan su nombre (p. ej. "Artículo de … en Wikipedia"), lo que
+// haría ambigua la búsqueda del link por nombre.
+const storyWithoutResources: Story = {
+	...storyMock,
+	resources: [],
+	author: { ...storyMock.author, resources: [] },
+};
 
 describe('BioSummaryCardComponent', () => {
 	it('should render the component', async () => {
@@ -44,7 +54,7 @@ describe('BioSummaryCardComponent', () => {
 	it('should display the author name', async () => {
 		await render(BioSummaryCardComponent, {
 			inputs: {
-				story: storyMock,
+				story: storyWithoutResources,
 			},
 		});
 		const authorTeaser = screen.getByRole('link', { name: nameRegex });
@@ -54,11 +64,24 @@ describe('BioSummaryCardComponent', () => {
 	it('should display the country', async () => {
 		await render(BioSummaryCardComponent, {
 			inputs: {
-				story: storyMock,
+				story: storyWithoutResources,
 			},
 		});
 		const authorTeaser = screen.getByRole('link', { name: nameRegex });
 
 		expect(authorTeaser).toHaveTextContent(country);
+	});
+
+	it('should render the story resources when present', async () => {
+		await render(BioSummaryCardComponent, {
+			inputs: {
+				story: storyMock,
+			},
+		});
+
+		const [resource] = storyMock.resources ?? [];
+		const resourceLink = screen.getByRole('link', { name: resource.title });
+
+		expect(resourceLink).toHaveAttribute('href', resource.url);
 	});
 });

--- a/src/app/components/bio-summary-card/bio-summary-card.component.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.ts
@@ -12,23 +12,24 @@ import { ResourceComponent } from '../resource/resource.component';
 @Component({
 	selector: 'cuentoneta-bio-summary-card',
 	template: `
-		<div class="rounded border-1 border-solid border-neutral-200 bg-neutral-100 p-6">
-			<section class="mb-4 grid grid-cols-[1fr] gap-4 sm:mb-8 sm:grid-cols-[auto_1fr]">
-				<cuentoneta-author-teaser [author]="story().author" [variant]="'md'" />
-				@if (resources.length > 0) {
-					<div class="xs-max:col-start-1 xs-max:col-end-3 flex justify-start gap-4 sm:justify-end">
-						@for (resource of resources(); track $index) {
-							<cuentoneta-resource [resource]="resource" />
-						}
-					</div>
-				}
-			</section>
-			<section class="font-inter text-base font-normal text-neutral-700">
-				<cuentoneta-portable-text-parser [paragraphs]="story().author.biography" [classes]="'mb-4'" />
-				<cuentoneta-portable-text-parser [paragraphs]="story().summary" [classes]="'mb-4 last:mb-0'" />
-			</section>
-		</div>
+		<section class="mb-4 grid grid-cols-[1fr] gap-4 sm:mb-8 sm:grid-cols-[auto_1fr]">
+			<cuentoneta-author-teaser [author]="story().author" [variant]="'md'" />
+			@if (resources.length > 0) {
+				<div class="xs-max:col-start-1 xs-max:col-end-3 flex justify-start gap-4 sm:justify-end">
+					@for (resource of resources(); track $index) {
+						<cuentoneta-resource [resource]="resource" />
+					}
+				</div>
+			}
+		</section>
+		<section class="font-inter text-base font-normal text-neutral-700">
+			<cuentoneta-portable-text-parser [paragraphs]="story().author.biography" [classes]="'mb-4'" />
+			<cuentoneta-portable-text-parser [paragraphs]="story().summary" [classes]="'mb-4 last:mb-0'" />
+		</section>
 	`,
+	host: {
+		class: 'rounded border-1 border-solid border-neutral-200 bg-neutral-100 p-6',
+	},
 	imports: [AuthorTeaserComponent, ResourceComponent, PortableTextParserComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/app/components/bio-summary-card/bio-summary-card.component.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.ts
@@ -28,7 +28,7 @@ import { ResourceComponent } from '../resource/resource.component';
 		</section>
 	`,
 	host: {
-		class: 'rounded border-1 border-solid border-neutral-200 bg-neutral-100 p-6',
+		class: 'block rounded border-1 border-solid border-neutral-200 bg-neutral-100 p-6',
 	},
 	imports: [AuthorTeaserComponent, ResourceComponent, PortableTextParserComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/components/bio-summary-card/bio-summary-card.component.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.ts
@@ -14,7 +14,7 @@ import { ResourceComponent } from '../resource/resource.component';
 	template: `
 		<section class="mb-4 grid grid-cols-[1fr] gap-4 sm:mb-8 sm:grid-cols-[auto_1fr]">
 			<cuentoneta-author-teaser [author]="story().author" [variant]="'md'" />
-			@if (resources.length > 0) {
+			@if (resources().length > 0) {
 				<div class="xs-max:col-start-1 xs-max:col-end-3 flex justify-start gap-4 sm:justify-end">
 					@for (resource of resources(); track $index) {
 						<cuentoneta-resource [resource]="resource" />

--- a/src/app/components/carousel/carousel-skeleton.component.ts
+++ b/src/app/components/carousel/carousel-skeleton.component.ts
@@ -7,7 +7,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 @Component({
 	selector: 'cuentoneta-carousel-skeleton',
 	imports: [NgxSkeletonLoaderModule],
-	host: { class: 'mx-auto' },
+	host: { class: 'mx-auto block' },
 	template: `<div class="slider">
 		<ngx-skeleton-loader
 			[theme]="{

--- a/src/app/components/carousel/carousel-skeleton.component.ts
+++ b/src/app/components/carousel/carousel-skeleton.component.ts
@@ -28,10 +28,6 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 		:host ::ng-deep .carousel-image-skeleton .skeleton-loader {
 			@apply bg-neutral-200;
 		}
-
-		:host ::ng-deep .carousel-text-skeleton .skeleton-loader {
-			@apply bg-neutral-300;
-		}
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/app/components/carousel/carousel-skeleton.component.ts
+++ b/src/app/components/carousel/carousel-skeleton.component.ts
@@ -7,21 +7,20 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 @Component({
 	selector: 'cuentoneta-carousel-skeleton',
 	imports: [NgxSkeletonLoaderModule],
-	template: ` <div class="mx-auto">
-		<div class="slider">
-			<ngx-skeleton-loader
-				[theme]="{
-					'justify-self': 'center',
-					'border-radius.px': '16',
-					'margin-bottom.px': 0,
-					height: '100%',
-					width: '100%',
-				}"
-				count="1"
-				appearance="line"
-				class="carousel-image-skeleton grid aspect-[540/220] w-full object-cover md:aspect-[1240/360]"
-			/>
-		</div>
+	host: { class: 'mx-auto' },
+	template: `<div class="slider">
+		<ngx-skeleton-loader
+			[theme]="{
+				'justify-self': 'center',
+				'border-radius.px': '16',
+				'margin-bottom.px': 0,
+				height: '100%',
+				width: '100%',
+			}"
+			count="1"
+			appearance="line"
+			class="carousel-image-skeleton grid aspect-[540/220] w-full object-cover md:aspect-[1240/360]"
+		/>
 	</div>`,
 	styles: `
 		@reference '#tailwind-theme';

--- a/src/app/pages/storylist/storylist-title/storylist-title-skeleton.ts
+++ b/src/app/pages/storylist/storylist-title/storylist-title-skeleton.ts
@@ -4,8 +4,8 @@ import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 @Component({
 	selector: 'cuentoneta-storylist-title-skeleton',
 	imports: [NgxSkeletonLoaderComponent],
-	template: ` <div class="flex flex-col gap-5">
-		<ngx-skeleton-loader
+	host: { class: 'flex flex-col gap-5' },
+	template: `<ngx-skeleton-loader
 			[theme]="{
 				height: '36px',
 				width: '320px',
@@ -46,8 +46,7 @@ import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 				appearance="line"
 				class="tag-skeleton"
 			/>
-		</div>
-	</div>`,
+		</div>`,
 	styles: `
 		@reference '#tailwind-theme';
 

--- a/src/app/pages/storylist/storylist-title/storylist-title-skeleton.ts
+++ b/src/app/pages/storylist/storylist-title/storylist-title-skeleton.ts
@@ -5,7 +5,8 @@ import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 	selector: 'cuentoneta-storylist-title-skeleton',
 	imports: [NgxSkeletonLoaderComponent],
 	host: { class: 'flex flex-col gap-5' },
-	template: `<ngx-skeleton-loader
+	template: `
+		<ngx-skeleton-loader
 			[theme]="{
 				height: '36px',
 				width: '320px',
@@ -46,7 +47,8 @@ import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 				appearance="line"
 				class="tag-skeleton"
 			/>
-		</div>`,
+		</div>
+	`,
 	styles: `
 		@reference '#tailwind-theme';
 


### PR DESCRIPTION
## Descripción

Colapsa el `<div>` raíz que actuaba solo como wrapper de estilado del host en los componentes donde es seguro, moviendo sus clases a `host: { class }` y eliminando el `<div>` del DOM.

De los 14 candidatos del issue, **solo 3 son seguros de colapsar** (el resto son estructurales: el `<div>` no es la raíz, ya hay `host: { class }` con varios nodos hermanos, o el `<div>` es funcional —`progress-bar` animado, `media-resource-tag` con `[class]` dinámico, etc.):

- **`bio-summary-card`** → `host: { class: 'block rounded border-1 border-solid border-neutral-200 bg-neutral-100 p-6' }`
- **`carousel-skeleton`** → `host: { class: 'mx-auto block' }`
- **`storylist-title-skeleton`** → `host: { class: 'flex flex-col gap-5' }`

**Paridad de render:** un `<div>` es `display: block`, pero el host (custom element) es `inline` por defecto y no hay regla global que lo cambie. Por eso `bio-summary-card` y `carousel-skeleton` llevan `block` explícito (sin él la card no sería un bloque y `mx-auto` no centraría); `storylist-title-skeleton` ya setea `display:flex` vía `flex`.


## Hallazgos de review abordados (a pedido del usuario)

- **Bug latente (bio-summary-card):** `@if (resources.length > 0)` -> `resources().length` — `resources` es un `computed` signal; tal como estaba, el bloque de recursos **nunca renderizaba**. Se agrega un test que cubre el render de recursos. Los tests de nombre/pais pasan a usar una historia sin recursos (los recursos del autor mencionan su nombre y generaban links ambiguos).
- **CSS muerto (carousel-skeleton):** se elimina el selector `:host ::ng-deep .carousel-text-skeleton` (no existe ese elemento en el template).

Closes #1548.

Parte de #1498.

## Plan de pruebas

- [x] `pnpm test` · `pnpm lint` · `pnpm stylelint` · `pnpm build` · `pnpm storybook:build` verdes.
- [x] `code-reviewer`: 0 críticos, sin regresiones de render (verificó paridad de `display`, `::ng-deep` intactos, y que ningún test/selector apunta al `<div>` eliminado).
- [x] Los 11 candidatos no colapsados quedan documentados con su razón en el cuerpo de #1548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


