### PR TITLE
[#1692] - Deriva la portada del story y elimina el input redundante coverImageUrl

### DIFF
--- a/src/app/components/home-story-card/home-story-card.component.spec.ts
+++ b/src/app/components/home-story-card/home-story-card.component.spec.ts
@@ -96,18 +96,17 @@ describe('HomeStoryCardComponent', () => {
 	});
 
 	describe('Cover image', () => {
-		it('should render the cover image when a URL is provided', async () => {
+		it('should render the cover image when the story has a cover', async () => {
 			await render(HomeStoryCardComponent, {
 				inputs: {
-					story: storyNavigationTeaserWithAuthorMock,
+					story: { ...storyNavigationTeaserWithAuthorMock, coverImage: 'https://example.com/cover.jpg' },
 					navigationParams,
-					coverImageUrl: 'https://example.com/cover.jpg',
 				},
 			});
 			expect(screen.getByTestId('cover-image')).toBeInTheDocument();
 		});
 
-		it('should render a placeholder when no cover URL is provided', async () => {
+		it('should render a placeholder when the story has no cover', async () => {
 			await render(HomeStoryCardComponent, {
 				inputs: { story: storyNavigationTeaserWithAuthorMock, navigationParams },
 			});
@@ -184,7 +183,7 @@ describe('HomeStoryCardComponent', () => {
 
 		it.each(onoffStoryTeasersMock)('should render title and reading time for "$title"', async (teaser) => {
 			await render(HomeStoryCardComponent, {
-				inputs: { story: teaser, coverImageUrl: teaser.coverImage },
+				inputs: { story: teaser },
 			});
 
 			expect(screen.getByText(teaser.title)).toBeInTheDocument();

--- a/src/app/components/home-story-card/home-story-card.component.stories.ts
+++ b/src/app/components/home-story-card/home-story-card.component.stories.ts
@@ -4,12 +4,7 @@ import { provideRouter } from '@angular/router';
 import { HomeStoryCardComponent } from './home-story-card.component';
 import { HomeStoryCardSkeletonComponent } from './home-story-card-skeleton.component';
 import { palacioNueveFronterasTeaserMock } from '../../mocks/onoff-story-teasers.mock';
-import {
-	corpusStories,
-	corpusCovers,
-	literaryWorkSelectArgType,
-	withRichMedia,
-} from '../../mocks/onoff-corpus.storybook';
+import { corpusStories, literaryWorkSelectArgType, withRichMedia } from '../../mocks/onoff-corpus.storybook';
 
 const meta: Meta<HomeStoryCardComponent> = {
 	component: HomeStoryCardComponent,
@@ -47,12 +42,6 @@ const meta: Meta<HomeStoryCardComponent> = {
 			description: 'Marca el cover como prioritario (above-the-fold) para la carga de imágenes',
 			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
 		},
-		coverImageUrl: {
-			control: { type: 'text' },
-			description:
-				'URL de la imagen alusiva a la historia (si no se provee, se muestra el placeholder del Design System)',
-			table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
-		},
 		tagLabel: {
 			control: { type: 'text' },
 			description: 'Etiqueta opcional que se muestra antes del tiempo de lectura',
@@ -86,11 +75,10 @@ export const Interactiva: StoryObj<HomeStoryCardComponent & { storyIndex: number
 		},
 	},
 	render: (args) => ({
-		props: { ...args, stories: corpusStories, covers: corpusCovers },
+		props: { ...args, stories: corpusStories },
 		template: `
 			<cuentoneta-home-story-card
 				[story]="stories[storyIndex]"
-				[coverImageUrl]="covers[storyIndex]"
 				[order]="order"
 				[tagLabel]="tagLabel"
 				[showMultimedia]="showMultimedia"
@@ -122,7 +110,6 @@ export const Default: Story = {
 	}),
 	args: {
 		story: withRichMedia(palacioNueveFronterasTeaserMock),
-		coverImageUrl: palacioNueveFronterasTeaserMock.coverImage,
 		order: 1,
 		tagLabel: 'Cuento',
 		showMultimedia: true,
@@ -155,7 +142,6 @@ export const Estados: StoryObj<HomeStoryCardComponent & { loading: boolean }> = 
 			<div class="w-[331px]">
 				<cuentoneta-home-story-card
 					[story]="loading ? undefined : story"
-					[coverImageUrl]="coverImageUrl"
 					[order]="order"
 					[tagLabel]="tagLabel"
 					[showMultimedia]="showMultimedia"
@@ -166,7 +152,6 @@ export const Estados: StoryObj<HomeStoryCardComponent & { loading: boolean }> = 
 	args: {
 		loading: true,
 		story: withRichMedia(palacioNueveFronterasTeaserMock),
-		coverImageUrl: palacioNueveFronterasTeaserMock.coverImage,
 		order: 1,
 		tagLabel: 'Cuento',
 		showMultimedia: true,

--- a/src/app/components/home-story-card/home-story-card.component.ts
+++ b/src/app/components/home-story-card/home-story-card.component.ts
@@ -110,12 +110,13 @@ export class HomeStoryCardComponent {
 	// Inputs
 	public readonly story = input<StoryTeaserWithAuthor | StoryNavigationTeaserWithAuthor>();
 	public readonly order = input<number>();
-	public readonly coverImageUrl = input<string>();
 	// Marca el cover como prioritario (above-the-fold) para la carga de imágenes.
 	public readonly priority = input<boolean>(false);
 	public readonly tagLabel = input<string>();
 	public readonly showMultimedia = input<boolean>(false);
 	public readonly navigationParams = input<{ navigation: string; navigationSlug: string }>();
 
+	// La portada se deriva del propio story; '' cuando no fue asignada, y el cover cae al placeholder.
+	protected readonly coverImageUrl = computed(() => this.story()?.coverImage);
 	protected readonly storyRouterLink = computed(() => ['/', this.appRoutes.Story, this.story()?.slug]);
 }

--- a/src/app/components/home-story-card/home-story-card.component.ts
+++ b/src/app/components/home-story-card/home-story-card.component.ts
@@ -116,7 +116,6 @@ export class HomeStoryCardComponent {
 	public readonly showMultimedia = input<boolean>(false);
 	public readonly navigationParams = input<{ navigation: string; navigationSlug: string }>();
 
-	// La portada se deriva del propio story; '' cuando no fue asignada, y el cover cae al placeholder.
 	protected readonly coverImageUrl = computed(() => this.story()?.coverImage);
 	protected readonly storyRouterLink = computed(() => ['/', this.appRoutes.Story, this.story()?.slug]);
 }

--- a/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.spec.ts
+++ b/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.spec.ts
@@ -103,18 +103,17 @@ describe('StoryCardTeaserV3Component', () => {
 	});
 
 	describe('Cover image', () => {
-		it('should render the cover image when a URL is provided', async () => {
+		it('should render the cover image when the story has a cover', async () => {
 			await render(StoryCardTeaserV3Component, {
 				inputs: {
-					story: storyNavigationTeaserWithAuthorMock,
+					story: { ...storyNavigationTeaserWithAuthorMock, coverImage: 'https://example.com/cover.jpg' },
 					navigationParams,
-					coverImageUrl: 'https://example.com/cover.jpg',
 				},
 			});
 			expect(screen.getByTestId('cover-image')).toBeInTheDocument();
 		});
 
-		it('should render a placeholder when no cover URL is provided', async () => {
+		it('should render a placeholder when the story has no cover', async () => {
 			await render(StoryCardTeaserV3Component, {
 				inputs: { story: storyNavigationTeaserWithAuthorMock, navigationParams },
 			});
@@ -124,9 +123,8 @@ describe('StoryCardTeaserV3Component', () => {
 		it('should keep the cover decorative, leaving a single accessible story link when the author is hidden', async () => {
 			await render(StoryCardTeaserV3Component, {
 				inputs: {
-					story: storyNavigationTeaserWithAuthorMock,
+					story: { ...storyNavigationTeaserWithAuthorMock, coverImage: 'https://example.com/cover.jpg' },
 					navigationParams,
-					coverImageUrl: 'https://example.com/cover.jpg',
 					showAuthor: false,
 				},
 			});
@@ -240,7 +238,7 @@ describe('StoryCardTeaserV3Component', () => {
 
 		it.each(onoffStoryTeasersMock)('should render title and reading time for "$title"', async (teaser) => {
 			await render(StoryCardTeaserV3Component, {
-				inputs: { story: teaser, coverImageUrl: teaser.coverImage },
+				inputs: { story: teaser },
 			});
 
 			expect(screen.getByText(teaser.title)).toBeInTheDocument();

--- a/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.stories.ts
+++ b/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.stories.ts
@@ -7,12 +7,7 @@ import {
 	geometriaTeaserMock,
 	palacioNueveFronterasTeaserMock,
 } from '../../mocks/onoff-story-teasers.mock';
-import {
-	corpusStories,
-	corpusCovers,
-	literaryWorkSelectArgType,
-	withRichMedia,
-} from '../../mocks/onoff-corpus.storybook';
+import { corpusStories, literaryWorkSelectArgType, withRichMedia } from '../../mocks/onoff-corpus.storybook';
 
 // Las descripciones de la doc van en una sola línea: el renderer de Markdown de los autodocs
 // interpreta como bloque de código cualquier línea con indentación, así que un HTML multilínea
@@ -49,12 +44,6 @@ const meta: Meta<StoryCardTeaserV3Component> = {
 			control: { type: 'number', min: 1, max: 99 },
 			description: 'Numeración opcional de la historia',
 			table: { type: { summary: 'number' }, defaultValue: { summary: 'undefined' } },
-		},
-		coverImageUrl: {
-			control: { type: 'text' },
-			description:
-				'URL de la imagen alusiva a la historia (si no se provee, se muestra el placeholder del Design System)',
-			table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
 		},
 		tagLabel: {
 			control: { type: 'text' },
@@ -104,11 +93,10 @@ export const Interactiva: StoryObj<StoryCardTeaserV3Component & { storyIndex: nu
 		},
 	},
 	render: (args) => ({
-		props: { ...args, stories: corpusStories, covers: corpusCovers },
+		props: { ...args, stories: corpusStories },
 		template: `
 			<cuentoneta-story-card-teaser-v3
 				[story]="stories[storyIndex]"
-				[coverImageUrl]="covers[storyIndex]"
 				[variant]="variant"
 				[order]="order"
 				[tagLabel]="tagLabel"
@@ -147,7 +135,6 @@ export const OnWhite: Story = {
 	}),
 	args: {
 		story: withRichMedia(palacioNueveFronterasTeaserMock),
-		coverImageUrl: palacioNueveFronterasTeaserMock.coverImage,
 		variant: 'on-white',
 		order: 1,
 		tagLabel: 'Cuento',
@@ -173,7 +160,6 @@ export const OnGray: Story = {
 	}),
 	args: {
 		story: withRichMedia(geometriaTeaserMock),
-		coverImageUrl: geometriaTeaserMock.coverImage,
 		variant: 'on-gray',
 		order: 1,
 		tagLabel: 'Cuento',
@@ -199,7 +185,6 @@ export const Highlighted: Story = {
 	}),
 	args: {
 		story: withRichMedia(elOdioTeaserMock),
-		coverImageUrl: elOdioTeaserMock.coverImage,
 		variant: 'highlighted',
 		order: 1,
 		tagLabel: 'Cuento',
@@ -229,7 +214,6 @@ export const AllVariants: Story = {
 				withRichMedia(geometriaTeaserMock),
 				withRichMedia(elOdioTeaserMock),
 			],
-			covers: [palacioNueveFronterasTeaserMock.coverImage, geometriaTeaserMock.coverImage, elOdioTeaserMock.coverImage],
 		},
 		template: `
 			<div class="flex flex-col gap-10">
@@ -238,7 +222,6 @@ export const AllVariants: Story = {
 					<cuentoneta-story-card-teaser-v3
 						variant="on-white"
 						[story]="stories[0]"
-						[coverImageUrl]="covers[0]"
 						[order]="order"
 						[tagLabel]="tagLabel"
 						[showAuthor]="showAuthor"
@@ -253,7 +236,6 @@ export const AllVariants: Story = {
 						<cuentoneta-story-card-teaser-v3
 							variant="on-gray"
 							[story]="stories[1]"
-							[coverImageUrl]="covers[1]"
 							[order]="order"
 							[tagLabel]="tagLabel"
 							[showAuthor]="showAuthor"
@@ -268,7 +250,6 @@ export const AllVariants: Story = {
 					<cuentoneta-story-card-teaser-v3
 						variant="highlighted"
 						[story]="stories[2]"
-						[coverImageUrl]="covers[2]"
 						[order]="order"
 						[tagLabel]="tagLabel"
 						[showAuthor]="showAuthor"
@@ -317,7 +298,6 @@ export const Estados: StoryObj<StoryCardTeaserV3Component & { loading: boolean }
 				} @else {
 					<cuentoneta-story-card-teaser-v3
 						[story]="story"
-						[coverImageUrl]="coverImageUrl"
 						[variant]="variant"
 						[order]="order"
 						[tagLabel]="tagLabel"
@@ -333,7 +313,6 @@ export const Estados: StoryObj<StoryCardTeaserV3Component & { loading: boolean }
 	args: {
 		loading: true,
 		story: withRichMedia(palacioNueveFronterasTeaserMock),
-		coverImageUrl: palacioNueveFronterasTeaserMock.coverImage,
 		variant: 'on-white',
 		order: 1,
 		tagLabel: 'Cuento',

--- a/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.ts
+++ b/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.ts
@@ -139,7 +139,6 @@ export class StoryCardTeaserV3Component {
 	public readonly story = input<StoryNavigationTeaserWithAuthor | StoryTeaserWithAuthor | StoryTeaser>();
 	public readonly variant = input<StoryCardTeaserV3Variant>('on-white');
 	public readonly order = input<number>();
-	public readonly coverImageUrl = input<string>();
 	// Marca el cover como prioritario (above-the-fold, p. ej. en la variante highlighted como hero).
 	public readonly priority = input<boolean>(false);
 	public readonly tagLabel = input<string>();
@@ -151,6 +150,8 @@ export class StoryCardTeaserV3Component {
 	public readonly excerptLines = input(2, { transform: (value: number) => Math.min(10, Math.max(1, value)) });
 	public readonly navigationParams = input<{ navigation: string; navigationSlug: string }>();
 
+	// La portada se deriva del propio story; '' cuando no fue asignada, y el cover cae al placeholder.
+	protected readonly coverImageUrl = computed(() => this.story()?.coverImage);
 	protected readonly storyRouterLink = computed(() => ['/', this.appRoutes.Story, this.story()?.slug]);
 
 	// Mapea la variante de la tarjeta al tema visual de los selectores de multimedia.

--- a/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.ts
+++ b/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.ts
@@ -150,7 +150,6 @@ export class StoryCardTeaserV3Component {
 	public readonly excerptLines = input(2, { transform: (value: number) => Math.min(10, Math.max(1, value)) });
 	public readonly navigationParams = input<{ navigation: string; navigationSlug: string }>();
 
-	// La portada se deriva del propio story; '' cuando no fue asignada, y el cover cae al placeholder.
 	protected readonly coverImageUrl = computed(() => this.story()?.coverImage);
 	protected readonly storyRouterLink = computed(() => ['/', this.appRoutes.Story, this.story()?.slug]);
 


### PR DESCRIPTION
## Descripción

Deriva la portada del propio `story` y **elimina el input redundante `coverImageUrl`** en `HomeStoryCard` y `StoryCardTeaserV3`, reemplazándolo por un `computed`:

```ts
// La portada se deriva del propio story; '' cuando no fue asignada, y el cover cae al placeholder.
protected readonly coverImageUrl = computed(() => this.story()?.coverImage);
```

Ambos componentes ya reciben el `story` completo (con `coverImage: string` en `StoryBase`). Mantener la portada como input separado obligaba a cada consumidor a ligar `[coverImageUrl]="story.coverImage"`; si lo omitía, la tarjeta caía al placeholder pese a tener `coverImage`. El defecto se observó en el spike `spike/1669-homestorycard-elements`, donde `latest-stories-card-deck` migró a `HomeStoryCard` sin ligar el input. La plantilla no cambia (`[src]="coverImageUrl()"`).

## Cambios

- `HomeStoryCardComponent` y `StoryCardTeaserV3Component`: input `coverImageUrl` → `computed` desde `story().coverImage`.
- Specs: los tests de cover construyen el estado desde `story.coverImage`.
- Stories: se elimina el `argType` y las ligaduras de `coverImageUrl`; las portadas se derivan del `coverImage` de los mocks del corpus. Se limpia el import `corpusCovers` sin uso.

## Fuera de alcance

La migración de `latest-stories-card-deck` a `HomeStoryCard` es del spike (en `develop` el deck usa `StoryCardTeaserComponent`) y **no forma parte de este PR**.

## Verificación

- `pnpm lint` ✅
- `pnpm test` (ambos componentes) ✅
- `pnpm storybook:build` ✅

Closes #1692
