### PR TITLE
[#1590] - Automatizar la release: tag + release notes + deploy de Sanity Studio

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -11,7 +11,8 @@ assignees: ''
 - [ ] Ajustar changelog.
 - [ ] Actualizar versión en package.json.
 - [ ] Sanity: Determinar si hay scripts de actualización de datos a ejecutar.
-- [ ] ~~Generar release + deploy de Studio~~ _(automatizado por el workflow `release.yml` al mergear a master)_
+- [ ] ~~Generar release desde GitHub (tag + notas)~~ _(automatizado por el workflow `release.yml` al mergear a master)_
+- [ ] ~~Sanity: Hacer deploy de Sanity Studio~~ _(automatizado por el workflow `release.yml` al mergear a master)_
 - [ ] Chequear si deben actualizarse en la documentación del proyecto las versiones de herramientas o dependencias
 
 `(Agregar otras tareas particulares de la versión, en caso de que sea necesario)`

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -10,10 +10,8 @@ assignees: ''
 
 - [ ] Ajustar changelog.
 - [ ] Actualizar versión en package.json.
-- [ ] Sanity: Hacer deploy de Sanity Studio.
 - [ ] Sanity: Determinar si hay scripts de actualización de datos a ejecutar.
-- [ ] Generar release desde GitHub.
-  - [ ] Listar todos los issues agregados a la release.
+- [ ] ~~Generar release + deploy de Studio~~ _(automatizado por el workflow `release.yml` al mergear a master)_
 - [ ] Chequear si deben actualizarse en la documentación del proyecto las versiones de herramientas o dependencias
 
 `(Agregar otras tareas particulares de la versión, en caso de que sea necesario)`

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,9 @@
+# Configura el listado de PRs que GitHub genera automáticamente para las release
+# notes (--generate-notes / botón "Generate release notes"). La categoría catch-all
+# agrupa todos los PRs bajo el encabezado "Bitácora de cambios", reproduciendo el
+# formato histórico de las releases del proyecto en vez del default "What's Changed".
+changelog:
+  categories:
+    - title: Bitácora de cambios
+      labels:
+        - '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,9 +99,13 @@ jobs:
         run: |
           set -euo pipefail
           echo "::group::Creando release ${VERSION}"
+          # --notes-file (prosa curada del CHANGELOG) se antepone al listado de PRs
+          # que genera --generate-notes desde el tag anterior. El encabezado de ese
+          # listado ("Bitácora de cambios") lo define .github/release.yml.
           gh release create "$VERSION" \
             --title "$VERSION" \
             --notes-file "$NOTES_FILE" \
+            --generate-notes \
             --target master
           echo "::endgroup::"
           echo "Release ${VERSION} publicado."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,18 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # 'true' si se creó el release en esta corrida; 'false' si el tag ya existía.
-      # El job deploy-studio lo usa para no re-deployar en pushes posteriores sin
-      # cambio de versión.
+      # Es un string ('true'/'false'), no un booleano — el job deploy-studio lo
+      # compara como string para no re-deployar en pushes sin cambio de versión.
       should_deploy: ${{ steps.check-tag.outputs.should_deploy }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22.22.3
 
       - name: Leer versión de package.json
         id: version
@@ -41,33 +46,47 @@ jobs:
 
       - name: Verificar si el tag ya existe (idempotencia)
         id: check-tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          version="${{ steps.version.outputs.version }}"
-          if git ls-remote --tags origin "refs/tags/$version" | grep -q "$version"; then
-            echo "El tag $version ya existe. No se vuelve a crear el release."
+          # ls-remote con un refspec exacto solo devuelve el tag si existe (no hace
+          # match por prefijo), así que basta con chequear si la salida es no-vacía.
+          if [ -n "$(git ls-remote --tags origin "refs/tags/${VERSION}")" ]; then
+            echo "El tag ${VERSION} ya existe. No se vuelve a crear el release."
             echo "should_deploy=false" >> "$GITHUB_OUTPUT"
           else
-            echo "El tag $version no existe. Se procede con el release."
+            echo "El tag ${VERSION} no existe. Se procede con el release."
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extraer notas del CHANGELOG.md
         id: notes
         if: steps.check-tag.outputs.should_deploy == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          version="${{ steps.version.outputs.version }}"
-          # Extrae el bloque entre "## Versión <version>" y el próximo "## Versión"
-          # (sin incluir ninguno de los dos encabezados). Falla si la sección no existe
-          # para forzar que el bump de versión vaya siempre acompañado de su CHANGELOG.
-          notes=$(sed -n "/^## Versión ${version}/,/^## Versión /{ /^## Versión ${version}/d; /^## Versión /d; p }" CHANGELOG.md)
-          if [ -z "$notes" ]; then
-            echo "::error::No se encontró la sección '## Versión ${version}' en CHANGELOG.md. Agregá la entrada antes de mergear a master." >&2
+          # awk con comparación literal (index, no regex) para que los puntos de la
+          # versión no actúen como metacaracteres. Imprime el cuerpo entre el header
+          # de la versión y el próximo "## Versión" (o EOF, si es la sección más
+          # reciente). El error si queda vacío fuerza que el bump de versión vaya
+          # siempre acompañado de su entrada de CHANGELOG.
+          notes=$(awk -v ver="$VERSION" '
+            BEGIN { header = "## Versión " ver }
+            index($0, header) == 1 {
+              after = substr($0, length(header) + 1, 1)
+              if (after == "" || after == " ") { found = 1; next }
+            }
+            found && index($0, "## Versión ") == 1 { exit }
+            found { print }
+          ' CHANGELOG.md)
+          if [ -z "${notes//[[:space:]]/}" ]; then
+            echo "::error::No se encontró la sección '## Versión ${VERSION}' en CHANGELOG.md. Agregá la entrada antes de mergear a master." >&2
             exit 1
           fi
-          # Escribe las notas en un archivo temporal para evitar problemas de quoting
-          # con caracteres especiales en GITHUB_OUTPUT.
+          # Archivo temporal para evitar problemas de quoting con caracteres
+          # especiales al pasar las notas a gh release create.
           echo "$notes" > "${RUNNER_TEMP}/release-notes.md"
           echo "notes_file=${RUNNER_TEMP}/release-notes.md" >> "$GITHUB_OUTPUT"
 
@@ -75,22 +94,23 @@ jobs:
         if: steps.check-tag.outputs.should_deploy == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          NOTES_FILE: ${{ steps.notes.outputs.notes_file }}
         run: |
           set -euo pipefail
-          version="${{ steps.version.outputs.version }}"
-          notes_file="${{ steps.notes.outputs.notes_file }}"
-          echo "::group::Creando release $version"
-          gh release create "$version" \
-            --title "$version" \
-            --notes-file "$notes_file" \
+          echo "::group::Creando release ${VERSION}"
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes-file "$NOTES_FILE" \
             --target master
           echo "::endgroup::"
-          echo "Release $version publicado."
+          echo "Release ${VERSION} publicado."
 
   deploy-studio:
     name: Deploy Sanity Studio
     needs: release
-    # Solo corre si el job release creó un release nuevo en esta corrida.
+    # should_deploy es un string ('true'/'false'); solo corre si release creó un
+    # release nuevo en esta corrida.
     if: needs.release.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release (tag + notas + deploy Studio)
+
+# Crea el tag, publica el GitHub Release con las notas del CHANGELOG y hace el
+# deploy de Sanity Studio al mergear develop → master con la versión bumpeada en
+# package.json. El deploy de la app en Vercel lo cubre la integración Git nativa
+# de Vercel — este workflow no lo toca.
+#
+# Prerequisitos (secrets del repo):
+#   - SANITY_AUTH_TOKEN: robot token de manage.sanity.io con permisos de deploy del Studio.
+#     Mismo token que usa sync-datasets.yml; ya existe.
+#   - SANITY_STUDIO_PROJECT_ID: id del proyecto Sanity (s4dbqkc5). Ya existe.
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Crear tag y GitHub Release
+    runs-on: ubuntu-latest
+    outputs:
+      # 'true' si se creó el release en esta corrida; 'false' si el tag ya existía.
+      # El job deploy-studio lo usa para no re-deployar en pushes posteriores sin
+      # cambio de versión.
+      should_deploy: ${{ steps.check-tag.outputs.should_deploy }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Leer versión de package.json
+        id: version
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Versión detectada: $version"
+
+      - name: Verificar si el tag ya existe (idempotencia)
+        id: check-tag
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          if git ls-remote --tags origin "refs/tags/$version" | grep -q "$version"; then
+            echo "El tag $version ya existe. No se vuelve a crear el release."
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "El tag $version no existe. Se procede con el release."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extraer notas del CHANGELOG.md
+        id: notes
+        if: steps.check-tag.outputs.should_deploy == 'true'
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          # Extrae el bloque entre "## Versión <version>" y el próximo "## Versión"
+          # (sin incluir ninguno de los dos encabezados). Falla si la sección no existe
+          # para forzar que el bump de versión vaya siempre acompañado de su CHANGELOG.
+          notes=$(sed -n "/^## Versión ${version}/,/^## Versión /{ /^## Versión ${version}/d; /^## Versión /d; p }" CHANGELOG.md)
+          if [ -z "$notes" ]; then
+            echo "::error::No se encontró la sección '## Versión ${version}' en CHANGELOG.md. Agregá la entrada antes de mergear a master." >&2
+            exit 1
+          fi
+          # Escribe las notas en un archivo temporal para evitar problemas de quoting
+          # con caracteres especiales en GITHUB_OUTPUT.
+          echo "$notes" > "${RUNNER_TEMP}/release-notes.md"
+          echo "notes_file=${RUNNER_TEMP}/release-notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Crear tag y publicar GitHub Release
+        if: steps.check-tag.outputs.should_deploy == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          notes_file="${{ steps.notes.outputs.notes_file }}"
+          echo "::group::Creando release $version"
+          gh release create "$version" \
+            --title "$version" \
+            --notes-file "$notes_file" \
+            --target master
+          echo "::endgroup::"
+          echo "Release $version publicado."
+
+  deploy-studio:
+    name: Deploy Sanity Studio
+    needs: release
+    # Solo corre si el job release creó un release nuevo en esta corrida.
+    if: needs.release.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+
+    env:
+      SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+      SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID }}
+      # El CLI de Sanity corre desatendido cuando CI=true (Actions ya lo setea;
+      # explícito por robustez ante un cambio futuro del runner).
+      CI: 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Select pnpm as package manager
+        uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.12.1
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22.22.3
+          cache: 'pnpm'
+          cache-dependency-path: cms/pnpm-lock.yaml
+
+      - name: Install CMS dependencies
+        working-directory: cms
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Deploy Sanity Studio
+        working-directory: cms
+        run: |
+          set -euo pipefail
+          echo "::group::Deploy de Sanity Studio"
+          pnpm exec sanity deploy
+          echo "::endgroup::"


### PR DESCRIPTION
## Descripción

- Agrega `.github/workflows/release.yml`: en push a `master` crea el tag, publica el GitHub Release y deploya Sanity Studio. Idempotente (no re-releasea si el tag ya existe).
- **Notas del release:** combina la **prosa curada del CHANGELOG** (sección `## Versión <version>`) con el **listado auto-generado de PRs** que produce GitHub (`--generate-notes`), reproduciendo el formato histórico de las releases hechas a mano desde la UI.
- Agrega `.github/release.yml` para que ese listado use el encabezado **"Bitácora de cambios"** en vez del default "What's Changed".
- El deploy de la app en Vercel queda cubierto por su integración Git nativa; el workflow no lo toca.
- Actualiza `.github/ISSUE_TEMPLATE/release.md` marcando como automatizados los pasos de generar el release y deployar el Studio; conserva la tarea manual de migración de datos.

Closes #1590.

## Plan de pruebas

- [x] `pnpm lint`, `pnpm stylelint`, `pnpm test`, `pnpm build`, `pnpm storybook:build` en verde (e2e no aplica: sin cambios de app).
- [x] Validación del YAML del workflow y de `.github/release.yml` con parser local.
- [x] Dry-run de la extracción de prosa con `awk` contra el `CHANGELOG.md` real y casos borde: sección más reciente al final del archivo (EOF), colisión de prefijo (`1.0` vs `1.0.1`), versión inexistente y sección solo-whitespace.
- [x] Verificación empírica de que `git ls-remote` con refspec exacto hace match exacto (base del check de idempotencia) y de que `gh release create` antepone `--notes-file` al listado de `--generate-notes`.
- [ ] Validación end-to-end real: ocurre en el primer merge a `master` con la versión bumpeada (crea tag + release con prosa + listado de PRs + deploy del Studio; segundo push sin cambio de versión no re-releasea).

> Requiere que los secrets `SANITY_AUTH_TOKEN` y `SANITY_STUDIO_PROJECT_ID` existan en el repo (ya configurados para `sync-datasets.yml`). Verificar que `SANITY_AUTH_TOKEN` tenga permiso de **deploy del Studio**.