### PR TITLE
[#1672] - Genera release para versión 2.8.2 de La Cuentoneta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ Los hitos futuros de desarrollo, en los cuales se detallan las funcionalidades a
 
 ## Versión 2.8.2 (2026-07-01)
 
-La versión 2.8.2 profundiza el Design System V3 y el modelo de dominio de historias: `story` gana una portada propia (`coverImage`) con su migración de backfill, `CollectionTeaser` incorpora la variante `Multiple` (tres portadas en abanico para colecciones multi-autor) y se completan los skeletons faltantes de los componentes V3 mediante stories `Estados` intercambiables (real↔skeleton).
+La versión 2.8.2 profundiza el Design System V3 y el modelo de dominio de historias: `story` gana una portada propia (`coverImage`) con su migración de backfill, `CollectionTeaser` incorpora la variante `Multiple` (tres portadas en abanico para colecciones multi-autor), la imagen de `Collection` se unifica alrededor del value object `imagery` (`representative`/`sample`, portada editorial opcional) y las tarjetas V3 derivan su portada del propio `story`. Además, se completan los skeletons faltantes de los componentes V3 mediante stories `Estados` intercambiables (real↔skeleton).
 
 En el Anti-Corruption Layer de Sanity, la asignación de `tags` en los mappers de teaser pasa a ser explícita y se incorpora un corpus crudo (shape Sanity) para testear mappers y services. En paralelo, se refuerza la infraestructura de tests y Storybook con un corpus de mocks enriquecido a partir de las obras de François Onoff —con sus portadas migradas a PNG—, aplicado a `StoryCardTeaserV3` y `HomeStoryCard`, se unifica la documentación de Storybook al estándar V3 y se depuran tests que afirmaban clases CSS estructurales en `CollectionTeaser`.
+
+Finalmente, sienta la base de las OG images dinámicas (`setImage()`/`removeImage()` en `HeadMetadataDirective`), corrige la generación de URLs de imágenes de Sanity con crop, incorpora un skill `/release-workflow` dedicado a los issues de release y suma una tanda de actualizaciones de dependencias (`groq`, Hono, Sanity CLI) y de GitHub Actions.
 
 ### Cambios completos
 
@@ -31,12 +33,14 @@ Ver el changelog completo en [2.8.2](https://github.com/cuentoneta/cuentoneta/re
 #### Modelo de dominio y ACL
 
 - [#1648] - `coverImage` como atributo propio de `story` para su representación visual, con migración de backfill en historias existentes.
+- [#1684] - Imagen de `Collection` modelada con el value object `imagery` (`representative`/`sample`) y portada editorial (`featuredImage`) opcional, en paridad con `CollectionTeaser`.
 - [#1593] - Asignación explícita de `tags: []` en los mappers de teaser de story (ACL).
 - [#1678] - Corpus Onoff crudo (shape Sanity) del lado del ACL para tests de mappers y services.
 
 #### Design System V3 y componentes
 
 - [#1638] - Variante `Multiple` de `CollectionTeaser`: tres portadas en abanico para colecciones multi-autor.
+- [#1692] - Las tarjetas `HomeStoryCard` y `StoryCardTeaserV3` derivan la portada del propio `story`, eliminando el input redundante `coverImageUrl`.
 - [#1675] - Skeletons faltantes de los componentes V3 con stories `Estados` intercambiables (real↔skeleton).
 
 #### Storybook, tests y corpus de mocks
@@ -47,6 +51,26 @@ Ver el changelog completo en [2.8.2](https://github.com/cuentoneta/cuentoneta/re
 - [#1669] - Refuerzo de tests y Storybook de `HomeStoryCard` con el corpus de Onoff.
 - [#1631] - Auditoría de documentación V3 en Storybook: unificación al estándar de `StoryCardTeaserV3` y `TagComponent`.
 - [#1639] - Limpieza de tests que afirmaban clases CSS en `collection-teaser` (testear comportamiento, no estructura).
+
+#### SEO y OpenGraph
+
+- [#1535] - Base de las OG images dinámicas: `setImage()` y `removeImage()` en `HeadMetadataDirective`, con fallback al logo estático.
+
+#### Correcciones
+
+- [#1694] - Corrección de la generación de URLs de imágenes de Sanity con crop (helper `withSanityImageParams`), que producía un doble `?` y un `rect` inválido.
+
+#### Flujos de trabajo y agentes de IA (Claude)
+
+- [#1685] - Skill `/release-workflow` dedicado a los issues de release.
+
+#### Dependencias e infraestructura
+
+- [#1613] - Actualización de `groq` a la versión 6.1.0.
+- [#1619] - Actualización de `@hono/node-server` a la versión 2.0.6.
+- [#1611] - Actualización de `@sanity/cli` a la versión 7.2.3 (CMS).
+- [#1612] · [#1662] · [#1660] · [#1608] - Actualización de los grupos `minor-and-patch` de dependencias de app y CMS (Dependabot).
+- [#1636] · [#1637] · [#1659] - Auto-bump de GitHub Actions (`pnpm/action-setup`, `actions/checkout`, `actions/cache`) vía Dependabot.
 
 ## Versión 2.8.1 (2026-06-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Los hitos futuros de desarrollo, en los cuales se detallan las funcionalidades a
 
 La versión 2.8.2 profundiza el Design System V3 y el modelo de dominio de historias: `story` gana una portada propia (`coverImage`) con su migración de backfill, `CollectionTeaser` incorpora la variante `Multiple` (tres portadas en abanico para colecciones multi-autor) y se completan los skeletons faltantes de los componentes V3 mediante stories `Estados` intercambiables (real↔skeleton).
 
-En el Anti-Corruption Layer de Sanity, la asignación de `tags` en los mappers de teaser pasa a ser explícita y se incorpora un corpus crudo (shape Sanity) para testear mappers y services. En paralelo, se refuerza la infraestructura de tests y Storybook con un corpus de mocks enriquecido a partir de las obras de François Onoff —con sus portadas migradas a PNG—, aplicado a `StoryCardTeaserV3` y `HomeStoryCard`, y se unifica la documentación de Storybook al estándar V3.
+En el Anti-Corruption Layer de Sanity, la asignación de `tags` en los mappers de teaser pasa a ser explícita y se incorpora un corpus crudo (shape Sanity) para testear mappers y services. En paralelo, se refuerza la infraestructura de tests y Storybook con un corpus de mocks enriquecido a partir de las obras de François Onoff —con sus portadas migradas a PNG—, aplicado a `StoryCardTeaserV3` y `HomeStoryCard`, se unifica la documentación de Storybook al estándar V3 y se depuran tests que afirmaban clases CSS estructurales en `CollectionTeaser`.
 
 ### Cambios completos
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,38 @@ La lista de características futuras a implementar puede hallarse en la sección
 
 Los hitos futuros de desarrollo, en los cuales se detallan las funcionalidades a desarrollar y los cambios a implementar, pueden encontrarse en las secciones [milestones](https://github.com/cuentoneta/cuentoneta/milestones) y [projects](https://github.com/cuentoneta/cuentoneta/projects) del repositorio de Github del proyecto.
 
+## Versión 2.8.2 (2026-07-01)
+
+La versión 2.8.2 profundiza el Design System V3 y el modelo de dominio de historias: `story` gana una portada propia (`coverImage`) con su migración de backfill, `CollectionTeaser` incorpora la variante `Multiple` (tres portadas en abanico para colecciones multi-autor) y se completan los skeletons faltantes de los componentes V3 mediante stories `Estados` intercambiables (real↔skeleton).
+
+En el Anti-Corruption Layer de Sanity, la asignación de `tags` en los mappers de teaser pasa a ser explícita y se incorpora un corpus crudo (shape Sanity) para testear mappers y services. En paralelo, se refuerza la infraestructura de tests y Storybook con un corpus de mocks enriquecido a partir de las obras de François Onoff —con sus portadas migradas a PNG—, aplicado a `StoryCardTeaserV3` y `HomeStoryCard`, y se unifica la documentación de Storybook al estándar V3.
+
+### Cambios completos
+
+Ver el changelog completo en [2.8.2](https://github.com/cuentoneta/cuentoneta/releases/tag/2.8.2)
+
+### Cambios
+
+#### Modelo de dominio y ACL
+
+- [#1648] - `coverImage` como atributo propio de `story` para su representación visual, con migración de backfill en historias existentes.
+- [#1593] - Asignación explícita de `tags: []` en los mappers de teaser de story (ACL).
+- [#1678] - Corpus Onoff crudo (shape Sanity) del lado del ACL para tests de mappers y services.
+
+#### Design System V3 y componentes
+
+- [#1638] - Variante `Multiple` de `CollectionTeaser`: tres portadas en abanico para colecciones multi-autor.
+- [#1675] - Skeletons faltantes de los componentes V3 con stories `Estados` intercambiables (real↔skeleton).
+
+#### Storybook, tests y corpus de mocks
+
+- [#1650] - Corpus de mocks de `Story` enriquecido con las obras de François Onoff.
+- [#1655] - Portadas mock del corpus de Onoff migradas de SVG a PNG (236×328).
+- [#1657] - Refuerzo de tests y Storybook de `StoryCardTeaserV3` con el corpus de Onoff.
+- [#1669] - Refuerzo de tests y Storybook de `HomeStoryCard` con el corpus de Onoff.
+- [#1631] - Auditoría de documentación V3 en Storybook: unificación al estándar de `StoryCardTeaserV3` y `TagComponent`.
+- [#1639] - Limpieza de tests que afirmaban clases CSS en `collection-teaser` (testear comportamiento, no estructura).
+
 ## Versión 2.8.1 (2026-06-23)
 
 La versión 2.8.1 continúa la implementación del Design System V3 con cuatro nuevas entregas: el componente `StoryCardTeaserV3` y el nuevo `HomeStoryCard`, el reemplazo de `BadgeComponent` por `TagComponent` en todos sus usos con documentación de story desde Figma, la adopción de `CoverImageComponent` en el `CollectionTeaser` y la reconciliación de tags en las vistas de story y autor con soporte de override de color.

--- a/cms/package.json
+++ b/cms/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/cms",
 	"private": true,
-	"version": "2.8.1",
+	"version": "2.8.2",
 	"description": "",
 	"main": "package.json",
 	"author": "Ramiro Olivencia <ramiro@olivencia.com.ar>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/app",
 	"type": "module",
-	"version": "2.8.1",
+	"version": "2.8.2",
 	"imports": {
 		"#tailwind-theme": "./src/tailwind.css"
 	},


### PR DESCRIPTION
## Descripción

Prepara el commit de release de la versión **2.8.2** de La Cuentoneta (issue de gestión #1672):

- Bump de versión a `2.8.2` en `package.json` y `cms/package.json` (en lockstep app/Studio, como en el release anterior).
- Nueva entrada `## Versión 2.8.2 (2026-07-01)` en `CHANGELOG.md`, con prosa y cambios agrupados por tema (Modelo de dominio y ACL · Design System V3 · Storybook, tests y corpus de mocks).

El tag `2.8.2`, el GitHub Release (notas del CHANGELOG) y el deploy de Sanity Studio los produce automáticamente el workflow `release.yml` al mergear `develop → master`.

**Tareas del issue verificadas:**
- Migración de Sanity de #1648 (`set-default-story-coverimage`): **ya ejecutada** contra producción por el mantenedor.
- Documentación de versiones de herramientas (`docs/DEVELOPMENT_GUIDE.md`): sin cambios (Node/pnpm ya coinciden con `package.json`).
- Milestone 2.8.2: todos los issues cerrados salvo este; el epic #1651 no tiene milestone y no bloquea.

Closes #1672.

## Plan de pruebas

- [x] `pnpm lint` · `pnpm stylelint` · `pnpm test` · `pnpm build` (confirma `@cuentoneta/app@2.8.2`) · `pnpm storybook:build` — verdes.
- [x] Extracción de notas del CHANGELOG por `release.yml` (awk) verificada localmente: devuelve la sección `## Versión 2.8.2` completa.
- [x] Code review local abordada (1 crítico: bump de `cms/package.json` en lockstep — corregido).

## Pasos manuales de release (post-merge)

1. Mergear este PR a `develop`.
2. Abrir PR `develop → master` y mergearlo → dispara `release.yml` (tag + GitHub Release + deploy de Studio).
3. Verificar: workflow Release verde, Release 2.8.2 publicado, Studio con schema nuevo, app en producción OK.
