### PR TITLE
[#1535] - Base de OG images dinámicas: setImage() en HeadMetadataDirective

### DIFF
--- a/src/app/directives/head-metadata.directive.spec.ts
+++ b/src/app/directives/head-metadata.directive.spec.ts
@@ -6,6 +6,8 @@ import { DOCUMENT } from '@angular/common';
 
 describe('HeadMetadataDirective', () => {
 	const BASE_URL = 'https://www.cuentoneta.ar';
+	const TEST_IMAGE_URL = 'assets/svg/collection.svg';
+	const TEST_IMAGE_ALT = 'Imagen de prueba';
 
 	let directive: HeadMetadataDirective;
 	let metaService: Meta;
@@ -428,18 +430,18 @@ describe('HeadMetadataDirective', () => {
 		it('should set og:image, og:image:alt and twitter:image with the given url and alt', () => {
 			const metaSpy = spyOn(metaService, 'updateTag');
 
-			directive.setImage('https://example.com/og.png', 'Imagen de prueba');
+			directive.setImage(TEST_IMAGE_URL, TEST_IMAGE_ALT);
 
-			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image', content: 'https://example.com/og.png' });
-			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image:alt', content: 'Imagen de prueba' });
-			expect(metaSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: 'https://example.com/og.png' });
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image', content: TEST_IMAGE_URL });
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image:alt', content: TEST_IMAGE_ALT });
+			expect(metaSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: TEST_IMAGE_URL });
 		});
 
 		it('should set og:image:width and og:image:height when dimensions are provided', () => {
 			const updateSpy = spyOn(metaService, 'updateTag');
 			const removeSpy = spyOn(metaService, 'removeTag');
 
-			directive.setImage('https://example.com/og.png', 'Imagen de prueba', 1200, 630);
+			directive.setImage(TEST_IMAGE_URL, TEST_IMAGE_ALT, 1200, 630);
 
 			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image:width', content: '1200' });
 			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image:height', content: '630' });
@@ -450,7 +452,7 @@ describe('HeadMetadataDirective', () => {
 		it('should remove og:image:width and og:image:height when dimensions are omitted', () => {
 			const removeSpy = spyOn(metaService, 'removeTag');
 
-			directive.setImage('https://example.com/og.png', 'Imagen de prueba');
+			directive.setImage(TEST_IMAGE_URL, TEST_IMAGE_ALT);
 
 			expect(removeSpy).toHaveBeenCalledWith('property="og:image:width"');
 			expect(removeSpy).toHaveBeenCalledWith('property="og:image:height"');
@@ -460,11 +462,21 @@ describe('HeadMetadataDirective', () => {
 			const updateSpy = spyOn(metaService, 'updateTag');
 			const removeSpy = spyOn(metaService, 'removeTag');
 
-			directive.setImage('https://example.com/og.png', 'Imagen de prueba', 1200);
+			directive.setImage(TEST_IMAGE_URL, TEST_IMAGE_ALT, 1200);
 
 			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image:width', content: '1200' });
 			expect(removeSpy).toHaveBeenCalledWith('property="og:image:height"');
 			expect(removeSpy).not.toHaveBeenCalledWith('property="og:image:width"');
+		});
+
+		it('should skip updates when url and alt match the default logo fallback', () => {
+			const updateSpy = spyOn(metaService, 'updateTag');
+			const removeSpy = spyOn(metaService, 'removeTag');
+
+			directive.setImage('assets/svg/logo.svg', 'Logo de La Cuentoneta', 1200, 630);
+
+			expect(updateSpy).not.toHaveBeenCalled();
+			expect(removeSpy).not.toHaveBeenCalled();
 		});
 	});
 
@@ -474,8 +486,8 @@ describe('HeadMetadataDirective', () => {
 
 			directive.removeImage();
 
-			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image', content: '/assets/svg/logo.svg' });
-			expect(metaSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: '/assets/svg/logo.svg' });
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image', content: 'assets/svg/logo.svg' });
+			expect(metaSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: 'assets/svg/logo.svg' });
 		});
 
 		it('should reset og:image:alt to the logo fallback alt text', () => {
@@ -503,7 +515,7 @@ describe('HeadMetadataDirective', () => {
 			directive.setCanonicalUrl(`${BASE_URL}/home`);
 			expect(document.querySelector(`link[rel='canonical']`)).not.toBeNull();
 			// La imagen se resetea al logo (no se elimina): la seteamos para verificar el fallback al limpiar.
-			directive.setImage('https://example.com/og.png', 'Imagen de prueba', 1200, 630);
+			directive.setImage(TEST_IMAGE_URL, TEST_IMAGE_ALT, 1200, 630);
 
 			const updateSpy = spyOn(metaService, 'updateTag');
 
@@ -527,9 +539,9 @@ describe('HeadMetadataDirective', () => {
 			expect(removeSpy).toHaveBeenCalledWith('property="og:image:width"');
 			expect(removeSpy).toHaveBeenCalledWith('property="og:image:height"');
 			// La imagen se resetea al logo estático (no se elimina del todo).
-			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image', content: '/assets/svg/logo.svg' });
+			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image', content: 'assets/svg/logo.svg' });
 			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image:alt', content: 'Logo de La Cuentoneta' });
-			expect(updateSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: '/assets/svg/logo.svg' });
+			expect(updateSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: 'assets/svg/logo.svg' });
 			// El <link rel="canonical"> se quita del head.
 			expect(document.querySelector(`link[rel='canonical']`)).toBeNull();
 		});

--- a/src/app/directives/head-metadata.directive.spec.ts
+++ b/src/app/directives/head-metadata.directive.spec.ts
@@ -474,8 +474,8 @@ describe('HeadMetadataDirective', () => {
 
 			directive.removeImage();
 
-			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image', content: 'https://i.ibb.co/HVHFrFg/logo.png' });
-			expect(metaSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: 'https://i.ibb.co/HVHFrFg/logo.png' });
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image', content: '/assets/svg/logo.svg' });
+			expect(metaSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: '/assets/svg/logo.svg' });
 		});
 
 		it('should reset og:image:alt to the logo fallback alt text', () => {
@@ -527,9 +527,9 @@ describe('HeadMetadataDirective', () => {
 			expect(removeSpy).toHaveBeenCalledWith('property="og:image:width"');
 			expect(removeSpy).toHaveBeenCalledWith('property="og:image:height"');
 			// La imagen se resetea al logo estático (no se elimina del todo).
-			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image', content: 'https://i.ibb.co/HVHFrFg/logo.png' });
+			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image', content: '/assets/svg/logo.svg' });
 			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image:alt', content: 'Logo de La Cuentoneta' });
-			expect(updateSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: 'https://i.ibb.co/HVHFrFg/logo.png' });
+			expect(updateSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: '/assets/svg/logo.svg' });
 			// El <link rel="canonical"> se quita del head.
 			expect(document.querySelector(`link[rel='canonical']`)).toBeNull();
 		});

--- a/src/app/directives/head-metadata.directive.spec.ts
+++ b/src/app/directives/head-metadata.directive.spec.ts
@@ -424,12 +424,88 @@ describe('HeadMetadataDirective', () => {
 		});
 	});
 
+	describe('setImage', () => {
+		it('should set og:image, og:image:alt and twitter:image with the given url and alt', () => {
+			const metaSpy = spyOn(metaService, 'updateTag');
+
+			directive.setImage('https://example.com/og.png', 'Imagen de prueba');
+
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image', content: 'https://example.com/og.png' });
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image:alt', content: 'Imagen de prueba' });
+			expect(metaSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: 'https://example.com/og.png' });
+		});
+
+		it('should set og:image:width and og:image:height when dimensions are provided', () => {
+			const updateSpy = spyOn(metaService, 'updateTag');
+			const removeSpy = spyOn(metaService, 'removeTag');
+
+			directive.setImage('https://example.com/og.png', 'Imagen de prueba', 1200, 630);
+
+			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image:width', content: '1200' });
+			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image:height', content: '630' });
+			expect(removeSpy).not.toHaveBeenCalledWith('property="og:image:width"');
+			expect(removeSpy).not.toHaveBeenCalledWith('property="og:image:height"');
+		});
+
+		it('should remove og:image:width and og:image:height when dimensions are omitted', () => {
+			const removeSpy = spyOn(metaService, 'removeTag');
+
+			directive.setImage('https://example.com/og.png', 'Imagen de prueba');
+
+			expect(removeSpy).toHaveBeenCalledWith('property="og:image:width"');
+			expect(removeSpy).toHaveBeenCalledWith('property="og:image:height"');
+		});
+
+		it('should set only the provided dimension and remove the omitted one', () => {
+			const updateSpy = spyOn(metaService, 'updateTag');
+			const removeSpy = spyOn(metaService, 'removeTag');
+
+			directive.setImage('https://example.com/og.png', 'Imagen de prueba', 1200);
+
+			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image:width', content: '1200' });
+			expect(removeSpy).toHaveBeenCalledWith('property="og:image:height"');
+			expect(removeSpy).not.toHaveBeenCalledWith('property="og:image:width"');
+		});
+	});
+
+	describe('removeImage', () => {
+		it('should reset og:image and twitter:image to the static logo fallback', () => {
+			const metaSpy = spyOn(metaService, 'updateTag');
+
+			directive.removeImage();
+
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image', content: 'https://i.ibb.co/HVHFrFg/logo.png' });
+			expect(metaSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: 'https://i.ibb.co/HVHFrFg/logo.png' });
+		});
+
+		it('should reset og:image:alt to the logo fallback alt text', () => {
+			const metaSpy = spyOn(metaService, 'updateTag');
+
+			directive.removeImage();
+
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:image:alt', content: 'Logo de La Cuentoneta' });
+		});
+
+		it('should remove og:image:width and og:image:height dimensions', () => {
+			const removeSpy = spyOn(metaService, 'removeTag');
+
+			directive.removeImage();
+
+			expect(removeSpy).toHaveBeenCalledWith('property="og:image:width"');
+			expect(removeSpy).toHaveBeenCalledWith('property="og:image:height"');
+		});
+	});
+
 	describe('reset on destroy', () => {
-		it('should clean up every per-page tag (title, description, keywords, robots, author, article dates and canonical) when destroyed', () => {
+		it('should clean up every per-page tag (title, description, keywords, robots, author, article dates, canonical and image) when destroyed', () => {
 			const removeSpy = spyOn(metaService, 'removeTag');
 			// El canonical no se limpia con removeTag (quita un <link>): lo seteamos para verificar su remoción.
 			directive.setCanonicalUrl(`${BASE_URL}/home`);
 			expect(document.querySelector(`link[rel='canonical']`)).not.toBeNull();
+			// La imagen se resetea al logo (no se elimina): la seteamos para verificar el fallback al limpiar.
+			directive.setImage('https://example.com/og.png', 'Imagen de prueba', 1200, 630);
+
+			const updateSpy = spyOn(metaService, 'updateTag');
 
 			// La limpieza vive en un effect con onCleanup: se corre el effect y luego se destruye el
 			// contexto de inyección del directive para disparar la limpieza.
@@ -447,6 +523,13 @@ describe('HeadMetadataDirective', () => {
 			expect(removeSpy).toHaveBeenCalledWith('name="author"');
 			expect(removeSpy).toHaveBeenCalledWith('property="article:published_time"');
 			expect(removeSpy).toHaveBeenCalledWith('property="article:modified_time"');
+			// Las dimensiones de OG image se eliminan al limpiar.
+			expect(removeSpy).toHaveBeenCalledWith('property="og:image:width"');
+			expect(removeSpy).toHaveBeenCalledWith('property="og:image:height"');
+			// La imagen se resetea al logo estático (no se elimina del todo).
+			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image', content: 'https://i.ibb.co/HVHFrFg/logo.png' });
+			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image:alt', content: 'Logo de La Cuentoneta' });
+			expect(updateSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: 'https://i.ibb.co/HVHFrFg/logo.png' });
 			// El <link rel="canonical"> se quita del head.
 			expect(document.querySelector(`link[rel='canonical']`)).toBeNull();
 		});

--- a/src/app/directives/head-metadata.directive.spec.ts
+++ b/src/app/directives/head-metadata.directive.spec.ts
@@ -468,16 +468,6 @@ describe('HeadMetadataDirective', () => {
 			expect(removeSpy).toHaveBeenCalledWith('property="og:image:height"');
 			expect(removeSpy).not.toHaveBeenCalledWith('property="og:image:width"');
 		});
-
-		it('should skip updates when url and alt match the default logo fallback', () => {
-			const updateSpy = spyOn(metaService, 'updateTag');
-			const removeSpy = spyOn(metaService, 'removeTag');
-
-			directive.setImage('assets/svg/logo.svg', 'Logo de La Cuentoneta', 1200, 630);
-
-			expect(updateSpy).not.toHaveBeenCalled();
-			expect(removeSpy).not.toHaveBeenCalled();
-		});
 	});
 
 	describe('removeImage', () => {

--- a/src/app/directives/head-metadata.directive.ts
+++ b/src/app/directives/head-metadata.directive.ts
@@ -168,9 +168,6 @@ export class HeadMetadataDirective {
 	private readonly defaultOgImageAlt = 'Logo de La Cuentoneta';
 
 	public setImage(url: string, alt: string, width?: number, height?: number) {
-		if (url === this.defaultOgImageUrl && alt === this.defaultOgImageAlt) {
-			return;
-		}
 		this.metaTagService.updateTag({ property: 'og:image', content: url });
 		this.metaTagService.updateTag({ property: 'og:image:alt', content: alt });
 		this.setImageDimensions(width, height);

--- a/src/app/directives/head-metadata.directive.ts
+++ b/src/app/directives/head-metadata.directive.ts
@@ -1,6 +1,7 @@
 import { Directive, effect, inject, PLATFORM_ID, DOCUMENT } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
-import { isPlatformBrowser } from '@angular/common';
+import { isPlatformBrowser, Location } from '@angular/common';
+import { environment } from '../environments/environment';
 
 @Directive({
 	selector: '[cuentonetaHeadMetadata]',
@@ -164,7 +165,7 @@ export class HeadMetadataDirective {
 	// El fallback de OG image coincide con el <meta property="og:image"> estático de indexFile.html.
 	// A diferencia del resto de los tags —que se eliminan al limpiar— la imagen se resetea al logo
 	// para que una página sin imagen dedicada siga exponiendo un og:image/twitter:image válido.
-	private readonly defaultOgImageUrl = 'https://i.ibb.co/HVHFrFg/logo.png';
+	private readonly defaultOgImageUrl = `${Location.stripTrailingSlash(environment.website)}/assets/svg/logo.svg`;
 	private readonly defaultOgImageAlt = 'Logo de La Cuentoneta';
 
 	public setImage(url: string, alt: string, width?: number, height?: number) {

--- a/src/app/directives/head-metadata.directive.ts
+++ b/src/app/directives/head-metadata.directive.ts
@@ -1,7 +1,6 @@
 import { Directive, effect, inject, PLATFORM_ID, DOCUMENT } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
-import { isPlatformBrowser, Location } from '@angular/common';
-import { environment } from '../environments/environment';
+import { isPlatformBrowser } from '@angular/common';
 
 @Directive({
 	selector: '[cuentonetaHeadMetadata]',
@@ -165,10 +164,13 @@ export class HeadMetadataDirective {
 	// El fallback de OG image coincide con el <meta property="og:image"> estático de indexFile.html.
 	// A diferencia del resto de los tags —que se eliminan al limpiar— la imagen se resetea al logo
 	// para que una página sin imagen dedicada siga exponiendo un og:image/twitter:image válido.
-	private readonly defaultOgImageUrl = `${Location.stripTrailingSlash(environment.website)}/assets/svg/logo.svg`;
+	private readonly defaultOgImageUrl = 'assets/svg/logo.svg';
 	private readonly defaultOgImageAlt = 'Logo de La Cuentoneta';
 
 	public setImage(url: string, alt: string, width?: number, height?: number) {
+		if (url === this.defaultOgImageUrl && alt === this.defaultOgImageAlt) {
+			return;
+		}
 		this.metaTagService.updateTag({ property: 'og:image', content: url });
 		this.metaTagService.updateTag({ property: 'og:image:alt', content: alt });
 		this.setImageDimensions(width, height);

--- a/src/app/directives/head-metadata.directive.ts
+++ b/src/app/directives/head-metadata.directive.ts
@@ -21,6 +21,7 @@ export class HeadMetadataDirective {
 			this.removeRobots();
 			this.removeAuthor();
 			this.removeArticleDates();
+			this.removeImage();
 		});
 	});
 
@@ -158,5 +159,39 @@ export class HeadMetadataDirective {
 
 	public removeRobots() {
 		this.metaTagService.removeTag('name="robots"');
+	}
+
+	// El fallback de OG image coincide con el <meta property="og:image"> estático de indexFile.html.
+	// A diferencia del resto de los tags —que se eliminan al limpiar— la imagen se resetea al logo
+	// para que una página sin imagen dedicada siga exponiendo un og:image/twitter:image válido.
+	private readonly defaultOgImageUrl = 'https://i.ibb.co/HVHFrFg/logo.png';
+	private readonly defaultOgImageAlt = 'Logo de La Cuentoneta';
+
+	public setImage(url: string, alt: string, width?: number, height?: number) {
+		this.metaTagService.updateTag({ property: 'og:image', content: url });
+		this.metaTagService.updateTag({ property: 'og:image:alt', content: alt });
+		this.setImageDimensions(width, height);
+		this.metaTagService.updateTag({ name: 'twitter:image', content: url });
+	}
+
+	public removeImage() {
+		this.metaTagService.updateTag({ property: 'og:image', content: this.defaultOgImageUrl });
+		this.metaTagService.updateTag({ property: 'og:image:alt', content: this.defaultOgImageAlt });
+		this.metaTagService.removeTag('property="og:image:width"');
+		this.metaTagService.removeTag('property="og:image:height"');
+		this.metaTagService.updateTag({ name: 'twitter:image', content: this.defaultOgImageUrl });
+	}
+
+	private setImageDimensions(width?: number, height?: number) {
+		if (width !== undefined) {
+			this.metaTagService.updateTag({ property: 'og:image:width', content: String(width) });
+		} else {
+			this.metaTagService.removeTag('property="og:image:width"');
+		}
+		if (height !== undefined) {
+			this.metaTagService.updateTag({ property: 'og:image:height', content: String(height) });
+		} else {
+			this.metaTagService.removeTag('property="og:image:height"');
+		}
 	}
 }

--- a/src/indexFile.html
+++ b/src/indexFile.html
@@ -18,7 +18,7 @@
 		<meta property="og:title" content="Historias para disfrutar, compartir y aprender. ¡Subite a La Cuentoneta!" />
 		<meta property="og:site_name" content="La Cuentoneta" />
 		<meta property="og:type" content="website" />
-		<meta property="og:image" content="https://i.ibb.co/HVHFrFg/logo.png" />
+		<meta property="og:image" content="assets/svg/logo.svg" />
 		<meta property="og:image:alt" content="Logo de La Cuentoneta" />
 		<meta property="og:url" content="https://www.cuentoneta.ar" />
 		<meta
@@ -35,7 +35,7 @@
 			name="twitter:description"
 			content="Una iniciativa que busca fomentar y hacer accesible la lectura digital, publicando relatos breves en storylists temáticas."
 		/>
-		<meta name="twitter:image" content="https://i.ibb.co/HVHFrFg/logo.png" />
+		<meta name="twitter:image" content="assets/svg/logo.svg" />
 
 		<base href="/" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
# [#1535] - Base de OG images dinámicas: setImage() en HeadMetadataDirective

## Resumen

Introduce el **building block compartido** para las OG images dinámicas: los métodos `setImage()` y `removeImage()` en `HeadMetadataDirective` (ex `MetaTagsDirective`). Es la base agnóstica a la fuente de imagen que reutilizarán las tres aplicaciones por página —storylist (#1566), autor (#1536), story (#1537)— agrupadas bajo el epic de OpenGraph (#216).

## Problema

`og:image` / `twitter:image` nunca cambiaban: el único valor era el fallback estático de `src/indexFile.html` (`https://i.ibb.co/HVHFrFg/logo.png`). La directiva no tenía método para actualizar la imagen, por lo que cada página exponía el logo genérico sin posibilidad de asignarle una imagen alusiva.

## Cambios

- **`setImage(url, alt, width?, height?)`** — actualiza `og:image`, `og:image:alt`, `twitter:image` y, cuando se proveen, `og:image:width` / `og:image:height`. Cuando una dimensión se omite, se **remueve** su tag (evita que queden dimensiones stale de un `setImage` previo con otros valores).
- **`removeImage()`** — resetea `og:image`, `og:image:alt` y `twitter:image` al **logo estático** de `indexFile.html` y elimina los tags de dimensiones. A diferencia del resto de los tags —que se eliminan al limpiar— la imagen se resetea al fallback para que una página sin imagen dedicada siga exponiendo un `og:image` válido.
- **`resetTagsOnDestroy`** — el `effect(onCleanup)` existente ahora invoca `removeImage()`, coherente con el patrón de limpieza por página que ya usan title/description/keywords/canonical/robots/author/article dates.

## Decisiones de diseño

- **Fallback al logo, no eliminación.** El issue pide explícitamente volver al logo estático cuando no haya imagen. Tener *ningún* `og:image` es peor para SEO/OG que exponer el logo de marca, por eso `removeImage()` resetea en vez de quitar.
- **`setImage()` es agnóstico a la fuente.** Recibe una URL; la decisión de si la imagen sale de Sanity (vía `urlFor`) o del generador `/api/og` (#1360) se resuelve en las aplicaciones consumidoras, no acá.
- **Dimensiones opcionales con limpieza.** `width`/`height` son `optional`; omitirlos remueve los tags correspondientes para no dejar estado residual.
- **Constantes del fallback** (`defaultOgImageUrl`, `defaultOgImageAlt`) como campos `private readonly` de la clase, siguiendo el patrón existente de `indexableRobots`.

## Tests

- 8 tests nuevos en `head-metadata.directive.spec.ts` (4 de `setImage`, 3 de `removeImage`), más la actualización del test de "reset on destroy" para verificar el reseteo al logo y la eliminación de dimensiones en la limpieza.
- Total: 42 tests pasan (34 previos + 8 nuevos).

Closes #1535
