### PR TITLE
[#1578] - Cleanup de JSON-LD al navegar a la home

### DIFF
--- a/src/app/directives/abstract-structured-data.directive.ts
+++ b/src/app/directives/abstract-structured-data.directive.ts
@@ -6,7 +6,8 @@ import { SchemaOrgService } from '../providers/schema-org.service';
 export abstract class AbstractStructuredDataDirective {
 	protected readonly schemaOrg = inject(SchemaOrgService);
 
-	protected abstract applyStructuredData(): void;
+	// eslint-disable-next-line @typescript-eslint/no-empty-function -- stub opcional: las páginas sin bloques propios (p. ej. home) no agregan structured data
+	protected applyStructuredData(): void {}
 	protected abstract removeStructuredData(): void;
 
 	private readonly structuredDataEffect = effect((onCleanup) => {

--- a/src/app/directives/abstract-structured-data.directive.ts
+++ b/src/app/directives/abstract-structured-data.directive.ts
@@ -6,7 +6,7 @@ import { SchemaOrgService } from '../providers/schema-org.service';
 export abstract class AbstractStructuredDataDirective {
 	protected readonly schemaOrg = inject(SchemaOrgService);
 
-	// eslint-disable-next-line @typescript-eslint/no-empty-function -- stub opcional: las páginas sin bloques propios (p. ej. home) no agregan structured data
+	// eslint-disable-next-line @typescript-eslint/no-empty-function -- stub opcional: las páginas sin bloques propios no agregan structured data
 	protected applyStructuredData(): void {}
 	protected abstract removeStructuredData(): void;
 

--- a/src/app/pages/author/author-structured-data.directive.ts
+++ b/src/app/pages/author/author-structured-data.directive.ts
@@ -17,8 +17,8 @@ export class AuthorStructuredDataDirective extends AbstractStructuredDataDirecti
 			return;
 		}
 		untracked(() => {
-			this.schemaOrg.setJsonLd('profile-page', buildAuthorProfilePageSchema(author, environment.website));
-			this.schemaOrg.setJsonLd('breadcrumb-author', buildAuthorBreadcrumb(author, environment.website));
+			this.schemaOrg.setPageScopedJsonLd('profile-page', buildAuthorProfilePageSchema(author, environment.website));
+			this.schemaOrg.setPageScopedJsonLd('breadcrumb-author', buildAuthorBreadcrumb(author, environment.website));
 		});
 	}
 

--- a/src/app/pages/home/home-structured-data.directive.spec.ts
+++ b/src/app/pages/home/home-structured-data.directive.spec.ts
@@ -2,7 +2,7 @@ import { clearAllMocks } from '@test-utils';
 import { TestBed } from '@angular/core/testing';
 import { DOCUMENT } from '@angular/common';
 
-import { PAGE_SCOPED_SCHEMA_IDS, SchemaOrgService } from '../../providers/schema-org.service';
+import { SchemaOrgService } from '../../providers/schema-org.service';
 import { HomeStructuredDataDirective } from './home-structured-data.directive';
 
 describe('HomeStructuredDataDirective', () => {
@@ -24,8 +24,8 @@ describe('HomeStructuredDataDirective', () => {
 
 	it('should remove collection and breadcrumb-storylist left by a previous storylist route', () => {
 		const schemaOrg = TestBed.inject(SchemaOrgService);
-		schemaOrg.setJsonLd('collection', { '@type': 'CollectionPage' });
-		schemaOrg.setJsonLd('breadcrumb-storylist', { '@type': 'BreadcrumbList' });
+		schemaOrg.setPageScopedJsonLd('collection', { '@type': 'CollectionPage' });
+		schemaOrg.setPageScopedJsonLd('breadcrumb-storylist', { '@type': 'BreadcrumbList' });
 
 		instantiate();
 		TestBed.tick();
@@ -35,26 +35,26 @@ describe('HomeStructuredDataDirective', () => {
 		expect(head.querySelector('script[data-schema-id="breadcrumb-storylist"]')).toBeNull();
 	});
 
-	it('should remove every page-scoped block on init', () => {
+	it('should remove page-scoped blocks left by any route, not just storylist', () => {
 		const schemaOrg = TestBed.inject(SchemaOrgService);
-		for (const id of PAGE_SCOPED_SCHEMA_IDS) {
-			schemaOrg.setJsonLd(id, { '@type': 'Test' });
-		}
+		schemaOrg.setPageScopedJsonLd('article', { '@type': 'Article' });
+		schemaOrg.setPageScopedJsonLd('profile-page', { '@type': 'ProfilePage' });
+		schemaOrg.setPageScopedJsonLd('collection', { '@type': 'CollectionPage' });
 
 		instantiate();
 		TestBed.tick();
 
 		const head = TestBed.inject(DOCUMENT).head;
-		for (const id of PAGE_SCOPED_SCHEMA_IDS) {
-			expect(head.querySelector(`script[data-schema-id="${id}"]`)).toBeNull();
-		}
+		expect(head.querySelector('script[data-schema-id="article"]')).toBeNull();
+		expect(head.querySelector('script[data-schema-id="profile-page"]')).toBeNull();
+		expect(head.querySelector('script[data-schema-id="collection"]')).toBeNull();
 	});
 
 	it('should not remove sitewide blocks (organization, website)', () => {
 		const schemaOrg = TestBed.inject(SchemaOrgService);
 		schemaOrg.setJsonLd('organization', { '@type': 'Organization' });
 		schemaOrg.setJsonLd('website', { '@type': 'WebSite' });
-		schemaOrg.setJsonLd('collection', { '@type': 'CollectionPage' });
+		schemaOrg.setPageScopedJsonLd('collection', { '@type': 'CollectionPage' });
 
 		instantiate();
 		TestBed.tick();

--- a/src/app/pages/home/home-structured-data.directive.spec.ts
+++ b/src/app/pages/home/home-structured-data.directive.spec.ts
@@ -1,0 +1,66 @@
+import { clearAllMocks } from '@test-utils';
+import { TestBed } from '@angular/core/testing';
+import { DOCUMENT } from '@angular/common';
+
+import { PAGE_SCOPED_SCHEMA_IDS, SchemaOrgService } from '../../providers/schema-org.service';
+import { HomeStructuredDataDirective } from './home-structured-data.directive';
+
+describe('HomeStructuredDataDirective', () => {
+	function instantiate(): void {
+		TestBed.runInInjectionContext(() => new HomeStructuredDataDirective());
+	}
+
+	beforeEach(() => {
+		clearAllMocks();
+		TestBed.configureTestingModule({ providers: [HomeStructuredDataDirective] });
+	});
+
+	afterEach(() => {
+		TestBed.inject(DOCUMENT)
+			.head.querySelectorAll('script[data-schema-id]')
+			.forEach((el) => el.remove());
+	});
+
+	it('should remove collection and breadcrumb-storylist left by a previous storylist route', () => {
+		const schemaOrg = TestBed.inject(SchemaOrgService);
+		schemaOrg.setJsonLd('collection', { '@type': 'CollectionPage' });
+		schemaOrg.setJsonLd('breadcrumb-storylist', { '@type': 'BreadcrumbList' });
+
+		instantiate();
+		TestBed.tick();
+
+		const head = TestBed.inject(DOCUMENT).head;
+		expect(head.querySelector('script[data-schema-id="collection"]')).toBeNull();
+		expect(head.querySelector('script[data-schema-id="breadcrumb-storylist"]')).toBeNull();
+	});
+
+	it('should remove every page-scoped block on init', () => {
+		const schemaOrg = TestBed.inject(SchemaOrgService);
+		for (const id of PAGE_SCOPED_SCHEMA_IDS) {
+			schemaOrg.setJsonLd(id, { '@type': 'Test' });
+		}
+
+		instantiate();
+		TestBed.tick();
+
+		const head = TestBed.inject(DOCUMENT).head;
+		for (const id of PAGE_SCOPED_SCHEMA_IDS) {
+			expect(head.querySelector(`script[data-schema-id="${id}"]`)).toBeNull();
+		}
+	});
+
+	it('should not remove sitewide blocks (organization, website)', () => {
+		const schemaOrg = TestBed.inject(SchemaOrgService);
+		schemaOrg.setJsonLd('organization', { '@type': 'Organization' });
+		schemaOrg.setJsonLd('website', { '@type': 'WebSite' });
+		schemaOrg.setJsonLd('collection', { '@type': 'CollectionPage' });
+
+		instantiate();
+		TestBed.tick();
+
+		const head = TestBed.inject(DOCUMENT).head;
+		expect(head.querySelector('script[data-schema-id="organization"]')).not.toBeNull();
+		expect(head.querySelector('script[data-schema-id="website"]')).not.toBeNull();
+		expect(head.querySelector('script[data-schema-id="collection"]')).toBeNull();
+	});
+});

--- a/src/app/pages/home/home-structured-data.directive.spec.ts
+++ b/src/app/pages/home/home-structured-data.directive.spec.ts
@@ -19,6 +19,7 @@ describe('HomeStructuredDataDirective', () => {
 		TestBed.inject(DOCUMENT)
 			.head.querySelectorAll('script[data-schema-id]')
 			.forEach((el) => el.remove());
+		TestBed.resetTestingModule();
 	});
 
 	it('should remove collection and breadcrumb-storylist left by a previous storylist route', () => {

--- a/src/app/pages/home/home-structured-data.directive.ts
+++ b/src/app/pages/home/home-structured-data.directive.ts
@@ -10,6 +10,6 @@ export class HomeStructuredDataDirective extends AbstractStructuredDataDirective
 		this.schemaOrg.removePageScopedJsonLd();
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-empty-function -- la home no inyecta bloques propios; no hay nada que remover al salir
+	// eslint-disable-next-line @typescript-eslint/no-empty-function -- la home no agrega bloques propios; no hay nada que remover al salir
 	protected removeStructuredData(): void {}
 }

--- a/src/app/pages/home/home-structured-data.directive.ts
+++ b/src/app/pages/home/home-structured-data.directive.ts
@@ -1,0 +1,15 @@
+import { Directive } from '@angular/core';
+
+import { AbstractStructuredDataDirective } from '../../directives/abstract-structured-data.directive';
+
+@Directive({
+	selector: '[cuentonetaHomeStructuredData]',
+})
+export class HomeStructuredDataDirective extends AbstractStructuredDataDirective {
+	protected applyStructuredData(): void {
+		this.schemaOrg.removePageScopedJsonLd();
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-empty-function -- la home no inyecta bloques propios; no hay nada que remover al salir
+	protected removeStructuredData(): void {}
+}

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -7,6 +7,7 @@ import { ContentApi } from '../../providers/content-api.interface';
 
 // SEO
 import { HomeMetaTagsDirective } from './home-meta-tags.directive';
+import { HomeStructuredDataDirective } from './home-structured-data.directive';
 
 // Componentes
 import { CarouselComponent } from '@components/carousel/carousel.component';
@@ -25,7 +26,7 @@ import { CollectionTeasersDeck } from '@components/collection-teasers-deck/colle
 		CarouselSkeletonComponent,
 		CollectionTeasersDeck,
 	],
-	hostDirectives: [HomeMetaTagsDirective],
+	hostDirectives: [HomeMetaTagsDirective, HomeStructuredDataDirective],
 })
 export default class HomeComponent {
 	// Services

--- a/src/app/pages/story/story-structured-data.directive.ts
+++ b/src/app/pages/story/story-structured-data.directive.ts
@@ -17,8 +17,8 @@ export class StoryStructuredDataDirective extends AbstractStructuredDataDirectiv
 			return;
 		}
 		untracked(() => {
-			this.schemaOrg.setJsonLd('article', buildStoryArticleSchema(story, environment.website));
-			this.schemaOrg.setJsonLd('breadcrumb-story', buildStoryBreadcrumb(story, environment.website));
+			this.schemaOrg.setPageScopedJsonLd('article', buildStoryArticleSchema(story, environment.website));
+			this.schemaOrg.setPageScopedJsonLd('breadcrumb-story', buildStoryBreadcrumb(story, environment.website));
 		});
 	}
 

--- a/src/app/pages/storylist/storylist-structured-data.directive.ts
+++ b/src/app/pages/storylist/storylist-structured-data.directive.ts
@@ -17,8 +17,11 @@ export class StorylistStructuredDataDirective extends AbstractStructuredDataDire
 			return;
 		}
 		untracked(() => {
-			this.schemaOrg.setJsonLd('collection', buildStorylistCollectionSchema(storylist, environment.website));
-			this.schemaOrg.setJsonLd('breadcrumb-storylist', buildStorylistBreadcrumb(storylist, environment.website));
+			this.schemaOrg.setPageScopedJsonLd('collection', buildStorylistCollectionSchema(storylist, environment.website));
+			this.schemaOrg.setPageScopedJsonLd(
+				'breadcrumb-storylist',
+				buildStorylistBreadcrumb(storylist, environment.website),
+			);
 		});
 	}
 

--- a/src/app/providers/schema-org.service.spec.ts
+++ b/src/app/providers/schema-org.service.spec.ts
@@ -1,7 +1,7 @@
 import { DOCUMENT } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { SchemaOrgService } from './schema-org.service';
+import { PAGE_SCOPED_SCHEMA_IDS, SchemaOrgService } from './schema-org.service';
 
 describe('SchemaOrgService', () => {
 	let service: SchemaOrgService;
@@ -62,5 +62,27 @@ describe('SchemaOrgService', () => {
 
 	it('should not throw when removing a missing id', () => {
 		expect(() => service.removeJsonLd('missing')).not.toThrow();
+	});
+
+	describe('removePageScopedJsonLd', () => {
+		it('should remove all page-scoped blocks and leave sitewide intact', () => {
+			service.setJsonLd('organization', { '@type': 'Organization' });
+			service.setJsonLd('website', { '@type': 'WebSite' });
+			for (const id of PAGE_SCOPED_SCHEMA_IDS) {
+				service.setJsonLd(id, { '@type': 'Test' });
+			}
+
+			service.removePageScopedJsonLd();
+
+			expect(scriptFor('organization')).not.toBeNull();
+			expect(scriptFor('website')).not.toBeNull();
+			for (const id of PAGE_SCOPED_SCHEMA_IDS) {
+				expect(scriptFor(id)).toBeNull();
+			}
+		});
+
+		it('should not throw when no page-scoped blocks are present', () => {
+			expect(() => service.removePageScopedJsonLd()).not.toThrow();
+		});
 	});
 });

--- a/src/app/providers/schema-org.service.spec.ts
+++ b/src/app/providers/schema-org.service.spec.ts
@@ -1,7 +1,7 @@
 import { DOCUMENT } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { PAGE_SCOPED_SCHEMA_IDS, SchemaOrgService } from './schema-org.service';
+import { SchemaOrgService } from './schema-org.service';
 
 describe('SchemaOrgService', () => {
 	let service: SchemaOrgService;
@@ -65,20 +65,18 @@ describe('SchemaOrgService', () => {
 	});
 
 	describe('removePageScopedJsonLd', () => {
-		it('should remove all page-scoped blocks and leave sitewide intact', () => {
+		it('should remove blocks set as page-scoped and leave sitewide intact', () => {
 			service.setJsonLd('organization', { '@type': 'Organization' });
 			service.setJsonLd('website', { '@type': 'WebSite' });
-			for (const id of PAGE_SCOPED_SCHEMA_IDS) {
-				service.setJsonLd(id, { '@type': 'Test' });
-			}
+			service.setPageScopedJsonLd('article', { '@type': 'Article' });
+			service.setPageScopedJsonLd('collection', { '@type': 'CollectionPage' });
 
 			service.removePageScopedJsonLd();
 
 			expect(scriptFor('organization')).not.toBeNull();
 			expect(scriptFor('website')).not.toBeNull();
-			for (const id of PAGE_SCOPED_SCHEMA_IDS) {
-				expect(scriptFor(id)).toBeNull();
-			}
+			expect(scriptFor('article')).toBeNull();
+			expect(scriptFor('collection')).toBeNull();
 		});
 
 		it('should not throw when no page-scoped blocks are present', () => {

--- a/src/app/providers/schema-org.service.ts
+++ b/src/app/providers/schema-org.service.ts
@@ -4,6 +4,19 @@ import { DOCUMENT, Injectable, inject } from '@angular/core';
 export type JsonLdSchema = Record<string, unknown>;
 
 /**
+ * Ids de los bloques JSON-LD de página (los no-sitewide). Si una nueva ruta indexable emite
+ * structured data propia, su id debe sumarse acá para que la home lo limpie al entrar.
+ */
+export const PAGE_SCOPED_SCHEMA_IDS = Object.freeze([
+	'article',
+	'breadcrumb-story',
+	'profile-page',
+	'breadcrumb-author',
+	'collection',
+	'breadcrumb-storylist',
+] as const);
+
+/**
  * Gestiona los bloques `<script type="application/ld+json">` del `<head>`.
  *
  * Inserta los bloques durante el SSR (usa `DOCUMENT`, no `window`) y es idempotente por `id`:
@@ -27,6 +40,12 @@ export class SchemaOrgService {
 	 */
 	public removeJsonLd(id: string): void {
 		this.findScript(id)?.remove();
+	}
+
+	public removePageScopedJsonLd(): void {
+		for (const id of PAGE_SCOPED_SCHEMA_IDS) {
+			this.removeJsonLd(id);
+		}
 	}
 
 	private resolveScript(id: string): HTMLScriptElement {

--- a/src/app/providers/schema-org.service.ts
+++ b/src/app/providers/schema-org.service.ts
@@ -4,19 +4,6 @@ import { DOCUMENT, Injectable, inject } from '@angular/core';
 export type JsonLdSchema = Record<string, unknown>;
 
 /**
- * Ids de los bloques JSON-LD de página (los no-sitewide). Si una nueva ruta indexable emite
- * structured data propia, su id debe sumarse acá para que la home lo limpie al entrar.
- */
-export const PAGE_SCOPED_SCHEMA_IDS = Object.freeze([
-	'article',
-	'breadcrumb-story',
-	'profile-page',
-	'breadcrumb-author',
-	'collection',
-	'breadcrumb-storylist',
-] as const);
-
-/**
  * Gestiona los bloques `<script type="application/ld+json">` del `<head>`.
  *
  * Inserta los bloques durante el SSR (usa `DOCUMENT`, no `window`) y es idempotente por `id`:
@@ -27,9 +14,18 @@ export const PAGE_SCOPED_SCHEMA_IDS = Object.freeze([
 export class SchemaOrgService {
 	private readonly document = inject(DOCUMENT);
 
-	/** Inserta o reemplaza (idempotente por `id`) un bloque JSON-LD en el `<head>`. */
+	/** Inserta o reemplaza (idempotente por `id`) un bloque JSON-LD sitewide, que persiste entre rutas. */
 	public setJsonLd(id: string, schema: JsonLdSchema): void {
-		this.resolveScript(id).textContent = JSON.stringify(schema);
+		this.writeScript(id, schema, 'sitewide');
+	}
+
+	/**
+	 * Inserta o reemplaza un bloque JSON-LD de página, marcándolo con `data-schema-scope="page"`.
+	 * El marcador permite que `removePageScopedJsonLd()` limpie todos los bloques de página al cambiar
+	 * de ruta sin mantener a mano una lista de ids.
+	 */
+	public setPageScopedJsonLd(id: string, schema: JsonLdSchema): void {
+		this.writeScript(id, schema, 'page');
 	}
 
 	/**
@@ -43,9 +39,13 @@ export class SchemaOrgService {
 	}
 
 	public removePageScopedJsonLd(): void {
-		for (const id of PAGE_SCOPED_SCHEMA_IDS) {
-			this.removeJsonLd(id);
-		}
+		this.document.head.querySelectorAll('script[data-schema-scope="page"]').forEach((script) => script.remove());
+	}
+
+	private writeScript(id: string, schema: JsonLdSchema, scope: 'sitewide' | 'page'): void {
+		const script = this.resolveScript(id);
+		script.setAttribute('data-schema-scope', scope);
+		script.textContent = JSON.stringify(schema);
 	}
 
 	private resolveScript(id: string): HTMLScriptElement {


### PR DESCRIPTION
## Descripción

- Al navegar in-app desde una storylist (u otra vista de contenido) hacia la home, los bloques JSON-LD de página (`collection`, `breadcrumb-storylist`, etc.) quedaban "leakeados" en el `<head>`: bajo `withViewTransitions()` el `onCleanup` de la directiva saliente no corría a tiempo. La home no tenía structured data propia que forzara el ciclo.
- Se invierte el contrato de `AbstractStructuredDataDirective`: `removeStructuredData()` pasa a ser `abstract` (cleanup obligatorio para todo descendiente) y `applyStructuredData()` queda como stub opcional para páginas sin bloques propios.
- Nueva `HomeStructuredDataDirective` (compuesta vía `hostDirectives` en `HomeComponent`) que, al entrar a la home, remueve los bloques de página remanentes.
- El cleanup es auto-mantenido: los bloques de página se marcan con `data-schema-scope="page"` (`SchemaOrgService.setPageScopedJsonLd()`) y `removePageScopedJsonLd()` los barre por atributo, sin una lista de ids hardcodeada.

Closes #1578.

Parte de #1525.

## Plan de pruebas

- [x] `pnpm lint` verde
- [x] `pnpm test` verde — specs nuevos de `SchemaOrgService.removePageScopedJsonLd()` y de `HomeStructuredDataDirective` (regresión storylist→home, limpieza cross-página, preservación de sitewide)
- [x] `pnpm build` verde
- [x] Verificación empírica con Playwright (SSR + `withViewTransitions()`): en `/storylist/verano-2022` el `<head>` tiene `organization, website, collection, breadcrumb-storylist`; tras navegar SPA a `/home` y esperar 5s (más que los 4s+ que persistía el bug) queda solo `organization, website`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)