### PR TITLE
[#1633] - Usar CoverImage en CollectionTeaser

### DIFF
--- a/src/app/components/collection-teaser/collection-teaser-skeleton.ts
+++ b/src/app/components/collection-teaser/collection-teaser-skeleton.ts
@@ -1,14 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import { SkeletonComponent } from '@components/skeleton/skeleton.component';
+import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton.component';
 
 @Component({
 	selector: 'cuentoneta-collection-teaser-skeleton',
-	imports: [SkeletonComponent],
+	imports: [SkeletonComponent, CoverImageSkeletonComponent],
 	template: `
 		<article class="flex items-start gap-5">
 			<section class="flex h-[192px] flex-1 items-end justify-center overflow-hidden rounded-xl bg-neutral-100 px-3">
-				<cuentoneta-skeleton appearance="line" class="-mb-2 h-[164px] w-[118px] bg-neutral-300" />
+				<cuentoneta-cover-image-skeleton class="-mb-2" />
 			</section>
 			<section class="flex flex-1 flex-col gap-1 overflow-hidden">
 				<cuentoneta-skeleton appearance="line" class="h-[18px] w-4/5 bg-neutral-300" />

--- a/src/app/components/collection-teaser/collection-teaser.spec.ts
+++ b/src/app/components/collection-teaser/collection-teaser.spec.ts
@@ -87,26 +87,24 @@ describe('CollectionTeaser', () => {
 		});
 	});
 
-	// Pruebas de la imagen
+	// Pruebas de la imagen (cover delegado a CoverImageComponent)
 	describe('Imagen de la colección', () => {
-		it('should render the featured image', async () => {
+		it('should render the cover image', async () => {
 			await render(CollectionTeaser, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
 
-			const image = screen.getByRole('img');
-			expect(image).toBeInTheDocument();
+			expect(screen.getByTestId('cover-image')).toBeInTheDocument();
 		});
 
-		it('should have correct alt text', async () => {
+		it('should render a decorative cover with empty alt', async () => {
 			await render(CollectionTeaser, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
 
-			const image = screen.getByRole('img');
-			expect(image).toHaveAttribute('alt', `Imagen alusiva a la storylist ${collectionTeaserMock.title}`);
+			expect(screen.getByTestId('cover-image')).toHaveAttribute('alt', '');
 		});
 
 		it('should have correct dimensions', async () => {
@@ -115,7 +113,7 @@ describe('CollectionTeaser', () => {
 				providers: defaultProviders,
 			});
 
-			const image = screen.getByRole('img');
+			const image = screen.getByTestId('cover-image');
 			expect(image).toHaveAttribute('height', '164');
 			expect(image).toHaveAttribute('width', '118');
 		});
@@ -233,15 +231,16 @@ describe('CollectionTeaser', () => {
 			expect(link).toBeInTheDocument();
 		});
 
-		it('should have accessible image with alt text', async () => {
+		it('should have a decorative cover and the link named by the collection title', async () => {
 			await render(CollectionTeaser, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
 
-			const image = screen.getByRole('img');
-			expect(image).toHaveAttribute('alt');
-			expect(image.getAttribute('alt')).not.toBe('');
+			// El cover es decorativo (alt vacío); el nombre accesible del enlace lo aporta el título.
+			expect(screen.getByTestId('cover-image')).toHaveAttribute('alt', '');
+			const link = screen.getByRole('link');
+			expect(within(link).getByText(collectionTeaserMock.title)).toBeInTheDocument();
 		});
 
 		it('should use semantic article element', async () => {

--- a/src/app/components/collection-teaser/collection-teaser.spec.ts
+++ b/src/app/components/collection-teaser/collection-teaser.spec.ts
@@ -11,16 +11,21 @@ import { storylistMock } from '@mocks/storylist.mock';
 // Modelos
 import { StorylistTeaser } from '@models/storylist.model';
 
-// Mock de StorylistTeaser basado en el mock existente
+// Utilidades de test
+import { clearAllMocks } from '@test-utils';
+
 const collectionTeaserMock: StorylistTeaser = {
 	...storylistMock,
 	stories: [],
 	tabs: [],
-} as StorylistTeaser;
+};
 
 describe('CollectionTeaser', () => {
-	// Providers necesarios para las pruebas
 	const defaultProviders = [provideRouter([])];
+
+	beforeEach(() => {
+		clearAllMocks();
+	});
 
 	// Pruebas de renderizado básico
 	describe('Renderizado del componente', () => {
@@ -87,7 +92,7 @@ describe('CollectionTeaser', () => {
 		});
 	});
 
-	// Pruebas de la imagen (cover delegado a CoverImageComponent)
+	// Pruebas del cover de la colección
 	describe('Imagen de la colección', () => {
 		it('should render the cover image', async () => {
 			await render(CollectionTeaser, {
@@ -105,17 +110,6 @@ describe('CollectionTeaser', () => {
 			});
 
 			expect(screen.getByTestId('cover-image')).toHaveAttribute('alt', '');
-		});
-
-		it('should have correct dimensions', async () => {
-			await render(CollectionTeaser, {
-				inputs: { collection: collectionTeaserMock },
-				providers: defaultProviders,
-			});
-
-			const image = screen.getByTestId('cover-image');
-			expect(image).toHaveAttribute('height', '164');
-			expect(image).toHaveAttribute('width', '118');
 		});
 	});
 

--- a/src/app/components/collection-teaser/collection-teaser.stories.ts
+++ b/src/app/components/collection-teaser/collection-teaser.stories.ts
@@ -3,6 +3,9 @@ import { CollectionTeaser } from './collection-teaser';
 import { provideRouter } from '@angular/router';
 import { CollectionTeaserSkeletonComponent } from './collection-teaser-skeleton';
 import { storylistMock } from '@mocks/storylist.mock';
+import { StorylistTeaser } from '@models/storylist.model';
+
+const collectionMock: StorylistTeaser = { ...storylistMock, stories: [], tabs: [] };
 
 const meta: Meta<CollectionTeaser> = {
 	component: CollectionTeaser,
@@ -40,7 +43,7 @@ export const Primary = {
 `,
 	}),
 	args: {
-		collection: storylistMock,
+		collection: collectionMock,
 	},
 };
 
@@ -59,7 +62,7 @@ export const Estados: StoryObj<CollectionTeaser & { loading: boolean }> = {
 			</div>
 		`,
 	}),
-	args: { loading: true, collection: storylistMock },
+	args: { loading: true, collection: collectionMock },
 	parameters: {
 		docs: { description: { story: 'Activá/desactivá "Cargando" para alternar entre el estado real y el skeleton.' } },
 	},

--- a/src/app/components/collection-teaser/collection-teaser.stories.ts
+++ b/src/app/components/collection-teaser/collection-teaser.stories.ts
@@ -47,7 +47,6 @@ export const Primary = {
 	},
 };
 
-// Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
 export const Estados: StoryObj<CollectionTeaser & { loading: boolean }> = {
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
 	render: (args) => ({

--- a/src/app/components/collection-teaser/collection-teaser.stories.ts
+++ b/src/app/components/collection-teaser/collection-teaser.stories.ts
@@ -1,6 +1,5 @@
-import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { CollectionTeaser } from './collection-teaser';
-import { NgOptimizedImage } from '@angular/common';
 import { provideRouter } from '@angular/router';
 import { CollectionTeaserSkeletonComponent } from './collection-teaser-skeleton';
 import { storylistMock } from '@mocks/storylist.mock';
@@ -8,18 +7,22 @@ import { storylistMock } from '@mocks/storylist.mock';
 const meta: Meta<CollectionTeaser> = {
 	component: CollectionTeaser,
 	title: 'Componentes V3/CollectionTeaser',
+	tags: ['autodocs'],
 	decorators: [
 		applicationConfig({
 			providers: [provideRouter([])],
 		}),
 		moduleMetadata({
-			imports: [NgOptimizedImage, CollectionTeaserSkeletonComponent],
+			imports: [CollectionTeaserSkeletonComponent],
 		}),
 	],
 	parameters: {
 		docs: {
 			canvas: {
 				sourceState: 'shown',
+			},
+			description: {
+				component: `<div><p>Tarjeta de una colección (storylist) para el Design System v3: portada, título, descripción y footer con tag y contador de historias. La portada usa <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> para unificar el tratamiento de imagen/placeholder con el resto de las tarjetas v3.</p></div>`,
 			},
 		},
 	},
@@ -38,5 +41,26 @@ export const Primary = {
 	}),
 	args: {
 		collection: storylistMock,
+	},
+};
+
+// Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
+export const Estados: StoryObj<CollectionTeaser & { loading: boolean }> = {
+	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="card p-4">
+				@if (loading) {
+					<cuentoneta-collection-teaser-skeleton class="w-full" />
+				} @else {
+					<cuentoneta-collection-teaser [collection]="collection" />
+				}
+			</div>
+		`,
+	}),
+	args: { loading: true, collection: storylistMock },
+	parameters: {
+		docs: { description: { story: 'Activá/desactivá "Cargando" para alternar entre el estado real y el skeleton.' } },
 	},
 };

--- a/src/app/components/collection-teaser/collection-teaser.ts
+++ b/src/app/components/collection-teaser/collection-teaser.ts
@@ -10,11 +10,11 @@ import { StorylistTeaser } from '@models/storylist.model';
 
 // Components
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
-import { NgOptimizedImage } from '@angular/common';
+import { CoverImageComponent } from '../cover-image/cover-image.component';
 
 @Component({
 	selector: 'cuentoneta-collection-teaser',
-	imports: [RouterLink, PortableTextParserComponent, NgOptimizedImage],
+	imports: [RouterLink, PortableTextParserComponent, CoverImageComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<article>
@@ -23,13 +23,7 @@ import { NgOptimizedImage } from '@angular/common';
 					<section
 						class="flex h-[192px] items-end justify-center overflow-hidden rounded-xl bg-neutral-100 px-3 sm:flex-1"
 					>
-						<img
-							[ngSrc]="storylist.featuredImage"
-							[alt]="'Imagen alusiva a la storylist ' + storylist.title"
-							class="mb-[-8px]"
-							height="164"
-							width="118"
-						/>
+						<cuentoneta-cover-image [src]="storylist.featuredImage" class="-mb-2" />
 					</section>
 					<section class="flex flex-1 flex-col gap-1 overflow-hidden">
 						<header

--- a/src/app/components/cover-image/cover-image.component.spec.ts
+++ b/src/app/components/cover-image/cover-image.component.spec.ts
@@ -14,4 +14,11 @@ describe('CoverImageComponent', () => {
 		expect(screen.getByTestId('cover-placeholder')).toBeInTheDocument();
 		expect(screen.queryByTestId('cover-image')).not.toBeInTheDocument();
 	});
+
+	it('should render the cover at the fixed 118×164 dimensions', async () => {
+		await render(CoverImageComponent, { inputs: { src: 'https://example.com/cover.jpg' } });
+		const image = screen.getByTestId('cover-image');
+		expect(image).toHaveAttribute('width', '118');
+		expect(image).toHaveAttribute('height', '164');
+	});
 });


### PR DESCRIPTION
## Descripción

- Reemplaza el manejo manual de portada (`<img [ngSrc]>` + `NgOptimizedImage`) en `CollectionTeaser` por el componente canónico del Design System v3 `cuentoneta-cover-image` (`CoverImageComponent`), y el skeleton de imagen por `cuentoneta-cover-image-skeleton`, unificando el tratamiento de portadas con `StoryCardTeaserV3` y `HomeStoryCard`.
- El cover pasa a ser decorativo (`alt=""`, según el contrato de `CoverImageComponent`); el nombre accesible del enlace lo aporta el título de la colección. Se actualiza el spec en consecuencia (queries por `data-testid="cover-image"`) y se agrega la story intercambiable `Estados` (real↔skeleton).
- No se parametriza el tamaño: las dimensiones de `CoverImage` (118×164) coinciden exactamente con las que `CollectionTeaser` ya declaraba.

Closes #1633.

## Fuera de alcance (follow-ups creados)

- **Variante "Multiple"** del nodo Figma (3 covers en abanico para colecciones multi-autor): requiere extender el modelo de datos (`StorylistTeaser.featuredImage` es hoy un único `string`), el mapper del ACL y la query GROQ. Seguimiento en #1638.
- **Limpieza de tests preexistentes** que afirman clases CSS (`navigation-link`, layout `flex`/`gap-5`) en `collection-teaser.spec.ts`, contra la regla de `testing.md` de testear comportamiento y no estructura. Seguimiento en #1639.

## Plan de pruebas

- [x] `pnpm lint` — verde
- [x] `pnpm stylelint` — verde
- [x] `pnpm test` — verde (spec de `CollectionTeaser` y `CoverImageComponent` actualizados; cobertura de dimensiones 118×164 movida a `CoverImageComponent`)
- [x] `pnpm build` — verde (warnings de budget/eventsource preexistentes en `develop`)
- [x] `pnpm storybook:build` — verde (story `Estados` intercambiable real↔skeleton)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
