### PR TITLE
[#1577] - Tests e2e de meta tags + JSON-LD en home, story, author y storylist

### DIFF
--- a/e2e/_utils/seo-fixtures.ts
+++ b/e2e/_utils/seo-fixtures.ts
@@ -1,0 +1,16 @@
+export const STABLE_SLUGS = Object.freeze({
+	story: 'el-aleph',
+	author: 'jorge-luis-borges',
+	storylist: 'verano-2022',
+} as const);
+
+export const SCHEMA_IDS = Object.freeze({
+	organization: 'organization',
+	website: 'website',
+	article: 'article',
+	breadcrumbStory: 'breadcrumb-story',
+	profilePage: 'profile-page',
+	breadcrumbAuthor: 'breadcrumb-author',
+	collection: 'collection',
+	breadcrumbStorylist: 'breadcrumb-storylist',
+} as const);

--- a/e2e/_utils/seo.ts
+++ b/e2e/_utils/seo.ts
@@ -1,0 +1,37 @@
+const JSONLD_PATTERN = /<script type="application\/ld\+json" data-schema-id="([^"]+)">([\s\S]*?)<\/script>/g;
+
+export function parseJsonLdBlocks(html: string): Map<string, Record<string, unknown>> {
+	const blocks = new Map<string, Record<string, unknown>>();
+	for (const match of html.matchAll(JSONLD_PATTERN)) {
+		const [, id, json] = match;
+		blocks.set(id, JSON.parse(json) as Record<string, unknown>);
+	}
+	return blocks;
+}
+
+export function getMetaContent(html: string, nameOrProperty: string): string | null {
+	const byName = html.match(new RegExp(`<meta[^>]+name="${nameOrProperty}"[^>]+content="([^"]*)"`, 'i'));
+	if (byName) {
+		return byName[1];
+	}
+	const byProperty = html.match(new RegExp(`<meta[^>]+property="${nameOrProperty}"[^>]+content="([^"]*)"`, 'i'));
+	if (byProperty) {
+		return byProperty[1];
+	}
+	const contentFirst = html.match(
+		new RegExp(`<meta[^>]+content="([^"]*)"[^>]+(?:name|property)="${nameOrProperty}"`, 'i'),
+	);
+	return contentFirst?.[1] ?? null;
+}
+
+export function getTitleText(html: string): string | null {
+	return html.match(/<title>([\s\S]*?)<\/title>/i)?.[1] ?? null;
+}
+
+export function getCanonicalHref(html: string): string | null {
+	return (
+		html.match(/<link[^>]+rel="canonical"[^>]+href="([^"]+)"/i)?.[1] ??
+		html.match(/<link[^>]+href="([^"]+)"[^>]+rel="canonical"/i)?.[1] ??
+		null
+	);
+}

--- a/e2e/_utils/seo.ts
+++ b/e2e/_utils/seo.ts
@@ -1,4 +1,4 @@
-const JSONLD_PATTERN = /<script type="application\/ld\+json" data-schema-id="([^"]+)">([\s\S]*?)<\/script>/g;
+const JSONLD_PATTERN = /<script[^>]*\bdata-schema-id="([^"]+)"[^>]*>([\s\S]*?)<\/script>/g;
 
 export function parseJsonLdBlocks(html: string): Map<string, Record<string, unknown>> {
 	const blocks = new Map<string, Record<string, unknown>>();

--- a/e2e/_utils/seo.ts
+++ b/e2e/_utils/seo.ts
@@ -10,22 +10,26 @@ export function parseJsonLdBlocks(html: string): Map<string, Record<string, unkn
 }
 
 export function getMetaContent(html: string, nameOrProperty: string): string | null {
-	const byName = html.match(new RegExp(`<meta[^>]+name="${nameOrProperty}"[^>]+content="([^"]*)"`, 'i'));
+	const key = escapeRegExp(nameOrProperty);
+	const byName = html.match(new RegExp(`<meta[^>]+name="${key}"[^>]+content="([^"]*)"`, 'i'));
 	if (byName) {
 		return byName[1];
 	}
-	const byProperty = html.match(new RegExp(`<meta[^>]+property="${nameOrProperty}"[^>]+content="([^"]*)"`, 'i'));
+	const byProperty = html.match(new RegExp(`<meta[^>]+property="${key}"[^>]+content="([^"]*)"`, 'i'));
 	if (byProperty) {
 		return byProperty[1];
 	}
-	const contentFirst = html.match(
-		new RegExp(`<meta[^>]+content="([^"]*)"[^>]+(?:name|property)="${nameOrProperty}"`, 'i'),
-	);
+	const contentFirst = html.match(new RegExp(`<meta[^>]+content="([^"]*)"[^>]+(?:name|property)="${key}"`, 'i'));
 	return contentFirst?.[1] ?? null;
 }
 
 export function getTitleText(html: string): string | null {
-	return html.match(/<title>([\s\S]*?)<\/title>/i)?.[1] ?? null;
+	const head = html.match(/<head[\s\S]*?<\/head>/i)?.[0] ?? html;
+	return head.match(/<title>([\s\S]*?)<\/title>/i)?.[1] ?? null;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 export function getCanonicalHref(html: string): string | null {

--- a/e2e/seo/author.spec.ts
+++ b/e2e/seo/author.spec.ts
@@ -47,6 +47,7 @@ test('author — B: JSON-LD ProfilePage y BreadcrumbList', async ({ request }) =
 	expect(mainEntity?.['name']).toBeTruthy();
 
 	const breadcrumb = blocks.get(SCHEMA_IDS.breadcrumbAuthor);
+	expect(breadcrumb?.['@context']).toBe('https://schema.org');
 	expect(breadcrumb?.['@type']).toBe('BreadcrumbList');
 	expect((breadcrumb?.['itemListElement'] as unknown[])?.length).toBeGreaterThanOrEqual(2);
 });

--- a/e2e/seo/author.spec.ts
+++ b/e2e/seo/author.spec.ts
@@ -71,5 +71,5 @@ test('author — D: al volver a la home se remueven los bloques del autor', asyn
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.breadcrumbAuthor}"]`)).toHaveCount(0);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.website}"]`)).toHaveCount(1);
 	await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
-	await expect(page.locator('title')).toHaveCount(1);
+	await expect(page.locator('head > title')).toHaveCount(1);
 });

--- a/e2e/seo/author.spec.ts
+++ b/e2e/seo/author.spec.ts
@@ -23,7 +23,7 @@ test('author — A: meta tags en el HTML server-rendered', async ({ request }) =
 	const html = await (await request.get(authorPath)).text();
 
 	expect(getTitleText(html)).toMatch(/borges/i);
-	expect(getMetaContent(html, 'description')).toContain('Perfil');
+	expect(getMetaContent(html, 'description')).toMatch(/borges/i);
 	expect(getMetaContent(html, 'og:title')).toBeTruthy();
 	expect(getMetaContent(html, 'og:description')).toBeTruthy();
 	expect(getMetaContent(html, 'twitter:title')).toBeTruthy();

--- a/e2e/seo/author.spec.ts
+++ b/e2e/seo/author.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests e2e de SEO para la página de autor (`/author/:slug`).
+ *
+ * Sobre el HTML server-rendered (lo que ve el crawler, sin ejecutar JS):
+ *  - A. Meta tags: <title> con el autor, description del perfil, og:/twitter: title y
+ *       description, canonical a la URL del autor, robots indexable y keywords.
+ *  - B. Datos estructurados: JSON-LD ProfilePage (dateCreated, dateModified, mainEntity Person)
+ *       y BreadcrumbList.
+ *  - C. Bloques sitewide Organization y WebSite.
+ *
+ * Sobre el DOM hidratado, vía navegación in-app (router):
+ *  - D. Al volver a la home (logo del header), los bloques del autor se remueven y los
+ *       sitewide persisten; sin duplicar canonical ni <title>.
+ */
+import { test, expect } from '@playwright/test';
+
+import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
+import { STABLE_SLUGS, SCHEMA_IDS } from '../_utils/seo-fixtures';
+
+const authorPath = `/author/${STABLE_SLUGS.author}`;
+
+test('author — A: meta tags en el HTML server-rendered', async ({ request }) => {
+	const html = await (await request.get(authorPath)).text();
+
+	expect(getTitleText(html)).toMatch(/borges/i);
+	expect(getMetaContent(html, 'description')).toContain('Perfil');
+	expect(getMetaContent(html, 'og:title')).toBeTruthy();
+	expect(getMetaContent(html, 'og:description')).toBeTruthy();
+	expect(getMetaContent(html, 'twitter:title')).toBeTruthy();
+	expect(getMetaContent(html, 'twitter:description')).toBeTruthy();
+	expect(getCanonicalHref(html)).toContain(authorPath);
+	expect(getMetaContent(html, 'robots')).toContain('index');
+	expect(getMetaContent(html, 'keywords')).toBeTruthy();
+});
+
+test('author — B: JSON-LD ProfilePage y BreadcrumbList', async ({ request }) => {
+	const html = await (await request.get(authorPath)).text();
+	const blocks = parseJsonLdBlocks(html);
+
+	const profilePage = blocks.get(SCHEMA_IDS.profilePage);
+	expect(profilePage?.['@context']).toBe('https://schema.org');
+	expect(profilePage?.['@type']).toBe('ProfilePage');
+	expect(profilePage?.['dateCreated']).toBeTruthy();
+	expect(profilePage?.['dateModified']).toBeTruthy();
+	const mainEntity = profilePage?.['mainEntity'] as Record<string, unknown>;
+	expect(mainEntity?.['@type']).toBe('Person');
+	expect(mainEntity?.['name']).toBeTruthy();
+
+	const breadcrumb = blocks.get(SCHEMA_IDS.breadcrumbAuthor);
+	expect(breadcrumb?.['@type']).toBe('BreadcrumbList');
+	expect((breadcrumb?.['itemListElement'] as unknown[])?.length).toBeGreaterThanOrEqual(2);
+});
+
+test('author — C: bloques sitewide Organization y WebSite presentes', async ({ request }) => {
+	const html = await (await request.get(authorPath)).text();
+	const blocks = parseJsonLdBlocks(html);
+
+	expect(blocks.get(SCHEMA_IDS.organization)?.['@type']).toBe('Organization');
+	expect(blocks.get(SCHEMA_IDS.website)?.['@type']).toBe('WebSite');
+});
+
+test('author — D: al volver a la home se remueven los bloques del autor', async ({ page }) => {
+	await page.goto(authorPath);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.profilePage}"]`)).toHaveCount(1);
+
+	await page.locator('header a[href="/home"]').first().click();
+	await expect(page).toHaveURL(/\/home$/);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
+
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.profilePage}"]`)).toHaveCount(0);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.breadcrumbAuthor}"]`)).toHaveCount(0);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.website}"]`)).toHaveCount(1);
+	await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
+	await expect(page.locator('title')).toHaveCount(1);
+});

--- a/e2e/seo/author.spec.ts
+++ b/e2e/seo/author.spec.ts
@@ -19,9 +19,13 @@ import { STABLE_SLUGS, SCHEMA_IDS } from '../_utils/seo-fixtures';
 
 const authorPath = `/author/${STABLE_SLUGS.author}`;
 
-test('author — A: meta tags en el HTML server-rendered', async ({ request }) => {
-	const html = await (await request.get(authorPath)).text();
+let html: string;
 
+test.beforeAll(async ({ request }) => {
+	html = await (await request.get(authorPath)).text();
+});
+
+test('author — A: meta tags en el HTML server-rendered', async () => {
 	expect(getTitleText(html)).toMatch(/borges/i);
 	expect(getMetaContent(html, 'description')).toMatch(/borges/i);
 	expect(getMetaContent(html, 'og:title')).toBeTruthy();
@@ -33,8 +37,7 @@ test('author — A: meta tags en el HTML server-rendered', async ({ request }) =
 	expect(getMetaContent(html, 'keywords')).toBeTruthy();
 });
 
-test('author — B: JSON-LD ProfilePage y BreadcrumbList', async ({ request }) => {
-	const html = await (await request.get(authorPath)).text();
+test('author — B: JSON-LD ProfilePage y BreadcrumbList', async () => {
 	const blocks = parseJsonLdBlocks(html);
 
 	const profilePage = blocks.get(SCHEMA_IDS.profilePage);
@@ -52,8 +55,7 @@ test('author — B: JSON-LD ProfilePage y BreadcrumbList', async ({ request }) =
 	expect((breadcrumb?.['itemListElement'] as unknown[])?.length).toBeGreaterThanOrEqual(2);
 });
 
-test('author — C: bloques sitewide Organization y WebSite presentes', async ({ request }) => {
-	const html = await (await request.get(authorPath)).text();
+test('author — C: bloques sitewide Organization y WebSite presentes', async () => {
 	const blocks = parseJsonLdBlocks(html);
 
 	expect(blocks.get(SCHEMA_IDS.organization)?.['@type']).toBe('Organization');

--- a/e2e/seo/home.spec.ts
+++ b/e2e/seo/home.spec.ts
@@ -56,5 +56,5 @@ test('home — D: al navegar a una story aparece el Article y el sitewide persis
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.website}"]`)).toHaveCount(1);
 	await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
-	await expect(page.locator('title')).toHaveCount(1);
+	await expect(page.locator('head > title')).toHaveCount(1);
 });

--- a/e2e/seo/home.spec.ts
+++ b/e2e/seo/home.spec.ts
@@ -16,9 +16,13 @@ import { test, expect } from '@playwright/test';
 import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
 import { SCHEMA_IDS } from '../_utils/seo-fixtures';
 
-test('home — A: meta tags en el HTML server-rendered', async ({ request }) => {
-	const html = await (await request.get('/home')).text();
+let html: string;
 
+test.beforeAll(async ({ request }) => {
+	html = await (await request.get('/home')).text();
+});
+
+test('home — A: meta tags en el HTML server-rendered', async () => {
 	expect(getTitleText(html)).toContain('La Cuentoneta');
 	expect(getMetaContent(html, 'description')).toBeTruthy();
 	expect(getMetaContent(html, 'og:title')).toBeTruthy();
@@ -30,8 +34,7 @@ test('home — A: meta tags en el HTML server-rendered', async ({ request }) => 
 	expect(getMetaContent(html, 'keywords')).toContain('relatos breves');
 });
 
-test('home — B/C: bloques JSON-LD sitewide Organization y WebSite', async ({ request }) => {
-	const html = await (await request.get('/home')).text();
+test('home — B/C: bloques JSON-LD sitewide Organization y WebSite', async () => {
 	const blocks = parseJsonLdBlocks(html);
 
 	const organization = blocks.get(SCHEMA_IDS.organization);

--- a/e2e/seo/home.spec.ts
+++ b/e2e/seo/home.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests e2e de SEO para la home (`/home`).
+ *
+ * Sobre el HTML server-rendered (lo que ve el crawler, sin ejecutar JS):
+ *  - A. Meta tags: <title> con la marca, description, og:/twitter: title y description,
+ *       link canonical, robots indexable y keywords.
+ *  - B+C. Datos estructurados sitewide: bloques JSON-LD Organization y WebSite (la home no
+ *         tiene una entidad propia, solo los sitewide del app initializer).
+ *
+ * Sobre el DOM hidratado, vía navegación in-app (router):
+ *  - D. Al navegar de la home a una story, los bloques sitewide persisten y aparece el Article;
+ *       sin duplicar canonical ni <title>.
+ */
+import { test, expect } from '@playwright/test';
+
+import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
+import { SCHEMA_IDS } from '../_utils/seo-fixtures';
+
+test('home — A: meta tags en el HTML server-rendered', async ({ request }) => {
+	const html = await (await request.get('/home')).text();
+
+	expect(getTitleText(html)).toContain('La Cuentoneta');
+	expect(getMetaContent(html, 'description')).toBeTruthy();
+	expect(getMetaContent(html, 'og:title')).toBeTruthy();
+	expect(getMetaContent(html, 'og:description')).toBeTruthy();
+	expect(getMetaContent(html, 'twitter:title')).toBeTruthy();
+	expect(getMetaContent(html, 'twitter:description')).toBeTruthy();
+	expect(getCanonicalHref(html)).toBeTruthy();
+	expect(getMetaContent(html, 'robots')).toContain('index');
+	expect(getMetaContent(html, 'keywords')).toContain('relatos breves');
+});
+
+test('home — B/C: bloques JSON-LD sitewide Organization y WebSite', async ({ request }) => {
+	const html = await (await request.get('/home')).text();
+	const blocks = parseJsonLdBlocks(html);
+
+	const organization = blocks.get(SCHEMA_IDS.organization);
+	expect(organization?.['@context']).toBe('https://schema.org');
+	expect(organization?.['@type']).toBe('Organization');
+	expect(organization?.['name']).toBe('La Cuentoneta');
+
+	const website = blocks.get(SCHEMA_IDS.website);
+	expect(website?.['@context']).toBe('https://schema.org');
+	expect(website?.['@type']).toBe('WebSite');
+	expect(website?.['name']).toBe('La Cuentoneta');
+});
+
+test('home — D: al navegar a una story aparece el Article y el sitewide persiste', async ({ page }) => {
+	await page.goto('/home');
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
+
+	await page.locator('a[href^="/story/"]').first().click();
+	await expect(page).toHaveURL(/\/story\//);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.article}"]`)).toHaveCount(1);
+
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.website}"]`)).toHaveCount(1);
+	await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
+	await expect(page.locator('title')).toHaveCount(1);
+});

--- a/e2e/seo/home.spec.ts
+++ b/e2e/seo/home.spec.ts
@@ -49,7 +49,7 @@ test('home — D: al navegar a una story aparece el Article y el sitewide persis
 	await page.goto('/home');
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
 
-	await page.locator('a[href^="/story/"]').first().click();
+	await page.locator('a[href^="/story/"]').filter({ visible: true }).first().click();
 	await expect(page).toHaveURL(/\/story\//);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.article}"]`)).toHaveCount(1);
 

--- a/e2e/seo/story.spec.ts
+++ b/e2e/seo/story.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests e2e de SEO para la página de cuento (`/story/:slug`).
+ *
+ * Sobre el HTML server-rendered (lo que ve el crawler, sin ejecutar JS):
+ *  - A. Meta tags: <title> con el cuento, description, og:/twitter: title y description,
+ *       canonical a la URL del cuento, robots indexable, keywords y author (señal E-E-A-T).
+ *  - B. Datos estructurados: JSON-LD Article (headline, author Person, datePublished,
+ *       dateModified, publisher Organization) y BreadcrumbList.
+ *  - C. Bloques sitewide Organization y WebSite.
+ *
+ * Sobre el DOM hidratado, vía navegación in-app (router):
+ *  - D. Al navegar del cuento al autor, los bloques del cuento (Article + breadcrumb) se
+ *       remueven y aparecen los del autor; sin duplicar canonical ni <title>.
+ */
+import { test, expect } from '@playwright/test';
+
+import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
+import { STABLE_SLUGS, SCHEMA_IDS } from '../_utils/seo-fixtures';
+
+const storyPath = `/story/${STABLE_SLUGS.story}`;
+
+test('story — A: meta tags en el HTML server-rendered', async ({ request }) => {
+	const html = await (await request.get(storyPath)).text();
+
+	expect(getTitleText(html)).toMatch(/aleph/i);
+	expect(getMetaContent(html, 'description')).toBeTruthy();
+	expect(getMetaContent(html, 'og:title')).toBeTruthy();
+	expect(getMetaContent(html, 'og:description')).toBeTruthy();
+	expect(getMetaContent(html, 'twitter:title')).toBeTruthy();
+	expect(getMetaContent(html, 'twitter:description')).toBeTruthy();
+	expect(getCanonicalHref(html)).toContain(storyPath);
+	expect(getMetaContent(html, 'robots')).toContain('index');
+	expect(getMetaContent(html, 'keywords')).toBeTruthy();
+	expect(getMetaContent(html, 'author')).toBeTruthy();
+});
+
+test('story — B: JSON-LD Article y BreadcrumbList', async ({ request }) => {
+	const html = await (await request.get(storyPath)).text();
+	const blocks = parseJsonLdBlocks(html);
+
+	const article = blocks.get(SCHEMA_IDS.article);
+	expect(article?.['@context']).toBe('https://schema.org');
+	expect(article?.['@type']).toBe('Article');
+	expect(article?.['headline']).toBeTruthy();
+	expect(article?.['datePublished']).toBeTruthy();
+	expect(article?.['dateModified']).toBeTruthy();
+	expect((article?.['author'] as Record<string, unknown>)?.['@type']).toBe('Person');
+	expect((article?.['publisher'] as Record<string, unknown>)?.['@type']).toBe('Organization');
+
+	const breadcrumb = blocks.get(SCHEMA_IDS.breadcrumbStory);
+	expect(breadcrumb?.['@context']).toBe('https://schema.org');
+	expect(breadcrumb?.['@type']).toBe('BreadcrumbList');
+	expect((breadcrumb?.['itemListElement'] as unknown[])?.length).toBeGreaterThanOrEqual(2);
+});
+
+test('story — C: bloques sitewide Organization y WebSite presentes', async ({ request }) => {
+	const html = await (await request.get(storyPath)).text();
+	const blocks = parseJsonLdBlocks(html);
+
+	expect(blocks.get(SCHEMA_IDS.organization)?.['@type']).toBe('Organization');
+	expect(blocks.get(SCHEMA_IDS.website)?.['@type']).toBe('WebSite');
+});
+
+test('story — D: al navegar al autor se remueven los bloques del cuento', async ({ page }) => {
+	await page.goto(storyPath);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.article}"]`)).toHaveCount(1);
+
+	await page.locator(`a[href="/author/${STABLE_SLUGS.author}"]`).first().click();
+	await expect(page).toHaveURL(/\/author\//);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.profilePage}"]`)).toHaveCount(1);
+
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.article}"]`)).toHaveCount(0);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.breadcrumbStory}"]`)).toHaveCount(0);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.breadcrumbAuthor}"]`)).toHaveCount(1);
+	await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
+	await expect(page.locator('title')).toHaveCount(1);
+});

--- a/e2e/seo/story.spec.ts
+++ b/e2e/seo/story.spec.ts
@@ -65,7 +65,8 @@ test('story — D: al navegar al autor se remueven los bloques del cuento', asyn
 	await page.goto(storyPath);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.article}"]`)).toHaveCount(1);
 
-	await page.locator(`a[href="/author/${STABLE_SLUGS.author}"]`).first().click();
+	// El-aleph es de Borges: la ficha del cuento enlaza a /author/jorge-luis-borges.
+	await page.locator(`a[href="/author/${STABLE_SLUGS.author}"]`).filter({ visible: true }).first().click();
 	await expect(page).toHaveURL(/\/author\//);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.profilePage}"]`)).toHaveCount(1);
 

--- a/e2e/seo/story.spec.ts
+++ b/e2e/seo/story.spec.ts
@@ -19,9 +19,13 @@ import { STABLE_SLUGS, SCHEMA_IDS } from '../_utils/seo-fixtures';
 
 const storyPath = `/story/${STABLE_SLUGS.story}`;
 
-test('story — A: meta tags en el HTML server-rendered', async ({ request }) => {
-	const html = await (await request.get(storyPath)).text();
+let html: string;
 
+test.beforeAll(async ({ request }) => {
+	html = await (await request.get(storyPath)).text();
+});
+
+test('story — A: meta tags en el HTML server-rendered', async () => {
 	expect(getTitleText(html)).toMatch(/aleph/i);
 	expect(getMetaContent(html, 'description')).toBeTruthy();
 	expect(getMetaContent(html, 'og:title')).toBeTruthy();
@@ -34,8 +38,7 @@ test('story — A: meta tags en el HTML server-rendered', async ({ request }) =>
 	expect(getMetaContent(html, 'author')).toBeTruthy();
 });
 
-test('story — B: JSON-LD Article y BreadcrumbList', async ({ request }) => {
-	const html = await (await request.get(storyPath)).text();
+test('story — B: JSON-LD Article y BreadcrumbList', async () => {
 	const blocks = parseJsonLdBlocks(html);
 
 	const article = blocks.get(SCHEMA_IDS.article);
@@ -53,8 +56,7 @@ test('story — B: JSON-LD Article y BreadcrumbList', async ({ request }) => {
 	expect((breadcrumb?.['itemListElement'] as unknown[])?.length).toBeGreaterThanOrEqual(2);
 });
 
-test('story — C: bloques sitewide Organization y WebSite presentes', async ({ request }) => {
-	const html = await (await request.get(storyPath)).text();
+test('story — C: bloques sitewide Organization y WebSite presentes', async () => {
 	const blocks = parseJsonLdBlocks(html);
 
 	expect(blocks.get(SCHEMA_IDS.organization)?.['@type']).toBe('Organization');

--- a/e2e/seo/story.spec.ts
+++ b/e2e/seo/story.spec.ts
@@ -73,5 +73,5 @@ test('story — D: al navegar al autor se remueven los bloques del cuento', asyn
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.breadcrumbStory}"]`)).toHaveCount(0);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.breadcrumbAuthor}"]`)).toHaveCount(1);
 	await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
-	await expect(page.locator('title')).toHaveCount(1);
+	await expect(page.locator('head > title')).toHaveCount(1);
 });

--- a/e2e/seo/storylist.spec.ts
+++ b/e2e/seo/storylist.spec.ts
@@ -67,7 +67,7 @@ test('storylist — D: al navegar a un cuento se remueven los bloques de la cole
 	await page.goto(storylistPath);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.collection}"]`)).toHaveCount(1);
 
-	await page.locator('a[href^="/story/"]').first().click();
+	await page.locator('a[href^="/story/"]').filter({ visible: true }).first().click();
 	await expect(page).toHaveURL(/\/story\//);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.article}"]`)).toHaveCount(1);
 
@@ -82,12 +82,13 @@ test('storylist — E: al navegar a la home se remueven los bloques de la colecc
 	await page.goto(storylistPath);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.collection}"]`)).toHaveCount(1);
 
-	await page.locator('a[href$="/home"]').first().click();
-	await expect(page).toHaveURL(/\/home/);
+	await page.locator('header a[href="/home"]').first().click();
+	await expect(page).toHaveURL(/\/home$/);
 
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.collection}"]`)).toHaveCount(0);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.breadcrumbStorylist}"]`)).toHaveCount(0);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.website}"]`)).toHaveCount(1);
+	await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
 	await expect(page.locator('head > title')).toHaveCount(1);
 });

--- a/e2e/seo/storylist.spec.ts
+++ b/e2e/seo/storylist.spec.ts
@@ -11,6 +11,8 @@
  * Sobre el DOM hidratado, vía navegación in-app (router):
  *  - D. Al navegar a un cuento de la colección, los bloques de la storylist (CollectionPage +
  *       breadcrumb) se remueven y aparece el Article; sin duplicar canonical ni <title>.
+ *  - E. Al navegar a la home (que no emite structured data propia), los bloques de la storylist
+ *       se remueven igual y persisten solo los sitewide — regresión de #1578.
  */
 import { test, expect } from '@playwright/test';
 
@@ -73,5 +75,19 @@ test('storylist — D: al navegar a un cuento se remueven los bloques de la cole
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.breadcrumbStorylist}"]`)).toHaveCount(0);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
 	await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
+	await expect(page.locator('head > title')).toHaveCount(1);
+});
+
+test('storylist — E: al navegar a la home se remueven los bloques de la colección', async ({ page }) => {
+	await page.goto(storylistPath);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.collection}"]`)).toHaveCount(1);
+
+	await page.locator('a[href$="/home"]').first().click();
+	await expect(page).toHaveURL(/\/home/);
+
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.collection}"]`)).toHaveCount(0);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.breadcrumbStorylist}"]`)).toHaveCount(0);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.website}"]`)).toHaveCount(1);
 	await expect(page.locator('head > title')).toHaveCount(1);
 });

--- a/e2e/seo/storylist.spec.ts
+++ b/e2e/seo/storylist.spec.ts
@@ -24,7 +24,7 @@ const storylistPath = `/storylist/${STABLE_SLUGS.storylist}`;
 test('storylist — A: meta tags en el HTML server-rendered', async ({ request }) => {
 	const html = await (await request.get(storylistPath)).text();
 
-	expect(getTitleText(html)).toBeTruthy();
+	expect(getTitleText(html)).toMatch(/verano/i);
 	expect(getMetaContent(html, 'description')).toBeTruthy();
 	expect(getMetaContent(html, 'og:title')).toBeTruthy();
 	expect(getMetaContent(html, 'og:description')).toBeTruthy();

--- a/e2e/seo/storylist.spec.ts
+++ b/e2e/seo/storylist.spec.ts
@@ -21,10 +21,16 @@ import { STABLE_SLUGS, SCHEMA_IDS } from '../_utils/seo-fixtures';
 
 const storylistPath = `/storylist/${STABLE_SLUGS.storylist}`;
 
-test('storylist — A: meta tags en el HTML server-rendered', async ({ request }) => {
-	const html = await (await request.get(storylistPath)).text();
+let html: string;
 
-	expect(getTitleText(html)).toMatch(/verano/i);
+test.beforeAll(async ({ request }) => {
+	html = await (await request.get(storylistPath)).text();
+});
+
+test('storylist — A: meta tags en el HTML server-rendered', async () => {
+	// El título de la storylist es editorial (no deriva del slug); la especificidad por colección
+	// la cubre la aserción del canonical más abajo.
+	expect(getTitleText(html)).toBeTruthy();
 	expect(getMetaContent(html, 'description')).toBeTruthy();
 	expect(getMetaContent(html, 'og:title')).toBeTruthy();
 	expect(getMetaContent(html, 'og:description')).toBeTruthy();
@@ -35,8 +41,7 @@ test('storylist — A: meta tags en el HTML server-rendered', async ({ request }
 	expect(getMetaContent(html, 'keywords')).toBeTruthy();
 });
 
-test('storylist — B: JSON-LD CollectionPage y BreadcrumbList', async ({ request }) => {
-	const html = await (await request.get(storylistPath)).text();
+test('storylist — B: JSON-LD CollectionPage y BreadcrumbList', async () => {
 	const blocks = parseJsonLdBlocks(html);
 
 	const collection = blocks.get(SCHEMA_IDS.collection);
@@ -56,8 +61,7 @@ test('storylist — B: JSON-LD CollectionPage y BreadcrumbList', async ({ reques
 	expect((breadcrumb?.['itemListElement'] as unknown[])?.length).toBeGreaterThanOrEqual(2);
 });
 
-test('storylist — C: bloques sitewide Organization y WebSite presentes', async ({ request }) => {
-	const html = await (await request.get(storylistPath)).text();
+test('storylist — C: bloques sitewide Organization y WebSite presentes', async () => {
 	const blocks = parseJsonLdBlocks(html);
 
 	expect(blocks.get(SCHEMA_IDS.organization)?.['@type']).toBe('Organization');

--- a/e2e/seo/storylist.spec.ts
+++ b/e2e/seo/storylist.spec.ts
@@ -9,8 +9,8 @@
  *  - C. Bloques sitewide Organization y WebSite.
  *
  * Sobre el DOM hidratado, vía navegación in-app (router):
- *  - D. Al volver a la home (logo del header), los bloques de la colección se remueven y los
- *       sitewide persisten; sin duplicar canonical ni <title>.
+ *  - D. Al navegar a un cuento de la colección, los bloques de la storylist (CollectionPage +
+ *       breadcrumb) se remueven y aparece el Article; sin duplicar canonical ni <title>.
  */
 import { test, expect } from '@playwright/test';
 
@@ -61,17 +61,17 @@ test('storylist — C: bloques sitewide Organization y WebSite presentes', async
 	expect(blocks.get(SCHEMA_IDS.website)?.['@type']).toBe('WebSite');
 });
 
-test('storylist — D: al volver a la home se remueven los bloques de la colección', async ({ page }) => {
+test('storylist — D: al navegar a un cuento se remueven los bloques de la colección', async ({ page }) => {
 	await page.goto(storylistPath);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.collection}"]`)).toHaveCount(1);
 
-	await page.locator('header a[href="/home"]').first().click();
-	await expect(page).toHaveURL(/\/home$/);
-	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
+	await page.locator('a[href^="/story/"]').first().click();
+	await expect(page).toHaveURL(/\/story\//);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.article}"]`)).toHaveCount(1);
 
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.collection}"]`)).toHaveCount(0);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.breadcrumbStorylist}"]`)).toHaveCount(0);
-	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.website}"]`)).toHaveCount(1);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
 	await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
-	await expect(page.locator('title')).toHaveCount(1);
+	await expect(page.locator('head > title')).toHaveCount(1);
 });

--- a/e2e/seo/storylist.spec.ts
+++ b/e2e/seo/storylist.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests e2e de SEO para la página de storylist/colección (`/storylist/:slug`).
+ *
+ * Sobre el HTML server-rendered (lo que ve el crawler, sin ejecutar JS):
+ *  - A. Meta tags: <title> con la colección, description, og:/twitter: title y description,
+ *       canonical a la URL de la storylist, robots indexable y keywords.
+ *  - B. Datos estructurados: JSON-LD CollectionPage (mainEntity ItemList con numberOfItems y
+ *       ListItems ordenados) y BreadcrumbList.
+ *  - C. Bloques sitewide Organization y WebSite.
+ *
+ * Sobre el DOM hidratado, vía navegación in-app (router):
+ *  - D. Al volver a la home (logo del header), los bloques de la colección se remueven y los
+ *       sitewide persisten; sin duplicar canonical ni <title>.
+ */
+import { test, expect } from '@playwright/test';
+
+import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
+import { STABLE_SLUGS, SCHEMA_IDS } from '../_utils/seo-fixtures';
+
+const storylistPath = `/storylist/${STABLE_SLUGS.storylist}`;
+
+test('storylist — A: meta tags en el HTML server-rendered', async ({ request }) => {
+	const html = await (await request.get(storylistPath)).text();
+
+	expect(getTitleText(html)).toBeTruthy();
+	expect(getMetaContent(html, 'description')).toBeTruthy();
+	expect(getMetaContent(html, 'og:title')).toBeTruthy();
+	expect(getMetaContent(html, 'og:description')).toBeTruthy();
+	expect(getMetaContent(html, 'twitter:title')).toBeTruthy();
+	expect(getMetaContent(html, 'twitter:description')).toBeTruthy();
+	expect(getCanonicalHref(html)).toContain(storylistPath);
+	expect(getMetaContent(html, 'robots')).toContain('index');
+	expect(getMetaContent(html, 'keywords')).toBeTruthy();
+});
+
+test('storylist — B: JSON-LD CollectionPage y BreadcrumbList', async ({ request }) => {
+	const html = await (await request.get(storylistPath)).text();
+	const blocks = parseJsonLdBlocks(html);
+
+	const collection = blocks.get(SCHEMA_IDS.collection);
+	expect(collection?.['@context']).toBe('https://schema.org');
+	expect(collection?.['@type']).toBe('CollectionPage');
+	const mainEntity = collection?.['mainEntity'] as Record<string, unknown>;
+	expect(mainEntity?.['@type']).toBe('ItemList');
+	expect(Number(mainEntity?.['numberOfItems'])).toBeGreaterThan(0);
+	const listElements = mainEntity?.['itemListElement'] as Record<string, unknown>[];
+	expect(listElements?.length).toBeGreaterThan(0);
+	expect(listElements?.[0]?.['@type']).toBe('ListItem');
+	expect(listElements?.[0]?.['position']).toBe(1);
+
+	const breadcrumb = blocks.get(SCHEMA_IDS.breadcrumbStorylist);
+	expect(breadcrumb?.['@type']).toBe('BreadcrumbList');
+	expect((breadcrumb?.['itemListElement'] as unknown[])?.length).toBeGreaterThanOrEqual(2);
+});
+
+test('storylist — C: bloques sitewide Organization y WebSite presentes', async ({ request }) => {
+	const html = await (await request.get(storylistPath)).text();
+	const blocks = parseJsonLdBlocks(html);
+
+	expect(blocks.get(SCHEMA_IDS.organization)?.['@type']).toBe('Organization');
+	expect(blocks.get(SCHEMA_IDS.website)?.['@type']).toBe('WebSite');
+});
+
+test('storylist — D: al volver a la home se remueven los bloques de la colección', async ({ page }) => {
+	await page.goto(storylistPath);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.collection}"]`)).toHaveCount(1);
+
+	await page.locator('header a[href="/home"]').first().click();
+	await expect(page).toHaveURL(/\/home$/);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
+
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.collection}"]`)).toHaveCount(0);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.breadcrumbStorylist}"]`)).toHaveCount(0);
+	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.website}"]`)).toHaveCount(1);
+	await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
+	await expect(page.locator('title')).toHaveCount(1);
+});

--- a/e2e/seo/storylist.spec.ts
+++ b/e2e/seo/storylist.spec.ts
@@ -51,6 +51,7 @@ test('storylist — B: JSON-LD CollectionPage y BreadcrumbList', async ({ reques
 	expect(listElements?.[0]?.['position']).toBe(1);
 
 	const breadcrumb = blocks.get(SCHEMA_IDS.breadcrumbStorylist);
+	expect(breadcrumb?.['@context']).toBe('https://schema.org');
 	expect(breadcrumb?.['@type']).toBe('BreadcrumbList');
 	expect((breadcrumb?.['itemListElement'] as unknown[])?.length).toBeGreaterThanOrEqual(2);
 });


### PR DESCRIPTION
## Descripción

- Cobertura e2e (Playwright, chromium + firefox) del SEO en las 4 páginas SSR indexables (home, story, author, storylist).
- Por página: A) meta tags sobre el **HTML crudo SSR** (`request.get`, lo que ve el crawler sin ejecutar JS); B) JSON-LD propio del tipo de página; C) bloques sitewide Organization/WebSite; D/E) navegación SPA con limpieza/no-fuga de bloques al cambiar de ruta.
- El caso `storylist — E` (storylist→home) cubre la regresión de #1578: al entrar a la home —que no emite structured data propia— los bloques de la colección se remueven y persisten solo los sitewide.
- Helpers de parseo SSR en `e2e/_utils/seo.ts` y fixtures de slugs estables en `e2e/_utils/seo-fixtures.ts` (story=el-aleph, author=jorge-luis-borges, storylist=verano-2022).

Closes #1577.

Parte de #1525.

## Plan de pruebas

- [x] `pnpm exec playwright test e2e/seo` → 32 passed (chromium + firefox)
- [x] `pnpm lint` verde
- [x] Verificada la regresión de #1578 en runtime (storylist→home deja el `<head>` solo con Organization + WebSite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)