### PR TITLE
[#1641] - Generar release para versión 2.8.1 de La Cuentoneta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,33 @@ La lista de características futuras a implementar puede hallarse en la sección
 
 Los hitos futuros de desarrollo, en los cuales se detallan las funcionalidades a desarrollar y los cambios a implementar, pueden encontrarse en las secciones [milestones](https://github.com/cuentoneta/cuentoneta/milestones) y [projects](https://github.com/cuentoneta/cuentoneta/projects) del repositorio de Github del proyecto.
 
+## Versión 2.8.1 (2026-06-23)
+
+La versión 2.8.1 continúa la implementación del Design System V3 con cuatro nuevas entregas: el componente `StoryCardTeaserV3` y el nuevo `HomeStoryCard`, el reemplazo de `BadgeComponent` por `TagComponent` en todos sus usos con documentación de story desde Figma, la adopción de `CoverImageComponent` en el `CollectionTeaser` y la reconciliación de tags en las vistas de story y autor con soporte de override de color.
+
+En paralelo, moderniza el tooling y la infraestructura de CI: actualización de Nx a la versión 23.0, angular-eslint a 21.4.0 con migración del executor `@nx/eslint:lint` deprecado, la migración de la configuración de Sanity TypeGen a `sanity.cli.ts`, la automatización completa del flujo de release (tag + release notes + deploy de Sanity Studio) y la configuración de Dependabot para el auto-bump de GitHub Actions.
+
+### Cambios completos
+
+Ver el changelog completo en [2.8.1](https://github.com/cuentoneta/cuentoneta/releases/tag/2.8.1)
+
+### Cambios
+
+#### Design System V3 y componentes
+
+- [#1510] - Implementación de `StoryCardTeaserV3` y `HomeStoryCard` (Design System V3).
+- [#1629] - Reemplazo de `BadgeComponent` por `TagComponent` y documentación de su story desde Figma.
+- [#1633] - Adopción de `CoverImageComponent` en `CollectionTeaser`.
+- [#1569] - Tags en las vistas de story y autor, reconciliación de tags de autor y override de color en tag.
+
+#### Tooling, CI y mantenimiento
+
+- [#1640] - Actualización de angular-eslint a 21.4.0 y migración del executor `@nx/eslint:lint` deprecado.
+- [#1622] - Actualización de Nx a la versión 23.0.
+- [#1624] - Migración de la configuración de Sanity TypeGen de `sanity-typegen.json` a `sanity.cli.ts`.
+- [#1590] - Automatización del flujo de release: tag, release notes y deploy de Sanity Studio.
+- [#1584] - Configuración de Dependabot para el auto-bump de versiones de GitHub Actions.
+
 ## Versión 2.8.0 (2026-06-20)
 
 La versión 2.8.0 implementa parcialmente el Design System V3 con una nueva familia de componentes —avatares circulares, tags con recorte por ancho, teasers de autor y skeletons de carga propios— y reemplaza la dependencia `ngx-skeleton-loader` por una implementación in-house.

--- a/cms/package.json
+++ b/cms/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/cms",
 	"private": true,
-	"version": "2.8.0",
+	"version": "2.8.1",
 	"description": "",
 	"main": "package.json",
 	"author": "Ramiro Olivencia <ramiro@olivencia.com.ar>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/app",
 	"type": "module",
-	"version": "2.8.0",
+	"version": "2.8.1",
 	"imports": {
 		"#tailwind-theme": "./src/tailwind.css"
 	},


### PR DESCRIPTION
## Descripción

Prepara la release **2.8.1** de La Cuentoneta (tareas manuales/editoriales del proceso de release):

- Bumpea `version` de `2.8.0` → `2.8.1` en `package.json` y `cms/package.json`.
- Agrega la sección `## Versión 2.8.1 (2026-06-23)` al `CHANGELOG.md` con la prosa editorial y el listado de los 9 issues del milestone, agrupados en Design System V3 y Tooling/CI.

Las tareas mecánicas (tag, release notes y deploy de Sanity Studio) las ejecuta automáticamente el workflow `release.yml` al mergear `develop → master`.

Closes #1641.

## Verificaciones del proceso de release

- [x] **CHANGELOG completo:** los 9 issues cerrados del milestone 2.8.1 están listados, sin omisiones ni invenciones (verificado contra `gh issue list --milestone 2.8.1`).
- [x] **Migraciones de Sanity:** no existe `cms/migrations/` propia; no hay scripts de datos que ejecutar.
- [x] **Docs:** scan de `docs/`, `CLAUDE.md` y `.claude/references/` sin versiones desactualizadas (Nx 23 y angular-eslint ya reflejados donde corresponde).
- [x] **Integración con `release.yml`:** el `awk` del workflow extrae la sección 2.8.1 correctamente (corta antes de 2.8.0, notas no vacías).
- [x] Gates de CI en verde: `lint`, `stylelint`, `test`, `build`, `storybook:build`.

## Plan de pruebas

- [ ] Validación end-to-end real: al mergear este PR a `develop` y luego `develop → master`, el workflow crea el tag `2.8.1`, publica el release (prosa del CHANGELOG + listado de PRs) y deploya el Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)