### PR TITLE
[#1493] - Automatizar replicación diaria del dataset de producción a staging y development

### DIFF
--- a/.github/workflows/sync-datasets.yml
+++ b/.github/workflows/sync-datasets.yml
@@ -88,7 +88,7 @@ jobs:
             echo "::error::El tarball $TARBALL no existe. Se aborta para no borrar los targets." >&2
             exit 1
           fi
-          actual_bytes=$(stat -c%s "$TARBALL")
+          actual_bytes=$(wc -c < "$TARBALL")
           if [ "$actual_bytes" -lt "$MIN_TARBALL_BYTES" ]; then
             echo "::error::El tarball pesa ${actual_bytes} bytes (< mínimo ${MIN_TARBALL_BYTES}). Posible export fallido; se aborta." >&2
             exit 1

--- a/.github/workflows/sync-datasets.yml
+++ b/.github/workflows/sync-datasets.yml
@@ -51,7 +51,8 @@ jobs:
       # Umbral mínimo: un export real de producción pesa varios MB; por debajo de 50 KB asumimos un
       # export fallido o un dataset vacío y abortamos sin tocar los targets.
       MIN_TARBALL_BYTES: 51200
-      # En el schedule no hay inputs → la corrida diaria sincroniza ambos targets.
+      # En schedule no hay inputs (github.event.inputs.targets = '') → el fallback deja TARGETS en
+      # 'both' y la corrida diaria sincroniza ambos targets. En workflow_dispatch toma el input.
       TARGETS: ${{ github.event.inputs.targets || 'both' }}
 
     steps:
@@ -119,6 +120,8 @@ jobs:
           for dataset in $datasets; do
             echo "::group::Sync $dataset"
             pnpm exec sanity dataset delete "$dataset" --force
+            # --visibility public preserva la visibilidad actual: staging y development son públicos
+            # (los lee el frontend de esos entornos sin token); production es el privado.
             pnpm exec sanity dataset create "$dataset" --visibility public
             pnpm exec sanity dataset import "$TARBALL" "$dataset"
             echo "::endgroup::"

--- a/.github/workflows/sync-datasets.yml
+++ b/.github/workflows/sync-datasets.yml
@@ -1,0 +1,109 @@
+name: Sync datasets (production → staging + development)
+
+# Replica el dataset `production` de Sanity hacia `staging` y `development` como espejo exacto
+# (wipe + import), para que los entornos no acumulen documentos huérfanos.
+#
+# Prerequisitos (secrets del repo — se configuran una sola vez, ver el PR del issue #1493):
+#   - SANITY_AUTH_TOKEN: robot token de manage.sanity.io con permisos para administrar datasets
+#     (crear/borrar/importar) y leer `production` (que es privado).
+#   - SANITY_STUDIO_PROJECT_ID: id del proyecto Sanity (s4dbqkc5). Ya existe (lo usa ci.yml).
+
+on:
+  schedule:
+    # 03:17 UTC (~00:17 ART), horario valle; minuto ≠ 0 para evitar el pico de carga de las :00.
+    # GitHub desactiva los schedules tras 60 días sin actividad en el repo (avisa por email); si el
+    # cron deja de correr, reactivarlo desde la pestaña Actions o con un push a la rama default.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: 'Datasets a sincronizar (los disparos manuales apuntan a development por defecto, para un dry-run seguro).'
+        type: choice
+        default: development
+        options:
+          - development
+          - staging
+          - both
+
+concurrency:
+  group: sync-datasets
+  # No cancelar una corrida en progreso: cortar a mitad de un wipe dejaría un dataset vacío.
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Export production → wipe + import targets
+    runs-on: ubuntu-latest
+
+    env:
+      SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+      SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID }}
+      SOURCE_DATASET: production
+      TARBALL: production.tar.gz
+      # Umbral mínimo: un export real de producción pesa varios MB; por debajo de 50 KB asumimos un
+      # export fallido o un dataset vacío y abortamos sin tocar los targets.
+      MIN_TARBALL_BYTES: 51200
+      # En el schedule no hay inputs → la corrida diaria sincroniza ambos targets.
+      TARGETS: ${{ github.event.inputs.targets || 'both' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Select pnpm as package manager
+        uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.12.1
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 22.22.3
+          cache: 'pnpm'
+          cache-dependency-path: cms/pnpm-lock.yaml
+
+      - name: Install CMS dependencies
+        working-directory: cms
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Export production dataset
+        working-directory: cms
+        run: |
+          set -euo pipefail
+          pnpm exec sanity dataset export "$SOURCE_DATASET" "$TARBALL" --overwrite
+
+      - name: Validate tarball (safety guard)
+        working-directory: cms
+        run: |
+          set -euo pipefail
+          if [ ! -f "$TARBALL" ]; then
+            echo "::error::El tarball $TARBALL no existe. Se aborta para no borrar los targets." >&2
+            exit 1
+          fi
+          actual_bytes=$(stat -c%s "$TARBALL")
+          if [ "$actual_bytes" -lt "$MIN_TARBALL_BYTES" ]; then
+            echo "::error::El tarball pesa ${actual_bytes} bytes (< mínimo ${MIN_TARBALL_BYTES}). Posible export fallido; se aborta." >&2
+            exit 1
+          fi
+          echo "Tarball válido: ${actual_bytes} bytes."
+
+      - name: Sync targets (wipe + import)
+        working-directory: cms
+        run: |
+          set -euo pipefail
+          case "$TARGETS" in
+            both) datasets="staging development" ;;
+            staging) datasets="staging" ;;
+            development) datasets="development" ;;
+            *) echo "::error::Valor de targets no soportado: $TARGETS" >&2; exit 1 ;;
+          esac
+          for dataset in $datasets; do
+            echo "::group::Sync $dataset"
+            pnpm exec sanity dataset delete "$dataset" --force
+            pnpm exec sanity dataset create "$dataset" --visibility public
+            pnpm exec sanity dataset import "$TARBALL" "$dataset"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/sync-datasets.yml
+++ b/.github/workflows/sync-datasets.yml
@@ -90,6 +90,17 @@ jobs:
           fi
           echo "Tarball válido: ${actual_bytes} bytes."
 
+      # Se sube ANTES del wipe: si un import falla tras el delete, el tarball queda disponible para
+      # restaurar el dataset manualmente sin re-exportar production.
+      - name: Upload tarball (recuperación manual)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-tarball
+          path: cms/production.tar.gz
+          retention-days: 1
+          if-no-files-found: ignore
+
       - name: Sync targets (wipe + import)
         working-directory: cms
         run: |
@@ -107,3 +118,10 @@ jobs:
             pnpm exec sanity dataset import "$TARBALL" "$dataset"
             echo "::endgroup::"
           done
+
+      - name: Instrucciones de recuperación ante fallo
+        if: failure()
+        run: |
+          echo "::error::La sincronización falló. Si un dataset quedó vacío tras el delete, restauralo:" >&2
+          echo "::error::  1) descargá el artefacto 'production-tarball' de este run;" >&2
+          echo "::error::  2) cd cms && pnpm exec sanity dataset import production.tar.gz <target>" >&2

--- a/.github/workflows/sync-datasets.yml
+++ b/.github/workflows/sync-datasets.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   sync:
-    name: Export production → wipe + import targets
+    name: Sync Sanity datasets from production
     runs-on: ubuntu-latest
 
     env:
@@ -126,6 +126,7 @@ jobs:
             pnpm exec sanity dataset import "$TARBALL" "$dataset"
             echo "::endgroup::"
           done
+          echo "Sync completado para: $datasets"
 
       - name: Instrucciones de recuperación ante fallo
         if: failure()

--- a/.github/workflows/sync-datasets.yml
+++ b/.github/workflows/sync-datasets.yml
@@ -41,6 +41,11 @@ jobs:
     env:
       SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
       SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID }}
+      # El CLI de Sanity corre desatendido cuando CI=true (Actions ya lo setea; explícito por
+      # robustez ante un cambio futuro del runner). El flujo además no dispara prompts: delete usa
+      # --force, create pasa --visibility, e import escribe en un dataset recién creado y vacío
+      # (sin conflictos de ids → sin prompt de --replace).
+      CI: 'true'
       SOURCE_DATASET: production
       TARBALL: production.tar.gz
       # Umbral mínimo: un export real de producción pesa varios MB; por debajo de 50 KB asumimos un


### PR DESCRIPTION
## Descripción

- Agrega `.github/workflows/sync-datasets.yml`: workflow de GitHub Actions que cada día (cron `17 3 * * *` UTC, horario valle) y por `workflow_dispatch` exporta el dataset `production` de Sanity y lo importa como **espejo exacto** (wipe + import) a `staging` y `development`, eliminando el proceso manual.
- **Guarda de seguridad:** el job aborta si el export no produce un tarball válido (> 50 KB) **antes** de borrar cualquier target. El tarball se sube como artefacto (retención 1 día) antes del wipe, y un step `if: failure()` emite las instrucciones de recuperación.
- El disparo manual apunta a `development` por defecto (dry-run seguro); el cron diario sincroniza ambos targets.

Closes #1493.

## Pasos manuales

**Antes del merge (prerequisitos):**
- [x] Robot token de Sanity (admin de datasets + lectura de `production`) creado y guardado como secret `SANITY_AUTH_TOKEN` — **confirmado configurado**.
- [x] Secret `SANITY_STUDIO_PROJECT_ID` existente (lo usa `ci.yml`).

**Después del merge (validación — GitHub solo expone `schedule`/`workflow_dispatch` desde la rama default `develop`):**
- [ ] Actions → *Sync datasets…* → **Run workflow** → branch `develop` → `targets: development` (dry-run seguro).
- [ ] Verificar: `development` con documentos (cantidad ≈ `production`) y visibilidad `public` en manage.sanity.io.
- [ ] Opcional: una corrida con `targets: both` para sembrar `staging`, o dejar que el cron nocturno lo haga.

> Mergear a `develop` activa el cron **y** habilita el botón Run workflow al mismo tiempo; conviene hacer el dry-run de `development` apenas se mergea, antes de la primera corrida nocturna.

## Plan de pruebas

- [x] Schema del workflow validado con `@action-validator/cli` (exit 0).
- [x] Line endings: el blob queda igual que `ci.yml` (el parser YAML normaliza los `run: |` a LF en runtime).
- [ ] Dry-run real contra `development` post-merge (ver pasos manuales).

## Follow-up

- #1584 — configurar Dependabot para auto-bump de GitHub Actions (detectado en review, fuera de alcance de este issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)