### PR TITLE
[#1624] - Migrar config de Sanity TypeGen a sanity.cli.ts

### DIFF
--- a/cms/sanity-typegen.json
+++ b/cms/sanity-typegen.json
@@ -1,5 +1,0 @@
-{
-	"path": "'../src/api/**/*.{ts,tsx,js,jsx}'",
-	"schema": "schema.json",
-	"generates": "../src/api/sanity/types.ts"
-}

--- a/cms/sanity.cli.ts
+++ b/cms/sanity.cli.ts
@@ -6,4 +6,9 @@ export default defineCliConfig({
 		projectId: process.env.SANITY_STUDIO_PROJECT_ID,
 		dataset: process.env.SANITY_STUDIO_DATASET,
 	},
+	typegen: {
+		path: '../src/api/**/*.{ts,tsx,js,jsx}',
+		schema: 'schema.json',
+		generates: '../src/api/sanity/types.ts',
+	},
 });

--- a/docs/SANITY.md
+++ b/docs/SANITY.md
@@ -10,7 +10,7 @@
 
 Para generar los tipos de las consultas de Sanity debemos seguir [esta guía](https://www.sanity.io/learn/course/typescripted-content/generating-type-for-groq-query-results). Solo en caso de que agreguemos nuevas entidades o se agreguen modificaciones en los schemas de entidades existentes necesitaremos actualizar el archivo `schema.json`. En este proyecto este archivo se encuentra en el directorio `cms/schema.json`.
 
-De acuerdo a lo definido en `cms/sanity-typegen.json` los tipos generados mediante `sanity typegen generate` pueden encontrarse en `src/api/sanity/types.ts`, con los tipos generados para campos en la parte superior, sucedidos luego por los tipos generados para las queries de GROQ. Este archivo oficia como interfaz entre las consultas de Sanity y el código de los servicios de backend que disparan consultas mediante el conector a Sanity.
+De acuerdo a lo definido en `cms/sanity.cli.ts` los tipos generados mediante `sanity typegen generate` pueden encontrarse en `src/api/sanity/types.ts`, con los tipos generados para campos en la parte superior, sucedidos luego por los tipos generados para las queries de GROQ. Este archivo oficia como interfaz entre las consultas de Sanity y el código de los servicios de backend que disparan consultas mediante el conector a Sanity.
 
 Se pueden ver ejemplos de consultas definidas con tipos generados en `src/api/_queries`. En `src/api/author/author.service.ts` o `src/api/story/stoy.service.ts` se pueden ver ejemplos de cómo utilizar estos mismos tipos, para referencia del equipo de desarrollo.
 


### PR DESCRIPTION
## Descripción

- Migra la configuración de Sanity TypeGen del archivo standalone deprecado `cms/sanity-typegen.json` a la propiedad `typegen` de `defineCliConfig()` en `cms/sanity.cli.ts`.
- Elimina `cms/sanity-typegen.json` y actualiza la referencia en `docs/SANITY.md`.
- El glob de `path` se normaliza al valor limpio (`'../src/api/**/*.{ts,tsx,js,jsx}'`), sin las comillas simples internas que eran un artefacto del formato JSON.

Closes #1624.

Requerimiento previo de #1560.

## Plan de pruebas

- [x] `pnpm sanity:extract-schema` + `pnpm sanity:run-typegen-generator` regeneran `src/api/sanity/types.ts` **idéntico** (16 queries / 39 schema types, `git diff` vacío).
- [x] El warning de deprecación de la CLI desaparece tras la migración.
- [x] `pnpm lint` verde.
- [x] `pnpm test` verde.
- [x] `pnpm build` verde.
- [x] `pnpm stylelint` verde.
- [x] `pnpm storybook:build` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)