### PR TITLE
[CI] - Reintenta tareas de Nx sin nube cuando Nx Cloud se queda sin crédito

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Los scripts de shell deben mantener fin de línea LF aunque se editen en Windows:
+# el CI los ejecuta con bash en Linux y un CR los rompería.
+*.sh text eol=lf

--- a/.github/scripts/nx-run.sh
+++ b/.github/scripts/nx-run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Ejecuta una tarea de Nx usando Nx Cloud. Si la nube queda deshabilitada por
+# falta de crédito (workspace disabled / límite excedido), Nx aborta con código
+# distinto de cero y SIN fallback propio. Acá detectamos ese caso puntual y
+# reintentamos con NX_NO_CLOUD=true: la tarea corre sin nube, apoyándose en el
+# caché local (.nx/cache, hidratado gratis por actions/cache), en vez de fallar.
+# Cualquier otro fallo (un test roto, lint en rojo, etc.) se propaga tal cual.
+set -o pipefail
+
+log="$(mktemp)"
+
+if npx "$@" 2>&1 | tee "$log"; then
+	exit 0
+fi
+
+if grep -qiE "workspace is disabled|nx cloud.*(disabled|limit|quota|exceed)" "$log"; then
+	echo "::warning title=Nx Cloud sin crédito::Workspace deshabilitado; reintentando sin nube (caché local)."
+	NX_NO_CLOUD=true npx "$@"
+else
+	exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
             nx-cache-test-
 
       - name: Run Tests
-        run: npx nx test
+        run: bash .github/scripts/nx-run.sh nx test
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
@@ -147,7 +147,7 @@ jobs:
             nx-cache-lint-
 
       - name: Run Linter
-        run: npx nx lint
+        run: bash .github/scripts/nx-run.sh nx lint
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
@@ -182,7 +182,7 @@ jobs:
             nx-cache-stylelint-
 
       - name: Run stylelint
-        run: npx nx stylelint @cuentoneta/app
+        run: bash .github/scripts/nx-run.sh nx stylelint @cuentoneta/app
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
@@ -212,7 +212,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Tests
-        run: npx nx run @cuentoneta/app:e2e
+        run: bash .github/scripts/nx-run.sh nx run @cuentoneta/app:e2e
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
@@ -255,7 +255,7 @@ jobs:
             nx-cache-build-
 
       - name: Run build
-        run: npx nx run @cuentoneta/app:build:production
+        run: bash .github/scripts/nx-run.sh nx run @cuentoneta/app:build:production
         env:
           # Nx Cloud (cache remota de tareas)
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
@@ -300,6 +300,6 @@ jobs:
             nx-cache-storybook-
 
       - name: Run Storybook build
-        run: npx nx run @cuentoneta/app:build-storybook
+        run: bash .github/scripts/nx-run.sh nx run @cuentoneta/app:build-storybook
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}


### PR DESCRIPTION
## Contexto

Cuando se agota el crédito de Nx Cloud, el workspace queda *disabled* y `nx`
aborta con código distinto de cero **sin** fallback a ejecución local — es una
limitación conocida del plan hobby, no hay flag oficial de degradación elegante.
Resultado: el CI quedaba en rojo aunque el código estuviera bien.

Referencias: [discusión #27318 (exceeding limits)](https://github.com/nrwl/nx/discussions/27318) · [CI Execution Failed](https://nx.dev/docs/troubleshooting/ci-execution-failed) · [#22444](https://github.com/nrwl/nx/issues/22444).

## Cambios

- **`.github/scripts/nx-run.sh`**: envuelve la invocación de Nx. Corre la tarea
  con Nx Cloud; si falla **y** la salida coincide con la firma de *workspace
  disabled* / límite excedido, reintenta con `NX_NO_CLOUD=true` (caché local de
  `.nx/cache`, ya hidratado gratis por la capa `actions/cache`). Cualquier otro
  fallo (test/lint/build roto) se propaga tal cual — no enmascara errores reales.
- **`ci.yml`**: los 6 jobs (`test`, `lint`, `stylelint`, `e2e`, `build`,
  `storybook`) pasan a invocar el script en vez de `npx nx ...` directo. El
  `env` de cada job (token de Nx Cloud y los `SANITY_*`/`CLARITY_*` del build) se
  hereda sin cambios al ser un `run:` normal.
- **`.gitattributes`**: `*.sh text eol=lf` para que el script no se rompa por
  CRLF al editarse en Windows.

**Nx Cloud se mantiene como caché primario.** Esto solo agrega el camino de
degradación cuando la nube no está disponible por falta de crédito.

## Cómo evaluarlo

Con crédito disponible, los jobs corren igual que antes (cache remoto). Sin
crédito, en los logs aparece el `::warning Nx Cloud sin crédito` y la tarea
vuelve a correr sin nube en vez de tirar el job. El guard de config (`guard-config.yml`)
no aplica acá por ser PR del mismo repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)