### PR TITLE
[#1550] - Hotfix de CI: compartir workspace por artifacts (no cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,10 @@ jobs:
       # El workspace se comparte entre jobs con upload/download-artifact (entrega garantizada
       # dentro del run), no con actions/cache: cachear todo el workspace (key por sha) se
       # evicta bajo el límite de 10 GB por repo y deja a los jobs downstream sin lockfile.
+      # --anchored + prefijo ./ : sin anclar, un --exclude sin slash matchea el basename en
+      # CUALQUIER nivel, así que 'dist' borraba todos los node_modules/**/dist (rompía los paquetes).
       - name: Pack workspace
-        run: tar -cf workspace.tar --exclude='workspace.tar' --exclude='.git' --exclude='dist' --exclude='.nx/cache' .
+        run: tar -cf workspace.tar --anchored --exclude='./workspace.tar' --exclude='./.git' --exclude='./dist' --exclude='./.nx/cache' .
 
       - name: Upload workspace artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,18 @@ jobs:
       - name: Rebuild and prepare
         run: pnpm rebuild && pnpm run prepare --if-present
 
-      - name: Cache repository
-        uses: actions/cache@v4.2.3
+      # El workspace se comparte entre jobs con upload/download-artifact (entrega garantizada
+      # dentro del run), no con actions/cache: cachear todo el workspace (key por sha) se
+      # evicta bajo el límite de 10 GB por repo y deja a los jobs downstream sin lockfile.
+      - name: Pack workspace
+        run: tar -cf workspace.tar --exclude='.git' --exclude='dist' --exclude='.nx/cache' .
+
+      - name: Upload workspace artifact
+        uses: actions/upload-artifact@v4
         with:
-          path: .
-          key: repo-${{ github.sha }}
-          restore-keys: |
-            repo-${{ github.sha }}
+          name: workspace
+          path: workspace.tar
+          retention-days: 1
 
   test:
     needs: setup
@@ -46,14 +51,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Restore repository
-        uses: actions/cache@v4.2.3
-        with:
-          path: .
-          key: repo-${{ github.sha }}
-          restore-keys: |
-            repo-${{ github.sha }}
-
       - name: Select pnpm as package manager
         uses: pnpm/action-setup@v4.1.0
         with:
@@ -63,7 +60,14 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: 22.22.3
-          cache: 'pnpm'
+
+      - name: Download workspace artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace
+
+      - name: Unpack workspace
+        run: tar -xf workspace.tar
 
       - name: Run Tests
         run: npx nx test --skip-nx-cache
@@ -97,14 +101,6 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - name: Restore repository
-        uses: actions/cache@v4.2.3
-        with:
-          path: .
-          key: repo-${{ github.sha }}
-          restore-keys: |
-            repo-${{ github.sha }}
-
       - name: Select pnpm as package manager
         uses: pnpm/action-setup@v4.1.0
         with:
@@ -114,7 +110,14 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: 22.22.3
-          cache: 'pnpm'
+
+      - name: Download workspace artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace
+
+      - name: Unpack workspace
+        run: tar -xf workspace.tar
 
       - name: Run Linter
         run: npx nx lint --skip-nx-cache
@@ -123,14 +126,6 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - name: Restore repository
-        uses: actions/cache@v4.2.3
-        with:
-          path: .
-          key: repo-${{ github.sha }}
-          restore-keys: |
-            repo-${{ github.sha }}
-
       - name: Select pnpm as package manager
         uses: pnpm/action-setup@v4.1.0
         with:
@@ -140,7 +135,14 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: 22.22.3
-          cache: 'pnpm'
+
+      - name: Download workspace artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace
+
+      - name: Unpack workspace
+        run: tar -xf workspace.tar
 
       - name: Run stylelint
         run: npx nx stylelint @cuentoneta/app --skip-nx-cache
@@ -149,14 +151,6 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - name: Restore repository
-        uses: actions/cache@v4.2.3
-        with:
-          path: .
-          key: repo-${{ github.sha }}
-          restore-keys: |
-            repo-${{ github.sha }}
-
       - name: Select pnpm as package manager
         uses: pnpm/action-setup@v4.1.0
         with:
@@ -166,7 +160,14 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: 22.22.3
-          cache: 'pnpm'
+
+      - name: Download workspace artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace
+
+      - name: Unpack workspace
+        run: tar -xf workspace.tar
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
@@ -185,13 +186,6 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - name: Restore repository
-        uses: actions/cache@v4.2.3
-        with:
-          path: .
-          key: repo-${{ github.sha }}
-          restore-keys: |
-            repo-${{ github.sha }}
       - name: Select pnpm as package manager
         uses: pnpm/action-setup@v4.1.0
         with:
@@ -201,7 +195,14 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: 22.22.3
-          cache: 'pnpm'
+
+      - name: Download workspace artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace
+
+      - name: Unpack workspace
+        run: tar -xf workspace.tar
 
       - name: Run build
         run: npx nx run @cuentoneta/app:build:production --skip-nx-cache
@@ -217,13 +218,6 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - name: Restore repository
-        uses: actions/cache@v4.2.3
-        with:
-          path: .
-          key: repo-${{ github.sha }}
-          restore-keys: |
-            repo-${{ github.sha }}
       - name: Select pnpm as package manager
         uses: pnpm/action-setup@v4.1.0
         with:
@@ -233,7 +227,14 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: 22.22.3
-          cache: 'pnpm'
+
+      - name: Download workspace artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace
+
+      - name: Unpack workspace
+        run: tar -xf workspace.tar
 
       - name: Run Storybook build
         run: npx nx run @cuentoneta/app:build-storybook --skip-nx-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       # dentro del run), no con actions/cache: cachear todo el workspace (key por sha) se
       # evicta bajo el límite de 10 GB por repo y deja a los jobs downstream sin lockfile.
       - name: Pack workspace
-        run: tar -cf workspace.tar --exclude='.git' --exclude='dist' --exclude='.nx/cache' .
+        run: tar -cf workspace.tar --exclude='workspace.tar' --exclude='.git' --exclude='dist' --exclude='.nx/cache' .
 
       - name: Upload workspace artifact
         uses: actions/upload-artifact@v4
@@ -175,7 +175,8 @@ jobs:
       - name: Run Tests
         run: npx nx run @cuentoneta/app:e2e --skip-nx-cache
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-report


### PR DESCRIPTION
## Descripción

Arregla el fallo **intermitente** del CI (lint/stylelint/e2e/build/storybook caían con `Dependencies lock file is not found`).

- **Causa raíz:** el workspace se compartía entre jobs con `actions/cache` (key por sha, `path: .`). `actions/cache` es para reuso *entre runs*, no para pasar datos *dentro* de un run: con todo el workspace (>1–2 GB) y key por commit, las caches se evictan bajo el límite de 10 GB por repo → el restore hace *miss* → workspace vacío → `setup-node` con `cache: pnpm` corta. Por eso era intermitente (`setup`/`test` pasaban, el resto no).
- **Fix:** se pasa el workspace con **`actions/upload-artifact` / `download-artifact`** (entrega garantizada dentro del run, sin eviction). Se mantiene el modelo **install-once** (solo `setup` instala; los downstream bajan/desempaquetan el `.tar` y corren su target, **sin re-instalar**). Se quita `cache: pnpm` de los `setup-node` downstream (ya no hace falta; `node_modules` viene del artifact).

**Reducción de minutos (parte B del issue):** `nx affected` no aplica (los 6 targets de CI son todos de `@cuentoneta/app`) y la cache remota de Nx está configurada pero **sin token** (401) — por eso el `--skip-nx-cache`. Eso queda como follow-up en #1553 (requiere el token de Nx Cloud como secret). Este PR no toca `--skip-nx-cache`.

Closes #1550.

## Plan de pruebas

- [x] YAML válido (parseado): 7 jobs; 0 downstream con `cache: pnpm`; 6 bajan el artifact; `setup` lo sube.
- [x] Se conservan `permissions` de `test`, `env:` con secrets de `build`, `playwright install --with-deps`, uploads de `coverage`/`playwright-report`, comentario de coverage y Codecov.
- [x] `code-reviewer`: 1 crítico (auto-inclusión del tar → **Fixed** con `--exclude='workspace.tar'`) · 1 advertencia de symlinks pnpm (**descartada**: falso positivo para CI Linux; el `actions/cache` original ya archivaba el mismo `node_modules` y funcionaba) · 1 advertencia cosmética (**Fixed**).
- [ ] **Validación definitiva: el primer run de este PR en GitHub Actions** (no reproducible localmente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
