### PR TITLE
[HF] - Mueve componentes a la sección Componentes V3 en Storybook

### DIFF
--- a/src/app/components/button/button.component.stories.ts
+++ b/src/app/components/button/button.component.stories.ts
@@ -5,7 +5,7 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { faBrandFacebook, faBrandTwitter, faBrandWhatsapp } from '@ng-icons/font-awesome/brands';
 
 const meta: Meta<ButtonComponent> = {
-	title: 'Components/Button',
+	title: 'Componentes V3/Button',
 	component: ButtonComponent,
 	parameters: {
 		layout: 'centered',

--- a/src/app/components/carousel/carousel.component.stories.ts
+++ b/src/app/components/carousel/carousel.component.stories.ts
@@ -7,7 +7,7 @@ import { ContentCampaign } from '@models/content-campaign.model';
 
 const meta: Meta<CarouselComponent> = {
 	component: CarouselComponent,
-	title: 'Componentes/Carousel',
+	title: 'Componentes V3/Carousel',
 	decorators: [
 		applicationConfig({
 			providers: [provideRouter([])],

--- a/src/app/components/collection-teaser/collection-teaser.stories.ts
+++ b/src/app/components/collection-teaser/collection-teaser.stories.ts
@@ -7,7 +7,7 @@ import { storylistMock } from '@mocks/storylist.mock';
 
 const meta: Meta<CollectionTeaser> = {
 	component: CollectionTeaser,
-	title: 'Componentes/CollectionTeaser',
+	title: 'Componentes V3/CollectionTeaser',
 	decorators: [
 		applicationConfig({
 			providers: [provideRouter([])],

--- a/src/app/components/image-profile/image-profile.component.stories.ts
+++ b/src/app/components/image-profile/image-profile.component.stories.ts
@@ -10,7 +10,7 @@ const alt = `Retrato de ${authorTeaserMock.name}`;
 
 const meta: Meta<ImageProfileComponent> = {
 	component: ImageProfileComponent,
-	title: 'Componentes/ImageProfile',
+	title: 'Componentes V3/ImageProfile',
 	parameters: {
 		docs: {
 			canvas: {

--- a/src/app/components/skeleton/skeleton.component.stories.ts
+++ b/src/app/components/skeleton/skeleton.component.stories.ts
@@ -4,7 +4,7 @@ import { SkeletonComponent } from './skeleton.component';
 
 const meta: Meta<SkeletonComponent> = {
 	component: SkeletonComponent,
-	title: 'Componentes/Skeleton',
+	title: 'Componentes V3/Skeleton',
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },

--- a/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
+++ b/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
@@ -20,7 +20,7 @@ const media: Media[] = [
 
 const meta: Meta<StoryMediaSelectorsComponent> = {
 	component: StoryMediaSelectorsComponent,
-	title: 'Componentes/StoryMediaSelectors',
+	title: 'Componentes V3/StoryMediaSelectors',
 	parameters: {
 		docs: {
 			canvas: {

--- a/src/app/components/tags-list/tags-list.component.stories.ts
+++ b/src/app/components/tags-list/tags-list.component.stories.ts
@@ -29,7 +29,7 @@ const boxed = (width: string) =>
 
 const meta: Meta<Args> = {
 	component: TagsListComponent,
-	title: 'Componentes/TagsList',
+	title: 'Componentes V3/TagsList',
 	decorators: [moduleMetadata({ imports: [TagComponent] })],
 	parameters: {
 		docs: {


### PR DESCRIPTION
## Resumen

Hotfix quick & dirty: reubica varios componentes en la jerarquía de Storybook bajo la sección **Componentes V3**.

Componentes movidos (cambio en el `title` del meta de cada story):

- `Button`: `Components/Button` → `Componentes V3/Button`
- `StoryMediaSelectors`: `Componentes/StoryMediaSelectors` → `Componentes V3/StoryMediaSelectors`
- `Skeleton`: `Componentes/Skeleton` → `Componentes V3/Skeleton`
- `CollectionTeaser`: `Componentes/CollectionTeaser` → `Componentes V3/CollectionTeaser`
- `ImageProfile`: `Componentes/ImageProfile` → `Componentes V3/ImageProfile`
- `TagsList`: `Componentes/TagsList` → `Componentes V3/TagsList`
- `Carousel`: `Componentes/Carousel` → `Componentes V3/Carousel`

Solo se modifican los `title` de los archivos `*.stories.ts`; no hay cambios de lógica ni de componentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)