### PR TITLE
[HF] - Corrige doble '?' en URLs de imágenes de Sanity con crop

### DIFF
--- a/src/app/components/author-teaser/author-teaser.component.ts
+++ b/src/app/components/author-teaser/author-teaser.component.ts
@@ -5,6 +5,7 @@ import { RouterLink } from '@angular/router';
 import { AppRoutes } from '../../app.routes';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { faSolidArrowRightLong } from '@ng-icons/font-awesome/solid';
+import { withSanityImageParams } from '@utils/sanity-image.utils';
 
 @Component({
 	selector: 'cuentoneta-author-teaser',
@@ -66,14 +67,19 @@ export class AuthorTeaserComponent {
 	protected readonly imageSize = computed(() => (this.variant() === 'sm' ? 40 : 64));
 
 	// Para un mejor scaling, a cargo del browser, se obtiene una imagen del 1.5x el tamaño final renderizado
-	protected readonly authorImageUrl = computed(() =>
-		this.author().imageUrl
-			? `${this.author().imageUrl}?h=${this.imageSize() * 1.5}&w=${this.imageSize() * 1.5}&auto=format`
-			: 'assets/img/default-avatar.jpg',
-	);
+	protected readonly authorImageUrl = computed(() => {
+		const size = this.imageSize() * 1.5;
+		return this.author().imageUrl
+			? withSanityImageParams(this.author().imageUrl, { h: size, w: size, auto: 'format' })
+			: 'assets/img/default-avatar.jpg';
+	});
 
-	protected readonly authorFlagUrl = computed(
-		() => `${this.author().nationality.flag}?h=${this.flagImageSize.height}&w=${this.flagImageSize.width}&auto=format`,
+	protected readonly authorFlagUrl = computed(() =>
+		withSanityImageParams(this.author().nationality.flag, {
+			h: this.flagImageSize.height,
+			w: this.flagImageSize.width,
+			auto: 'format',
+		}),
 	);
 
 	protected readonly appRoutes = AppRoutes;

--- a/src/app/components/cover-image/cover-image.component.ts
+++ b/src/app/components/cover-image/cover-image.component.ts
@@ -19,15 +19,15 @@ import { NgOptimizedImage } from '@angular/common';
 			<img
 				[ngSrc]="url"
 				[priority]="priority()"
+				class="h-auto w-full"
 				width="118"
 				height="164"
 				alt=""
-				class="h-full w-full object-cover"
 				data-testid="cover-image"
 			/>
 		} @else {
 			<div class="flex h-full w-full items-center justify-center" data-testid="cover-placeholder">
-				<img ngSrc="./assets/svg/cover-placeholder.svg" width="60" height="60" alt="" />
+				<img class="h-auto w-full" ngSrc="./assets/svg/cover-placeholder.svg" width="60" height="60" alt="" />
 			</div>
 		}
 	`,

--- a/src/app/components/image-profile/image-profile.component.ts
+++ b/src/app/components/image-profile/image-profile.component.ts
@@ -1,6 +1,8 @@
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
 
+import { withSanityImageParams } from '@utils/sanity-image.utils';
+
 /** Tamaños del avatar (Design System v3): small=24px, medium=40px, lg=80px, xl=120px. */
 export type ImageProfileSize = 'small' | 'medium' | 'lg' | 'xl';
 
@@ -72,7 +74,7 @@ export class ImageProfileComponent {
 			default:
 				// photo: la imagen se solicita al CDN a 2x (HiDPI) del tamaño de display.
 				return {
-					url: `${this.src()}?h=${px * 2}&w=${px * 2}`,
+					url: withSanityImageParams(this.src(), { h: px * 2, w: px * 2 }),
 					px,
 					classes: 'size-full object-cover',
 					background: 'bg-neutral-300',

--- a/src/app/components/image-profile/image-profile.component.ts
+++ b/src/app/components/image-profile/image-profile.component.ts
@@ -13,14 +13,6 @@ export type ImageProfileSize = 'small' | 'medium' | 'lg' | 'xl';
  */
 export type ImageProfileVariant = 'profile' | 'collection';
 
-/**
- * Estado de render efectivo (derivado de `variant` + `src`), no es parte de la API pública:
- * - `photo`: imagen real solicitada al CDN.
- * - `placeholder`: ícono de persona (variante `profile` sin `src`).
- * - `collection`: ícono de biblioteca.
- */
-type RenderMode = 'photo' | 'placeholder' | 'collection';
-
 const COLLECTION_ICON = './assets/svg/collection.svg';
 const PROFILE_PLACEHOLDER = './assets/svg/profile-placeholder.svg';
 
@@ -55,31 +47,24 @@ export class ImageProfileComponent {
 		xl: { px: 120, circle: 'size-30', icon: 'size-15' },
 	};
 
-	// Estado de render efectivo: única fuente de verdad de "qué se dibuja", derivada de variant + src.
-	private readonly renderMode = computed<RenderMode>(() => {
-		if (this.variant() === 'collection') {
-			return 'collection';
-		}
-		return this.src() ? 'photo' : 'placeholder';
-	});
-
-	// Descriptor único por estado: centraliza url, tamaño, clases de la imagen y fondo del círculo.
+	// Descriptor único de "qué se dibuja" (url, tamaño, clases de la imagen y fondo del círculo),
+	// derivado de variant + src. Ramifica sobre `src` para estrechar su tipo antes de armar la URL.
 	protected readonly view = computed(() => {
 		const { px, icon } = this.sizeMap[this.size()];
-		switch (this.renderMode()) {
-			case 'collection':
-				return { url: COLLECTION_ICON, px: px / 2, classes: icon, background: 'bg-brand-100' };
-			case 'placeholder':
-				return { url: PROFILE_PLACEHOLDER, px: px / 2, classes: icon, background: 'bg-neutral-300' };
-			default:
-				// photo: la imagen se solicita al CDN a 2x (HiDPI) del tamaño de display.
-				return {
-					url: withSanityImageParams(this.src(), { h: px * 2, w: px * 2 }),
-					px,
-					classes: 'size-full object-cover',
-					background: 'bg-neutral-300',
-				};
+		const src = this.src();
+		if (this.variant() === 'collection') {
+			return { url: COLLECTION_ICON, px: px / 2, classes: icon, background: 'bg-brand-100' };
 		}
+		if (!src) {
+			return { url: PROFILE_PLACEHOLDER, px: px / 2, classes: icon, background: 'bg-neutral-300' };
+		}
+		// photo: la imagen se solicita al CDN a 2x (HiDPI) del tamaño de display.
+		return {
+			url: withSanityImageParams(src, { h: px * 2, w: px * 2 }),
+			px,
+			classes: 'size-full object-cover',
+			background: 'bg-neutral-300',
+		};
 	});
 
 	protected readonly containerClasses = computed(() => {

--- a/src/app/components/story-card-teaser/story-card-teaser.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.ts
@@ -5,6 +5,7 @@ import { RouterLink } from '@angular/router';
 import { StoryCardTeaserSkeletonComponent } from './story-card-teaser-skeleton.component';
 import { AppRoutes } from '../../app.routes';
 import { PortableTextParserComponent } from '../portable-text-parser/portable-text-parser.component';
+import { withSanityImageParams } from '@utils/sanity-image.utils';
 
 @Component({
 	selector: 'cuentoneta-story-card-teaser',
@@ -79,7 +80,7 @@ export class StoryCardTeaserComponent {
 	protected readonly authorImageUrl = computed(() => {
 		const story = this.story();
 		if (story && 'author' in story) {
-			return `${story.author.imageUrl}?h=64&w=64`;
+			return withSanityImageParams(story.author.imageUrl, { h: 64, w: 64 });
 		}
 		return '';
 	});

--- a/src/app/utils/sanity-image.utils.spec.ts
+++ b/src/app/utils/sanity-image.utils.spec.ts
@@ -1,0 +1,31 @@
+import { withSanityImageParams } from './sanity-image.utils';
+
+describe('withSanityImageParams', () => {
+	const base = 'https://cdn.sanity.io/images/s4dbqkc5/production/abc-580x579.avif';
+
+	it('should append params with `?` when the url has no query string', () => {
+		expect(withSanityImageParams(base, { h: 64, w: 64 })).toBe(`${base}?h=64&w=64`);
+	});
+
+	it('should append params with `&` when the url already carries a crop (`?rect=...`)', () => {
+		const cropped = `${base}?rect=44,0,480,480`;
+
+		expect(withSanityImageParams(cropped, { h: 64, w: 64 })).toBe(`${cropped}&h=64&w=64`);
+	});
+
+	it('should include auto=format when requested', () => {
+		expect(withSanityImageParams(base, { h: 60, w: 60, auto: 'format' })).toBe(`${base}?h=60&w=60&auto=format`);
+	});
+
+	it('should omit params whose value is undefined', () => {
+		expect(withSanityImageParams(base, { w: 32 })).toBe(`${base}?w=32`);
+	});
+
+	it('should return the url untouched when there are no params', () => {
+		expect(withSanityImageParams(base, {})).toBe(base);
+	});
+
+	it('should return an empty string as-is', () => {
+		expect(withSanityImageParams('', { w: 64 })).toBe('');
+	});
+});

--- a/src/app/utils/sanity-image.utils.ts
+++ b/src/app/utils/sanity-image.utils.ts
@@ -1,0 +1,27 @@
+// Parámetros de transformación del CDN de Sanity que la UI agrega sobre una URL ya resuelta.
+export type SanityImageParams = {
+	w?: number;
+	h?: number;
+	auto?: 'format';
+};
+
+/**
+ * Agrega parámetros de transformación a una URL de imagen de Sanity respetando la query string
+ * existente. Las URLs con crop aplicado en el Studio ya vienen con `?rect=...`; concatenar un
+ * segundo `?` corrompe el valor de `rect` y el CDN responde 400. El separador se elige según la
+ * URL ya tenga o no query string.
+ */
+export function withSanityImageParams(url: string, params: SanityImageParams): string {
+	if (!url) {
+		return url;
+	}
+	const query = Object.entries(params)
+		.filter(([, value]) => value !== undefined)
+		.map(([key, value]) => `${key}=${value}`)
+		.join('&');
+	if (!query) {
+		return url;
+	}
+	const separator = url.includes('?') ? '&' : '?';
+	return `${url}${separator}${query}`;
+}


### PR DESCRIPTION
## Contexto

Al reajustar (crop) una imagen en Sanity Studio y luego procesarla en la app, el CDN devolvía `400 Bad Request: Parameter "rect" must be a valid integer`.

Ejemplo de URL rota:
```
...580x579.avif?rect=44,0,480,480?h=64&w=64
```

## Causa raíz

Los teasers reciben `imageUrl: string` (ya resuelto por el ACL/`urlFor` del backend) y le agregaban los params de tamaño concatenando un `?` **fijo**. Cuando la imagen tiene crop aplicado en el Studio, la URL base ya trae `?rect=...`, así que el segundo `?` corrompe el valor de `rect`. No se puede usar `@sanity/image-url` en el front porque ya no está el `SanityImageSource`, solo el string.

## Cambios

- **Helper nuevo** `withSanityImageParams(url, params)` en `src/app/utils/sanity-image.utils.ts`: elige el separador (`?` o `&`) según la URL ya tenga o no query string, y omite params `undefined`. Cubierto con spec (incluye el caso del crop).
- **Call-sites migrados:** `author-teaser` (foto + bandera), `image-profile` (avatar 2x) y `story-card-teaser` (avatar 64×64).
- **Ajuste de layout** en `cover-image.component.ts`.

## Verificación

- `pnpm test` (util + componentes afectados): verde.
- `pnpm lint`: verde.
