### PR TITLE
[#1678] - Corpus Onoff crudo (ACL/backend)

### DIFF
--- a/src/api/_mocks/onoff-raw-author.mock.ts
+++ b/src/api/_mocks/onoff-raw-author.mock.ts
@@ -1,7 +1,5 @@
 import type { RotatingContentQueryResult, StoryBySlugQueryResult } from '../sanity/types';
 
-// Autor François Onoff en shape crudo de GROQ. Valores replicados de src/app/mocks/author.mock.ts (separación de
-// capas: la capa API no importa del frontend). `nationality` viene expandida (la query usa `nationality->`).
 export const rawOnoffAuthor: NonNullable<StoryBySlugQueryResult>['author'] = {
 	_id: 'author_1',
 	slug: 'francois-onoff',
@@ -143,8 +141,6 @@ export const rawOnoffAuthor: NonNullable<StoryBySlugQueryResult>['author'] = {
 	tags: [],
 };
 
-// Variante para el sub-shape de nav-teaser (`RotatingContentQueryResult['mostRead'][0]['author']`): la query
-// proyecta `'biography': []` y `'resources': []`.
 export const rawOnoffAuthorTeaser: NonNullable<RotatingContentQueryResult>['mostRead'][0]['author'] = {
 	_id: 'author_1',
 	slug: 'francois-onoff',

--- a/src/api/_mocks/onoff-raw-author.mock.ts
+++ b/src/api/_mocks/onoff-raw-author.mock.ts
@@ -1,0 +1,174 @@
+import type { RotatingContentQueryResult, StoryBySlugQueryResult } from '../sanity/types';
+
+// Autor François Onoff en shape crudo de GROQ. Valores replicados de src/app/mocks/author.mock.ts (separación de
+// capas: la capa API no importa del frontend). `nationality` viene expandida (la query usa `nationality->`).
+export const rawOnoffAuthor: NonNullable<StoryBySlugQueryResult>['author'] = {
+	_id: 'author_1',
+	slug: 'francois-onoff',
+	name: 'François Onoff',
+	image: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-f656d95d41369adb6f7d3a7d0b20b36861fd2028-350x350-jpg' },
+	},
+	nationality: {
+		_id: 'nationality-francia',
+		_type: 'nationality',
+		_createdAt: '2021-12-28T00:00:00Z',
+		_updatedAt: '2021-12-28T00:00:00Z',
+		_rev: 'rev-francia',
+		country: 'Francia',
+		flag: {
+			_type: 'image',
+			asset: { _type: 'reference', _ref: 'image-b80876a5f3a89e13acc14254b1f45dd6d29b79f4-30x20-png' },
+		},
+	},
+	biography: [
+		{
+			children: [
+				{
+					_type: 'span',
+					marks: ['strong'],
+					text: 'François Onoff ',
+					_key: 'b2399ab5fba8',
+				},
+				{
+					_type: 'span',
+					marks: [],
+					text: '(Chateauroux, 1948 - París, 1994) fue un escritor francés, reconocido como uno de los principales exponentes del realismo psicológico en la literatura de finales del siglo XX. La novela ',
+					_key: '184064d1e14e',
+				},
+				{
+					_key: 'c8faa6f7502e',
+					_type: 'span',
+					marks: ['em'],
+					text: 'El palacio de las nueve fronteras',
+				},
+				{
+					_type: 'span',
+					marks: [],
+					text: ' (1990), en la cual realiza una profunda exploración de la psique humana y la ambigüedad de la memoria, lo catapultó a la fama internacional y es considerada su obra maestra.',
+					_key: '4a569a405101',
+				},
+			],
+			_type: 'block',
+			style: 'normal',
+			_key: '55d66b6f6c01',
+			markDefs: [],
+		},
+		{
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					marks: [],
+					text: 'Onoff se destacó por su habilidad para fusionar elementos del thriller psicológico con reflexiones filosóficas sobre la identidad y la percepción de la realidad. Su colección de cuentos ',
+					_key: 'a58c717facf60',
+				},
+				{
+					_type: 'span',
+					marks: ['em'],
+					text: 'Ecos del silencio',
+					_key: 'f09f2317edf1',
+				},
+				{
+					_type: 'span',
+					marks: [],
+					text: ' (1983) mostró por primera vez su talento para crear atmósferas inquietantes y personajes atormentados por sus propios recuerdos.',
+					_key: '31a9df1990bc',
+				},
+			],
+			_type: 'block',
+			style: 'normal',
+			_key: 'cdc729412a8f',
+		},
+		{
+			markDefs: [],
+			children: [
+				{
+					marks: [],
+					text: 'Su último manuscrito inacabado, ',
+					_key: 'c9ad2571947b0',
+					_type: 'span',
+				},
+				{
+					_type: 'span',
+					marks: ['em'],
+					text: 'Sinfonía de sombras',
+					_key: 'd29c792cc843',
+				},
+				{
+					_type: 'span',
+					marks: [],
+					text: ', fue publicado en 1998 y es considerado por muchos como un testimonio conmovedor de su genio creativo y una visión de la dirección que su escritura podría haber tomado de haber vivido más tiempo.',
+					_key: 'f258a3f8d34e',
+				},
+			],
+			_type: 'block',
+			style: 'normal',
+			_key: '59089d1c58c4',
+		},
+	],
+	bornOn: '1948-01-01',
+	bornOnYear: 1948,
+	diedOn: '1994-12-31',
+	diedOnYear: 1994,
+	resources: [
+		{
+			title: 'Artículo de François Onoff en Wikipedia',
+			url: 'https://es.wikipedia.org/wiki/Francois_Onoff',
+			resourceType: {
+				slug: 'wikipedia',
+				title: 'Wikipedia',
+				shortDescription: 'Enlace a artículo de Wikipedia',
+				description: [
+					{
+						_key: '020ccde1fe7d',
+						markDefs: [],
+						children: [
+							{
+								text: 'Enlace a artículo de Wikipedia',
+								_key: '1dadfddec1750',
+								_type: 'span',
+								marks: [],
+							},
+						],
+						_type: 'block',
+						style: 'normal',
+					},
+				],
+				icon: { _type: 'iconPicker', provider: 'fa', name: 'fa-wikipedia-w' },
+			},
+		},
+	],
+	tags: [],
+};
+
+// Variante para el sub-shape de nav-teaser (`RotatingContentQueryResult['mostRead'][0]['author']`): la query
+// proyecta `'biography': []` y `'resources': []`.
+export const rawOnoffAuthorTeaser: NonNullable<RotatingContentQueryResult>['mostRead'][0]['author'] = {
+	_id: 'author_1',
+	slug: 'francois-onoff',
+	name: 'François Onoff',
+	image: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-f656d95d41369adb6f7d3a7d0b20b36861fd2028-350x350-jpg' },
+	},
+	nationality: {
+		_id: 'nationality-francia',
+		_type: 'nationality',
+		_createdAt: '2021-12-28T00:00:00Z',
+		_updatedAt: '2021-12-28T00:00:00Z',
+		_rev: 'rev-francia',
+		country: 'Francia',
+		flag: {
+			_type: 'image',
+			asset: { _type: 'reference', _ref: 'image-b80876a5f3a89e13acc14254b1f45dd6d29b79f4-30x20-png' },
+		},
+	},
+	biography: [],
+	bornOn: '1948-01-01',
+	bornOnYear: 1948,
+	diedOn: '1994-12-31',
+	diedOnYear: 1994,
+	resources: [],
+};

--- a/src/api/_mocks/onoff-raw-stories.mock.ts
+++ b/src/api/_mocks/onoff-raw-stories.mock.ts
@@ -1,0 +1,95 @@
+import type {
+	RotatingContentQueryResult,
+	StoriesByAuthorSlugQueryResult,
+	StoryBySlugQueryResult,
+} from '../sanity/types';
+import { rawOnoffAuthorTeaser } from './onoff-raw-author.mock';
+import { elOdioRawStory } from './onoff/el-odio.raw.mock';
+import { elPalacioRawStory } from './onoff/el-palacio-de-las-nueve-fronteras.raw.mock';
+import { elTratadoRawStory } from './onoff/el-tratado-de-los-placeres.raw.mock';
+import { geometriaRawStory } from './onoff/geometria.raw.mock';
+import { lasDosAntorchasRawStory } from './onoff/las-dos-antorchas.raw.mock';
+import { lasEscalerasRawStory } from './onoff/las-escaleras.raw.mock';
+import { losPeldanosRawStory } from './onoff/los-peldanos.raw.mock';
+import { neronRawStory } from './onoff/neron.raw.mock';
+
+// Corpus crudo del autor Onoff en shape de GROQ, espejo de src/app/mocks/onoff-stories.mock.ts. El orden coincide
+// con el del frontend para facilitar comparaciones de paridad.
+export const onoffRawStoriesMock: NonNullable<StoryBySlugQueryResult>[] = [
+	elPalacioRawStory,
+	geometriaRawStory,
+	losPeldanosRawStory,
+	lasEscalerasRawStory,
+	elOdioRawStory,
+	elTratadoRawStory,
+	lasDosAntorchasRawStory,
+	neronRawStory,
+];
+
+// Proyecta el sub-shape de teaser de autor (`storiesByAuthorSlugQuery`): trunca el cuerpo a los primeros 3 bloques
+// (igual que `coalesce(body[0...3], [])`) y descarta `author`, `epigraphs`, `review` y `tags`.
+function toRawTeaser(raw: NonNullable<StoryBySlugQueryResult>): StoriesByAuthorSlugQueryResult[0] {
+	return {
+		_id: raw._id,
+		slug: raw.slug,
+		title: raw.title,
+		badLanguage: raw.badLanguage,
+		body: raw.body.slice(0, 3),
+		originalPublication: raw.originalPublication,
+		approximateReadingTime: raw.approximateReadingTime,
+		coverImage: raw.coverImage,
+		mediaSources: raw.mediaSources,
+		resources: raw.resources,
+	};
+}
+
+// Proyecta el sub-shape de nav-teaser con autor (`mostRead` de `rotatingContentQuery`): `body` y `resources`
+// vacíos, y el autor en su variante de teaser (`biography: []`, `resources: []`).
+function toRawNavTeaser(
+	raw: NonNullable<StoryBySlugQueryResult>,
+): NonNullable<RotatingContentQueryResult>['mostRead'][0] {
+	return {
+		_id: raw._id,
+		slug: raw.slug,
+		title: raw.title,
+		badLanguage: raw.badLanguage,
+		body: [],
+		originalPublication: raw.originalPublication,
+		approximateReadingTime: raw.approximateReadingTime,
+		coverImage: raw.coverImage,
+		resources: [],
+		mediaSources: raw.mediaSources,
+		author: rawOnoffAuthorTeaser,
+	};
+}
+
+export const elPalacioRawTeaser = toRawTeaser(elPalacioRawStory);
+export const geometriaRawTeaser = toRawTeaser(geometriaRawStory);
+export const losPeldanosRawTeaser = toRawTeaser(losPeldanosRawStory);
+export const lasEscalerasRawTeaser = toRawTeaser(lasEscalerasRawStory);
+export const elOdioRawTeaser = toRawTeaser(elOdioRawStory);
+export const elTratadoRawTeaser = toRawTeaser(elTratadoRawStory);
+export const lasDosAntorchasRawTeaser = toRawTeaser(lasDosAntorchasRawStory);
+export const neronRawTeaser = toRawTeaser(neronRawStory);
+
+export const onoffRawTeasersMock: StoriesByAuthorSlugQueryResult = [
+	elPalacioRawTeaser,
+	geometriaRawTeaser,
+	losPeldanosRawTeaser,
+	lasEscalerasRawTeaser,
+	elOdioRawTeaser,
+	elTratadoRawTeaser,
+	lasDosAntorchasRawTeaser,
+	neronRawTeaser,
+];
+
+export const onoffRawNavTeasersMock: NonNullable<RotatingContentQueryResult>['mostRead'] = [
+	toRawNavTeaser(elPalacioRawStory),
+	toRawNavTeaser(geometriaRawStory),
+	toRawNavTeaser(losPeldanosRawStory),
+	toRawNavTeaser(lasEscalerasRawStory),
+	toRawNavTeaser(elOdioRawStory),
+	toRawNavTeaser(elTratadoRawStory),
+	toRawNavTeaser(lasDosAntorchasRawStory),
+	toRawNavTeaser(neronRawStory),
+];

--- a/src/api/_mocks/onoff-raw-stories.mock.ts
+++ b/src/api/_mocks/onoff-raw-stories.mock.ts
@@ -13,8 +13,6 @@ import { lasEscalerasRawStory } from './onoff/las-escaleras.raw.mock';
 import { losPeldanosRawStory } from './onoff/los-peldanos.raw.mock';
 import { neronRawStory } from './onoff/neron.raw.mock';
 
-// Corpus crudo del autor Onoff en shape de GROQ, espejo de src/app/mocks/onoff-stories.mock.ts. El orden coincide
-// con el del frontend para facilitar comparaciones de paridad.
 export const onoffRawStoriesMock: NonNullable<StoryBySlugQueryResult>[] = [
 	elPalacioRawStory,
 	geometriaRawStory,
@@ -26,8 +24,6 @@ export const onoffRawStoriesMock: NonNullable<StoryBySlugQueryResult>[] = [
 	neronRawStory,
 ];
 
-// Proyecta el sub-shape de teaser de autor (`storiesByAuthorSlugQuery`): trunca el cuerpo a los primeros 3 bloques
-// (igual que `coalesce(body[0...3], [])`) y descarta `author`, `epigraphs`, `review` y `tags`.
 function toRawTeaser(raw: NonNullable<StoryBySlugQueryResult>): StoriesByAuthorSlugQueryResult[0] {
 	return {
 		_id: raw._id,
@@ -43,8 +39,6 @@ function toRawTeaser(raw: NonNullable<StoryBySlugQueryResult>): StoriesByAuthorS
 	};
 }
 
-// Proyecta el sub-shape de nav-teaser con autor (`mostRead` de `rotatingContentQuery`): `body` y `resources`
-// vacíos, y el autor en su variante de teaser (`biography: []`, `resources: []`).
 function toRawNavTeaser(
 	raw: NonNullable<StoryBySlugQueryResult>,
 ): NonNullable<RotatingContentQueryResult>['mostRead'][0] {

--- a/src/api/_mocks/onoff/el-odio.raw.mock.ts
+++ b/src/api/_mocks/onoff/el-odio.raw.mock.ts
@@ -1,8 +1,6 @@
 import type { StoryBySlugQueryResult } from '../../sanity/types';
 import { rawOnoffAuthor } from '../onoff-raw-author.mock';
 
-// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/el-odio.mock.ts (separación de capas:
-// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
 export const elOdioRawStory: NonNullable<StoryBySlugQueryResult> = {
 	_id: 'onoff-story-el-odio',
 	slug: 'el-odio',

--- a/src/api/_mocks/onoff/el-odio.raw.mock.ts
+++ b/src/api/_mocks/onoff/el-odio.raw.mock.ts
@@ -1,0 +1,257 @@
+import type { StoryBySlugQueryResult } from '../../sanity/types';
+import { rawOnoffAuthor } from '../onoff-raw-author.mock';
+
+// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/el-odio.mock.ts (separación de capas:
+// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
+export const elOdioRawStory: NonNullable<StoryBySlugQueryResult> = {
+	_id: 'onoff-story-el-odio',
+	slug: 'el-odio',
+	title: 'El odio',
+	badLanguage: false,
+	epigraphs: [],
+	body: [
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b1',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b1-s1',
+					text: 'No empezó por nada. Eso es lo primero que conviene aclarar. No hubo un agravio, ni una herida, ni una infancia que pudiera invocarse después como excusa. El odio estaba ahí desde antes, igual que el peso del cuerpo o el color de los ojos, una propiedad y no un acontecimiento.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b2',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b2-s1',
+					text: 'La gente cree que odiar quema. Lo dicen así: ',
+				},
+				{
+					_type: 'span',
+					_key: 'odio-b2-s2',
+					marks: ['em'],
+					text: 'arde por dentro, se consume.',
+				},
+				{
+					_type: 'span',
+					_key: 'odio-b2-s3',
+					text: ' Conmigo no. Lo mío era frío y ordenado, una habitación con los muebles en su sitio. Entraba en ella todas las mañanas y nada se había movido durante la noche.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b3',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b3-s1',
+					text: 'A los que me importaban menos los trataba con cortesía. La cortesía es barata y compra tiempo. Sonreía lo justo, recordaba sus nombres, preguntaba por sus hijos. Ninguno sospechó nunca lo que había detrás, y no porque yo lo escondiera, sino porque nadie mira con atención una cara que sonríe.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b4',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b4-s1',
+					text: 'Había uno, sin embargo, al que dediqué los años. Lo llamaré ',
+				},
+				{
+					_type: 'span',
+					_key: 'odio-b4-s2',
+					marks: ['strong'],
+					text: 'el hombre',
+				},
+				{
+					_type: 'span',
+					_key: 'odio-b4-s3',
+					text: ', porque su nombre no agrega nada. Lo elegí como se elige un oficio: con calma, sabiendo que iba a ocuparme de él el resto de mi vida.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b5',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b5-s1',
+					text: 'No quería destruirlo. Esa es la confusión más común. La venganza es ruidosa, exige público, necesita un final. Yo no buscaba ningún final. Lo que quería era seguir odiándolo bien, con limpieza, durante mucho tiempo, sin que el sentimiento se gastara ni se ensuciara.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b6',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b6-s1',
+					text: 'Lo observaba. Sabía cómo desayunaba, a qué hora salía, de qué lado de la cama dormía. No para hacerle daño. Para conocerlo. Uno no odia de verdad lo que no conoce; lo demás es rencor, y el rencor es vulgar.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b7',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b7-s1',
+					text: 'Una vez se enfermó. Estuvo a punto de morirse y yo sentí algo parecido al pánico. No por afecto: ',
+				},
+				{
+					_type: 'span',
+					_key: 'odio-b7-s2',
+					marks: ['em'],
+					text: 'si se moría, me quedaba sin nada.',
+				},
+				{
+					_type: 'span',
+					_key: 'odio-b7-s3',
+					text: ' Recé, a mi manera, que se curara. Y se curó. Volví a respirar.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b8',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b8-s1',
+					text: 'No hay catarsis en esto. Lo advierto porque el lector espera siempre una. Espera que en algún punto yo entienda, que perdone, que me libere. No va a pasar. No tengo nada de qué liberarme. El odio no es una cadena: es una casa, y yo vivo cómodo en ella.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b9',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b9-s1',
+					text: 'Tampoco hay fiebre. La fiebre es para los que odian mal, los que gritan y tiemblan y al día siguiente se arrepienten. Yo nunca me arrepentí de nada. Lo que se hace con método no deja resaca.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b10',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b10-s1',
+					text: 'Lo que más le molestaba a la gente, cuando intuía algo, era la ausencia de motivo. Querían una razón. ',
+				},
+				{
+					_type: 'span',
+					_key: 'odio-b10-s2',
+					marks: ['strong'],
+					text: 'Una razón los habría tranquilizado.',
+				},
+				{
+					_type: 'span',
+					_key: 'odio-b10-s3',
+					text: ' Si yo hubiera dicho que él me arruinó, que me traicionó, todos habrían asentido. El odio sin causa, en cambio, los aterra, porque no se sabe dónde termina.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b11',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b11-s1',
+					text: 'Envejecimos los dos. Él del lado de su vida, yo del lado de la mía, atado a la suya por un hilo que solo yo veía. Su pelo se volvió blanco. El mío también. No cambió nada esencial.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b12',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b12-s1',
+					text: 'Murió un martes, en su cama, sin enterarse de mí. Fui al entierro. Me quedé atrás, donde nadie me viera, y miré bajar el cajón con la atención con que se cierra un libro que uno ha leído muchas veces.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b13',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b13-s1',
+					text: 'Esa noche no sentí alivio. Sentí, por primera vez, el frío de la habitación vacía. ',
+				},
+				{
+					_type: 'span',
+					_key: 'odio-b13-s2',
+					marks: ['em'],
+					text: 'Había perdido lo único que había cuidado en mi vida.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'odio-b14',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'odio-b14-s1',
+					text: 'Ahora busco a otro. No por necesidad, sino por costumbre, que es una forma más honesta de la necesidad. Hay candidatos. Llevará su tiempo. Estas cosas no se improvisan, y a mí no me queda demasiado.',
+				},
+			],
+		},
+	],
+	review: [],
+	originalPublication: 'Éditions du Méridien (1971)',
+	publishedAt: '1971-01-01T00:00:00Z',
+	updatedAt: '1971-01-01T00:00:00Z',
+	approximateReadingTime: 6,
+	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
+	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	mediaSources: [],
+	resources: [],
+	tags: [],
+	author: rawOnoffAuthor,
+};

--- a/src/api/_mocks/onoff/el-palacio-de-las-nueve-fronteras.raw.mock.ts
+++ b/src/api/_mocks/onoff/el-palacio-de-las-nueve-fronteras.raw.mock.ts
@@ -1,0 +1,240 @@
+import type { StoryBySlugQueryResult } from '../../sanity/types';
+import { rawOnoffAuthor } from '../onoff-raw-author.mock';
+
+// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/el-palacio-de-las-nueve-fronteras.mock.ts (separación de capas:
+// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
+export const elPalacioRawStory: NonNullable<StoryBySlugQueryResult> = {
+	_id: 'onoff-story-el-palacio-de-las-nueve-fronteras',
+	slug: 'el-palacio-de-las-nueve-fronteras',
+	title: 'El palacio de las nueve fronteras',
+	badLanguage: false,
+	epigraphs: [],
+	body: [
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b1',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b1-s1',
+					text: 'La primera frontera no tiene nombre porque el nombre se quedó del otro lado, con los que no cruzaron. Avancé al amanecer, cuando la nieve aún no decidía si caer, y el funcionario que revisó mis papeles no levantó la vista. Escribí entonces la primera línea, que no era mía: era de un hombre que había visto caer una hora antes, en una plaza sin testigos, con un orden tan limpio que parecía ensayado.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b2',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b2-s1',
+					text: 'No lo conocía. Eso es lo que conviene aclarar antes de seguir: ',
+				},
+				{
+					_type: 'span',
+					_key: 'palacio-b2-s2',
+					marks: ['em'],
+					text: 'no lo conocía, y sin embargo le debía un cuerpo',
+				},
+				{
+					_type: 'span',
+					_key: 'palacio-b2-s3',
+					text: '. Lo había visto desplomarse y, en el segundo exacto en que su mirada se vaciaba, supe que esa mirada quedaba a mi cargo, como un equipaje que alguien deja en un andén y nadie reclama.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b3',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b3-s1',
+					text: 'En la segunda frontera se hablaba una lengua que se deshacía al pronunciarla. Las palabras servían una sola vez; después se enfriaban y caían al suelo como insectos. Aprendí a economizar. Aprendí, sobre todo, que escribir allí no era nombrar las cosas sino devolverles el calor que perdían apenas dichas.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b4',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b4-s1',
+					text: 'El palacio aparecía a lo lejos cada tantas jornadas, siempre del lado contrario al que yo iba. Tenía nueve muros y cada muro era una frontera, y dentro —me dijeron, nadie lo había visto— dormía el hombre que yo había visto caer. ',
+				},
+				{
+					_type: 'span',
+					_key: 'palacio-b4-s2',
+					marks: ['strong'],
+					text: 'Cruzar era escribir; escribir era acercarlo a su propio sueño.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b5',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b5-s1',
+					text: 'Le di primero el aliento. Es lo más fácil y lo más impúdico: bastó respirar despacio sobre la página hasta que el ritmo de mi pecho se volviera el suyo. Entonces el cuerpo, allá lejos, detrás de su muro, empezó a subir y bajar apenas, como una marea que recuerda de pronto que tiene una luna.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b6',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b6-s1',
+					text: 'La mirada fue más difícil. Una mirada no se inventa: se cede. Tuve que entregarle, en la cuarta frontera, lo que yo había visto esa mañana en la plaza, y al hacerlo perdí la imagen para siempre. ',
+				},
+				{
+					_type: 'span',
+					_key: 'palacio-b6-s2',
+					marks: ['em'],
+					text: 'Ahora él recuerda mi recuerdo, y yo cargo solamente el hueco con la forma exacta de aquello que le di.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b7',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b7-s1',
+					text: 'En la quinta frontera entendí que el orden se había invertido sin que yo lo notara. No era ya yo quien lo escribía a él. Era él, despertando de a poco contra el muro, quien empezaba a escribirme a mí: mis pasos, mi frío, la mano con que sostenía la pluma. ',
+				},
+				{
+					_type: 'span',
+					_key: 'palacio-b7-s2',
+					marks: ['strong'],
+					text: 'El durmiente había aprendido a soñar a su soñador.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b8',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b8-s1',
+					text: 'No me asustó tanto como debería. Hay un alivio antiguo en dejar de ser el origen de la propia frase. Quien cruza nueve fronteras desea, en secreto, que alguna lo cruce a él de vuelta, que alguien lo lea desde el otro lado y lo declare, por fin, escrito y terminado.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b9',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b9-s1',
+					text: 'La sexta y la séptima fronteras las atravesé casi sin escribir. Bastaba con que él soñara y yo apareciera, dócil, en la página de su sueño. Comía cuando él tenía hambre. Tenía sed con su sed. ',
+				},
+				{
+					_type: 'span',
+					_key: 'palacio-b9-s2',
+					marks: ['em'],
+					text: 'Mi biografía se había vuelto una nota al margen de la suya.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b10',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b10-s1',
+					text: 'En la octava frontera quise rebelarme. Escribí una frase que no le pertenecía, una frase enteramente mía, torpe, sin destino: el nombre de una mujer que tal vez no existió nunca. El muro tembló. Por un instante el palacio entero dudó de cuál de los dos era el autor, y en esa duda los dos respiramos por primera vez con el mismo pulmón.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b11',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b11-s1',
+					text: 'La novena frontera no era un muro. Era una página en blanco del tamaño de un país. Lo comprendí al pisarla: aquí no había nada escrito porque aquí debíamos escribirnos a la vez, él desde su sueño y yo desde mi vigilia, hasta que ninguna de las dos manos pudiera reclamar la última palabra.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b12',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b12-s1',
+					text: 'Le faltaba todavía la voz. Le había dado aliento, mirada, casi un cuerpo entero, pero los labios seguían quietos. ',
+				},
+				{
+					_type: 'span',
+					_key: 'palacio-b12-s2',
+					marks: ['strong'],
+					text: 'Para darle una voz tuve que perder la mía.',
+				},
+				{
+					_type: 'span',
+					_key: 'palacio-b12-s3',
+					text: ' Escribí el último gemido que le faltaba y, al escribirlo, dejé de oír el sonido de mi propio nombre cuando intentaba pronunciarlo.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'palacio-b13',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'palacio-b13-s1',
+					text: 'Entonces el hombre que yo había visto caer abrió los ojos contra el último muro, miró con mi mirada cedida, respiró con mi aliento prestado, y dijo, con la voz que acababa de quitarme, una sola frase. No la transcribo. La frase era yo: era todo lo que de mí quedaba ya escrito y vivo del otro lado de las nueve fronteras, y un autor no se cita a sí mismo en boca de aquello que terminó por escribirlo.',
+				},
+			],
+		},
+	],
+	review: [],
+	originalPublication: 'Éditions du Méridien (1985)',
+	publishedAt: '1985-01-01T00:00:00Z',
+	updatedAt: '1985-01-01T00:00:00Z',
+	approximateReadingTime: 11,
+	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
+	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	mediaSources: [],
+	resources: [],
+	tags: [],
+	author: rawOnoffAuthor,
+};

--- a/src/api/_mocks/onoff/el-palacio-de-las-nueve-fronteras.raw.mock.ts
+++ b/src/api/_mocks/onoff/el-palacio-de-las-nueve-fronteras.raw.mock.ts
@@ -1,8 +1,6 @@
 import type { StoryBySlugQueryResult } from '../../sanity/types';
 import { rawOnoffAuthor } from '../onoff-raw-author.mock';
 
-// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/el-palacio-de-las-nueve-fronteras.mock.ts (separación de capas:
-// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
 export const elPalacioRawStory: NonNullable<StoryBySlugQueryResult> = {
 	_id: 'onoff-story-el-palacio-de-las-nueve-fronteras',
 	slug: 'el-palacio-de-las-nueve-fronteras',

--- a/src/api/_mocks/onoff/el-tratado-de-los-placeres.raw.mock.ts
+++ b/src/api/_mocks/onoff/el-tratado-de-los-placeres.raw.mock.ts
@@ -1,8 +1,6 @@
 import type { StoryBySlugQueryResult } from '../../sanity/types';
 import { rawOnoffAuthor } from '../onoff-raw-author.mock';
 
-// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/el-tratado-de-los-placeres.mock.ts (separación de capas:
-// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
 export const elTratadoRawStory: NonNullable<StoryBySlugQueryResult> = {
 	_id: 'onoff-story-el-tratado-de-los-placeres',
 	slug: 'el-tratado-de-los-placeres',

--- a/src/api/_mocks/onoff/el-tratado-de-los-placeres.raw.mock.ts
+++ b/src/api/_mocks/onoff/el-tratado-de-los-placeres.raw.mock.ts
@@ -1,0 +1,262 @@
+import type { StoryBySlugQueryResult } from '../../sanity/types';
+import { rawOnoffAuthor } from '../onoff-raw-author.mock';
+
+// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/el-tratado-de-los-placeres.mock.ts (separación de capas:
+// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
+export const elTratadoRawStory: NonNullable<StoryBySlugQueryResult> = {
+	_id: 'onoff-story-el-tratado-de-los-placeres',
+	slug: 'el-tratado-de-los-placeres',
+	title: 'El tratado de los placeres',
+	badLanguage: false,
+	epigraphs: [],
+	body: [
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b1',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b1-s1',
+					text: 'Conviene advertir, antes de toda enumeración, que un tratado de los placeres no es un repertorio de placeres sino su contrario exacto. Quien escribe ',
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b1-s2',
+					text: 'esto',
+					marks: ['em'],
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b1-s3',
+					text: ' ya ha dejado de gozar; ha pasado al otro lado de la mesa, donde se mide y se nombra.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b2',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b2-s1',
+					text: 'El primer placer que registramos es el del orden. Lo situamos arriba, no por su intensidad, sino porque preside a los demás: es la voluntad de poner cada cosa en su sitio, de saber dónde duerme cada apetito. Quien lo posee cree dominar a los otros placeres; en rigor, los ha sustituido por su catálogo.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b3',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b3-s1',
+					text: 'Sigue el placer de la mesa, que parece concreto y resulta el más huidizo. Lo describimos por sus instrumentos —el peso del cubierto, la temperatura del vino, el orden de los platos— porque el sabor mismo se niega a comparecer. ',
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b3-s2',
+					text: 'Nombrar un sabor es ya haberlo perdido.',
+					marks: ['strong'],
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b4',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b4-s1',
+					text: 'Del placer del cuerpo diremos poco, y ese poco lo diremos en tercera persona, como si le ocurriera a otro. Es la única manera honesta de catalogarlo: el que goza no clasifica, y el que clasifica recuerda. Entre ambos hay una distancia que ningún tratado consigue cerrar.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b5',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b5-s1',
+					text: 'Hay un placer menor, casi vergonzante, que es el de la anticipación. Se lo suele confundir con la esperanza, pero la esperanza mira un objeto y la anticipación se contempla a sí misma. Goza de la víspera y teme la fiesta. ',
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b5-s2',
+					text: 'Es, quizá, el más fiel de todos: nunca llega tarde porque nunca llega.',
+					marks: ['em'],
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b6',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b6-s1',
+					text: 'El placer de la conversación merecería un capítulo aparte si no fuera, él mismo, el aparte de todos los demás. Se lo reconoce en que no deja residuo: terminada la charla, no queda nada que pueda guardarse, salvo la certeza de haber estado, por un rato, exento del propio peso.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b7',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b7-s1',
+					text: 'Llegamos al placer de la lectura, que es el más sospechoso de cuantos hemos inventariado, porque se disfraza de los otros. El lector cree comer, viajar, amar; en verdad sólo asiste a la descripción de esas cosas. ',
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b7-s2',
+					text: 'Quien lee un tratado de los placeres no goza: estudia su propia renuncia.',
+					marks: ['strong'],
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b8',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b8-s1',
+					text: 'Advierto, hacia la mitad del inventario, que el método se vuelve contra el objeto. Cada placer, en cuanto recibe su número y su definición, se enfría sobre la página como un insecto bajo el alfiler. Conservo la forma; pierdo la criatura.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b9',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b9-s1',
+					text: 'Queda, entonces, un solo placer no contaminado por la lista, y es el de hacer la lista. ',
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b9-s2',
+					text: 'El deseo de clasificar',
+					marks: ['em'],
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b9-s3',
+					text: ' sobrevive a todo lo clasificado; es el apetito que se alimenta de los apetitos ajenos y no se sacia con ninguno.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b10',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b10-s1',
+					text: 'Por eso este tratado, que prometía un orden, se desordena desde dentro. No falla por exceso ni por defecto, sino por su naturaleza: ',
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b10-s2',
+					text: 'toda taxonomía del goce es una manera elegante de no gozar.',
+					marks: ['strong'],
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b12',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b12-s1',
+					text: 'Hacia el final intenté una entrada nueva, la más ambiciosa: el placer de renunciar a clasificar. Pero apenas lo nombré, ya estaba ',
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b12-s2',
+					text: 'dentro del sistema',
+					marks: ['em'],
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b12-s3',
+					text: ', convertido en una casilla más. No hay afuera del catálogo para quien escribe catálogos.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b13',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b13-s1',
+					text: 'Tardé en admitir lo que el cuaderno repetía en cada margen: ',
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b13-s2',
+					text: 'el deseo no se deja inventariar sin morir un poco',
+					marks: ['strong'],
+				},
+				{
+					_type: 'span',
+					_key: 'tratado-b13-s3',
+					text: '. Cada definición era una pequeña autopsia, y yo, su forense más fiel.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'tratado-b11',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'tratado-b11-s1',
+					text: 'Cierro el cuaderno donde lo abrí. Los placeres siguen, indiferentes a sus nombres, ocurriendo en otra parte, en cuerpos que no leen. Y el clasificador, fiel a su único vicio, levanta la pluma y se queda mirando la página en blanco, que es la antesala de un silencio mucho más grande.',
+				},
+			],
+		},
+	],
+	review: [],
+	originalPublication: 'Éditions du Méridien (1981)',
+	publishedAt: '1981-01-01T00:00:00Z',
+	updatedAt: '1981-01-01T00:00:00Z',
+	approximateReadingTime: 10,
+	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
+	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	mediaSources: [],
+	resources: [],
+	tags: [],
+	author: rawOnoffAuthor,
+};

--- a/src/api/_mocks/onoff/geometria.raw.mock.ts
+++ b/src/api/_mocks/onoff/geometria.raw.mock.ts
@@ -1,0 +1,260 @@
+import type { StoryBySlugQueryResult } from '../../sanity/types';
+import { rawOnoffAuthor } from '../onoff-raw-author.mock';
+
+// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/geometria.mock.ts (separación de capas:
+// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
+export const geometriaRawStory: NonNullable<StoryBySlugQueryResult> = {
+	_id: 'onoff-story-geometria',
+	slug: 'geometria',
+	title: 'Geometría',
+	badLanguage: false,
+	epigraphs: [],
+	body: [
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b1',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b1-s1',
+					text: 'A las tres y media en punto, sin que ningún despertador lo convoque, Shannon abre los ojos. La oscuridad de la habitación tiene siempre el mismo peso, el mismo gramaje exacto, como si la noche hubiera sido recortada con escuadra. No hay sobresalto: hay precisión.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b2',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b2-s1',
+					text: 'Durante años creyó que padecía un trastorno. Más tarde comprendió que se trataba de otra cosa: ',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b2-s2',
+					marks: ['em'],
+					text: 'una vocación involuntaria por la medida',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b2-s3',
+					text: '. El cuerpo se había vuelto instrumento, y el tiempo, materia que podía trazarse.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b3',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b3-s1',
+					text: 'Se incorporaba sin encender la luz. Conocía la distancia entre la cama y la ventana con una certeza que no admitía error: once pasos, ni uno más. El piso frío bajo los pies descalzos era la primera coordenada de la madrugada.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b4',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b4-s1',
+					text: 'Dormía, a lo sumo, dos horas. Lo sabía no por reloj sino por una aritmética interna, exacta e inflexible. ',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b4-s2',
+					marks: ['strong'],
+					text: 'El sueño era un segmento, no un océano',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b4-s3',
+					text: ': tenía principio, fin y una longitud que jamás se desbordaba.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b5',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b5-s1',
+					text: 'En la cocina, a oscuras, trazaba con la mente el perímetro de la mesa. Calculaba ángulos, hipotenusas imaginarias, la diagonal exacta que iba del picaporte a la silla. El insomnio le había enseñado que todo objeto encierra un teorema.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b6',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b6-s1',
+					text: 'Los vecinos dormían el sueño informe de los que no miden. Shannon los compadecía un poco. ',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b6-s2',
+					marks: ['em'],
+					text: 'Ellos atravesaban la noche como quien cae; él la recorría como quien dibuja',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b6-s3',
+					text: '.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b7',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b7-s1',
+					text: 'Tenía cuadernos llenos de horarios. No anotaba pensamientos ni recuerdos: anotaba cifras. La hora de despertar, la duración del desvelo, los minutos que tardaba el agua en hervir. Su biografía era una tabla de coordenadas sin una sola palabra.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b8',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b8-s1',
+					text: 'A veces se preguntaba qué habría al otro lado de la regularidad. ',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b8-s2',
+					marks: ['strong'],
+					text: 'Una madrugada sin medida le parecía tan inconcebible como una recta sin dirección',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b8-s3',
+					text: '. La sola idea le producía un vértigo limpio, casi geométrico.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b9',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b9-s1',
+					text: 'La ventana daba a un patio interior donde la luna, cuando aparecía, proyectaba sombras de una nitidez quirúrgica. Shannon estudiaba esas sombras como un cartógrafo: sabía a qué hora la diagonal del marco tocaría el borde exacto de la baldosa.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b10',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b10-s1',
+					text: 'No se aburría. El aburrimiento, pensaba, es de quienes no observan. Él tenía un mundo entero que medir: el goteo de un grifo, la dilatación del frío, ',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b10-s2',
+					marks: ['em'],
+					text: 'la lentísima rotación de la madrugada sobre su propio eje',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b10-s3',
+					text: '.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b11',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b11-s1',
+					text: 'Cuando al fin volvía a la cama, ya cerca del amanecer, lo hacía con la satisfacción serena de quien ha completado una figura. El desvelo había sido trazado de extremo a extremo, sin un solo punto fuera de lugar.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b12',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b12-s1',
+					text: 'El día, en cambio, le resultaba impreciso, lleno de horarios elásticos y conversaciones sin escuadra. ',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b12-s2',
+					marks: ['strong'],
+					text: 'Solo en la madrugada el mundo aceptaba ser medido',
+				},
+				{
+					_type: 'span',
+					_key: 'geometria-b12-s3',
+					text: ', y por eso esperaba cada noche, sin temor, el llamado puntual de las tres y media.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'geometria-b13',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'geometria-b13-s1',
+					text: 'No le pediría a nadie que lo entendiera. Su manía horaria no era una enfermedad ni un castigo: era una forma de mirar. Una geometría exacta del tiempo donde, por fin, todo coincidía consigo mismo.',
+				},
+			],
+		},
+	],
+	review: [],
+	originalPublication: 'Éditions du Méridien (1974)',
+	publishedAt: '1974-01-01T00:00:00Z',
+	updatedAt: '1974-01-01T00:00:00Z',
+	approximateReadingTime: 7,
+	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
+	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	mediaSources: [],
+	resources: [],
+	tags: [],
+	author: rawOnoffAuthor,
+};

--- a/src/api/_mocks/onoff/geometria.raw.mock.ts
+++ b/src/api/_mocks/onoff/geometria.raw.mock.ts
@@ -1,8 +1,6 @@
 import type { StoryBySlugQueryResult } from '../../sanity/types';
 import { rawOnoffAuthor } from '../onoff-raw-author.mock';
 
-// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/geometria.mock.ts (separación de capas:
-// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
 export const geometriaRawStory: NonNullable<StoryBySlugQueryResult> = {
 	_id: 'onoff-story-geometria',
 	slug: 'geometria',

--- a/src/api/_mocks/onoff/las-dos-antorchas.raw.mock.ts
+++ b/src/api/_mocks/onoff/las-dos-antorchas.raw.mock.ts
@@ -1,0 +1,271 @@
+import type { StoryBySlugQueryResult } from '../../sanity/types';
+import { rawOnoffAuthor } from '../onoff-raw-author.mock';
+
+// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/las-dos-antorchas.mock.ts (separación de capas:
+// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
+export const lasDosAntorchasRawStory: NonNullable<StoryBySlugQueryResult> = {
+	_id: 'onoff-story-las-dos-antorchas',
+	slug: 'las-dos-antorchas',
+	title: 'Las dos antorchas',
+	badLanguage: false,
+	epigraphs: [],
+	body: [
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b1',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b1-s1',
+					text: 'El corredor no tenía principio que alguien recordara. Avanzábamos por él como se avanza en un cálculo: sin esperanza de llegada, atentos sólo a no perder el hilo. Dos antorchas iban con nosotros, una a cada lado, y desde el primer paso comprendí que nunca alumbrarían lo mismo.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b2',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b2-s1',
+					text: 'La de la derecha mostraba la piedra: su grano, su humedad, las venas minerales que la atravesaban como una escritura anterior a toda lengua. La de la izquierda mostraba ',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b2-s2',
+					marks: ['em'],
+					text: 'la sombra de esa misma piedra',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b2-s3',
+					text: ', y la sombra parecía más exacta que el muro que la proyectaba.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b3',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b3-s1',
+					text: 'Ningún portador sostenía las antorchas. Iban a la altura de los hombros, a una distancia constante una de otra, y entre las dos quedaba un intervalo de oscuridad que ninguna de ellas se decidía a invadir. En ese intervalo, supe después, ocurría todo lo que importaba.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b4',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b4-s1',
+					text: 'Quise acercarlas. Bastó que extendiera la mano hacia una para que la otra retrocediera la misma medida, como si obedecieran a una ley de conservación. ',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b4-s2',
+					marks: ['strong'],
+					text: 'La distancia era el sentido',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b4-s3',
+					text: ', y la distancia se defendía sola.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b5',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b5-s1',
+					text: 'Había estudiado el caso años atrás, en una monografía que nadie leyó. Allí escribí que dos fuentes de luz convergentes anulan la sombra. La proposición era correcta y por eso no servía. Estas antorchas no convergían: avanzaban en paralelo, fieles a un eje que jamás se cruzaba, y por eso la sombra sobrevivía indefinidamente.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b6',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b6-s1',
+					text: 'La piedra y su sombra no eran dos versiones de una misma cosa. Eran ',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b6-s2',
+					marks: ['em'],
+					text: 'dos cosas que se negaban a coincidir',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b6-s3',
+					text: ', y la novela —porque entonces entendí que avanzaba dentro de una novela— consistía en sostener esa negativa el mayor tiempo posible.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b7',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b7-s1',
+					text: 'A intervalos regulares el corredor se bifurcaba, y en cada bifurcación las antorchas tomaban ramales distintos. Yo no podía seguir a las dos. Elegía una, y la otra seguía ardiendo en su pasillo, alumbrando una piedra o una sombra que ya no vería nunca. La elección no resolvía la dualidad: la mutilaba.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b8',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b8-s1',
+					text: 'Quien siga a la derecha, leí grabado en el dintel de una de las bifurcaciones, conocerá la materia y olvidará su forma. ',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b8-s2',
+					marks: ['strong'],
+					text: 'Quien siga a la izquierda conocerá la forma y olvidará la materia',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b8-s3',
+					text: '. No había una tercera inscripción para quien quisiera ambas, porque ese camino no existía.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b9',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b9-s1',
+					text: 'Soñé, o creí soñar, que las dos antorchas se apagaban a la vez. En esa oscuridad total la piedra y la sombra eran por fin idénticas, indistinguibles, una sola cosa perfecta y muerta. Desperté con la certeza de que la identidad es la forma más cortés del aniquilamiento.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b10',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b10-s1',
+					text: 'Entonces volví a abrir los ojos y las dos luces seguían ahí, prudentes, separadas, negándose con una obstinación casi tierna a alumbrar lo mismo. ',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b10-s2',
+					marks: ['em'],
+					text: 'Comprendí que su distancia me mantenía vivo',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b10-s3',
+					text: ', y dejé de querer juntarlas.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b12',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b12-s1',
+					text: 'Probé, una noche, apagar una de las dos. Quería saber si la otra bastaba, si el muro existía sin su sombra o la sombra sin su muro. La oscuridad que siguió no era una ni dos: era ',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b12-s2',
+					text: 'ninguna',
+					marks: ['em'],
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b12-s3',
+					text: ', un país sin contorno donde mi propia mano dejó de pertenecerme.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b13',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b13-s1',
+					text: 'Volví a encenderla con dedos que no reconocía. ',
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b13-s2',
+					text: 'Dos llamas, dos lecturas, dos verdades que no se tocan',
+					marks: ['strong'],
+				},
+				{
+					_type: 'span',
+					_key: 'antorchas-b13-s3',
+					text: ': comprendí que el corredor no me pedía elegir sino sostener la distancia. Caminar era eso: no avanzar, sino mantener abierto el intervalo.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'antorchas-b11',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'antorchas-b11-s1',
+					text: 'Sigo caminando. No sé si el corredor avanza conmigo o si soy yo quien se repite. La piedra a un lado, la sombra al otro, y en medio el intervalo intacto donde no me atrevo a entrar. Dicen que al final del corredor las dos antorchas se funden en una. Espero, con todas mis fuerzas, no llegar nunca al final.',
+				},
+			],
+		},
+	],
+	review: [],
+	originalPublication: 'Éditions du Méridien (1987)',
+	publishedAt: '1987-01-01T00:00:00Z',
+	updatedAt: '1987-01-01T00:00:00Z',
+	approximateReadingTime: 8,
+	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
+	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	mediaSources: [],
+	resources: [],
+	tags: [],
+	author: rawOnoffAuthor,
+};

--- a/src/api/_mocks/onoff/las-dos-antorchas.raw.mock.ts
+++ b/src/api/_mocks/onoff/las-dos-antorchas.raw.mock.ts
@@ -1,8 +1,6 @@
 import type { StoryBySlugQueryResult } from '../../sanity/types';
 import { rawOnoffAuthor } from '../onoff-raw-author.mock';
 
-// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/las-dos-antorchas.mock.ts (separación de capas:
-// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
 export const lasDosAntorchasRawStory: NonNullable<StoryBySlugQueryResult> = {
 	_id: 'onoff-story-las-dos-antorchas',
 	slug: 'las-dos-antorchas',

--- a/src/api/_mocks/onoff/las-escaleras.raw.mock.ts
+++ b/src/api/_mocks/onoff/las-escaleras.raw.mock.ts
@@ -1,8 +1,6 @@
 import type { StoryBySlugQueryResult } from '../../sanity/types';
 import { rawOnoffAuthor } from '../onoff-raw-author.mock';
 
-// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/las-escaleras.mock.ts (separación de capas:
-// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
 export const lasEscalerasRawStory: NonNullable<StoryBySlugQueryResult> = {
 	_id: 'onoff-story-las-escaleras',
 	slug: 'las-escaleras',

--- a/src/api/_mocks/onoff/las-escaleras.raw.mock.ts
+++ b/src/api/_mocks/onoff/las-escaleras.raw.mock.ts
@@ -1,0 +1,247 @@
+import type { StoryBySlugQueryResult } from '../../sanity/types';
+import { rawOnoffAuthor } from '../onoff-raw-author.mock';
+
+// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/las-escaleras.mock.ts (separación de capas:
+// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
+export const lasEscalerasRawStory: NonNullable<StoryBySlugQueryResult> = {
+	_id: 'onoff-story-las-escaleras',
+	slug: 'las-escaleras',
+	title: 'Las escaleras',
+	badLanguage: false,
+	epigraphs: [],
+	body: [
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b1',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b1-s1',
+					text: 'Dos años después la encontré donde la había dejado, al pie de la escalera, midiendo con el pulgar la distancia exacta que separaba un peldaño del siguiente. La Sra. Oneiras no había envejecido; se había vuelto más precisa, como una cifra que se repite hasta perder su sentido.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b2',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b2-s1',
+					text: 'Me dijo que había aprendido a subir sin tocar la baranda y que eso, en su geometría privada, equivalía a un perdón. Yo no entendí, pero anoté la frase ',
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b2-s2',
+					text: 'subir sin tocar la baranda',
+					marks: ['em'],
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b2-s3',
+					text: ' en el reverso de un billete que ya no servía para ningún tranvía.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b3',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b3-s1',
+					text: 'El edificio tenía trece escaleras y ninguna conducía a un piso distinto. Eran trece maneras de quedarse en el mismo sitio, trece insistencias del mármol sobre la misma idea fría: que ascender y permanecer son, vistos desde arriba, el mismo gesto.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b4',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b4-s1',
+					text: 'El tercer capítulo del libro que ella sostenía se titulaba ',
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b4-s2',
+					text: 'El regreso del druso',
+					marks: ['strong'],
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b4-s3',
+					text: ', y allí, entre dos descripciones de polvo, hablaba el príncipe Cosme la víspera de colocar los mosaicos.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b5',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b5-s1',
+					text: 'El príncipe Cosme imaginaba un parque poblado de hombres arrodillados, cada uno fijado en su acto de devoción como un insecto en ámbar, y entre ellos bailarines abandonados a mitad de un giro que ya nadie recordaría haber pedido.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b6',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b6-s1',
+					text: 'En las paredes del fondo, dijo el príncipe, irían los frescos: ',
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b6-s2',
+					text: 'figuras en cuclillas en la sombra',
+					marks: ['em'],
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b6-s3',
+					text: ', tan quietas que el visitante dudaría si esperan algo o si ya lo han recibido y guardan silencio por cortesía.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b7',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b7-s1',
+					text: 'La Sra. Oneiras leyó ese discurso en voz alta, sin levantar la vista, y cuando llegó a la palabra ',
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b7-s2',
+					text: 'mosaicos',
+					marks: ['strong'],
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b7-s3',
+					text: ' hizo una pausa exacta, como si entre dos teselas cupiera todo lo que no nos habíamos dicho en dos años.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b8',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b8-s1',
+					text: 'Comprendí entonces que el libro y la escalera eran un díptico del desencuentro: en un panel, el príncipe ordenaba un jardín que nunca pisaría; en el otro, nosotros subíamos hacia una conversación que ya había terminado antes de empezar.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b9',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b9-s1',
+					text: 'Los hombres arrodillados del fresco imaginario se parecían a nosotros más de lo que ella habría tolerado admitir: fijados en una postura de espera, devotos de una cosa que no llegaba, decentes y vencidos a la vez.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b10',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b10-s1',
+					text: 'Le pregunté si los bailarines abandonados volverían alguna vez al compás. Respondió que un bailarín abandonado no es el que dejó de bailar, sino ',
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b10-s2',
+					text: 'aquel a quien la música dejó de mirar',
+					marks: ['em'],
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b10-s3',
+					text: ', y cerró el libro con la cautela de quien clausura un parque al anochecer.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b11',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b11-s1',
+					text: 'La ruptura no tuvo escena. Fue una sustracción: un peldaño que dejó de existir entre nosotros sin que ninguno lo viera caer, y de pronto había un tramo más largo, una sombra donde antes apoyábamos el pie con confianza.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'escaleras-b12',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'escaleras-b12-s1',
+					text: 'Bajó la Sra. Oneiras los trece tramos sin tocar la baranda, fiel hasta el final a su único perdón disponible. Yo me quedé arriba, entre las ',
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b12-s2',
+					text: 'figuras en cuclillas',
+					marks: ['strong'],
+				},
+				{
+					_type: 'span',
+					_key: 'escaleras-b12-s3',
+					text: ' que el príncipe Cosme nunca llegó a colocar, esperando que la sombra terminara de cubrir el díptico.',
+				},
+			],
+		},
+	],
+	review: [],
+	originalPublication: 'Éditions du Méridien (1979)',
+	publishedAt: '1979-01-01T00:00:00Z',
+	updatedAt: '1979-01-01T00:00:00Z',
+	approximateReadingTime: 9,
+	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
+	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	mediaSources: [],
+	resources: [],
+	tags: [],
+	author: rawOnoffAuthor,
+};

--- a/src/api/_mocks/onoff/los-peldanos.raw.mock.ts
+++ b/src/api/_mocks/onoff/los-peldanos.raw.mock.ts
@@ -1,0 +1,250 @@
+import type { StoryBySlugQueryResult } from '../../sanity/types';
+import { rawOnoffAuthor } from '../onoff-raw-author.mock';
+
+// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/los-peldanos.mock.ts (separación de capas:
+// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
+export const losPeldanosRawStory: NonNullable<StoryBySlugQueryResult> = {
+	_id: 'onoff-story-los-peldanos',
+	slug: 'los-peldanos',
+	title: 'Los peldaños',
+	badLanguage: false,
+	epigraphs: [],
+	body: [
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b1',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b1-s1',
+					text: 'La escalera empezaba en ninguna parte y terminaba un poco más arriba de eso. La Sra. Oneiras vivía en alguno de sus peldaños, aunque jamás conseguí determinar en cuál, porque cada vez que creía haberlo hecho el peldaño se desplazaba, o yo me desplazaba, o el día entero cambiaba de número sin avisarle a nadie.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b2',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b2-s1',
+					text: 'A las nueve, o a una hora que ocupaba el lugar de las nueve, sacaba del bolsillo de la falda un trozo de pescado hervido. Lo comía con una lentitud sin hambre, mirando fijamente el aire que tenía delante, ',
+				},
+				{
+					_type: 'span',
+					_key: 'peldanos-b2-s2',
+					marks: ['em'],
+					text: 'como si en ese aire hubiera otra escalera que sólo ella supiera subir.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b3',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b3-s1',
+					text: 'Yo subía hacia ella. Ella no subía hacia mí. Eran dos hechos que no se tocaban en ningún punto, dos líneas paralelas que alguien, por economía, había decidido dibujar en la misma página.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b4',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b4-s1',
+					text: 'Cuando pasaba a mi lado lo hacía a un centímetro exacto, ni más ni menos, con la precisión de quien ha medido tantas veces el vacío que ya no necesita mirarlo. ',
+				},
+				{
+					_type: 'span',
+					_key: 'peldanos-b4-s2',
+					marks: ['strong'],
+					text: 'No me veía.',
+				},
+				{
+					_type: 'span',
+					_key: 'peldanos-b4-s3',
+					text: ' No es que me ignorara: ignorar exige reconocer primero, y ese trabajo previo ella nunca lo hacía.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b5',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b5-s1',
+					text: 'Comprendí, con el tiempo que allí no avanzaba, que subir y bajar peldaños no era para ella un desplazamiento. Era un estado de ánimo. Bajaba cuando estaba triste y subía cuando la tristeza, cansada, se volvía costumbre.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b6',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b6-s1',
+					text: 'Una tarde le hablé. Las palabras salieron de mí, cruzaron el centímetro reglamentario y se quedaron flotando en el rellano, ',
+				},
+				{
+					_type: 'span',
+					_key: 'peldanos-b6-s2',
+					marks: ['em'],
+					text: 'mojadas, inútiles, como peces devueltos al aire en lugar de al agua.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b7',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b7-s1',
+					text: 'Su nombre, me dijeron en el descansillo, venía de una lengua antigua donde significaba sueño. Por eso, supuse, dormía despierta y caminaba dormida, y por eso su pescado hervido sabía siempre a una comida que se come en otro cuarto.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b8',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b8-s1',
+					text: 'Hubo un día, o lo que el edificio llamaba día, en que conté los peldaños. Eran ',
+				},
+				{
+					_type: 'span',
+					_key: 'peldanos-b8-s2',
+					marks: ['strong'],
+					text: 'diecisiete',
+				},
+				{
+					_type: 'span',
+					_key: 'peldanos-b8-s3',
+					text: ' al subir y catorce al bajar, y nadie en la casa encontró eso digno de alarma, salvo yo, que ya empezaba a no pertenecer del todo a mí mismo.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b9',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b9-s1',
+					text: 'La Sra. Oneiras no cerraba nunca la boca del todo. Por la rendija se le escapaba un aire frío que olía a mar de invierno, y ese aire, decían los otros inquilinos, era lo único suyo que de verdad existía.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b10',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b10-s1',
+					text: 'Intenté seguirla una vez hasta arriba. Subí los diecisiete peldaños y, al llegar, ',
+				},
+				{
+					_type: 'span',
+					_key: 'peldanos-b10-s2',
+					marks: ['em'],
+					text: 'no había arriba.',
+				},
+				{
+					_type: 'span',
+					_key: 'peldanos-b10-s3',
+					text: ' Había, en cambio, otro tramo idéntico, y al final de ese tramo ella, comiendo el mismo trozo de pescado por primera vez de nuevo.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b11',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b11-s1',
+					text: 'Aprendí a no esperar que me devolviera la mirada. Uno no le pide a una escalera que lo recuerde; uno sube, y si la escalera es amable, lo deja llegar a otra parte de sí mismo.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b12',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b12-s1',
+					text: 'La última vez que la vi bajaba muy despacio, con el trozo de pescado intacto en la mano, ',
+				},
+				{
+					_type: 'span',
+					_key: 'peldanos-b12-s2',
+					marks: ['strong'],
+					text: 'sin estado de ánimo alguno',
+				},
+				{
+					_type: 'span',
+					_key: 'peldanos-b12-s3',
+					text: ', como quien ha descubierto que también la tristeza tiene un fondo y que ese fondo, igual que el resto, no lleva a ningún sitio.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'peldanos-b13',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'peldanos-b13-s1',
+					text: 'Ahora soy yo quien vive en un peldaño que no consigo precisar. A veces, al pasar, alguien me habla a un centímetro de la oreja y yo no lo veo, y entiendo, demasiado tarde y de un modo que ya no me sirve, qué clase de sueño era ella.',
+				},
+			],
+		},
+	],
+	review: [],
+	originalPublication: 'Éditions du Méridien (1977)',
+	publishedAt: '1977-01-01T00:00:00Z',
+	updatedAt: '1977-01-01T00:00:00Z',
+	approximateReadingTime: 8,
+	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
+	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	mediaSources: [],
+	resources: [],
+	tags: [],
+	author: rawOnoffAuthor,
+};

--- a/src/api/_mocks/onoff/los-peldanos.raw.mock.ts
+++ b/src/api/_mocks/onoff/los-peldanos.raw.mock.ts
@@ -1,8 +1,6 @@
 import type { StoryBySlugQueryResult } from '../../sanity/types';
 import { rawOnoffAuthor } from '../onoff-raw-author.mock';
 
-// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/los-peldanos.mock.ts (separación de capas:
-// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
 export const losPeldanosRawStory: NonNullable<StoryBySlugQueryResult> = {
 	_id: 'onoff-story-los-peldanos',
 	slug: 'los-peldanos',

--- a/src/api/_mocks/onoff/neron.raw.mock.ts
+++ b/src/api/_mocks/onoff/neron.raw.mock.ts
@@ -1,0 +1,273 @@
+import type { StoryBySlugQueryResult } from '../../sanity/types';
+import { rawOnoffAuthor } from '../onoff-raw-author.mock';
+
+// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/neron.mock.ts (separación de capas:
+// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
+export const neronRawStory: NonNullable<StoryBySlugQueryResult> = {
+	_id: 'onoff-story-neron',
+	slug: 'neron',
+	title: 'Nerón',
+	badLanguage: false,
+	epigraphs: [],
+	body: [
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b1',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b1-s1',
+					text: 'Escribí Nerón porque creí, durante algunos meses, que el incendio podía contarse desde adentro. Me equivoqué con método y precisión, que son las dos únicas formas decentes de equivocarse.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b2',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b2-s1',
+					text: 'Era mi primera obra para la escena, y también la última. Hay decisiones que uno toma una sola vez y que después, vistas a distancia, se parecen demasiado a una ',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b2-s2',
+					marks: ['em'],
+					text: 'condena',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b2-s3',
+					text: ' firmada de antemano.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b3',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b3-s1',
+					text: 'En la página, el emperador me obedecía. Cada frase suya era una frase mía dispuesta a ser leída en el orden exacto, sin testigos, sin cuerpos, sin esa humedad insoportable que tiene la voz de los otros.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b4',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b4-s1',
+					text: 'La dirigí yo mismo. La dirigí ',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b4-s2',
+					marks: ['strong'],
+					text: 'muy mal',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b4-s3',
+					text: ', con la torpeza desdeñosa del que cree que la escena es apenas una página vertical y respira por error.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b5',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b5-s1',
+					text: 'Descubrí entonces, tarde, la diferencia entre la palabra escrita y la palabra dicha. La escrita es mía hasta el punto final. La dicha pertenece, en el instante mismo de pronunciarse, a quien la escucha.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b6',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b6-s1',
+					text: 'Yo había construido toda una vida sobre la primera certeza. La frase que se queda quieta, que se relee, que no envejece entre el sujeto y el predicado. La frase ',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b6-s2',
+					marks: ['em'],
+					text: 'que no respira',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b6-s3',
+					text: '.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b7',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b7-s1',
+					text: 'En el escenario, en cambio, todo se corrompía a la velocidad de un pulmón. Un actor tomaba mi línea más pulida y la ensuciaba con saliva, con miedo, con su biografía pequeña y ajena a la mía.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b8',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b8-s1',
+					text: 'Comprendí que Nerón no incendiaba Roma: incendiaba el silencio. Y que yo, sentado en la última fila, asistía sin entenderlo del todo al incendio de mi propio ',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b8-s2',
+					marks: ['strong'],
+					text: 'método',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b8-s3',
+					text: '.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b9',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b9-s1',
+					text: 'Hay un límite, y la noche del estreno lo toqué con las dos manos. El límite no está en lo que uno sabe escribir, sino en lo que uno se niega a entregar a la boca de otro.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b10',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b10-s1',
+					text: 'El público aplaudió con cortesía, que es la forma más exacta del desprecio. Yo no quería cortesía. Quería el viejo orden de la página, donde nadie aplaude porque nadie está, y la frase queda sola conmigo.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b11',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b11-s1',
+					text: 'Después del estreno vino el silencio. No el silencio del que no tiene nada que decir, sino el del que ha visto, con una claridad ',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b11-s2',
+					marks: ['em'],
+					text: 'demasiado nítida',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b11-s3',
+					text: ', dónde termina aquello que sabe hacer.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b12',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b12-s1',
+					text: 'Dejé de escribir como quien deja de respirar a propósito: con una disciplina que los otros confundieron con orgullo, y que era apenas el respeto frío de un hombre por su propia frontera.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b13',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b13-s1',
+					text: 'Entre lo que se escribe y lo que se calla pasa una línea fina, y yo aprendí a habitarla. La palabra dicha me había mostrado el abismo; la palabra ',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b13-s2',
+					marks: ['strong'],
+					text: 'callada',
+				},
+				{
+					_type: 'span',
+					_key: 'neron-b13-s3',
+					text: ' fue mi última obra, la que nadie dirigió mal porque nadie la dirigió.',
+				},
+			],
+		},
+		{
+			_type: 'block',
+			style: 'normal',
+			_key: 'neron-b14',
+			markDefs: [],
+			children: [
+				{
+					_type: 'span',
+					_key: 'neron-b14-s1',
+					text: 'De Nerón me queda esto: la certeza de que un imperio se incendia más rápido por dentro, y de que el incendio más callado de todos es el de un hombre que decide, por fin, no decir.',
+				},
+			],
+		},
+	],
+	review: [],
+	originalPublication: 'Estreno teatral (1988)',
+	publishedAt: '1988-01-01T00:00:00Z',
+	updatedAt: '1988-01-01T00:00:00Z',
+	approximateReadingTime: 7,
+	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
+	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	mediaSources: [],
+	resources: [],
+	tags: [],
+	author: rawOnoffAuthor,
+};

--- a/src/api/_mocks/onoff/neron.raw.mock.ts
+++ b/src/api/_mocks/onoff/neron.raw.mock.ts
@@ -1,8 +1,6 @@
 import type { StoryBySlugQueryResult } from '../../sanity/types';
 import { rawOnoffAuthor } from '../onoff-raw-author.mock';
 
-// Cuerpo replicado verbatim del campo `paragraphs` de src/app/mocks/onoff/neron.mock.ts (separación de capas:
-// la capa API no importa del frontend). Espeja el shape crudo de GROQ `storyBySlugQuery` (`body` = BlockContent).
 export const neronRawStory: NonNullable<StoryBySlugQueryResult> = {
 	_id: 'onoff-story-neron',
 	slug: 'neron',

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -1,4 +1,5 @@
 import { mapStoryNavigationTeaser, mapStoryNavigationTeaserWithAuthor, mapStoryTeaser, mapTags } from './functions';
+import { elOdioRawTeaser, onoffRawNavTeasersMock } from '../_mocks/onoff-raw-stories.mock';
 
 describe('mapTags (ACL)', () => {
 	it('maps a raw Sanity tag to the domain Tag model', () => {
@@ -75,38 +76,9 @@ describe('mapTags (ACL)', () => {
 });
 
 // El input crudo no incluye `tags`: el mapper es la única fuente del campo vacío (consistente con `mapAuthorTeaser`).
-function rawStoryTeaserItem() {
-	return {
-		_id: 'story-1',
-		slug: 'historia-1',
-		title: 'Historia 1',
-		badLanguage: false,
-		body: [],
-		originalPublication: '',
-		approximateReadingTime: 2,
-		coverImage: null,
-		mediaSources: [],
-		resources: [],
-	};
-}
-
-function rawAuthorTeaser() {
-	return {
-		_id: 'author-1',
-		slug: 'autor',
-		name: 'Autor',
-		image: null,
-		nationality: { country: 'AR', flag: null },
-		bornOn: null,
-		bornOnYear: null,
-		diedOn: null,
-		diedOnYear: null,
-	};
-}
-
 describe('mapStoryTeaser (ACL)', () => {
 	it('sets tags to [] from the mapper, not from the raw spread', () => {
-		const result = mapStoryTeaser([rawStoryTeaserItem()] as unknown as Parameters<typeof mapStoryTeaser>[0]);
+		const result = mapStoryTeaser([elOdioRawTeaser]);
 
 		expect(result[0].tags).toEqual([]);
 	});
@@ -114,9 +86,7 @@ describe('mapStoryTeaser (ACL)', () => {
 
 describe('mapStoryNavigationTeaser (ACL)', () => {
 	it('sets tags to [] from the mapper, not from the raw spread', () => {
-		const result = mapStoryNavigationTeaser([rawStoryTeaserItem()] as unknown as Parameters<
-			typeof mapStoryNavigationTeaser
-		>[0]);
+		const result = mapStoryNavigationTeaser([elOdioRawTeaser]);
 
 		expect(result[0].tags).toEqual([]);
 	});
@@ -124,9 +94,7 @@ describe('mapStoryNavigationTeaser (ACL)', () => {
 
 describe('mapStoryNavigationTeaserWithAuthor (ACL)', () => {
 	it('sets tags to [] from the mapper, not from the raw spread', () => {
-		const result = mapStoryNavigationTeaserWithAuthor([
-			{ ...rawStoryTeaserItem(), author: rawAuthorTeaser() },
-		] as unknown as Parameters<typeof mapStoryNavigationTeaserWithAuthor>[0]);
+		const result = mapStoryNavigationTeaserWithAuthor([onoffRawNavTeasersMock[0]]);
 
 		expect(result[0].tags).toEqual([]);
 	});

--- a/src/api/modules/story/story.service.spec.ts
+++ b/src/api/modules/story/story.service.spec.ts
@@ -1,7 +1,7 @@
 import { clearAllMocks, type Mock } from '@test-utils';
 import * as storyRepository from './story.repository';
 import * as storyService from './story.service';
-import { StoriesByAuthorSlugQueryResult, StoryBySlugQueryResult } from '../../sanity/types';
+import type { StoriesByAuthorSlugQueryResult, StoryBySlugQueryResult } from '../../sanity/types';
 import { elOdioRawStory } from '../../_mocks/onoff/el-odio.raw.mock';
 import { elOdioRawTeaser } from '../../_mocks/onoff-raw-stories.mock';
 
@@ -41,7 +41,7 @@ describe('StoryService', () => {
 		it('should map coverImage to an empty string when the story has no image', async () => {
 			(storyRepository.fetchStoriesByAuthorSlug as Mock).mockResolvedValue([rawTeaserNoCover]);
 
-			const [story] = await storyService.getStoriesByAuthorSlug({ slug: 'autor', limit: 10, offset: 0 });
+			const [story] = await storyService.getStoriesByAuthorSlug({ slug: 'francois-onoff', limit: 10, offset: 0 });
 
 			expect(story.coverImage).toBe('');
 		});
@@ -49,7 +49,7 @@ describe('StoryService', () => {
 		it('should expose coverImage as a string, never the raw Sanity image object', async () => {
 			(storyRepository.fetchStoriesByAuthorSlug as Mock).mockResolvedValue([rawTeaserWithCover]);
 
-			const [story] = await storyService.getStoriesByAuthorSlug({ slug: 'autor', limit: 10, offset: 0 });
+			const [story] = await storyService.getStoriesByAuthorSlug({ slug: 'francois-onoff', limit: 10, offset: 0 });
 
 			expect(typeof story.coverImage).toBe('string');
 			expect(story.coverImage).not.toBeInstanceOf(Object);
@@ -60,7 +60,7 @@ describe('StoryService', () => {
 		it('should map coverImage to an empty string when the story has no image', async () => {
 			(storyRepository.fetchStoryBySlug as Mock).mockResolvedValue(rawContentNoCover);
 
-			const story = await storyService.getStoryBySlug('historia-1');
+			const story = await storyService.getStoryBySlug('el-odio');
 
 			expect(story.coverImage).toBe('');
 		});

--- a/src/api/modules/story/story.service.spec.ts
+++ b/src/api/modules/story/story.service.spec.ts
@@ -2,6 +2,8 @@ import { clearAllMocks, type Mock } from '@test-utils';
 import * as storyRepository from './story.repository';
 import * as storyService from './story.service';
 import { StoriesByAuthorSlugQueryResult, StoryBySlugQueryResult } from '../../sanity/types';
+import { elOdioRawStory } from '../../_mocks/onoff/el-odio.raw.mock';
+import { elOdioRawTeaser } from '../../_mocks/onoff-raw-stories.mock';
 
 /* eslint-disable no-restricted-syntax -- vi.mock/vi.fn: mock de módulo del repository; se migra a inyección de dependencias en #1503 */
 vi.mock('./story.repository', () => ({
@@ -13,57 +15,22 @@ vi.mock('./story.repository', () => ({
 }));
 /* eslint-enable no-restricted-syntax */
 
-// REASON: el shape crudo de la query es extenso; el cast acota el mock a los campos que el mapper consume.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- REASON: coverImage crudo es image | null; el test cubre ambos
-function rawStoryTeaser(coverImage: any) {
-	return {
-		_id: 'story-1',
-		slug: 'historia-1',
-		title: 'Historia 1',
-		badLanguage: false,
-		body: [],
-		originalPublication: '',
-		approximateReadingTime: 2,
-		coverImage,
-		mediaSources: [],
-		resources: [],
-	};
-}
+// REASON: GROQ devuelve null para stories sin imagen; el typegen declara coverImage non-nullable.
+const rawTeaserNoCover: StoriesByAuthorSlugQueryResult[0] = {
+	...elOdioRawTeaser,
+	coverImage: null as unknown as StoriesByAuthorSlugQueryResult[0]['coverImage'],
+};
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- REASON: coverImage crudo es image | null; el test cubre el caso null
-function rawStoryContent(coverImage: any) {
-	return {
-		_id: 'story-1',
-		slug: 'historia-1',
-		title: 'Historia 1',
-		badLanguage: false,
-		epigraphs: [],
-		body: [],
-		review: [],
-		originalPublication: '',
-		publishedAt: '2024-01-01T00:00:00Z',
-		updatedAt: '2024-01-01T00:00:00Z',
-		approximateReadingTime: 2,
-		coverImage,
-		mediaSources: [],
-		resources: [],
-		tags: [],
-		author: {
-			_id: 'author-1',
-			slug: 'autor',
-			name: 'Autor',
-			image: null,
-			nationality: { country: 'AR', flag: null },
-			biography: [],
-			bornOn: null,
-			bornOnYear: null,
-			diedOn: null,
-			diedOnYear: null,
-			resources: [],
-			tags: [],
-		},
-	};
-}
+const rawTeaserWithCover: StoriesByAuthorSlugQueryResult[0] = {
+	...elOdioRawTeaser,
+	coverImage: { _type: 'image', asset: { _type: 'reference', _ref: 'image-abc-100x100-jpg' } },
+};
+
+// REASON: GROQ devuelve null para stories sin imagen; el typegen declara coverImage non-nullable.
+const rawContentNoCover: NonNullable<StoryBySlugQueryResult> = {
+	...elOdioRawStory,
+	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+};
 
 describe('StoryService', () => {
 	beforeEach(() => {
@@ -72,9 +39,7 @@ describe('StoryService', () => {
 
 	describe('getStoriesByAuthorSlug — mapeo de coverImage', () => {
 		it('should map coverImage to an empty string when the story has no image', async () => {
-			(storyRepository.fetchStoriesByAuthorSlug as Mock).mockResolvedValue([
-				rawStoryTeaser(null),
-			] as unknown as StoriesByAuthorSlugQueryResult);
+			(storyRepository.fetchStoriesByAuthorSlug as Mock).mockResolvedValue([rawTeaserNoCover]);
 
 			const [story] = await storyService.getStoriesByAuthorSlug({ slug: 'autor', limit: 10, offset: 0 });
 
@@ -82,9 +47,7 @@ describe('StoryService', () => {
 		});
 
 		it('should expose coverImage as a string, never the raw Sanity image object', async () => {
-			(storyRepository.fetchStoriesByAuthorSlug as Mock).mockResolvedValue([
-				rawStoryTeaser({ _type: 'image', asset: { _type: 'reference', _ref: 'image-abc-100x100-jpg' } }),
-			] as unknown as StoriesByAuthorSlugQueryResult);
+			(storyRepository.fetchStoriesByAuthorSlug as Mock).mockResolvedValue([rawTeaserWithCover]);
 
 			const [story] = await storyService.getStoriesByAuthorSlug({ slug: 'autor', limit: 10, offset: 0 });
 
@@ -95,9 +58,7 @@ describe('StoryService', () => {
 
 	describe('getStoryBySlug — mapeo de coverImage', () => {
 		it('should map coverImage to an empty string when the story has no image', async () => {
-			(storyRepository.fetchStoryBySlug as Mock).mockResolvedValue(
-				rawStoryContent(null) as unknown as StoryBySlugQueryResult,
-			);
+			(storyRepository.fetchStoryBySlug as Mock).mockResolvedValue(rawContentNoCover);
 
 			const story = await storyService.getStoryBySlug('historia-1');
 


### PR DESCRIPTION
## Descripción

Crea un **corpus Onoff crudo** (shape Sanity `*QueryResult`) del lado del **ACL/backend** (`src/api/_mocks/`), espejando el corpus de dominio del frontend, para que los specs de mappers/services consuman fixtures canónicos tipados en vez de factories ad-hoc con `any`.

- **8 archivos `onoff/<slug>.raw.mock.ts`** — cada obra como `NonNullable<StoryBySlugQueryResult>` con el **cuerpo completo** (bloques replicados del frontend; sin importar `src/app` — separación de capas).
- **`onoff-raw-author.mock.ts`** — autor crudo François Onoff en 2 variantes de sub-shape.
- **`onoff-raw-stories.mock.ts`** — agregador + derivaciones `toRawTeaser`/`toRawNavTeaser` (fieles a `storiesByAuthorSlugQuery` y `rotatingContentQuery`).
- **`functions.spec.ts`**: elimina los factories ad-hoc y **todos los `as unknown as`**; usa el corpus tipado.
- **`story.service.spec.ts`**: elimina los `eslint-disable no-explicit-any`; el `as unknown as` queda acotado solo a `coverImage: null` (typegen non-nullable vs GROQ null) con `// REASON:`.

Closes #1678.

Parte de #1651.

## Notas (deuda / fuera de alcance)

- **Drift frontend↔backend:** los cuerpos se replican (decisión aprobada); un test de paridad `paragraphs` ↔ `body` queda fuera de scope (cruzaría capas).
- **Imports type-only:** la review detectó que la regla `consistent-type-imports` no está enforced (la convención es manual). Habilitarla destapa ~231 violaciones repo-wide → se difirió a un PR aparte: **#1679**.

## Plan de pruebas

- [x] `pnpm test` (suite completa) · `pnpm lint` · `pnpm build` — verdes.
- [x] `tsc -p tsconfig.server.json --noEmit` (type-check de `src/api`, que la CI no cubre) — limpio.
- [x] Specs migrados (`functions.spec`, `story.service.spec`): aserciones intactas, sin `any`, casts acotados.
- [x] Separación de capas verificada (sin imports de `src/app` en `src/api/_mocks/`).
- [x] Code review local: 1 crítico + 2 advertencias + 2 sugerencias abordadas (1 sugerencia diferida a #1679).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
