### PR TITLE
[#1598] - Script reconcile-author-tags + automatización

### DIFF
--- a/.github/workflows/reconcile-author-tags.yml
+++ b/.github/workflows/reconcile-author-tags.yml
@@ -1,0 +1,46 @@
+name: Reconcile author tags from stories
+
+on:
+  schedule:
+    # Domingo medianoche UTC (~21:00 ART del sábado). Horario valle, sin tráfico
+    # editorial concurrente.
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: reconcile-author-tags
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  reconcile:
+    name: Reconcile author tags
+    runs-on: ubuntu-latest
+
+    env:
+      SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID || 's4dbqkc5' }}
+      SANITY_STUDIO_DATASET: ${{ secrets.SANITY_STUDIO_DATASET || 'development' }}
+      SANITY_STUDIO_TOKEN: ${{ secrets.SANITY_STUDIO_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+
+      - name: Select pnpm as package manager
+        uses: pnpm/action-setup@v6.0.9
+        with:
+          version: 10.12.1
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22.22.3
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Reconcile author tags
+        run: pnpm run reconcile-author-tags

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"build": "nx run @cuentoneta/app:build:production --skip-nx-cache",
 		"config": "node --loader ts-node/esm ./scripts/set-environment.ts",
 		"delete-unused-assets": "node --import tsx --env-file=.env ./scripts/delete-unused-assets.ts",
+		"reconcile-author-tags": "node --import tsx --env-file=.env ./scripts/reconcile-author-tags.ts",
 		"storybook": "nx run @cuentoneta/app:storybook",
 		"storybook:build": "nx run @cuentoneta/app:build-storybook",
 		"lint": "nx eslint:lint --skip-nx-cache",

--- a/scripts/reconcile-author-tags.ts
+++ b/scripts/reconcile-author-tags.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from 'node:crypto';
+import { client } from '../src/api/_helpers/sanity-connector';
+
+interface StoryProjection {
+	authorRef?: string;
+	tagRefs: Array<string | null>;
+}
+
+interface AuthorProjection {
+	_id: string;
+	tagRefs: Array<string | null>;
+}
+
+const runReconciliation = async () => {
+	const stories: StoryProjection[] = await client.fetch(`*[_type == 'story' && !(_id in path('drafts.**'))] {
+      'authorRef': author._ref,
+      'tagRefs': tags[]._ref
+    }`);
+
+	const authors: AuthorProjection[] = await client.fetch(`*[_type == 'author' && !(_id in path('drafts.**'))] {
+      _id,
+      'tagRefs': coalesce(tags[]._ref, [])
+    }`);
+
+	const authorsById = new Map(authors.map((a) => [a._id, a]));
+
+	const authorTagsFromStories = new Map<string, Set<string>>();
+
+	for (const story of stories) {
+		const authorRef = story.authorRef;
+		if (!authorRef) continue;
+
+		const tagRefs = story.tagRefs.filter((ref): ref is string => ref !== null);
+		if (tagRefs.length === 0) continue;
+
+		const tagSet = authorTagsFromStories.get(authorRef);
+		if (tagSet) {
+			for (const ref of tagRefs) {
+				tagSet.add(ref);
+			}
+		} else {
+			authorTagsFromStories.set(authorRef, new Set(tagRefs));
+		}
+	}
+
+	const transaction = [...authorTagsFromStories].reduce((tx, [authorRef, derivedRefs]) => {
+		const existingRefs = new Set(
+			(authorsById.get(authorRef)?.tagRefs ?? []).filter((ref): ref is string => ref !== null),
+		);
+
+		const allTags = [...existingRefs];
+		let added = 0;
+		for (const ref of derivedRefs) {
+			if (!existingRefs.has(ref)) {
+				allTags.push(ref);
+				added++;
+			}
+		}
+
+		return added === 0
+			? tx
+			: tx.patch(authorRef, (patch) =>
+					patch.set({ tags: allTags.map((ref) => ({ _key: randomUUID(), _ref: ref, _type: 'reference' as const })) }),
+				);
+	}, client.transaction());
+
+	await transaction.commit();
+};
+
+runReconciliation().catch((err) => {
+	console.error('Reconciliation failed:', err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Descripción
- Script idempotente `reconcile-author-tags.ts` que deriva `author.tags` desde `story.tags` (merge, no overwrite)
- GitHub Action programada semanal (domingo) + `workflow_dispatch`
- Entry `pnpm run reconcile-author-tags` en `package.json`

Closes #1598.

Parte de #1595.

## Plan de pruebas
- [x] Gates de CI local: lint, test, stylelint, build, storybook:build
- [x] Script compila y sigue patrones existentes del repo
- [x] Dos queries GROQ + una transacción — sin N+1
- [x] Merge vía unión (manuales + derivados), no overwrite
- [x] Idempotente — correr múltiples veces produce el mismo resultado