### PR TITLE
[HF] - Configura deployment.appId para el deploy no interactivo de Sanity Studio en CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -11,11 +11,16 @@ assignees: ''
 - [ ] Ajustar changelog.
 - [ ] Actualizar versión en package.json.
 - [ ] Sanity: Determinar si hay scripts de actualización de datos a ejecutar.
-- [ ] ~~Generar release desde GitHub (tag + notas)~~ _(automatizado por el workflow `release.yml` al mergear a master)_
-- [ ] ~~Sanity: Hacer deploy de Sanity Studio~~ _(automatizado por el workflow `release.yml` al mergear a master)_
 - [ ] Chequear si deben actualizarse en la documentación del proyecto las versiones de herramientas o dependencias
 
 `(Agregar otras tareas particulares de la versión, en caso de que sea necesario)`
+
+## Pasos automatizados (post-merge a master)
+
+Estos pasos los ejecuta el workflow `release.yml` automáticamente al mergear `develop → master` con la versión bumpeada en `package.json`. No requieren acción manual:
+
+- Creación del tag y publicación del GitHub Release (notas del CHANGELOG + listado de PRs).
+- Deploy de Sanity Studio.
 
 ## Criterios de aceptación
 

--- a/cms/sanity.cli.ts
+++ b/cms/sanity.cli.ts
@@ -5,6 +5,9 @@ export default defineCliConfig({
 		projectId: process.env.SANITY_STUDIO_PROJECT_ID,
 		dataset: process.env.SANITY_STUDIO_DATASET,
 	},
+	// Sin studioHost, `sanity deploy` pide el hostname por prompt interactivo y falla
+	// en CI (entorno no interactivo). Fija el deploy a cuentoneta.sanity.studio.
+	studioHost: 'cuentoneta',
 	typegen: {
 		path: '../src/api/**/*.{ts,tsx,js,jsx}',
 		schema: 'schema.json',

--- a/cms/sanity.cli.ts
+++ b/cms/sanity.cli.ts
@@ -5,9 +5,11 @@ export default defineCliConfig({
 		projectId: process.env.SANITY_STUDIO_PROJECT_ID,
 		dataset: process.env.SANITY_STUDIO_DATASET,
 	},
-	// Sin studioHost, `sanity deploy` pide el hostname por prompt interactivo y falla
-	// en CI (entorno no interactivo).
-	studioHost: 'cuentoneta',
+	// Sin appId fijo, `sanity deploy` pide seleccionar la aplicación por prompt
+	// interactivo y falla en CI (entorno no interactivo).
+	deployment: {
+		appId: '250c71d418c638b6f4236e23',
+	},
 	typegen: {
 		path: '../src/api/**/*.{ts,tsx,js,jsx}',
 		schema: 'schema.json',

--- a/cms/sanity.cli.ts
+++ b/cms/sanity.cli.ts
@@ -6,7 +6,7 @@ export default defineCliConfig({
 		dataset: process.env.SANITY_STUDIO_DATASET,
 	},
 	// Sin studioHost, `sanity deploy` pide el hostname por prompt interactivo y falla
-	// en CI (entorno no interactivo). Fija el deploy a cuentoneta.sanity.studio.
+	// en CI (entorno no interactivo).
 	studioHost: 'cuentoneta',
 	typegen: {
 		path: '../src/api/**/*.{ts,tsx,js,jsx}',


### PR DESCRIPTION
## Descripción

Hotfix del job `deploy-studio` del workflow `release.yml`, que falló al releasear 2.8.1 con `Cannot run "select" prompt in a non-interactive environment`.

- **Causa:** `cms/sanity.cli.ts` no fijaba la aplicación de Studio, así que `sanity deploy` intentaba seleccionarla por prompt interactivo y abortaba en CI.
- **Fix:** se configura `deployment.appId` con el appId de la aplicación de Studio existente (`cuentoneta.sanity.studio`). Se usa `deployment.appId` y no `studioHost` porque este último quedó deprecado en `CliConfig` (`@deprecated Use deployment.appId`).
- Además, se reestructura el template de release (`.github/ISSUE_TEMPLATE/release.md`): los pasos automatizados (tag/release/deploy) dejan de ser ítems de checklist tachados y pasan a una sección de texto "Pasos automatizados (post-merge a master)".

## Notas

- **2.8.1 ya fue releaseada** (tag + GitHub Release publicados); solo falló el deploy del Studio. Como el workflow es idempotente, **no re-deployará el Studio de 2.8.1 automáticamente**. Tras mergear este hotfix, el Studio de 2.8.1 se puede deployar con un `sanity deploy` manual (ahora no interactivo), o quedará cubierto en la próxima release.
- **Back-merge:** tras mergear a `master`, sincronizar `master → develop` (o cherry-pick) para que el fix quede también en la rama de desarrollo.

## Plan de pruebas

- [x] Verificado que `deployment.appId` es campo válido de `CliConfig` (`@sanity/cli-core`) y que el runtime de `sanity deploy` lo resuelve sin prompt.
- [x] Gates de la app en verde (lint, stylelint, test, build, storybook); el cambio de `cms/` queda fuera de su scope.
- [ ] Validación real: el job `deploy-studio` corre sin prompt en la próxima ejecución del workflow / en un `sanity deploy` manual.