### PR TITLE
[#1553] - Cache de Nx en CI: Nx Cloud + fallback actions/cache + hardening ante PRs de forks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Code owners de rutas sensibles de La Cuentoneta.
+#
+# Todo PR (incluido uno desde un fork) que toque estos archivos auto-asigna a un maintainer como
+# reviewer. Para que además BLOQUEE el merge sin su aprobación, activar en branch protection de
+# `develop`: "Require a pull request before merging" → "Require approvals" (>= 1) + "Require review
+# from Code Owners".
+#
+# Motivación: evitar que un PR externo cambie config sensible —p. ej. SANITY_STUDIO_PROJECT_ID /
+# SANITY_STUDIO_DATASET, o los secrets/defaults del CI— sin revisión de un maintainer. Sumar acá
+# nuevas rutas a medida que aparezcan más valores sensibles.
+
+# Configuración de entorno / target de Sanity (projectId, dataset, token)
+/scripts/set-environment.ts        @rolivencia
+/cms/set-environment.ts            @rolivencia
+/src/api/_helpers/environment.ts   @rolivencia
+/cms/sanity.config.ts              @rolivencia
+/cms/sanity.cli.ts                 @rolivencia
+
+# CI/CD y configuración de Actions (workflows, secrets, defaults — y este mismo archivo)
+/.github/                          @rolivencia

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,9 @@ jobs:
       - name: Run build
         run: npx nx run @cuentoneta/app:build:production
         env:
+          # Nx Cloud (cache remota de tareas)
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          # Sanity / terceros (consumidos por el build de producción)
           SANITY_STUDIO_DATASET: ${{ secrets.SANITY_STUDIO_DATASET }}
           SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID }}
           SANITY_STUDIO_TOKEN: ${{ secrets.SANITY_STUDIO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,9 +259,12 @@ jobs:
         env:
           # Nx Cloud (cache remota de tareas)
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          # Sanity / terceros (consumidos por el build de producción)
-          SANITY_STUDIO_DATASET: ${{ secrets.SANITY_STUDIO_DATASET }}
-          SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID }}
+          # Sanity / terceros. En PRs de forks los secrets llegan vacíos: para projectId/dataset
+          # (públicos, ya son los defaults de set-environment.ts) caemos a esos valores para que el
+          # build compile contra el dataset público de desarrollo. El token y los de terceros quedan
+          # vacíos a propósito — no se exponen credenciales reales a un fork.
+          SANITY_STUDIO_DATASET: ${{ secrets.SANITY_STUDIO_DATASET || 'development' }}
+          SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID || 's4dbqkc5' }}
           SANITY_STUDIO_TOKEN: ${{ secrets.SANITY_STUDIO_TOKEN }}
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
           CLARITY_TOKEN: ${{ secrets.CLARITY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on:
   pull_request:
+  # Push a develop: corre el CI al mergear y, sobre todo, guarda el cache de Nx en la rama default.
+  # Por el scoping de actions/cache, ese cache base lo pueden restaurar todos los PRs (warm desde
+  # el primer push), no solo los pushes de un mismo PR.
+  push:
+    branches: [develop]
 
 jobs:
   setup:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,16 @@ jobs:
       - name: Unpack workspace
         run: tar -xf workspace.tar
 
+      # Capa de cache gratuita (cache de Actions) sobre el cache local de Nx: da hits sin consumir
+      # créditos de Nx Cloud, y sigue funcionando si Nx Cloud se queda sin créditos o no responde.
+      - name: Cache de Nx local (fallback sin Nx Cloud)
+        uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: nx-cache-test-${{ github.sha }}
+          restore-keys: |
+            nx-cache-test-
+
       - name: Run Tests
         run: npx nx test
         env:
@@ -123,6 +133,14 @@ jobs:
       - name: Unpack workspace
         run: tar -xf workspace.tar
 
+      - name: Cache de Nx local (fallback sin Nx Cloud)
+        uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: nx-cache-lint-${{ github.sha }}
+          restore-keys: |
+            nx-cache-lint-
+
       - name: Run Linter
         run: npx nx lint
         env:
@@ -149,6 +167,14 @@ jobs:
 
       - name: Unpack workspace
         run: tar -xf workspace.tar
+
+      - name: Cache de Nx local (fallback sin Nx Cloud)
+        uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: nx-cache-stylelint-${{ github.sha }}
+          restore-keys: |
+            nx-cache-stylelint-
 
       - name: Run stylelint
         run: npx nx stylelint @cuentoneta/app
@@ -215,6 +241,14 @@ jobs:
       - name: Unpack workspace
         run: tar -xf workspace.tar
 
+      - name: Cache de Nx local (fallback sin Nx Cloud)
+        uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: nx-cache-build-${{ github.sha }}
+          restore-keys: |
+            nx-cache-build-
+
       - name: Run build
         run: npx nx run @cuentoneta/app:build:production
         env:
@@ -249,6 +283,14 @@ jobs:
 
       - name: Unpack workspace
         run: tar -xf workspace.tar
+
+      - name: Cache de Nx local (fallback sin Nx Cloud)
+        uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: nx-cache-storybook-${{ github.sha }}
+          restore-keys: |
+            nx-cache-storybook-
 
       - name: Run Storybook build
         run: npx nx run @cuentoneta/app:build-storybook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,6 @@ jobs:
           SANITY_STUDIO_DATASET: ${{ secrets.SANITY_STUDIO_DATASET || 'development' }}
           SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID || 's4dbqkc5' }}
           SANITY_STUDIO_TOKEN: ${{ secrets.SANITY_STUDIO_TOKEN }}
-          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
           CLARITY_TOKEN: ${{ secrets.CLARITY_TOKEN }}
           CLARITY_PROJECT_ID: ${{ secrets.CLARITY_PROJECT_ID }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,9 @@ jobs:
         run: tar -xf workspace.tar
 
       - name: Run Tests
-        run: npx nx test --skip-nx-cache
+        run: npx nx test
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
       # A) Reporte navegable (html + lcov) como artefacto descargable del workflow.
       - name: Upload coverage artifact
@@ -122,7 +124,9 @@ jobs:
         run: tar -xf workspace.tar
 
       - name: Run Linter
-        run: npx nx lint --skip-nx-cache
+        run: npx nx lint
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
   stylelint:
     needs: setup
@@ -147,7 +151,9 @@ jobs:
         run: tar -xf workspace.tar
 
       - name: Run stylelint
-        run: npx nx stylelint @cuentoneta/app --skip-nx-cache
+        run: npx nx stylelint @cuentoneta/app
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
   e2e:
     needs: setup
@@ -175,7 +181,9 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Tests
-        run: npx nx run @cuentoneta/app:e2e --skip-nx-cache
+        run: npx nx run @cuentoneta/app:e2e
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
@@ -208,8 +216,9 @@ jobs:
         run: tar -xf workspace.tar
 
       - name: Run build
-        run: npx nx run @cuentoneta/app:build:production --skip-nx-cache
+        run: npx nx run @cuentoneta/app:build:production
         env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
           SANITY_STUDIO_DATASET: ${{ secrets.SANITY_STUDIO_DATASET }}
           SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID }}
           SANITY_STUDIO_TOKEN: ${{ secrets.SANITY_STUDIO_TOKEN }}
@@ -240,4 +249,6 @@ jobs:
         run: tar -xf workspace.tar
 
       - name: Run Storybook build
-        run: npx nx run @cuentoneta/app:build-storybook --skip-nx-cache
+        run: npx nx run @cuentoneta/app:build-storybook
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}

--- a/.github/workflows/guard-config.yml
+++ b/.github/workflows/guard-config.yml
@@ -1,0 +1,48 @@
+name: Guard de config sensible
+
+# Bloquea que un PR desde un fork modifique configuración sensible (env/target de Sanity, CI).
+#
+# Usa `pull_request_target` a propósito: el workflow corre desde la rama base, así un fork NO puede
+# neutralizar este guard editándolo en su propio PR (lo que sí podría con `pull_request`). Es seguro
+# pese a correr en contexto base porque SOLO lee la lista de archivos del PR vía la API con un token
+# read-only — no hace checkout del código del fork ni ejecuta nada de él (sin install/build/test).
+#
+# Para que efectivamente BLOQUEE, agregar el check de este job a los required status checks de
+# branch protection de `develop`.
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guard:
+    name: Config sensible (forks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verificar archivos protegidos
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_FORK" != "true" ]; then
+            echo "PR del mismo repo: el guard no aplica (los maintainers pueden cambiar config)."
+            exit 0
+          fi
+          # Rutas sensibles: env/target de Sanity (SANITY_STUDIO_PROJECT_ID/DATASET viven acá) + toda
+          # la config de CI. Sumar nuevas rutas a medida que aparezcan más valores sensibles.
+          protected='^(scripts/set-environment\.ts|cms/set-environment\.ts|src/api/_helpers/environment\.ts|cms/sanity\.config\.ts|cms/sanity\.cli\.ts|\.github/)'
+          changed=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
+          offending=$(echo "$changed" | grep -E "$protected" || true)
+          if [ -n "$offending" ]; then
+            echo "::error::Este PR de fork modifica configuración protegida (env/target de Sanity o CI). Un maintainer debe revisarlo o adoptar el PR a una rama del repo." >&2
+            echo "Archivos protegidos tocados:" >&2
+            echo "$offending" >&2
+            exit 1
+          fi
+          echo "OK: el PR de fork no toca configuración protegida."

--- a/nx.json
+++ b/nx.json
@@ -5,9 +5,7 @@
 	"tasksRunnerOptions": {
 		"default": {
 			"runner": "nx-cloud",
-			"options": {
-				"cacheableOperations": ["lint", "test", "e2e", "build-storybook"]
-			}
+			"options": {}
 		}
 	},
 	"targetDefaults": {
@@ -17,10 +15,15 @@
 			"cache": true
 		},
 		"e2e": {
-			"inputs": ["default", "^production"]
+			"inputs": ["default", "^production"],
+			"cache": false
 		},
 		"lint": {
-			"inputs": ["default", "{workspaceRoot}/eslint.config.mjs"]
+			"inputs": ["default", "{workspaceRoot}/eslint.config.mjs"],
+			"cache": true
+		},
+		"test": {
+			"cache": true
 		},
 		"build-storybook": {
 			"inputs": ["default", "^production", "{projectRoot}/.storybook/**/*", "{projectRoot}/tsconfig.storybook.json"],

--- a/nx.json
+++ b/nx.json
@@ -6,52 +6,28 @@
 		"default": {
 			"runner": "nx-cloud",
 			"options": {
-				"cacheableOperations": [
-					"lint",
-					"test",
-					"e2e",
-					"build-storybook"
-				]
+				"cacheableOperations": ["lint", "test", "e2e", "build-storybook"]
 			}
 		}
 	},
 	"targetDefaults": {
 		"build": {
-			"dependsOn": [
-				"^build"
-			],
-			"inputs": [
-				"production",
-				"^production"
-			]
+			"dependsOn": ["^build"],
+			"inputs": ["production", "^production"],
+			"cache": true
 		},
 		"e2e": {
-			"inputs": [
-				"default",
-				"^production"
-			]
+			"inputs": ["default", "^production"]
 		},
 		"lint": {
-			"inputs": [
-				"default",
-				"{workspaceRoot}/eslint.config.mjs"
-			]
+			"inputs": ["default", "{workspaceRoot}/eslint.config.mjs"]
 		},
 		"build-storybook": {
-			"inputs": [
-				"default",
-				"^production",
-				"{projectRoot}/.storybook/**/*",
-				"{projectRoot}/tsconfig.storybook.json"
-			],
+			"inputs": ["default", "^production", "{projectRoot}/.storybook/**/*", "{projectRoot}/tsconfig.storybook.json"],
 			"cache": true
 		},
 		"@nx/jest:jest": {
-			"inputs": [
-				"default",
-				"^production",
-				"{workspaceRoot}/jest.preset.js"
-			],
+			"inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
 			"cache": true,
 			"options": {
 				"passWithNoTests": true
@@ -64,18 +40,12 @@
 			}
 		},
 		"stylelint": {
-			"inputs": [
-				"default",
-				"{workspaceRoot}/.stylelintrc(.(json|yml|yaml|js))?"
-			],
+			"inputs": ["default", "{workspaceRoot}/.stylelintrc(.(json|yml|yaml|js))?"],
 			"cache": true
 		}
 	},
 	"namedInputs": {
-		"default": [
-			"{projectRoot}/**/*",
-			"sharedGlobals"
-		],
+		"default": ["{projectRoot}/**/*", "sharedGlobals"],
 		"production": [
 			"default",
 			"!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",


### PR DESCRIPTION
## Descripción

PR de **hardening de CI** que arrancó como "activar la cache remota de Nx" y se amplió a resiliencia de cache y seguridad ante PRs de forks. Cambios:

### 1. Cache de tareas de Nx
- Quita `--skip-nx-cache` de los 6 jobs y expone `NX_CLOUD_ACCESS_TOKEN` como `env:` por step (cache remota de Nx Cloud). El skip era un workaround contra el 401 por falta de token, no una optimización.
- `nx.json`: consolida el caching en `targetDefaults.<target>.cache` (Nx 22) y elimina `cacheableOperations` legado. `build` cacheable; `e2e` con `cache: false` (Playwright no determinista). Verificado con `nx show project`.
- **Fallback gratuito:** `actions/cache` sobre `.nx/cache` en los 5 jobs cacheables (no e2e). Da hits **sin consumir créditos de Nx Cloud** y sigue funcionando si Nx Cloud no responde — Nx chequea el cache local antes que el remoto.
- **Trigger `push: develop`:** siembra el cache de Nx en la rama default; por el scoping de `actions/cache`, ese cache base lo restauran todos los PRs (warm desde el primer push).

### 2. Seguridad ante PRs desde forks
- **Build en forks:** `SANITY_STUDIO_PROJECT_ID`/`DATASET` caen a sus defaults públicos (`s4dbqkc5`/`development`, los mismos de `set-environment.ts`) cuando los secrets llegan vacíos → el build compila contra el dataset público sin exponer credenciales (token/Clarity quedan vacíos a propósito).
- **Guard `pull_request_target`** (`.github/workflows/guard-config.yml`): bloquea PRs de forks que toquen env/target de Sanity o la config de CI. Corre desde la rama base (el fork no puede neutralizarlo) y solo lee la lista de archivos del PR vía API read-only — no hace checkout ni ejecuta código del fork.
- **`.github/CODEOWNERS`:** auto-request de review de un maintainer ante cambios a rutas sensibles.

### 3. Limpieza
- Elimina `TWITTER_API_KEY` del job `build` (twitter/rettiwt se removió en #1438; era el último vestigio).

Closes #1553.

Parte de #1498.

## Pasos manuales (del owner)

- [x] Token de Nx Cloud + secret `NX_CLOUD_ACCESS_TOKEN` (confirmado).
- [x] Política de fork PRs → `all_external_contributors` (aplicada).
- [ ] **Post-merge:** agregar el check `Config sensible (forks)` a los required status checks de `develop` (el guard usa `pull_request_target`, así que recién corre cuando el workflow está en `develop`).
- [ ] Opcional: borrar el secret huérfano `TWITTER_API_KEY` (`gh secret delete TWITTER_API_KEY`).

## Decisiones de seguridad

- **Token único read-write** (no patrón de dos tokens): los secrets no se exponen a `pull_request` de forks (el token vale `""` ahí → no pueden escribir el cache remoto) y los PRs de forks no pueden escribir el `actions/cache` del repo base. El token solo tiene efecto en workflows del mismo repo. Migrable sin tocar `nx.json` si el modelo de contribución cambia.
- **Self-hosted cache por bucket descartado** (deprecado por CVE-2025-36852, cache-poisoning); el `actions/cache` nativo de GitHub no tiene ese problema.

## Plan de pruebas

- [x] Schema de los workflows validado con `@action-validator/cli`; `nx.json` es JSON válido.
- [x] `nx show project @cuentoneta/app --json`: cacheabilidad correcta por target (lint/test/stylelint/build/storybook sí, e2e no).
- [x] El step de comentario de coverage queda guardado a `github.event_name == 'pull_request'` (no corre en push a develop).
- [x] `TWITTER_API_KEY`: 0 referencias en el repo.
- [ ] **Post-merge** (manual): push a `develop` siembra el cache base; el siguiente PR muestra cache-hits; logs de Nx Cloud sin 401; el guard corre en un PR de prueba.

## Notas

- Los `--skip-nx-cache` de los scripts de `package.json` (build/lint/test locales) **no** se tocan a propósito.
- El `CODEOWNERS` y el guard son complementarios: CODEOWNERS pide review (visibilidad, todos los PRs), el guard bloquea (PRs de forks que tocan config). El CODEOWNERS no bloquea solo (no se activó el toggle de branch protection a propósito).
- Follow-ups diferidos: evaluar remover `tasksRunnerOptions` por completo; migrar a dos tokens si se adoptan PRs desde forks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)