### PR TITLE
[#1456] - Implementar LoggerService con niveles configurables para producción

### DIFF
--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -2,6 +2,7 @@
 import { client } from '../_helpers/sanity-connector';
 
 // Funciones
+import { logger } from './logger';
 import { mapMediaSources, mapMediaSourcesTeasers } from './media-sources.functions';
 
 // Tipos de Sanity
@@ -112,26 +113,26 @@ export function mapAuthorBiography(biography: BiographySubQuery): TextBlockConte
 
 export function urlFor(source: SanityImageSource): string {
 	if (!source) {
-		console.warn('urlFor: Se recibió source vacío o nulo');
+		logger.warn('urlFor: Se recibió source vacío o nulo');
 		return '';
 	}
 	try {
 		return createImageUrlBuilder(client).image(source).url();
 	} catch (error) {
-		console.error('urlFor: Error al construir URL de imagen', { error, source: JSON.stringify(source) });
+		logger.error('urlFor: Error al construir URL de imagen', { error, source: JSON.stringify(source) });
 		return '';
 	}
 }
 
 export function urlForWithAutoFormat(source: SanityImageSource): string {
 	if (!source) {
-		console.warn('urlForWithAutoFormat: Se recibió source vacío o nulo');
+		logger.warn('urlForWithAutoFormat: Se recibió source vacío o nulo');
 		return '';
 	}
 	try {
 		return createImageUrlBuilder(client).image(source).auto('format').url();
 	} catch (error) {
-		console.error('urlForWithAutoFormat: Error al construir URL de imagen', {
+		logger.error('urlForWithAutoFormat: Error al construir URL de imagen', {
 			error,
 			source: JSON.stringify(source),
 		});

--- a/src/api/_utils/logger.spec.ts
+++ b/src/api/_utils/logger.spec.ts
@@ -1,0 +1,110 @@
+/* eslint-disable testing-library/no-debugging-utils -- logger.debug() es el método de logging bajo test, no screen.debug() de RTL */
+import { restoreAllMocks, spyOn } from '@test-utils';
+
+import { logger, LOG_LEVELS, type LogLevel } from './logger';
+
+describe('logger', () => {
+	let errorSpy: ReturnType<typeof spyOn>;
+	let warnSpy: ReturnType<typeof spyOn>;
+	let infoSpy: ReturnType<typeof spyOn>;
+	let logSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(() => {
+		errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
+		warnSpy = spyOn(console, 'warn').mockImplementation(() => undefined);
+		infoSpy = spyOn(console, 'info').mockImplementation(() => undefined);
+		logSpy = spyOn(console, 'log').mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		restoreAllMocks();
+	});
+
+	it('exposes the four severity levels ordered from most to least severe', () => {
+		expect(LOG_LEVELS.error).toBeLessThan(LOG_LEVELS.warn);
+		expect(LOG_LEVELS.warn).toBeLessThan(LOG_LEVELS.info);
+		expect(LOG_LEVELS.info).toBeLessThan(LOG_LEVELS.debug);
+	});
+
+	describe('error', () => {
+		it('always logs errors regardless of the configured level', () => {
+			logger.setLevel('error');
+
+			logger.error('boom', { code: 500 });
+
+			expect(errorSpy).toHaveBeenCalledWith('boom', { code: 500 });
+		});
+
+		it('logs the message without context when context is omitted', () => {
+			logger.setLevel('error');
+
+			logger.error('boom');
+
+			expect(errorSpy).toHaveBeenCalledWith('boom');
+		});
+	});
+
+	describe('level gating', () => {
+		it('logs every level when the level is debug', () => {
+			logger.setLevel('debug');
+
+			logger.error('e');
+			logger.warn('w');
+			logger.info('i');
+			logger.debug('d');
+
+			expect(errorSpy).toHaveBeenCalledWith('e');
+			expect(warnSpy).toHaveBeenCalledWith('w');
+			expect(infoSpy).toHaveBeenCalledWith('i');
+			expect(logSpy).toHaveBeenCalledWith('d');
+		});
+
+		it('suppresses debug when the level is info', () => {
+			logger.setLevel('info');
+
+			logger.error('e');
+			logger.warn('w');
+			logger.info('i');
+			logger.debug('d');
+
+			expect(errorSpy).toHaveBeenCalledWith('e');
+			expect(warnSpy).toHaveBeenCalledWith('w');
+			expect(infoSpy).toHaveBeenCalledWith('i');
+			expect(logSpy).not.toHaveBeenCalled();
+		});
+
+		it('suppresses info and debug when the level is warn', () => {
+			logger.setLevel('warn');
+
+			logger.warn('w');
+			logger.info('i');
+			logger.debug('d');
+
+			expect(warnSpy).toHaveBeenCalledWith('w');
+			expect(infoSpy).not.toHaveBeenCalled();
+			expect(logSpy).not.toHaveBeenCalled();
+		});
+
+		it('suppresses warn, info and debug when the level is error (production)', () => {
+			logger.setLevel('error');
+
+			logger.error('e');
+			logger.warn('w');
+			logger.info('i');
+			logger.debug('d');
+
+			expect(errorSpy).toHaveBeenCalledWith('e');
+			expect(warnSpy).not.toHaveBeenCalled();
+			expect(infoSpy).not.toHaveBeenCalled();
+			expect(logSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('setLevel / getLevel', () => {
+		it('exposes the current level after setLevel', () => {
+			logger.setLevel('warn');
+
+			expect(logger.getLevel()).toBe<LogLevel>('warn');
+		});
+	});
+});

--- a/src/api/_utils/logger.ts
+++ b/src/api/_utils/logger.ts
@@ -1,0 +1,46 @@
+import { environment } from '../_helpers/environment';
+
+export const LOG_LEVELS = Object.freeze({ error: 0, warn: 1, info: 2, debug: 3 } as const);
+export type LogLevel = keyof typeof LOG_LEVELS;
+
+type ConsoleMethod = 'error' | 'warn' | 'info' | 'log';
+
+const defaultLevel: LogLevel = environment.production ? 'error' : 'debug';
+let currentLevel: LogLevel = defaultLevel;
+
+function isGated(level: LogLevel): boolean {
+	return LOG_LEVELS[level] > LOG_LEVELS[currentLevel];
+}
+
+function emit(level: LogLevel, method: ConsoleMethod, message: string, context?: unknown): void {
+	if (level !== 'error' && isGated(level)) {
+		return;
+	}
+	const fn = console[method] as (message: string, context?: unknown) => void;
+	if (context === undefined) {
+		fn.call(console, message);
+	} else {
+		fn.call(console, message, context);
+	}
+}
+
+export const logger = {
+	getLevel(): LogLevel {
+		return currentLevel;
+	},
+	setLevel(level: LogLevel): void {
+		currentLevel = level;
+	},
+	error(message: string, context?: unknown): void {
+		emit('error', 'error', message, context);
+	},
+	warn(message: string, context?: unknown): void {
+		emit('warn', 'warn', message, context);
+	},
+	info(message: string, context?: unknown): void {
+		emit('info', 'info', message, context);
+	},
+	debug(message: string, context?: unknown): void {
+		emit('debug', 'log', message, context);
+	},
+};

--- a/src/api/modules/sitemap/sitemap.controller.ts
+++ b/src/api/modules/sitemap/sitemap.controller.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { generateSitemap } from './sitemap.service';
+import { logger } from '../../_utils/logger';
 
 const sitemapController = new Hono();
 
@@ -17,7 +18,7 @@ sitemapController.get('/', async (c) => {
 		});
 	} catch (error) {
 		const err = error instanceof Error ? error : new Error(String(error));
-		console.error('[Sitemap] Error generating sitemap:', {
+		logger.error('[Sitemap] Error generating sitemap:', {
 			message: err.message,
 			stack: err.stack,
 		});

--- a/src/app/components/tabs/tabs.component.ts
+++ b/src/app/components/tabs/tabs.component.ts
@@ -1,6 +1,7 @@
-import { ChangeDetectionStrategy, Component, contentChildren, input, linkedSignal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, contentChildren, inject, input, linkedSignal } from '@angular/core';
 import Tab from './tab.component';
 import { NgTemplateOutlet } from '@angular/common';
+import { LoggerService } from '../../providers/logging/logger.service';
 
 @Component({
 	selector: 'cuentoneta-tabs',
@@ -35,6 +36,7 @@ import { NgTemplateOutlet } from '@angular/common';
 export default class Tabs {
 	public readonly initialTab = input<string>();
 	public readonly tabs = contentChildren(Tab);
+	private readonly logger = inject(LoggerService);
 	protected readonly active = linkedSignal({
 		source: this.tabs,
 		computation: (tabs) => {
@@ -49,7 +51,7 @@ export default class Tabs {
 
 			const found = tabs.find((tab) => tab.name() === name);
 			if (!found) {
-				console.error(`Tab with name ${name} not found, falling back to first tab`);
+				this.logger.error(`Tab with name ${name} not found, falling back to first tab`);
 				return tabs[0];
 			}
 

--- a/src/app/providers/analytics/analytics.service.ts
+++ b/src/app/providers/analytics/analytics.service.ts
@@ -1,10 +1,13 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { environment } from '../../environments/environment';
+import { LoggerService } from '../logging/logger.service';
 
 @Injectable({
 	providedIn: 'root',
 })
 export class AnalyticsService {
+	private readonly logger = inject(LoggerService);
+
 	public async init() {
 		if (!environment.clarityProjectId) {
 			return;
@@ -16,7 +19,7 @@ export class AnalyticsService {
 			const clarity = clarityModule.default;
 			clarity.init(environment.clarityProjectId);
 		} catch (error) {
-			console.error('Failed to initialize Clarity:', error);
+			this.logger.error('Failed to initialize Clarity:', error);
 		}
 	}
 }

--- a/src/app/providers/logging/logger.service.spec.ts
+++ b/src/app/providers/logging/logger.service.spec.ts
@@ -1,0 +1,137 @@
+/* eslint-disable testing-library/no-debugging-utils -- service.debug() es el método de logging bajo test, no screen.debug() de RTL */
+import { TestBed } from '@angular/core/testing';
+import { restoreAllMocks, spyOn } from '@test-utils';
+
+import { LoggerService, LOG_LEVELS, type LogLevel } from './logger.service';
+
+describe('LoggerService', () => {
+	let service: LoggerService;
+	let errorSpy: ReturnType<typeof spyOn>;
+	let warnSpy: ReturnType<typeof spyOn>;
+	let infoSpy: ReturnType<typeof spyOn>;
+	let logSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({});
+		service = TestBed.inject(LoggerService);
+		errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
+		warnSpy = spyOn(console, 'warn').mockImplementation(() => undefined);
+		infoSpy = spyOn(console, 'info').mockImplementation(() => undefined);
+		logSpy = spyOn(console, 'log').mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		restoreAllMocks();
+	});
+
+	it('defaults to debug in the development environment', () => {
+		expect(service.getLevel()).toBe<LogLevel>('debug');
+	});
+
+	it('exposes the four severity levels ordered from most to least severe', () => {
+		expect(LOG_LEVELS.error).toBeLessThan(LOG_LEVELS.warn);
+		expect(LOG_LEVELS.warn).toBeLessThan(LOG_LEVELS.info);
+		expect(LOG_LEVELS.info).toBeLessThan(LOG_LEVELS.debug);
+	});
+
+	describe('error', () => {
+		it('always logs errors regardless of the configured level', () => {
+			service.setLevel('error');
+
+			service.error('boom', { code: 500 });
+
+			expect(errorSpy).toHaveBeenCalledWith('boom', { code: 500 });
+		});
+
+		it('logs the message without context when context is omitted', () => {
+			service.setLevel('error');
+
+			service.error('boom');
+
+			expect(errorSpy).toHaveBeenCalledWith('boom');
+		});
+	});
+
+	describe('level gating', () => {
+		it('logs every level when the level is debug', () => {
+			service.setLevel('debug');
+
+			service.error('e');
+			service.warn('w');
+			service.info('i');
+			service.debug('d');
+
+			expect(errorSpy).toHaveBeenCalledWith('e');
+			expect(warnSpy).toHaveBeenCalledWith('w');
+			expect(infoSpy).toHaveBeenCalledWith('i');
+			expect(logSpy).toHaveBeenCalledWith('d');
+		});
+
+		it('suppresses debug when the level is info', () => {
+			service.setLevel('info');
+
+			service.error('e');
+			service.warn('w');
+			service.info('i');
+			service.debug('d');
+
+			expect(errorSpy).toHaveBeenCalledWith('e');
+			expect(warnSpy).toHaveBeenCalledWith('w');
+			expect(infoSpy).toHaveBeenCalledWith('i');
+			expect(logSpy).not.toHaveBeenCalled();
+		});
+
+		it('suppresses info and debug when the level is warn', () => {
+			service.setLevel('warn');
+
+			service.warn('w');
+			service.info('i');
+			service.debug('d');
+
+			expect(warnSpy).toHaveBeenCalledWith('w');
+			expect(infoSpy).not.toHaveBeenCalled();
+			expect(logSpy).not.toHaveBeenCalled();
+		});
+
+		it('suppresses warn, info and debug when the level is error (production)', () => {
+			service.setLevel('error');
+
+			service.error('e');
+			service.warn('w');
+			service.info('i');
+			service.debug('d');
+
+			expect(errorSpy).toHaveBeenCalledWith('e');
+			expect(warnSpy).not.toHaveBeenCalled();
+			expect(infoSpy).not.toHaveBeenCalled();
+			expect(logSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('setLevel / getLevel', () => {
+		it('exposes the current level after setLevel', () => {
+			service.setLevel('warn');
+
+			expect(service.getLevel()).toBe<LogLevel>('warn');
+		});
+	});
+
+	describe('context passthrough', () => {
+		it('passes the context object through to the console method', () => {
+			service.setLevel('debug');
+			const ctx = { foo: 'bar' };
+
+			service.warn('hello', ctx);
+
+			expect(warnSpy).toHaveBeenCalledWith('hello', ctx);
+		});
+
+		it('calls the console method with a single argument when context is omitted', () => {
+			service.setLevel('debug');
+
+			service.info('hello');
+
+			expect(infoSpy).toHaveBeenCalledWith('hello');
+		});
+	});
+});

--- a/src/app/providers/logging/logger.service.ts
+++ b/src/app/providers/logging/logger.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+
+import { environment } from '../../environments/environment';
+
+export const LOG_LEVELS = Object.freeze({ error: 0, warn: 1, info: 2, debug: 3 } as const);
+export type LogLevel = keyof typeof LOG_LEVELS;
+
+type ConsoleMethod = 'error' | 'warn' | 'info' | 'log';
+
+@Injectable({ providedIn: 'root' })
+export class LoggerService {
+	private readonly defaultLevel: LogLevel = environment.environment === 'production' ? 'error' : 'debug';
+	private currentLevel: LogLevel = this.defaultLevel;
+
+	public getLevel(): LogLevel {
+		return this.currentLevel;
+	}
+
+	public setLevel(level: LogLevel): void {
+		this.currentLevel = level;
+	}
+
+	public error(message: string, context?: unknown): void {
+		this.emit('error', 'error', message, context);
+	}
+
+	public warn(message: string, context?: unknown): void {
+		this.emit('warn', 'warn', message, context);
+	}
+
+	public info(message: string, context?: unknown): void {
+		this.emit('info', 'info', message, context);
+	}
+
+	public debug(message: string, context?: unknown): void {
+		this.emit('debug', 'log', message, context);
+	}
+
+	private isGated(level: LogLevel): boolean {
+		return LOG_LEVELS[level] > LOG_LEVELS[this.currentLevel];
+	}
+
+	private emit(level: LogLevel, method: ConsoleMethod, message: string, context?: unknown): void {
+		if (level !== 'error' && this.isGated(level)) {
+			return;
+		}
+		const fn = console[method] as (message: string, context?: unknown) => void;
+		if (context === undefined) {
+			fn.call(console, message);
+		} else {
+			fn.call(console, message, context);
+		}
+	}
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { secureHeaders } from 'hono/secure-headers';
 import apiRoutes from './api/routes';
 import sitemapController from './api/modules/sitemap/sitemap.controller';
 import { getAllowedHosts } from './api/_helpers/environment';
+import { logger } from './api/_utils/logger';
 
 /**
  * Inicializa Hono y exporta la instancia de la aplicación
@@ -64,7 +65,7 @@ app.notFound((c) => {
  * Handler para Error 500: Internal Server Error
  */
 app.onError((error, c) => {
-	console.error('Server Error:', error);
+	logger.error('Server Error:', error);
 	const isDev = process.env['NODE_ENV'] !== 'production';
 	const message = isDev ? error.message : 'Internal Server Error';
 	return c.json({ error: message }, 500);


### PR DESCRIPTION
[#1456] - Implementar LoggerService con niveles configurables para producción

## Resumen

Implementa una abstracción de logging con niveles configurables que reemplaza el uso directo de `console.warn`/`console.error` en el código de producción, suprimiendo los logs no críticos en producción pero manteniendo los errores.

## Problema

El proyecto usaba `console.warn()` y `console.error()` directamente en varios archivos. En producción, los warnings aparecen en la consola del navegador/servidor sin forma de silenciarlos, y no existe un punto único para integrar futuramente un servicio externo (Sentry, etc.) ni para ajustar el nivel de log por entorno.

## Solución

Se introducen **dos** loggers, uno por contexto de ejecución, respetando la frontera arquitectónica entre backend (Hono, sin DI) y frontend (Angular, con DI):

### Backend — `src/api/_utils/logger.ts`
- Objeto `logger` (sin DI, patrón consistente con el resto de `src/api/_utils/`).
- Nivel por defecto derivado de `environment.production` (`error` en producción, `debug` en desarrollo).
- Niveles: `error` (siempre loguea), `warn`, `info`, `debug` (gated por `setLevel`).

### Frontend — `src/app/providers/logging/logger.service.ts`
- `@Injectable({ providedIn: 'root' })` (`LoggerService`), inyectable vía `inject()`.
- Nivel por defecto derivado de `environment.environment === 'production'`.
- Misma API y semántica de niveles que el logger del backend.

### Niveles (`Object.freeze`, sin `enum` — convención del repo)
```ts
export const LOG_LEVELS = Object.freeze({ error: 0, warn: 1, info: 2, debug: 3 } as const);
```
Un mensaje de nivel `L` se emite si `LOG_LEVELS[L] <= LOG_LEVELS[nivelActual]`. `error` (piso 0) siempre se emite, cumpliendo el requisito de "mantener errores críticos".

## Migraciones

| Archivo | Cambio |
| --- | --- |
| `src/api/_utils/functions.ts` | `console.warn`/`console.error` en `urlFor`/`urlForWithAutoFormat` → `logger.*` |
| `src/api/modules/sitemap/sitemap.controller.ts` | `console.error` → `logger.error` |
| `src/server.ts` | `console.error` en `app.onError` → `logger.error` |
| `src/app/components/tabs/tabs.component.ts` | `console.error` → `LoggerService` (vía `inject`) |
| `src/app/providers/analytics/analytics.service.ts` | `console.error` → `LoggerService` (vía `inject`) |

## Usos de `console.*` no migrados (intencional)

- **`src/main.ts`** — `console.error` en el catch del `bootstrapApplication()`. Ejecuta **antes** de que Angular DI esté disponible, por lo que no se puede inyectar `LoggerService`. Es el reporter de última instancia cuando el bootstrap mismo falla.
- **`src/server.ts:87`** — `console.log` con el banner de inicio del server ("Aplicación corriendo en…"). Mensaje operativo de startup que debe verse siempre, no un log diagnóstico gated. Además está fuera del alcance del issue (warn/error).
- **`src/api/_helpers/environment.ts`** — `console.info` sobre la carga de `.env`. Fuera del alcance (info, no warn/error) y migrarlo crearía una dependencia circular (`logger` importa `environment`).

## Tests

- `src/api/_utils/logger.spec.ts` (8 tests) — gating por nivel, `error` siempre loguea, `setLevel`/`getLevel`, passthrough de contexto.
- `src/app/providers/logging/logger.service.spec.ts` (11 tests) — ídem + default `debug` en desarrollo.
- Los specs existentes (`tabs.component.spec.ts`, `sitemap.service.spec.ts`) siguen pasando.

## Gates de CI

- `test` ✅ (exit 0)
- `lint` ✅ (0 errores, 0 warnings)
- `build` ✅ (SSR + prerender)
- `stylelint` — n/a (sin cambios de CSS)

## Notas de revisión

- Los `LOG_LEVELS`/`LogLevel` se duplican en cada logger (3 líneas) en lugar de compartirse, para respetar la frontera `src/api/` ↔ `src/app/` (no existe un módulo compartido inter-capas).
- `LoggerService` se nombró `*.service.ts` (no `*.provider.ts`) porque es un servicio transversal como `LayoutService`/`SchemaOrgService`, no un API provider con `InjectionToken` + `provideX()`.
- Se agregó `eslint-disable testing-library/no-debugging-utils` (a nivel archivo, con justificación) en los specs: la regla flaggea falsos positivos sobre `logger.debug()`/`service.debug()` (métodos de logging bajo test), confundiéndolos con `screen.debug()` de RTL.

Closes #1456
