### PR TITLE
[#1669] - HomeStoryCard: corpus Onoff + helper centralizado del selector de obra

### DIFF
--- a/src/app/components/cover-image/cover-image.component.stories.ts
+++ b/src/app/components/cover-image/cover-image.component.stories.ts
@@ -2,13 +2,9 @@ import { argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angul
 
 import { CoverImageComponent } from './cover-image.component';
 import { CoverImageSkeletonComponent } from './cover-image-skeleton.component';
-import { onoffStoryTeasersMock } from '../../mocks/onoff-story-teasers.mock';
+import { corpusCovers, obraSelectArgType } from '../../mocks/onoff-corpus.storybook';
 
 const coverImageUrl = 'assets/img/mocks/stories/geometria.png';
-
-// Portadas disponibles en los assets del proyecto (corpus de Onoff); el índice se elige en el selector "Obra".
-const corpusCovers = onoffStoryTeasersMock.map((teaser) => teaser.coverImage);
-const corpusLabels = Object.fromEntries(onoffStoryTeasersMock.map((teaser, index) => [index, teaser.title]));
 
 const meta: Meta<CoverImageComponent> = {
 	component: CoverImageComponent,
@@ -50,11 +46,8 @@ export const WithImage: Story = {
 export const Interactiva: StoryObj<CoverImageComponent & { coverIndex: number }> = {
 	argTypes: {
 		coverIndex: {
-			name: 'Obra',
-			control: { type: 'select', labels: corpusLabels },
-			options: corpusCovers.map((_, index) => index),
+			...obraSelectArgType,
 			description: 'Portada a visualizar, elegida entre las covers del corpus disponibles en los assets del proyecto',
-			table: { type: { summary: 'number' } },
 		},
 	},
 	render: (args) => ({

--- a/src/app/components/cover-image/cover-image.component.stories.ts
+++ b/src/app/components/cover-image/cover-image.component.stories.ts
@@ -2,7 +2,7 @@ import { argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angul
 
 import { CoverImageComponent } from './cover-image.component';
 import { CoverImageSkeletonComponent } from './cover-image-skeleton.component';
-import { corpusCovers, obraSelectArgType } from '../../mocks/onoff-corpus.storybook';
+import { corpusCovers, literaryWorkSelectArgType } from '../../mocks/onoff-corpus.storybook';
 
 const coverImageUrl = 'assets/img/mocks/stories/geometria.png';
 
@@ -46,7 +46,7 @@ export const WithImage: Story = {
 export const Interactiva: StoryObj<CoverImageComponent & { coverIndex: number }> = {
 	argTypes: {
 		coverIndex: {
-			...obraSelectArgType,
+			...literaryWorkSelectArgType,
 			description: 'Portada a visualizar, elegida entre las covers del corpus disponibles en los assets del proyecto',
 		},
 	},

--- a/src/app/components/home-story-card/home-story-card.component.spec.ts
+++ b/src/app/components/home-story-card/home-story-card.component.spec.ts
@@ -179,7 +179,7 @@ describe('HomeStoryCardComponent', () => {
 	});
 
 	// Variedad de obras reales del corpus de François Onoff (#1650): detecta regresiones de datos del corpus.
-	describe('Corpus Onoff — variedad de obras', () => {
+	describe('Onoff corpus — story variety', () => {
 		beforeEach(() => clearAllMocks());
 
 		it.each(onoffStoryTeasersMock)('should render title and reading time for "$title"', async (teaser) => {

--- a/src/app/components/home-story-card/home-story-card.component.spec.ts
+++ b/src/app/components/home-story-card/home-story-card.component.spec.ts
@@ -3,6 +3,7 @@ import { DefaultUrlSerializer, UrlTree } from '@angular/router';
 import { render, screen } from '@testing-library/angular';
 import { storyNavigationTeaserWithAuthorMock, storyTeaserMock } from '../../mocks/story.mock';
 import { authorTeaserMock } from '../../mocks/author.mock';
+import { onoffStoryTeasersMock } from '../../mocks/onoff-story-teasers.mock';
 import { clearAllMocks } from '@test-utils';
 import type { Media } from '@models/media.model';
 import type { StoryTeaserWithAuthor } from '@models/story.model';
@@ -174,6 +175,20 @@ describe('HomeStoryCardComponent', () => {
 				inputs: { story: storyNavigationTeaserWithAuthorMock, navigationParams },
 			});
 			expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument();
+		});
+	});
+
+	// Variedad de obras reales del corpus de François Onoff (#1650): detecta regresiones de datos del corpus.
+	describe('Corpus Onoff — variedad de obras', () => {
+		beforeEach(() => clearAllMocks());
+
+		it.each(onoffStoryTeasersMock)('should render title and reading time for "$title"', async (teaser) => {
+			await render(HomeStoryCardComponent, {
+				inputs: { story: teaser, coverImageUrl: teaser.coverImage },
+			});
+
+			expect(screen.getByText(teaser.title)).toBeInTheDocument();
+			expect(screen.getByText(`${teaser.approximateReadingTime} minutos de lectura`)).toBeInTheDocument();
 		});
 	});
 });

--- a/src/app/components/home-story-card/home-story-card.component.stories.ts
+++ b/src/app/components/home-story-card/home-story-card.component.stories.ts
@@ -85,6 +85,7 @@ export const Interactiva: StoryObj<HomeStoryCardComponent & { storyIndex: number
 				[order]="order"
 				[tagLabel]="tagLabel"
 				[showMultimedia]="showMultimedia"
+				[navigationParams]="navigationParams"
 			/>
 		`,
 	}),
@@ -93,6 +94,7 @@ export const Interactiva: StoryObj<HomeStoryCardComponent & { storyIndex: number
 		order: 1,
 		tagLabel: 'Cuento',
 		showMultimedia: true,
+		navigationParams: { navigation: 'author', navigationSlug: 'francois-onoff' },
 	},
 	parameters: {
 		docs: {

--- a/src/app/components/home-story-card/home-story-card.component.stories.ts
+++ b/src/app/components/home-story-card/home-story-card.component.stories.ts
@@ -148,6 +148,7 @@ export const Estados: StoryObj<HomeStoryCardComponent & { loading: boolean }> = 
 				} @else {
 					<cuentoneta-home-story-card
 						[story]="story"
+						[coverImageUrl]="coverImageUrl"
 						[order]="order"
 						[tagLabel]="tagLabel"
 						[showMultimedia]="showMultimedia"

--- a/src/app/components/home-story-card/home-story-card.component.stories.ts
+++ b/src/app/components/home-story-card/home-story-card.component.stories.ts
@@ -3,31 +3,13 @@ import { provideRouter } from '@angular/router';
 
 import { HomeStoryCardComponent } from './home-story-card.component';
 import { HomeStoryCardSkeletonComponent } from './home-story-card-skeleton.component';
-import { storyTeaserMock } from '../../mocks/story.mock';
-import { authorTeaserMock } from '../../mocks/author.mock';
-import type { StoryTeaserWithAuthor } from '@models/story.model';
-import type { Media } from '@models/media.model';
-
-// Conjunto de medios variado para ilustrar los selectores de multimedia y el contador (badge):
-// 3 videos de YouTube (muestra el contador), un Space de X y un episodio de Spotify.
-const richMedia: Media[] = [
-	{ title: 'Video 1', type: 'youTubeVideo', description: [], data: { videoId: 'a' } },
-	{ title: 'Video 2', type: 'youTubeVideo', description: [], data: { videoId: 'b' } },
-	{ title: 'Video 3', type: 'youTubeVideo', description: [], data: { videoId: 'c' } },
-	{
-		title: 'Space',
-		type: 'spaceRecording',
-		description: [],
-		data: { url: null, duration: '', hostName: '', date: '' },
-	},
-	{ title: 'Podcast', type: 'spotifyPodcastEpisode', description: [], data: { url: 'https://spotify.com' } },
-];
-
-const storyMock: StoryTeaserWithAuthor = {
-	...storyTeaserMock,
-	author: authorTeaserMock,
-	media: richMedia,
-};
+import { palacioNueveFronterasTeaserMock } from '../../mocks/onoff-story-teasers.mock';
+import {
+	corpusStories,
+	corpusCovers,
+	literaryWorkSelectArgType,
+	withRichMedia,
+} from '../../mocks/onoff-corpus.storybook';
 
 // Las descripciones de la doc van en una sola línea: el renderer de Markdown de los autodocs
 // interpreta como bloque de código cualquier línea con indentación, así que un HTML multilínea
@@ -45,7 +27,7 @@ const meta: Meta<HomeStoryCardComponent> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>Utilizado para representar una vista previa de una historia en la Home. Resume la información principal del contenido, incluyendo autor, título, categoría, tiempo estimado de lectura, imagen asociada y accesos a archivos multimediales como video, X o Spotify.</p><p>Su objetivo es facilitar un vistazo rápido del contenido disponible y ayudar al usuario a decidir si quiere profundizar en la historia.</p><p>Derivada de <a href="./?path=/docs/componentes-v3-storycardteaserv3--docs" target="_top"><strong>StoryCardTeaserV3</strong></a>, presenta un layout vertical angosto con la imagen, la numeración y los selectores de multimedia apilados sobre un contenedor gris.</p><ul><li>El título de la historia se trunca siempre a una sola línea.</li><li>Los selectores de multimedia usan siempre la variante <code>Filled</code> del MediaTag (recuadros blancos sobre el gris).</li><li>El avatar y el nombre del autor son elementos clickeables que enlazan al perfil del autor; en estado hover, el nombre se subraya.</li></ul></div>`,
+				component: `<div><p>Utilizado para representar una vista previa de una historia en la Home. Resume la información principal del contenido, incluyendo autor, título, categoría, tiempo estimado de lectura, imagen asociada y accesos a archivos multimediales como video, X o Spotify.</p><p>Su objetivo es facilitar un vistazo rápido del contenido disponible y ayudar al usuario a decidir si quiere profundizar en la historia.</p><p>Derivada de <a href="./?path=/docs/componentes-v3-storycardteaserv3--docs" target="_top"><strong>StoryCardTeaserV3</strong></a>, presenta un layout vertical angosto con la imagen, la numeración y los selectores de multimedia apilados sobre un contenedor gris.</p><ul><li>El título de la historia se trunca siempre a una sola línea.</li><li>Los selectores de multimedia usan siempre la variante <code>Filled</code> del MediaTag (recuadros blancos sobre el gris).</li><li>El avatar y el nombre del autor son elementos clickeables que enlazan al perfil del autor; en estado hover, el nombre se subraya.</li></ul><p>Se compone de <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> (portada), <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar del autor) y <a href="./?path=/docs/componentes-v3-storymediaselectors--docs" target="_top"><strong>StoryMediaSelectors</strong></a> (accesos multimedia); el skeleton es <strong>HomeStoryCardSkeleton</strong>.</p></div>`,
 			},
 		},
 		layout: 'padded',
@@ -86,14 +68,28 @@ const meta: Meta<HomeStoryCardComponent> = {
 export default meta;
 type Story = StoryObj<HomeStoryCardComponent>;
 
-// Playground interactivo. Sin coverImageUrl: se muestra el placeholder del Design System.
-export const Docs: Story = {
+// Playground interactivo: un único selector de Obra; la portada y el título cambian juntos.
+export const Interactiva: StoryObj<HomeStoryCardComponent & { storyIndex: number }> = {
+	argTypes: {
+		storyIndex: {
+			...literaryWorkSelectArgType,
+			description: 'Obra del corpus de François Onoff; su portada y título cambian de forma conjunta',
+		},
+	},
 	render: (args) => ({
-		props: args,
-		template: `<cuentoneta-home-story-card ${argsToTemplate(args)} />`,
+		props: { ...args, stories: corpusStories, covers: corpusCovers },
+		template: `
+			<cuentoneta-home-story-card
+				[story]="stories[storyIndex]"
+				[coverImageUrl]="covers[storyIndex]"
+				[order]="order"
+				[tagLabel]="tagLabel"
+				[showMultimedia]="showMultimedia"
+			/>
+		`,
 	}),
 	args: {
-		story: storyMock,
+		storyIndex: 0,
 		order: 1,
 		tagLabel: 'Cuento',
 		showMultimedia: true,
@@ -101,7 +97,8 @@ export const Docs: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Playground interactivo. Usá los controles de abajo para alternar los inputs del componente.',
+				story:
+					'Playground interactivo. Elegí la <strong>Obra</strong> del corpus: su portada y título cambian de forma conjunta. El resto de los controles ajusta numeración, etiqueta y multimedia.',
 			},
 		},
 	},
@@ -114,7 +111,8 @@ export const Default: Story = {
 		template: `<cuentoneta-home-story-card ${argsToTemplate(args)} />`,
 	}),
 	args: {
-		story: storyMock,
+		story: withRichMedia(palacioNueveFronterasTeaserMock),
+		coverImageUrl: palacioNueveFronterasTeaserMock.coverImage,
 		order: 1,
 		tagLabel: 'Cuento',
 		showMultimedia: true,
@@ -158,7 +156,14 @@ export const Estados: StoryObj<HomeStoryCardComponent & { loading: boolean }> = 
 			</div>
 		`,
 	}),
-	args: { loading: true, story: storyMock, order: 1, tagLabel: 'Cuento', showMultimedia: true },
+	args: {
+		loading: true,
+		story: withRichMedia(palacioNueveFronterasTeaserMock),
+		coverImageUrl: palacioNueveFronterasTeaserMock.coverImage,
+		order: 1,
+		tagLabel: 'Cuento',
+		showMultimedia: true,
+	},
 	parameters: {
 		docs: { description: { story: 'Activá/desactivá "Cargando" para alternar entre el estado real y el skeleton.' } },
 	},

--- a/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.spec.ts
+++ b/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.spec.ts
@@ -235,7 +235,7 @@ describe('StoryCardTeaserV3Component', () => {
 	});
 
 	// Variedad de obras reales del corpus de François Onoff (#1650): detecta regresiones de datos del corpus.
-	describe('Corpus Onoff — variedad de obras', () => {
+	describe('Onoff corpus — story variety', () => {
 		beforeEach(() => clearAllMocks());
 
 		it.each(onoffStoryTeasersMock)('should render title and reading time for "$title"', async (teaser) => {

--- a/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.stories.ts
+++ b/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.stories.ts
@@ -5,34 +5,9 @@ import { StoryCardTeaserV3Component } from './story-card-teaser-v3.component';
 import {
 	elOdioTeaserMock,
 	geometriaTeaserMock,
-	onoffStoryTeasersMock,
 	palacioNueveFronterasTeaserMock,
 } from '../../mocks/onoff-story-teasers.mock';
-import type { StoryTeaserWithAuthor } from '@models/story.model';
-import type { Media } from '@models/media.model';
-
-// Conjunto de medios variado para ilustrar los selectores de multimedia y el contador (badge):
-// 3 videos de YouTube (muestra el contador), un Space de X y un episodio de Spotify.
-const richMedia: Media[] = [
-	{ title: 'Video 1', type: 'youTubeVideo', description: [], data: { videoId: 'a' } },
-	{ title: 'Video 2', type: 'youTubeVideo', description: [], data: { videoId: 'b' } },
-	{ title: 'Video 3', type: 'youTubeVideo', description: [], data: { videoId: 'c' } },
-	{
-		title: 'Space',
-		type: 'spaceRecording',
-		description: [],
-		data: { url: null, duration: '', hostName: '', date: '' },
-	},
-	{ title: 'Podcast', type: 'spotifyPodcastEpisode', description: [], data: { url: 'https://spotify.com' } },
-];
-
-// Los teasers del corpus tienen media: []; se les compone richMedia para ilustrar los selectores de multimedia.
-const withMedia = (teaser: StoryTeaserWithAuthor): StoryTeaserWithAuthor => ({ ...teaser, media: richMedia });
-
-// Las portadas se derivan del coverImage de cada teaser; los tres arrays comparten el índice del corpus.
-const corpusStories = onoffStoryTeasersMock.map(withMedia);
-const corpusCovers = onoffStoryTeasersMock.map((teaser) => teaser.coverImage);
-const corpusLabels = Object.fromEntries(onoffStoryTeasersMock.map((teaser, index) => [index, teaser.title]));
+import { corpusStories, corpusCovers, obraSelectArgType, withRichMedia } from '../../mocks/onoff-corpus.storybook';
 
 // Las descripciones de la doc van en una sola línea: el renderer de Markdown de los autodocs
 // interpreta como bloque de código cualquier línea con indentación, así que un HTML multilínea
@@ -119,12 +94,8 @@ type Story = StoryObj<StoryCardTeaserV3Component>;
 export const Interactiva: StoryObj<StoryCardTeaserV3Component & { storyIndex: number }> = {
 	argTypes: {
 		storyIndex: {
-			name: 'Obra',
-			// `labels` debe ir dentro de `control`; como hermano del argType, Storybook lo ignora y muestra el índice.
-			control: { type: 'select', labels: corpusLabels },
-			options: corpusStories.map((_, index) => index),
+			...obraSelectArgType,
 			description: 'Obra del corpus de François Onoff; su portada, título y extracto cambian de forma conjunta',
-			table: { type: { summary: 'number' } },
 		},
 	},
 	render: (args) => ({
@@ -170,7 +141,7 @@ export const OnWhite: Story = {
 		template: `<cuentoneta-story-card-teaser-v3 ${argsToTemplate(args)} />`,
 	}),
 	args: {
-		story: withMedia(palacioNueveFronterasTeaserMock),
+		story: withRichMedia(palacioNueveFronterasTeaserMock),
 		coverImageUrl: palacioNueveFronterasTeaserMock.coverImage,
 		variant: 'on-white',
 		order: 1,
@@ -196,7 +167,7 @@ export const OnGray: Story = {
 		template: `<div class="rounded-lg bg-neutral-100 p-6"><cuentoneta-story-card-teaser-v3 ${argsToTemplate(args)} /></div>`,
 	}),
 	args: {
-		story: withMedia(geometriaTeaserMock),
+		story: withRichMedia(geometriaTeaserMock),
 		coverImageUrl: geometriaTeaserMock.coverImage,
 		variant: 'on-gray',
 		order: 1,
@@ -222,7 +193,7 @@ export const Highlighted: Story = {
 		template: `<cuentoneta-story-card-teaser-v3 ${argsToTemplate(args)} />`,
 	}),
 	args: {
-		story: withMedia(elOdioTeaserMock),
+		story: withRichMedia(elOdioTeaserMock),
 		coverImageUrl: elOdioTeaserMock.coverImage,
 		variant: 'highlighted',
 		order: 1,
@@ -249,9 +220,9 @@ export const AllVariants: Story = {
 		props: {
 			...args,
 			stories: [
-				withMedia(palacioNueveFronterasTeaserMock),
-				withMedia(geometriaTeaserMock),
-				withMedia(elOdioTeaserMock),
+				withRichMedia(palacioNueveFronterasTeaserMock),
+				withRichMedia(geometriaTeaserMock),
+				withRichMedia(elOdioTeaserMock),
 			],
 			covers: [palacioNueveFronterasTeaserMock.coverImage, geometriaTeaserMock.coverImage, elOdioTeaserMock.coverImage],
 		},
@@ -356,7 +327,7 @@ export const Estados: StoryObj<StoryCardTeaserV3Component & { loading: boolean }
 	}),
 	args: {
 		loading: true,
-		story: withMedia(palacioNueveFronterasTeaserMock),
+		story: withRichMedia(palacioNueveFronterasTeaserMock),
 		coverImageUrl: palacioNueveFronterasTeaserMock.coverImage,
 		variant: 'on-white',
 		order: 1,

--- a/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.stories.ts
+++ b/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.stories.ts
@@ -7,7 +7,12 @@ import {
 	geometriaTeaserMock,
 	palacioNueveFronterasTeaserMock,
 } from '../../mocks/onoff-story-teasers.mock';
-import { corpusStories, corpusCovers, obraSelectArgType, withRichMedia } from '../../mocks/onoff-corpus.storybook';
+import {
+	corpusStories,
+	corpusCovers,
+	literaryWorkSelectArgType,
+	withRichMedia,
+} from '../../mocks/onoff-corpus.storybook';
 
 // Las descripciones de la doc van en una sola línea: el renderer de Markdown de los autodocs
 // interpreta como bloque de código cualquier línea con indentación, así que un HTML multilínea
@@ -94,7 +99,7 @@ type Story = StoryObj<StoryCardTeaserV3Component>;
 export const Interactiva: StoryObj<StoryCardTeaserV3Component & { storyIndex: number }> = {
 	argTypes: {
 		storyIndex: {
-			...obraSelectArgType,
+			...literaryWorkSelectArgType,
 			description: 'Obra del corpus de François Onoff; su portada, título y extracto cambian de forma conjunta',
 		},
 	},

--- a/src/app/mocks/onoff-corpus.storybook.ts
+++ b/src/app/mocks/onoff-corpus.storybook.ts
@@ -2,9 +2,7 @@ import type { Media } from '@models/media.model';
 import type { StoryTeaserWithAuthor } from '@models/story.model';
 import { onoffStoryTeasersMock } from './onoff-story-teasers.mock';
 
-// Conjunto de medios variado para ilustrar los selectores de multimedia y el contador (badge):
-// 3 videos de YouTube (muestra el contador), un Space de X y un episodio de Spotify.
-// Privado: los consumidores usan `withRichMedia`, no el array crudo.
+// Conjunto de medios variado para ilustrar los selectores de multimedia y el contador
 const richMedia: Media[] = [
 	{ title: 'Video 1', type: 'youTubeVideo', description: [], data: { videoId: 'a' } },
 	{ title: 'Video 2', type: 'youTubeVideo', description: [], data: { videoId: 'b' } },
@@ -18,7 +16,6 @@ const richMedia: Media[] = [
 	{ title: 'Podcast', type: 'spotifyPodcastEpisode', description: [], data: { url: 'https://spotify.com' } },
 ];
 
-// Los teasers del corpus tienen media: []; se les compone richMedia para ilustrar los selectores de multimedia.
 export const withRichMedia = (teaser: StoryTeaserWithAuthor): StoryTeaserWithAuthor => ({
 	...teaser,
 	media: richMedia,
@@ -28,11 +25,9 @@ export const withRichMedia = (teaser: StoryTeaserWithAuthor): StoryTeaserWithAut
 export const corpusStories = onoffStoryTeasersMock.map(withRichMedia);
 export const corpusCovers = onoffStoryTeasersMock.map((teaser) => teaser.coverImage);
 
-// Privado: solo lo consume `literaryWorkSelectArgType` (mapea índice → título para el select).
 const corpusLabels = Object.fromEntries(onoffStoryTeasersMock.map((teaser, index) => [index, teaser.title]));
 
-// argType reutilizable del selector "Obra". `labels` va DENTRO de `control` (si no, Storybook muestra el índice crudo).
-// Key-agnóstico: el consumidor lo asigna a su propia key (`storyIndex`, `coverIndex`, …) y agrega su `description`.
+// argType reutilizable del selector "Obra". Key-agnóstico: el consumidor lo asigna a su propia key (`storyIndex`, `coverIndex`, …) y agrega su `description`.
 export const literaryWorkSelectArgType = {
 	name: 'Obra',
 	control: { type: 'select' as const, labels: corpusLabels },

--- a/src/app/mocks/onoff-corpus.storybook.ts
+++ b/src/app/mocks/onoff-corpus.storybook.ts
@@ -30,7 +30,7 @@ export const corpusLabels = Object.fromEntries(onoffStoryTeasersMock.map((teaser
 
 // argType reutilizable del selector "Obra". `labels` va DENTRO de `control` (si no, Storybook muestra el índice crudo).
 // Key-agnóstico: el consumidor lo asigna a su propia key (`storyIndex`, `coverIndex`, …) y agrega su `description`.
-export const obraSelectArgType = {
+export const literaryWorkSelectArgType = {
 	name: 'Obra',
 	control: { type: 'select' as const, labels: corpusLabels },
 	options: corpusStories.map((_, index) => index),

--- a/src/app/mocks/onoff-corpus.storybook.ts
+++ b/src/app/mocks/onoff-corpus.storybook.ts
@@ -4,7 +4,8 @@ import { onoffStoryTeasersMock } from './onoff-story-teasers.mock';
 
 // Conjunto de medios variado para ilustrar los selectores de multimedia y el contador (badge):
 // 3 videos de YouTube (muestra el contador), un Space de X y un episodio de Spotify.
-export const richMedia: Media[] = [
+// Privado: los consumidores usan `withRichMedia`, no el array crudo.
+const richMedia: Media[] = [
 	{ title: 'Video 1', type: 'youTubeVideo', description: [], data: { videoId: 'a' } },
 	{ title: 'Video 2', type: 'youTubeVideo', description: [], data: { videoId: 'b' } },
 	{ title: 'Video 3', type: 'youTubeVideo', description: [], data: { videoId: 'c' } },
@@ -23,10 +24,12 @@ export const withRichMedia = (teaser: StoryTeaserWithAuthor): StoryTeaserWithAut
 	media: richMedia,
 });
 
-// Obras del corpus (con multimedia), sus portadas y labels; los tres comparten el índice del corpus.
+// Obras del corpus (con multimedia) y sus portadas; comparten el índice del corpus.
 export const corpusStories = onoffStoryTeasersMock.map(withRichMedia);
 export const corpusCovers = onoffStoryTeasersMock.map((teaser) => teaser.coverImage);
-export const corpusLabels = Object.fromEntries(onoffStoryTeasersMock.map((teaser, index) => [index, teaser.title]));
+
+// Privado: solo lo consume `literaryWorkSelectArgType` (mapea índice → título para el select).
+const corpusLabels = Object.fromEntries(onoffStoryTeasersMock.map((teaser, index) => [index, teaser.title]));
 
 // argType reutilizable del selector "Obra". `labels` va DENTRO de `control` (si no, Storybook muestra el índice crudo).
 // Key-agnóstico: el consumidor lo asigna a su propia key (`storyIndex`, `coverIndex`, …) y agrega su `description`.

--- a/src/app/mocks/onoff-corpus.storybook.ts
+++ b/src/app/mocks/onoff-corpus.storybook.ts
@@ -1,0 +1,38 @@
+import type { Media } from '@models/media.model';
+import type { StoryTeaserWithAuthor } from '@models/story.model';
+import { onoffStoryTeasersMock } from './onoff-story-teasers.mock';
+
+// Conjunto de medios variado para ilustrar los selectores de multimedia y el contador (badge):
+// 3 videos de YouTube (muestra el contador), un Space de X y un episodio de Spotify.
+export const richMedia: Media[] = [
+	{ title: 'Video 1', type: 'youTubeVideo', description: [], data: { videoId: 'a' } },
+	{ title: 'Video 2', type: 'youTubeVideo', description: [], data: { videoId: 'b' } },
+	{ title: 'Video 3', type: 'youTubeVideo', description: [], data: { videoId: 'c' } },
+	{
+		title: 'Space',
+		type: 'spaceRecording',
+		description: [],
+		data: { url: null, duration: '', hostName: '', date: '' },
+	},
+	{ title: 'Podcast', type: 'spotifyPodcastEpisode', description: [], data: { url: 'https://spotify.com' } },
+];
+
+// Los teasers del corpus tienen media: []; se les compone richMedia para ilustrar los selectores de multimedia.
+export const withRichMedia = (teaser: StoryTeaserWithAuthor): StoryTeaserWithAuthor => ({
+	...teaser,
+	media: richMedia,
+});
+
+// Obras del corpus (con multimedia), sus portadas y labels; los tres comparten el índice del corpus.
+export const corpusStories = onoffStoryTeasersMock.map(withRichMedia);
+export const corpusCovers = onoffStoryTeasersMock.map((teaser) => teaser.coverImage);
+export const corpusLabels = Object.fromEntries(onoffStoryTeasersMock.map((teaser, index) => [index, teaser.title]));
+
+// argType reutilizable del selector "Obra". `labels` va DENTRO de `control` (si no, Storybook muestra el índice crudo).
+// Key-agnóstico: el consumidor lo asigna a su propia key (`storyIndex`, `coverIndex`, …) y agrega su `description`.
+export const obraSelectArgType = {
+	name: 'Obra',
+	control: { type: 'select' as const, labels: corpusLabels },
+	options: corpusStories.map((_, index) => index),
+	table: { type: { summary: 'number' } },
+};


### PR DESCRIPTION
## Descripción

Refuerza los tests y los ejemplos de Storybook de `HomeStoryCard` con el corpus de obras de François Onoff (#1650), análogo a #1657 (StoryCardTeaserV3).

- **Spec:** nuevo `describe('Onoff corpus — story variety')` con `it.each` sobre las 8 obras (título + tiempo de lectura), con `beforeEach(clearAllMocks)` propio.
- **Stories:** consumen obras reales del corpus con sus **portadas PNG locales**; la story `Docs` se convierte en **`Interactiva`** con un selector de obra (story + portada + título ligados) — evita la colisión de nombre con la página autodocs "Docs"; `Estados` mantiene el switch real↔skeleton; la descripción enumera las dependencias con links a sus Docs (**CoverImage**, **ImageProfile**, **StoryMediaSelectors**).

### Centralización (decidida en el issue)

El patrón del selector de obra estaba duplicado en `StoryCardTeaserV3` y `CoverImage`. Se extrajo a un helper de Storybook **`src/app/mocks/onoff-corpus.storybook.ts`** (`withRichMedia`, `corpusStories`, `corpusCovers`, `literaryWorkSelectArgType` — encapsula el `labels` dentro de `control`). HomeStoryCard lo usa; `StoryCardTeaserV3` y `CoverImage` se refactorizan para consumirlo, **sin cambio de comportamiento**.

Closes #1669.

Parte de #1651.

## Notas (alcance que excede a HomeStoryCard)

- **`story-card-teaser-v3.component.stories.ts`** y **`cover-image.component.stories.ts`**: refactor para consumir el helper (sin cambio de comportamiento).
- **`story-card-teaser-v3.component.spec.ts`**: se renombró a inglés el `describe` del corpus (mismo caso que en HomeStoryCard; regla de código en inglés).

## Plan de pruebas

- [x] `pnpm lint` · `pnpm stylelint` · `pnpm test` · `pnpm build` · `pnpm storybook:build` — verdes.
- [x] Spec de HomeStoryCard: 8 casos del corpus vía `it.each`, sin regresión en los describe existentes.
- [x] Storybook: `Interactiva` con selector de obra; `Estados` con switch real↔skeleton; links de dependencias correctos.
- [x] Code review local: 0 críticos; 2 advertencias + 3 sugerencias abordadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
