### PR TITLE
[#1631] - [Storybook] Auditoría de documentación V3: unificar componentes al estándar de StoryCardTeaserV3 y Tag

### DIFF
--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -256,10 +256,11 @@ Todo componente nuevo en **`src/app/components/`** lleva su `*.stories.ts` (docu
 
 ### Convenciones (según las stories existentes)
 
-- `title` en español bajo `Componentes/...` (p. ej. `'Componentes/Tag'`).
-- `parameters.docs.description.component` con descripción en español (markdown/HTML).
-- `argTypes` para cada `input()` público, con `control`, `options` y `table.defaultValue`.
-- Una **story por estado/variante** (`Soft`, `Filled`, `Gray`, …) y opcionalmente un `Showcase`.
+- `title` en español bajo `Componentes V3/...` (p. ej. `'Componentes V3/Tag'`).
+- **autodocs es global.** `.storybook/preview.js` exporta `tags = ['autodocs']`, así que **no** hace falta repetir `tags: ['autodocs']` por archivo (es redundante).
+- `parameters.docs.description.component` con descripción en español (HTML, ver reglas abajo).
+- `argTypes` para **cada `input()` público**, con `control`, `options`/`type` y `table` (`type` + `defaultValue`). Aplica también a inputs de tipo objeto complejo (p. ej. `story`, `collection`): aunque no se editen cómodamente en el panel, usar `control: { type: 'object' }` y documentar `table.type`/`table.defaultValue`.
+- Una **story por estado/variante** (`Soft`, `Filled`, `Gray`, …) y opcionalmente un `Showcase` con todas las variantes en simultáneo. Cada story lleva su `docs.description.story` con el **comportamiento** y una línea **`<strong>Usos:</strong>`** que indica en qué páginas/componentes se usa la variante.
 - Render con `argsToTemplate(args)` y el selector real del componente (`cuentoneta-...`).
 
 ```typescript
@@ -268,9 +269,9 @@ import { TagComponent } from './tag.component';
 
 const meta: Meta<TagComponent> = {
 	component: TagComponent,
-	title: 'Componentes/Tag',
+	title: 'Componentes V3/Tag',
 	parameters: {
-		docs: { description: { component: `El **TagComponent** del Design System v3...` } },
+		docs: { description: { component: `<div><p>El <strong>TagComponent</strong> del Design System v3...</p></div>` } },
 		layout: 'padded',
 	},
 	argTypes: {

--- a/src/app/components/author-teaser-v3/author-teaser-v3.component.stories.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3.component.stories.ts
@@ -41,19 +41,27 @@ const meta: Meta<AuthorTeaserV3Component> = {
 				sourceState: 'shown',
 			},
 			description: {
-				component: `<div>
-					<p>El componente **AuthorTeaserV3Component** muestra una vista previa de un autor enlazada a su perfil,
-					según el Design System v3. Está pensado para listar y visualizar perfiles de autores, mostrando el
-					avatar (80px), los tags, el nombre + bandera de nacionalidad y la cantidad de historias.</p>
-				</div>`,
+				component: `<div><p>El componente <strong>AuthorTeaserV3Component</strong> muestra una vista previa de un autor enlazada a su perfil, según el Design System v3. Está pensado para listar y visualizar perfiles de autores, mostrando el avatar, los tags, el nombre con la bandera de nacionalidad y la cantidad de historias.</p><p>Se modela como un <code>&lt;article&gt;</code> con un único enlace real sobre el nombre del autor, estirado con un pseudo-elemento para que toda la tarjeta sea clickeable sin inflar el nombre accesible del link.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar) y <a href="./?path=/docs/componentes-v3-tagslist--docs" target="_top"><strong>TagsList</strong></a> con instancias de <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> (etiquetas del autor).</p></div>`,
 			},
 		},
 		layout: 'padded',
 	},
 	argTypes: {
-		author: { control: { type: 'object' }, description: 'Datos del autor (slug, nombre, imageUrl, nacionalidad)' },
-		tags: { control: { type: 'object' }, description: 'Tags asociados al autor' },
-		storyCount: { control: { type: 'number' }, description: 'Cantidad de historias del autor' },
+		author: {
+			control: { type: 'object' },
+			description: 'Datos del autor (slug, nombre, imageUrl, nacionalidad)',
+			table: { type: { summary: 'AuthorTeaser' }, defaultValue: { summary: 'required' } },
+		},
+		tags: {
+			control: { type: 'object' },
+			description: 'Tags asociados al autor',
+			table: { type: { summary: 'Tag[]' }, defaultValue: { summary: '[]' } },
+		},
+		storyCount: {
+			control: { type: 'number' },
+			description: 'Cantidad de historias del autor',
+			table: { type: { summary: 'number' }, defaultValue: { summary: 'undefined' } },
+		},
 	},
 };
 
@@ -65,7 +73,11 @@ export const Default: Story = {
 	render: (args) => ({ props: args, template: `<cuentoneta-author-teaser-v3 ${argsToTemplate(args)} />` }),
 	args: { author: authorTeaserMock, tags, storyCount: 21 },
 	parameters: {
-		docs: { description: { story: 'Teaser completo del autor.' } },
+		docs: {
+			description: {
+				story: `<p>Teaser completo del autor: avatar, fila de tags, nombre con bandera de nacionalidad y cantidad de historias. Toda la tarjeta es clickeable y navega al perfil del autor.</p><p><strong>Usos:</strong> Author List (listado de autores).</p>`,
+			},
+		},
 	},
 };
 
@@ -78,7 +90,7 @@ export const ManyTags: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Autor con varios tags en un contenedor de 320px: los que no entran se colapsan tras un contador "+N".',
+				story: `<p>Autor con varios tags en un contenedor acotado de 320px: los que no entran se recortan por ancho y colapsan tras un contador "+N" (ejemplo: Eduardo Galeano).</p><p><strong>Usos:</strong> Author List, en columnas angostas o viewports reducidos donde la fila de tags no entra completa.</p>`,
 			},
 		},
 	},
@@ -89,7 +101,11 @@ export const WithoutImage: Story = {
 	render: (args) => ({ props: args, template: `<cuentoneta-author-teaser-v3 ${argsToTemplate(args)} />` }),
 	args: { author: { ...authorTeaserMock, imageUrl: '' }, tags, storyCount: 21 },
 	parameters: {
-		docs: { description: { story: 'Autor sin imagen: avatar con placeholder.' } },
+		docs: {
+			description: {
+				story: `<p>Autor sin imagen: el avatar cae al placeholder circular del Design System que resuelve <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a>.</p><p><strong>Usos:</strong> Author List, para autores cuyo perfil todavía no tiene retrato cargado en el CMS.</p>`,
+			},
+		},
 	},
 };
 

--- a/src/app/components/button/button.component.stories.ts
+++ b/src/app/components/button/button.component.stories.ts
@@ -13,15 +13,18 @@ const meta: Meta<ButtonComponent> = {
 			canvas: {
 				sourceState: 'shown',
 			},
+			description: {
+				component: `<div><p>El <strong>ButtonComponent</strong> del Design System v3 es un componente basado en atributo (<code>cuentoneta-button</code>) que se aplica indistintamente sobre elementos <code>&lt;button&gt;</code> y <code>&lt;a&gt;</code>, manteniendo estilos consistentes y la semántica correcta de cada elemento (acción vs. navegación).</p><p>Se implementa en tres variantes seleccionables mediante el input <code>type</code>:</p><ul><li><strong>filled</strong> (default): fondo blanco, sin borde, para la acción principal.</li><li><strong>outline</strong>: fondo blanco con borde neutral-300, para acciones secundarias y enlaces de tipo "Ver todo".</li><li><strong>share</strong>: fondo neutral-100, tamaño más compacto, pensado para botones de compartir en redes (admite un ícono al inicio).</li></ul></div>`,
+			},
 		},
 	},
-	tags: ['autodocs'],
 	argTypes: {
 		type: {
 			control: 'select',
 			options: ['filled', 'outline', 'share'],
 			description: 'Estilo visual del botón basado en el sistema de diseño de Figma',
 			table: {
+				type: { summary: "'filled' | 'outline' | 'share'" },
 				defaultValue: { summary: 'filled' },
 			},
 		},
@@ -44,6 +47,13 @@ export const Filled: Story = {
 	args: {
 		type: 'filled',
 	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Variante <strong>filled</strong> (default): fondo blanco sin borde, para la acción principal de un bloque.</p><p><strong>Usos:</strong> llamados a la acción primarios sobre fondos de marca o destacados.</p>`,
+			},
+		},
+	},
 };
 
 export const Outline: Story = {
@@ -53,6 +63,13 @@ export const Outline: Story = {
 	}),
 	args: {
 		type: 'outline',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Variante <strong>outline</strong>: fondo blanco con borde neutral-300, para acciones secundarias.</p><p><strong>Usos:</strong> enlaces "Ver todo" al pie de los listados de la Home y secciones de exploración.</p>`,
+			},
+		},
 	},
 };
 
@@ -69,12 +86,26 @@ export const Share: Story = {
 			imports: [NgIcon],
 		},
 	}),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Variante <strong>share</strong>: tamaño compacto con fondo neutral-100; admite un ícono de red al inicio del texto.</p><p><strong>Usos:</strong> barra de compartir en redes dentro de la página de Story.</p>`,
+			},
+		},
+	},
 };
 
 export const OnAnchorElement: Story = {
 	render: () => ({
 		template: `<a cuentoneta-button type="outline" routerLink="/storylist">Ver todo</a>`,
 	}),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El componente se aplica sobre un <code>&lt;a&gt;</code> con <code>routerLink</code>: conserva el estilo de botón pero la semántica de enlace, navegando como un link accesible.</p><p><strong>Usos:</strong> "Ver todo" cuando la acción es una navegación de ruta y no una acción imperativa.</p>`,
+			},
+		},
+	},
 };
 
 export const Disabled: Story = {
@@ -87,4 +118,30 @@ export const Disabled: Story = {
 			</div>
 		`,
 	}),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Estado deshabilitado (<code>disabled</code>) de las tres variantes: cursor bloqueado y opacidad reducida.</p><p><strong>Usos:</strong> acciones no disponibles temporalmente (p. ej. mientras se completa una precondición).</p>`,
+			},
+		},
+	},
+};
+
+// Vitrina con las tres variantes activas en simultáneo.
+export const Showcase: Story = {
+	render: () => ({
+		template: `
+			<div class="flex flex-wrap items-center gap-4">
+				<button cuentoneta-button type="filled">Filled</button>
+				<button cuentoneta-button type="outline">Outline</button>
+				<button cuentoneta-button type="share"><ng-icon name="faBrandTwitter"/>Share</button>
+			</div>
+		`,
+		moduleMetadata: {
+			imports: [NgIcon],
+		},
+	}),
+	parameters: {
+		docs: { description: { story: 'Las tres variantes activas: filled, outline y share.' } },
+	},
 };

--- a/src/app/components/carousel/carousel.component.stories.ts
+++ b/src/app/components/carousel/carousel.component.stories.ts
@@ -1,4 +1,4 @@
-import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { applicationConfig, argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { provideRouter } from '@angular/router';
 
 import { CarouselComponent } from './carousel.component';
@@ -58,6 +58,7 @@ type Story = StoryObj<CarouselComponent>;
 
 // Historia principal con documentación
 export const Default: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
 	args: {
 		slides: contentCampaignMock,
 		transitionDuration: 600,
@@ -73,6 +74,7 @@ export const Default: Story = {
 
 // Carousel con una sola diapositiva
 export const SingleSlide: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
 	args: {
 		slides: [contentCampaignMock[0]],
 		transitionDuration: 600,
@@ -88,6 +90,7 @@ export const SingleSlide: Story = {
 
 // Carousel con transición rápida
 export const FastTransition: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
 	args: {
 		slides: contentCampaignMock,
 		transitionDuration: 300,
@@ -103,6 +106,7 @@ export const FastTransition: Story = {
 
 // Carousel con transición lenta
 export const SlowTransition: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
 	args: {
 		slides: contentCampaignMock,
 		transitionDuration: 1200,
@@ -158,6 +162,7 @@ const extendedSlidesMock: ContentCampaign[] = [
 
 // Carousel con múltiples diapositivas
 export const MultipleSlides: Story = {
+	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
 	args: {
 		slides: extendedSlidesMock,
 		transitionDuration: 600,

--- a/src/app/components/carousel/carousel.component.stories.ts
+++ b/src/app/components/carousel/carousel.component.stories.ts
@@ -1,7 +1,8 @@
-import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { provideRouter } from '@angular/router';
 
 import { CarouselComponent } from './carousel.component';
+import { CarouselSkeletonComponent } from './carousel-skeleton.component';
 import { contentCampaignMock } from '@mocks/content-campaign.mock';
 import { ContentCampaign } from '@models/content-campaign.model';
 
@@ -19,26 +20,7 @@ const meta: Meta<CarouselComponent> = {
 				sourceState: 'shown',
 			},
 			description: {
-				component: `<div>
-					<p>El componente **CarouselComponent** es un carousel de contenido interactivo que permite mostrar campañas de contenido destacado con navegación automática y manual.</p>
-					<h4>Características:</h4>
-					<ul>
-						<li>Reproducción automática con pausa al hacer hover o durante interacción táctil</li>
-						<li>Navegación por gestos táctiles (swipe izquierda/derecha)</li>
-						<li>Navegación por teclado (flechas izquierda/derecha)</li>
-						<li>Indicadores de progreso clickeables</li>
-						<li>Controles de navegación (solo en desktop)</li>
-						<li>Soporte para imágenes responsive (mobile/desktop)</li>
-						<li>Respeta preferencias de reducción de movimiento del usuario</li>
-					</ul>
-					<h4>Accesibilidad:</h4>
-					<ul>
-						<li>Atributos ARIA completos para lectores de pantalla</li>
-						<li>Navegación por teclado</li>
-						<li>Focus visible para navegación</li>
-						<li>Soporte para <code>prefers-reduced-motion</code></li>
-					</ul>
-				</div>`,
+				component: `<div><p>El componente <strong>CarouselComponent</strong> es un carousel de contenido interactivo que muestra campañas de contenido destacado con navegación automática y manual. Compone <strong>CarouselIndicator</strong> (indicadores de progreso clickeables) y <strong>CarouselControls</strong> (controles de navegación, solo en desktop).</p><p><strong>Características:</strong> reproducción automática con pausa al hacer hover o durante interacción táctil; navegación por gestos táctiles (swipe) y por teclado (flechas ← →); indicadores de progreso clickeables; controles de navegación solo en desktop; imágenes responsive (mobile/desktop); respeta <code>prefers-reduced-motion</code>.</p><p><strong>Accesibilidad:</strong> atributos ARIA completos para lectores de pantalla, navegación por teclado y focus visible.</p></div>`,
 			},
 		},
 		layout: 'padded',
@@ -60,6 +42,14 @@ const meta: Meta<CarouselComponent> = {
 				defaultValue: { summary: '600' },
 			},
 		},
+		autoPlayInterval: {
+			control: { type: 'number', min: 1000, max: 10000, step: 500 },
+			description: 'Intervalo de reproducción automática entre diapositivas en milisegundos',
+			table: {
+				type: { summary: 'number' },
+				defaultValue: { summary: '5000' },
+			},
+		},
 	},
 };
 
@@ -75,7 +65,7 @@ export const Default: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Carousel con configuración por defecto mostrando múltiples campañas de contenido.',
+				story: `<p>Carousel con configuración por defecto mostrando múltiples campañas de contenido.</p><p><strong>Usos:</strong> Home, en la sección de campañas de contenido destacado.</p>`,
 			},
 		},
 	},
@@ -90,8 +80,7 @@ export const SingleSlide: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story:
-					'Carousel con una única diapositiva. Los controles de navegación e indicadores se ocultan automáticamente.',
+				story: `<p>Carousel con una única diapositiva. Los controles de navegación e indicadores se ocultan automáticamente y se pausa la reproducción.</p><p><strong>Usos:</strong> Home cuando hay una sola campaña activa.</p>`,
 			},
 		},
 	},
@@ -106,7 +95,7 @@ export const FastTransition: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Carousel con transición rápida de 300ms.',
+				story: `<p>Carousel con transición rápida de 300ms.</p><p><strong>Usos:</strong> referencia para ajustar la velocidad de transición a un ritmo más ágil.</p>`,
 			},
 		},
 	},
@@ -121,7 +110,7 @@ export const SlowTransition: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Carousel con transición lenta de 1200ms.',
+				story: `<p>Carousel con transición lenta de 1200ms.</p><p><strong>Usos:</strong> referencia para una transición más pausada y enfática.</p>`,
 			},
 		},
 	},
@@ -176,7 +165,7 @@ export const MultipleSlides: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Carousel con tres diapositivas para demostrar la navegación cíclica.',
+				story: `<p>Carousel con tres diapositivas para demostrar la navegación cíclica.</p><p><strong>Usos:</strong> Home cuando hay varias campañas activas en rotación.</p>`,
 			},
 		},
 	},
@@ -208,7 +197,7 @@ export const Interactive: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Carousel interactivo con instrucciones de uso. Prueba las diferentes formas de navegación.',
+				story: `<p>Carousel interactivo con instrucciones de uso. Probá las diferentes formas de navegación (teclado, indicadores, swipe, hover).</p><p><strong>Usos:</strong> verificación manual de las interacciones del componente.</p>`,
 			},
 		},
 	},
@@ -246,9 +235,32 @@ export const DesktopAndMobile: Story = {
 		layout: 'fullscreen',
 		docs: {
 			description: {
-				story:
-					'Comparativa del carousel en vista desktop (960px) y mobile (375px) para visualizar las diferencias de diseño responsivo.',
+				story: `<p>Comparativa del carousel en vista desktop (960px) y mobile (375px) para visualizar las diferencias de diseño responsivo.</p><p><strong>Usos:</strong> referencia de comportamiento responsive entre breakpoints.</p>`,
 			},
 		},
+	},
+};
+
+// Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
+export const Estados: StoryObj<CarouselComponent & { loading: boolean }> = {
+	decorators: [moduleMetadata({ imports: [CarouselSkeletonComponent] })],
+	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
+	render: (args) => ({
+		props: args,
+		template: `
+			@if (loading) {
+				<cuentoneta-carousel-skeleton />
+			} @else {
+				<cuentoneta-carousel [slides]="slides" [transitionDuration]="transitionDuration" />
+			}
+		`,
+	}),
+	args: {
+		loading: true,
+		slides: contentCampaignMock,
+		transitionDuration: 600,
+	},
+	parameters: {
+		docs: { description: { story: 'Activá/desactivá "Cargando" para alternar entre el estado real y el skeleton.' } },
 	},
 };

--- a/src/app/components/collection-teaser/collection-teaser.stories.ts
+++ b/src/app/components/collection-teaser/collection-teaser.stories.ts
@@ -7,7 +7,6 @@ import { storylistTeaserRepresentativeMock, storylistTeaserSampleMock } from '@m
 const meta: Meta<CollectionTeaser> = {
 	component: CollectionTeaser,
 	title: 'Componentes V3/CollectionTeaser',
-	tags: ['autodocs'],
 	decorators: [
 		applicationConfig({
 			providers: [provideRouter([])],

--- a/src/app/components/collection-teaser/collection-teaser.stories.ts
+++ b/src/app/components/collection-teaser/collection-teaser.stories.ts
@@ -22,8 +22,15 @@ const meta: Meta<CollectionTeaser> = {
 				sourceState: 'shown',
 			},
 			description: {
-				component: `<div><p>Tarjeta de una colección (storylist) para el Design System v3: portada, título, descripción y footer con tag y contador de historias. La portada se resuelve con el objeto de valor <strong>imagery</strong>: <strong>representative</strong> (una portada editorial propia de la colección) o <strong>sample</strong> (composición de 3 portadas de sus historias, con placeholder en los slots vacíos). Usa <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> para cada portada.</p></div>`,
+				component: `<div><p>El <strong>CollectionTeaser</strong> es la tarjeta de una colección (storylist) para el Design System v3: portada, título, descripción y footer con tag y contador de historias. La portada se resuelve con el objeto de valor <strong>imagery</strong>: <strong>representative</strong> (una portada editorial propia de la colección) o <strong>sample</strong> (composición de 3 portadas de sus historias, con placeholder en los slots vacíos). Usa <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> para cada portada.</p></div>`,
 			},
+		},
+	},
+	argTypes: {
+		collection: {
+			control: { type: 'object' },
+			description: 'Colección a previsualizar (título, descripción, tags, contador e imagery)',
+			table: { type: { summary: 'StorylistTeaser' }, defaultValue: { summary: 'undefined' } },
 		},
 	},
 };
@@ -42,8 +49,7 @@ export const Primary: StoryObj<CollectionTeaser> = {
 	parameters: {
 		docs: {
 			description: {
-				story:
-					'Columna izquierda: variante representative (portada editorial propia). Columna derecha: variante sample (composición de portadas de historias).',
+				story: `<p>Columna izquierda: variante representative (portada editorial propia). Columna derecha: variante sample (composición de portadas de historias).</p><p><strong>Usos:</strong> Home, en la grilla de colecciones destacadas.</p>`,
 			},
 		},
 	},
@@ -71,8 +77,7 @@ export const Interactiva: StoryObj<CollectionTeaser & { kind: 'representative' |
 	parameters: {
 		docs: {
 			description: {
-				story:
-					'Cambiá "Tipo de imagery" para alternar entre la variante representative (portada editorial propia) y sample (composición de 3 portadas de historias).',
+				story: `<p>Cambiá "Tipo de imagery" para alternar entre la variante representative (portada editorial propia) y sample (composición de 3 portadas de historias).</p><p><strong>Usos:</strong> Home; usar representative cuando la colección tiene portada editorial y sample cuando se compone de las portadas de sus historias.</p>`,
 			},
 		},
 	},

--- a/src/app/components/home-story-card/home-story-card.component.stories.ts
+++ b/src/app/components/home-story-card/home-story-card.component.stories.ts
@@ -33,10 +33,23 @@ const meta: Meta<HomeStoryCardComponent> = {
 		layout: 'padded',
 	},
 	argTypes: {
+		story: {
+			control: { type: 'object' },
+			description: 'Historia a previsualizar (con autor); si no se provee, la tarjeta renderiza su skeleton',
+			table: {
+				type: { summary: 'StoryTeaserWithAuthor | StoryNavigationTeaserWithAuthor' },
+				defaultValue: { summary: 'undefined' },
+			},
+		},
 		order: {
 			control: { type: 'number', min: 1, max: 99 },
 			description: 'Numeración opcional de la historia',
 			table: { type: { summary: 'number' }, defaultValue: { summary: 'undefined' } },
+		},
+		priority: {
+			control: { type: 'boolean' },
+			description: 'Marca el cover como prioritario (above-the-fold) para la carga de imágenes',
+			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
 		},
 		coverImageUrl: {
 			control: { type: 'text' },
@@ -99,8 +112,7 @@ export const Interactiva: StoryObj<HomeStoryCardComponent & { storyIndex: number
 	parameters: {
 		docs: {
 			description: {
-				story:
-					'Playground interactivo. Elegí la <strong>Obra</strong> del corpus: su portada y título cambian de forma conjunta. El resto de los controles ajusta numeración, etiqueta y multimedia.',
+				story: `<p>Playground interactivo. Elegí la <strong>Obra</strong> del corpus: su portada y título cambian de forma conjunta. El resto de los controles ajusta numeración, etiqueta y multimedia.</p><p><strong>Usos:</strong> Home.</p>`,
 			},
 		},
 	},

--- a/src/app/components/home-story-card/home-story-card.component.stories.ts
+++ b/src/app/components/home-story-card/home-story-card.component.stories.ts
@@ -11,13 +11,9 @@ import {
 	withRichMedia,
 } from '../../mocks/onoff-corpus.storybook';
 
-// Las descripciones de la doc van en una sola línea: el renderer de Markdown de los autodocs
-// interpreta como bloque de código cualquier línea con indentación, así que un HTML multilínea
-// indentado se mostraría dentro de un recuadro de código.
 const meta: Meta<HomeStoryCardComponent> = {
 	component: HomeStoryCardComponent,
 	title: 'Componentes V3/HomeStoryCard',
-	tags: ['autodocs'],
 	decorators: [
 		applicationConfig({
 			providers: [provideRouter([])],
@@ -157,17 +153,13 @@ export const Estados: StoryObj<HomeStoryCardComponent & { loading: boolean }> = 
 		props: args,
 		template: `
 			<div class="w-[331px]">
-				@if (loading) {
-					<cuentoneta-home-story-card />
-				} @else {
-					<cuentoneta-home-story-card
-						[story]="story"
-						[coverImageUrl]="coverImageUrl"
-						[order]="order"
-						[tagLabel]="tagLabel"
-						[showMultimedia]="showMultimedia"
-					/>
-				}
+				<cuentoneta-home-story-card
+					[story]="loading ? undefined : story"
+					[coverImageUrl]="coverImageUrl"
+					[order]="order"
+					[tagLabel]="tagLabel"
+					[showMultimedia]="showMultimedia"
+				/>
 			</div>
 		`,
 	}),

--- a/src/app/components/image-profile/image-profile.component.stories.ts
+++ b/src/app/components/image-profile/image-profile.component.stories.ts
@@ -17,17 +17,7 @@ const meta: Meta<ImageProfileComponent> = {
 				sourceState: 'shown',
 			},
 			description: {
-				component: `<div>
-					<p>El componente **ImageProfileComponent** es la foto de perfil circular del Design System v3, usada para
-					mostrar la imagen de autores (y, a futuro, de usuarios logueados). Es el componente más anidado del árbol
-					de teasers v3.</p>
-					<ul>
-						<li><code>size</code>: small (24px), medium (40px), lg (80px), xl (120px).</li>
-						<li><code>src</code>/<code>alt</code>: foto del perfil. Sin <code>src</code> se muestra el placeholder de persona.</li>
-						<li><code>variant</code>: <code>profile</code> (default) o <code>collection</code> (fondo brand-100 + ícono de biblioteca).</li>
-					</ul>
-					<p>Encapsula el redimensionado de la imagen (solicita al CDN 2× del tamaño de display).</p>
-				</div>`,
+				component: `<div><p>El componente <strong>ImageProfileComponent</strong> es la foto de perfil circular del Design System v3, usada para mostrar la imagen de autores (y, a futuro, de usuarios logueados). Es el componente más anidado del árbol de teasers v3. Encapsula el recorte circular, el placeholder y el redimensionado de la imagen (solicita al CDN 2× del tamaño de display).</p><ul><li><code>size</code>: small (24px), medium (40px), lg (80px), xl (120px).</li><li><code>src</code>/<code>alt</code>: foto del perfil. Sin <code>src</code> se muestra el placeholder de persona.</li><li><code>variant</code>: <code>profile</code> (default) o <code>collection</code> (fondo brand-100 + ícono de biblioteca).</li></ul><p>Se consume desde <a href="./?path=/docs/componentes-v3-authorteaserv3--docs" target="_top"><strong>AuthorTeaserV3</strong></a>, <a href="./?path=/docs/componentes-v3-homestorycard--docs" target="_top"><strong>HomeStoryCard</strong></a> y <a href="./?path=/docs/componentes-v3-storycardteaserv3--docs" target="_top"><strong>StoryCardTeaserV3</strong></a> como avatar del autor.</p></div>`,
 			},
 		},
 		layout: 'padded',
@@ -36,15 +26,26 @@ const meta: Meta<ImageProfileComponent> = {
 		size: {
 			control: { type: 'inline-radio' },
 			options: ['small', 'medium', 'lg', 'xl'],
-			table: { defaultValue: { summary: 'medium' } },
+			description: 'Tamaño del avatar: small (24px), medium (40px), lg (80px), xl (120px)',
+			table: { type: { summary: "'small' | 'medium' | 'lg' | 'xl'" }, defaultValue: { summary: 'medium' } },
 		},
 		variant: {
 			control: { type: 'inline-radio' },
 			options: ['profile', 'collection'],
-			table: { defaultValue: { summary: 'profile' } },
+			description:
+				'Variante: profile (foto/placeholder de persona) o collection (fondo brand-100 + ícono de biblioteca)',
+			table: { type: { summary: "'profile' | 'collection'" }, defaultValue: { summary: 'profile' } },
 		},
-		src: { control: { type: 'text' } },
-		alt: { control: { type: 'text' } },
+		src: {
+			control: { type: 'text' },
+			description: 'URL de la foto; sin valor se muestra el placeholder de persona',
+			table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
+		},
+		alt: {
+			control: { type: 'text' },
+			description: 'Texto alternativo de la imagen',
+			table: { type: { summary: 'string' }, defaultValue: { summary: "''" } },
+		},
 	},
 };
 
@@ -55,20 +56,39 @@ type Story = StoryObj<ImageProfileComponent>;
 export const Default: Story = {
 	render: (args) => ({ props: args, template: `<cuentoneta-image-profile ${argsToTemplate(args)} />` }),
 	args: { src, alt, size: 'medium', variant: 'profile' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Playground interactivo: ajustá tamaño, variante, foto y texto alternativo desde los controles.</p><p><strong>Usos:</strong> referencia para integrar el avatar dentro de teasers y tarjetas.</p>`,
+			},
+		},
+	},
 };
 
 // Placeholder (sin imagen).
 export const Placeholder: Story = {
 	render: (args) => ({ props: args, template: `<cuentoneta-image-profile ${argsToTemplate(args)} />` }),
 	args: { size: 'medium', variant: 'profile' },
-	parameters: { docs: { description: { story: 'Sin `src`: placeholder de persona sobre fondo gris.' } } },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Sin <code>src</code>: placeholder de persona sobre fondo gris.</p><p><strong>Usos:</strong> autores cuyo perfil todavía no tiene retrato cargado en el CMS.</p>`,
+			},
+		},
+	},
 };
 
 // Variante Collections.
 export const Collection: Story = {
 	render: (args) => ({ props: args, template: `<cuentoneta-image-profile ${argsToTemplate(args)} />` }),
 	args: { size: 'medium', variant: 'collection' },
-	parameters: { docs: { description: { story: 'Variante collection: fondo brand-100 + ícono de biblioteca.' } } },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Variante collection: fondo brand-100 + ícono de biblioteca, en lugar de una foto.</p><p><strong>Usos:</strong> representación de una colección (storylist) donde no aplica un retrato de persona.</p>`,
+			},
+		},
+	},
 };
 
 // Vitrina de tamaños y estados.
@@ -108,5 +128,11 @@ export const Showcase: Story = {
 		`,
 	}),
 	args: { src, alt },
-	parameters: { docs: { description: { story: 'Todos los tamaños y estados (foto, placeholder, collection).' } } },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Todos los tamaños y estados (foto, placeholder, collection) en simultáneo.</p><p><strong>Usos:</strong> referencia visual de la escala de tamaños del avatar.</p>`,
+			},
+		},
+	},
 };

--- a/src/app/components/skeleton/skeleton.component.stories.ts
+++ b/src/app/components/skeleton/skeleton.component.stories.ts
@@ -9,14 +9,7 @@ const meta: Meta<SkeletonComponent> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div>
-					<p>El componente **SkeletonComponent** es la barra de carga (skeleton) in-house del Design System v3.
-					Reemplaza a la dependencia <code>ngx-skeleton-loader</code>. El host <em>es</em> la barra: el alto, el
-					ancho y el color se controlan con clases utilitarias de Tailwind directamente sobre el elemento
-					(<code>&lt;cuentoneta-skeleton class="h-[36px] w-[40px] bg-brand-300" /&gt;</code>). El único input es
-					<code>appearance</code> (<strong>line</strong> / <strong>circle</strong> / <strong>square</strong>), que
-					define la forma. Para múltiples barras, el consumidor repite el elemento con <code>@for</code>.</p>
-				</div>`,
+				component: `<div><p>El componente <strong>SkeletonComponent</strong> es la barra de carga (skeleton) in-house del Design System v3. Reemplaza a la dependencia <code>ngx-skeleton-loader</code>. El host <em>es</em> la barra: el alto, el ancho y el color se controlan con clases utilitarias de Tailwind directamente sobre el elemento (<code>&lt;cuentoneta-skeleton class="h-[36px] w-[40px] bg-brand-300" /&gt;</code>). El único input es <code>appearance</code> (<strong>line</strong> / <strong>circle</strong> / <strong>square</strong>), que define la forma. Para múltiples barras, el consumidor repite el elemento con <code>@for</code>.</p></div>`,
 			},
 		},
 		layout: 'padded',
@@ -25,7 +18,8 @@ const meta: Meta<SkeletonComponent> = {
 		appearance: {
 			control: { type: 'inline-radio' },
 			options: ['line', 'circle', 'square'],
-			table: { defaultValue: { summary: 'line' } },
+			description: 'Forma del skeleton: line (radio chico), circle (avatar redondo) o square (sin radio impuesto)',
+			table: { type: { summary: "'line' | 'circle' | 'square'" }, defaultValue: { summary: 'line' } },
 		},
 	},
 };
@@ -35,14 +29,35 @@ type Story = StoryObj<SkeletonComponent>;
 
 export const Line: Story = {
 	render: () => ({ template: `<cuentoneta-skeleton appearance="line" class="h-4 w-48 bg-neutral-300" />` }),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Forma <strong>line</strong> (default): barra con radio chico para representar líneas de texto.</p><p><strong>Usos:</strong> placeholders de títulos, párrafos y metadatos en los skeletons de las tarjetas.</p>`,
+			},
+		},
+	},
 };
 
 export const Circle: Story = {
 	render: () => ({ template: `<cuentoneta-skeleton appearance="circle" class="w-10 bg-neutral-300" />` }),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Forma <strong>circle</strong>: fuerza un aspecto cuadrado redondeado para representar avatares.</p><p><strong>Usos:</strong> placeholder del avatar del autor en los skeletons de teasers y tarjetas.</p>`,
+			},
+		},
+	},
 };
 
 export const Square: Story = {
 	render: () => ({ template: `<cuentoneta-skeleton appearance="square" class="h-20 w-20 bg-neutral-200" />` }),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Forma <strong>square</strong>: no impone radio (lo deja en manos del consumidor) para representar bloques e imágenes.</p><p><strong>Usos:</strong> placeholder de portadas e imágenes dentro de los skeletons.</p>`,
+			},
+		},
+	},
 };
 
 export const MultipleLines: Story = {

--- a/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
+++ b/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
@@ -27,17 +27,7 @@ const meta: Meta<StoryMediaSelectorsComponent> = {
 				sourceState: 'shown',
 			},
 			description: {
-				component: `<div>
-					<p>El componente **StoryMediaSelectorsComponent** renderiza los selectores de los recursos multimedia
-					(YouTube, X, Spotify, audio) asociados a una historia. Es un componente de presentación: no monta los
-					widgets, solo emite el recurso seleccionado vía el output <code>selected</code>.</p>
-					<ul>
-						<li><code>selectable = false</code> (por defecto): agrupa por plataforma con un contador (badge). Decorativo.</li>
-						<li><code>selectable = true</code>: un selector clickeable por recurso; al click emite el <code>Media</code> vía <code>selected</code>.</li>
-					</ul>
-					<p>El input <code>theme</code> (<code>subtle</code> / <code>solid</code> / <code>bordered</code>) y
-					<code>orientation</code> (<code>horizontal</code> / <code>vertical</code>) controlan la presentación.</p>
-				</div>`,
+				component: `<div><p>El componente <strong>StoryMediaSelectorsComponent</strong> renderiza los selectores de los recursos multimedia (YouTube, X, Spotify, audio) asociados a una historia. Es un componente de presentación: no monta los widgets, solo emite el recurso seleccionado vía el output <code>selected</code>.</p><ul><li><code>selectable = false</code> (por defecto): agrupa por plataforma con un contador (badge). Decorativo.</li><li><code>selectable = true</code>: un selector clickeable por recurso; al click emite el <code>Media</code> vía <code>selected</code>.</li></ul><p>Los inputs <code>theme</code> (<code>subtle</code> / <code>solid</code> / <code>bordered</code>) y <code>orientation</code> (<code>horizontal</code> / <code>vertical</code>) controlan la presentación.</p><p>Se consume desde <a href="./?path=/docs/componentes-v3-storycardteaserv3--docs" target="_top"><strong>StoryCardTeaserV3</strong></a> y <a href="./?path=/docs/componentes-v3-homestorycard--docs" target="_top"><strong>HomeStoryCard</strong></a> (modo agrupado), y en la página de Story en modo seleccionable.</p></div>`,
 			},
 		},
 		layout: 'padded',
@@ -53,6 +43,7 @@ const meta: Meta<StoryMediaSelectorsComponent> = {
 		orientation: {
 			control: { type: 'inline-radio' },
 			options: ['horizontal', 'vertical'],
+			description: 'Disposición de los selectores: en fila (horizontal) o en columna (vertical)',
 			table: { defaultValue: { summary: 'horizontal' } },
 		},
 		selectable: {
@@ -73,7 +64,9 @@ export const Grouped: Story = {
 	args: { media, theme: 'subtle', orientation: 'horizontal', selectable: false },
 	parameters: {
 		docs: {
-			description: { story: 'Modo agrupado: un selector por plataforma con contador. Tema `subtle` (OnWhite).' },
+			description: {
+				story: `<p>Modo agrupado (decorativo): un selector por plataforma con contador. Tema <code>subtle</code> (OnWhite).</p><p><strong>Usos:</strong> <a href="./?path=/docs/componentes-v3-storycardteaserv3--docs" target="_top"><strong>StoryCardTeaserV3</strong></a> y <a href="./?path=/docs/componentes-v3-homestorycard--docs" target="_top"><strong>HomeStoryCard</strong></a>, como resumen de los recursos disponibles.</p>`,
+			},
 		},
 	},
 };
@@ -85,7 +78,7 @@ export const Selectable: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Modo seleccionable: un botón por recurso. Al hacer click emite el `Media` (ver la pestaña Actions).',
+				story: `<p>Modo seleccionable: un botón por recurso. Al hacer click emite el <code>Media</code> vía el output <code>selected</code> (ver la pestaña Actions).</p><p><strong>Usos:</strong> página de Story, donde el padre monta el widget del recurso seleccionado.</p>`,
 			},
 		},
 	},
@@ -124,6 +117,10 @@ export const Themes: Story = {
 	}),
 	args: { media, selectable: false },
 	parameters: {
-		docs: { description: { story: 'Los tres temas en su contexto de fondo y la orientación vertical.' } },
+		docs: {
+			description: {
+				story: `<p>Vitrina de los tres temas en su contexto de fondo (subtle/solid/bordered) y la orientación vertical.</p><p><strong>Usos:</strong> referencia para elegir el tema según el fondo de la tarjeta contenedora.</p>`,
+			},
+		},
 	},
 };

--- a/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
+++ b/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
@@ -33,7 +33,11 @@ const meta: Meta<StoryMediaSelectorsComponent> = {
 		layout: 'padded',
 	},
 	argTypes: {
-		media: { control: { type: 'object' }, description: 'Recursos multimedia de la historia' },
+		media: {
+			control: { type: 'object' },
+			description: 'Recursos multimedia de la historia',
+			table: { type: { summary: 'Media[]' }, defaultValue: { summary: '[]' } },
+		},
 		theme: {
 			control: { type: 'inline-radio' },
 			options: ['subtle', 'solid', 'bordered'],

--- a/src/app/components/tag/tag.component.stories.ts
+++ b/src/app/components/tag/tag.component.stories.ts
@@ -36,7 +36,7 @@ export const Soft: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Variante <strong>soft</strong> (default): solo texto en brand-500, sin fondo. Comportamiento (Figma): la primera letra del texto en mayúscula y el resto en minúsculas (sentence-case).</p><p><strong>Usos:</strong> Home (en <a href="./?path=/docs/componentes-collectionteaser--docs" target="_top"><strong>CollectionTeaser</strong></a> y <a href="./?path=/docs/componentes-v3-homestorycard--docs" target="_top"><strong>HomeStoryCard</strong></a>); Story, Story List y Author Profile (en <a href="./?path=/docs/componentes-v3-storycardteaserv3--docs" target="_top"><strong>StoryCardTeaserV3</strong></a>).</p>`,
+				story: `<p>Variante <strong>soft</strong> (default): solo texto en brand-500, sin fondo. Comportamiento (Figma): la primera letra del texto en mayúscula y el resto en minúsculas (sentence-case).</p><p><strong>Usos:</strong> Home (en <a href="./?path=/docs/componentes-v3-collectionteaser--docs" target="_top"><strong>CollectionTeaser</strong></a> y <a href="./?path=/docs/componentes-v3-homestorycard--docs" target="_top"><strong>HomeStoryCard</strong></a>); Story, Story List y Author Profile (en <a href="./?path=/docs/componentes-v3-storycardteaserv3--docs" target="_top"><strong>StoryCardTeaserV3</strong></a>).</p>`,
 			},
 		},
 	},

--- a/src/app/components/tags-list/tags-list.component.stories.ts
+++ b/src/app/components/tags-list/tags-list.component.stories.ts
@@ -37,16 +37,7 @@ const meta: Meta<Args> = {
 				sourceState: 'shown',
 			},
 			description: {
-				component: `<div>
-					<p>El componente **TagsListComponent** recibe los tags por <strong>content projection</strong>
-					(<code>&lt;ng-content&gt;</code>) y, cuando <strong>no entran en el ancho del contenedor</strong>,
-					colapsa el excedente detrás de un contador <strong>"+N"</strong> de ancho fijo ubicado justo
-					después del último tag visible.</p>
-					<p>El recorte es <strong>por ancho real</strong> (vía <code>IntersectionObserver</code>, sin
-					<code>ResizeObserver</code>), no por cantidad, y vive en <code>TagsOverflowDirective</code> aplicada
-					como <code>hostDirective</code>. <code>maxVisible</code> es un <strong>tope duro opcional</strong>.</p>
-					<p>Probá el <em>Playground</em> para arrastrar el ancho y ver el contador aparecer/desaparecer en vivo.</p>
-				</div>`,
+				component: `<div><p>El componente <strong>TagsListComponent</strong> recibe instancias de <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> por <strong>content projection</strong> (<code>&lt;ng-content&gt;</code>) y, cuando <strong>no entran en el ancho del contenedor</strong>, colapsa el excedente detrás de un contador <strong>"+N"</strong> de ancho fijo ubicado justo después del último tag visible.</p><p>El recorte es <strong>por ancho real</strong> (vía <code>IntersectionObserver</code>, sin <code>ResizeObserver</code>), no por cantidad, y vive en <code>TagsOverflowDirective</code> aplicada como <code>hostDirective</code>. <code>maxVisible</code> es un <strong>tope duro opcional</strong>.</p><p>Probá el <em>Playground</em> para arrastrar el ancho y ver el contador aparecer/desaparecer en vivo.</p></div>`,
 			},
 		},
 		layout: 'padded',
@@ -55,12 +46,13 @@ const meta: Meta<Args> = {
 		variant: {
 			control: { type: 'inline-radio' },
 			options: ['soft', 'filled', 'gray'],
-			table: { defaultValue: { summary: 'filled' } },
+			description: 'Variante aplicada a los tags proyectados (ver Tag)',
+			table: { type: { summary: "'soft' | 'filled' | 'gray'" }, defaultValue: { summary: 'filled' } },
 		},
 		maxVisible: {
 			control: { type: 'number' },
 			description: 'Tope duro opcional de tags visibles. Vacío = recorte solo por ancho.',
-			table: { defaultValue: { summary: '— (sin tope)' } },
+			table: { type: { summary: 'number' }, defaultValue: { summary: '— (sin tope)' } },
 		},
 	},
 };
@@ -73,7 +65,13 @@ export const Default: Story = {
 	render: (args) => ({ props: { ...args, tags }, template: projected }),
 	args: { variant: 'filled' },
 	decorators: [boxed('100%')],
-	parameters: { docs: { description: { story: 'Con espacio de sobra, los 5 tags se muestran sin contador.' } } },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Con espacio de sobra, los 5 tags se muestran sin contador.</p><p><strong>Usos:</strong> <a href="./?path=/docs/componentes-v3-authorteaserv3--docs" target="_top"><strong>AuthorTeaserV3</strong></a>, en columnas anchas donde la fila de tags entra completa.</p>`,
+			},
+		},
+	},
 };
 
 // Contenedor acotado: el excedente que no entra por ancho se colapsa en "+N".
@@ -84,7 +82,7 @@ export const WidthOverflow: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'En 240px no entran los 5 tags: los que sobran se colapsan tras un "+N" después del último visible.',
+				story: `<p>En 240px no entran los 5 tags: los que sobran se colapsan tras un "+N" después del último visible.</p><p><strong>Usos:</strong> <a href="./?path=/docs/componentes-v3-authorteaserv3--docs" target="_top"><strong>AuthorTeaserV3</strong></a> en anchos intermedios.</p>`,
 			},
 		},
 	},
@@ -95,7 +93,13 @@ export const NarrowWidth: Story = {
 	render: (args) => ({ props: { ...args, tags }, template: projected }),
 	args: { variant: 'filled' },
 	decorators: [boxed('130px')],
-	parameters: { docs: { description: { story: 'A 130px casi nada entra; el contador refleja todo lo colapsado.' } } },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>A 130px casi nada entra; el contador refleja todo lo colapsado.</p><p><strong>Usos:</strong> teasers en viewports muy reducidos o columnas muy angostas.</p>`,
+			},
+		},
+	},
 };
 
 // Tope duro: el contenedor daría para más, pero maxVisible corta antes.
@@ -106,7 +110,7 @@ export const MaxVisibleCap: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Con ancho de sobra pero maxVisible=2, se muestran 2 + "+3"; el tope manda sobre el ancho.',
+				story: `<p>Con ancho de sobra pero maxVisible=2, se muestran 2 + "+3"; el tope manda sobre el ancho.</p><p><strong>Usos:</strong> cuando el diseño exige un máximo fijo de tags independientemente del ancho disponible.</p>`,
 			},
 		},
 	},
@@ -131,7 +135,11 @@ export const Variants: Story = {
 		`,
 	}),
 	parameters: {
-		docs: { description: { story: 'soft / filled / gray recortando por ancho en contenedores de 240px.' } },
+		docs: {
+			description: {
+				story: `<p>soft / filled / gray recortando por ancho en contenedores de 240px.</p><p><strong>Usos:</strong> referencia visual de cómo afecta la variante de <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> a la fila completa.</p>`,
+			},
+		},
 	},
 };
 
@@ -148,7 +156,7 @@ export const Playground: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Arrastrá el handle de resize del contenedor: el "+N" aparece/desaparece según el ancho disponible.',
+				story: `<p>Arrastrá el handle de resize del contenedor: el "+N" aparece/desaparece según el ancho disponible.</p><p><strong>Usos:</strong> verificación interactiva del recorte por ancho real (IntersectionObserver).</p>`,
 			},
 		},
 	},


### PR DESCRIPTION
## Descripción

Auditoría de documentación de Storybook de la sección **Componentes V3**: se niveló la documentación viva de todos los componentes al estándar de oro de **StoryCardTeaserV3** y **Tag** (autodocs, descripción en una sola línea de HTML con cross-refs navegables, `argTypes` completos, una story por variante con su sección **Usos**, Showcase y story `Estados` intercambiable real↔skeleton).

- **Componentes nivelados:** AuthorTeaserV3, HomeStoryCard, Button, StoryMediaSelectors, Skeleton, CollectionTeaser, ImageProfile, TagsList y Carousel.
- **Carousel:** se agregó la story `Estados` intercambiable que faltaba (pese a tener `CarouselSkeleton`).
- **Tag (gold standard):** se corrigió un cross-ref roto a CollectionTeaser introducido por el rename del hotfix #1630.
- **`.claude/references/testing.md`:** se actualizó la sección Storybook con las convenciones que reveló la auditoría — `title` en `Componentes V3/...`, autodocs global (no repetir `tags: ['autodocs']` por archivo), sección **Usos** obligatoria en `description.story`, y `argTypes` también para inputs de objeto complejo.

Closes #1631.

## Fuera de alcance (señalado para seguimiento)

Se detectaron componentes V3 **sin skeleton propio** (ImageProfile, TagsList, StoryMediaSelectors) candidatos a un futuro **epic de skeletons**. No se aborda en este PR (solo documentación).

## Plan de pruebas

- [x] `pnpm lint` — verde
- [x] `pnpm stylelint` — verde
- [x] `pnpm test` — verde
- [x] `pnpm build` — verde (warnings de budget pre-existentes)
- [x] `pnpm storybook:build` — verde, sin warnings nuevos de autodocs
- [x] Code review local (0 críticos; 5 advertencias y 1 sugerencia abordadas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
