### PR TITLE
[#1584] - Configurar Dependabot para auto-bump de GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      # Martes para esquivar el pico de PRs de Dependabot de los lunes.
+      day: tuesday
+    target-branch: develop
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: 'chore(deps-ci)'
+
+  # package-ecosystem: npm es el valor correcto para pnpm: Dependabot no tiene
+  # ecosystem "pnpm"; detecta pnpm-lock.yaml y respeta packageManager.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+    target-branch: develop
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: 'chore(deps)'
+
+  - package-ecosystem: npm
+    directory: /cms
+    schedule:
+      interval: weekly
+      day: tuesday
+    target-branch: develop
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: 'chore(deps-cms)'


### PR DESCRIPTION
[#1584] - Configurar Dependabot para auto-bump de GitHub Actions

## Resumen

Agrega `.github/dependabot.yml` para habilitar las actualizaciones de versión de Dependabot (los bumps proactivos, no las de seguridad, que ya estaban activas vía UI). Se configuran tres ecosystems:

- **`github-actions`** en `/` — cubre todos los workflows de `.github/workflows/` (`ci.yml`, `sync-datasets.yml`). Las actions pineadas (`actions/checkout`, `pnpm/action-setup`, `actions/setup-node`, `actions/upload-artifact`, `actions/download-artifact`, `davelosert/vitest-coverage-report-action`, `codecov/codecov-action`) pasan a actualizarse automáticamente.
- **`npm`** en `/` — frontend (`@cuentoneta/app`).
- **`npm`** en `/cms` — Studio de Sanity (`@cuentoneta/cms`), que tiene su propio `pnpm-lock.yaml`.

## Decisión de diseño

- **Agrupado de minor+patch** (`groups`): para `github-actions` todos los bumps se agrupan en un único PR semanal (coherencia entre steps del workflow). Para `npm`, minor+patch se agrupan por ecosystem; las **major quedan individuales** para revisar breaking changes con calma (Angular, Nx, Vitest, Storybook, etc.).
- **`target-branch: develop`** explícito — coincide con la convención del repo (PRs base `develop`) y con la rama default del repo. Queda auto-documentado.
- **Schedule semanal los martes** — evita el pico de carga de los PRs de Dependabot que se disparan los lunes.
- **Prefijos de commit** diferenciados (`chore(deps)`, `chore(deps-ci)`, `chore(deps-cms)`) — para distinguir el origen del bump en el historial.
- Sin `labels`: la etiqueta `tooling` del repo incluye emoji y el config se mantiene limpio sin emojis. Si se quiere etiquetar los PRs de Dependabot, haría falta crear una etiqueta sin emoji en el repo.

## Parte opcional del issue

El issue proponía opcionalmente sumar el ecosystem `npm` para `/` y `/cms` "si se quiere unificar el bump de dependencias acá (evaluar contra la config de Dependabot que hoy pueda estar via UI)". Verificado vía `gh api` que **no** existe config de version-update (solo security updates activos), así que se incluyen los ecosystems `npm` para unificar la gestión de bumps en-repo.

## Criterios de aceptación

- [x] Existe `.github/dependabot.yml` con `package-ecosystem: github-actions`.
- [x] Dependabot abrirá PRs de bump de actions cuando haya nuevas versiones (config de version-update habilitada).

## Notas

- Es un cambio de configuración de tooling sin efecto en runtime sobre la app, por lo que está exento del requisito de tests (`coding-agent-policies.md` Sección 2).
- No se modifica ningún workflow existente; Dependabot se encargará de los bumps a futuro.

Closes #1584
