### PR TITLE
[#1639] - Limpieza de tests con clases CSS estructurales en CollectionTeaser

### DIFF
--- a/src/app/components/collection-teaser/collection-teaser.spec.ts
+++ b/src/app/components/collection-teaser/collection-teaser.spec.ts
@@ -48,7 +48,6 @@ describe('CollectionTeaser', () => {
 				providers: defaultProviders,
 			});
 
-			// Solo debe existir el article vacío, sin link
 			const article = screen.getByRole('article');
 			expect(article).toBeInTheDocument();
 			expect(screen.queryByRole('link')).not.toBeInTheDocument();

--- a/src/app/components/collection-teaser/collection-teaser.spec.ts
+++ b/src/app/components/collection-teaser/collection-teaser.spec.ts
@@ -76,16 +76,6 @@ describe('CollectionTeaser', () => {
 			const link = screen.getByRole('link');
 			expect(link).toHaveAttribute('href', `/storylist/${collectionTeaserMock.slug}`);
 		});
-
-		it('should have navigation-link class', async () => {
-			await render(CollectionTeaser, {
-				inputs: { collection: collectionTeaserMock },
-				providers: defaultProviders,
-			});
-
-			const link = screen.getByRole('link');
-			expect(link).toHaveClass('navigation-link');
-		});
 	});
 
 	// Pruebas del cover de la colección
@@ -227,21 +217,6 @@ describe('CollectionTeaser', () => {
 			fixture.detectChanges();
 
 			expect(screen.getByText('Nueva Colección')).toBeInTheDocument();
-		});
-	});
-
-	// Pruebas de estructura del layout
-	describe('Estructura del layout', () => {
-		it('should have flex layout with gap on link', async () => {
-			await render(CollectionTeaser, {
-				inputs: { collection: collectionTeaserMock },
-				providers: defaultProviders,
-			});
-
-			const link = screen.getByRole('link');
-			expect(link).toHaveClass('flex');
-			expect(link).toHaveClass('items-start');
-			expect(link).toHaveClass('gap-5');
 		});
 	});
 

--- a/src/app/components/collection-teaser/collection-teaser.ts
+++ b/src/app/components/collection-teaser/collection-teaser.ts
@@ -19,7 +19,7 @@ import { CoverImageComponent } from '../cover-image/cover-image.component';
 	template: `
 		<article>
 			@if (collection(); as storylist) {
-				<a [routerLink]="['/' + appRoutes.StoryList, storylist.slug]" class="navigation-link flex items-start gap-5">
+				<a [routerLink]="['/' + appRoutes.StoryList, storylist.slug]" class="flex items-start gap-5">
 					<section
 						class="relative flex h-48 items-end justify-center overflow-hidden rounded-xl bg-neutral-100 px-3 sm:flex-1"
 					>


### PR DESCRIPTION
## Descripción

Limpieza de tests que afirman **clases CSS estructurales** en `collection-teaser.spec.ts`, alineando el spec con `testing.md` (testear comportamiento, no implementación).

- Elimina `'should have navigation-link class'` (afirmaba `toHaveClass('navigation-link')`) y el `describe('Estructura del layout')` con `'should have flex layout with gap on link'` (`flex`/`items-start`/`gap-5`). Sin pérdida de cobertura: el destino del enlace ya lo cubre el test de `href` y la accesibilidad sus tests.
- **`navigation-link` era una clase huérfana** (sin ninguna regla CSS en el proyecto ni uso en E2E/JS): se la quita también del template de `collection-teaser.ts`.
- Quita un comentario redundante (parafraseaba la línea siguiente).

**Barrido del repo:** de 14 specs con `toHaveClass`, solo estos 2 eran estructura pura; el resto son contrato de input/variante o comportamiento configurable (legítimos) → no se limpian.

Closes #1639.

## Plan de pruebas

- [x] `pnpm test` (suite completa) · `pnpm lint` · `pnpm build` · `pnpm storybook:build` — verdes.
- [x] `collection-teaser.spec.ts` pasa sin los 2 tests eliminados; sin `describe` vacío ni `toHaveClass` estructural residual.
- [x] Code review local: 0 críticos; 1 advertencia + 1 sugerencia abordadas en el branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
