### PR TITLE
[#1681] - Eliminar los casts null as unknown as en los tests del ACL (coverImage real)

### DIFF
--- a/src/api/_mocks/onoff/el-inventario-de-las-pasiones.collection.raw.mock.ts
+++ b/src/api/_mocks/onoff/el-inventario-de-las-pasiones.collection.raw.mock.ts
@@ -4,16 +4,16 @@ import { onoffRawNavTeasersMock } from '../onoff-raw-stories.mock';
 // Collection cruda Onoff — "El inventario de las pasiones" (el deseo de ordenar lo inordenable).
 // Forma cruda de `storylistStoriesNavigationTeasersQuery`, para testear
 // `fetchStorylistStoriesNavigationTeaserByStorylistSlug`.
-// TODO(#1681): `featuredImage` queda en null (imagery 'sample') hasta contar con la ref de Sanity
-// de `src/assets/img/mocks/collections/el-inventario-de-las-pasiones.png`; junto con `storyCoverImages`,
-// se resuelve el tema imagery de los raws de una sola vez en el follow-up.
 export const elInventarioDeLasPasionesRawNavCollection: NonNullable<StorylistStoriesNavigationTeasersQueryResult> = {
 	_id: 'onoff-inventario-de-las-pasiones',
 	slug: 'inventario-de-las-pasiones',
 	title: 'El inventario de las pasiones',
 	description: [],
-	featuredImage: null,
-	storyCoverImages: [],
+	featuredImage: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-b02ff4ca997e7b8d5244cae72b704f59a4855fb1-236x328-png' },
+	},
+	storyCoverImages: onoffRawNavTeasersMock.slice(0, 3).map((story) => story.coverImage),
 	tags: [],
 	stories: onoffRawNavTeasersMock,
 	count: onoffRawNavTeasersMock.length,

--- a/src/api/_mocks/onoff/el-odio.raw.mock.ts
+++ b/src/api/_mocks/onoff/el-odio.raw.mock.ts
@@ -246,9 +246,10 @@ export const elOdioRawStory: NonNullable<StoryBySlugQueryResult> = {
 	publishedAt: '1971-01-01T00:00:00Z',
 	updatedAt: '1971-01-01T00:00:00Z',
 	approximateReadingTime: 6,
-	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
-	// TODO(#1681): reemplazar el cast por una ref de imagen real de Sanity; el imagery de los raws se resuelve de una vez en el follow-up.
-	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	coverImage: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-83588a6210ea3de0cee7f493f3d41140427958bf-236x328-png' },
+	},
 	mediaSources: [],
 	resources: [],
 	tags: [],

--- a/src/api/_mocks/onoff/el-palacio-de-las-nueve-fronteras.raw.mock.ts
+++ b/src/api/_mocks/onoff/el-palacio-de-las-nueve-fronteras.raw.mock.ts
@@ -229,9 +229,10 @@ export const elPalacioRawStory: NonNullable<StoryBySlugQueryResult> = {
 	publishedAt: '1985-01-01T00:00:00Z',
 	updatedAt: '1985-01-01T00:00:00Z',
 	approximateReadingTime: 11,
-	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
-	// TODO(#1681): reemplazar el cast por una ref de imagen real de Sanity; el imagery de los raws se resuelve de una vez en el follow-up.
-	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	coverImage: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-3f8774ea01abc54483829d982035a810667240e1-236x328-png' },
+	},
 	mediaSources: [],
 	resources: [],
 	tags: [],

--- a/src/api/_mocks/onoff/el-tratado-de-los-placeres.raw.mock.ts
+++ b/src/api/_mocks/onoff/el-tratado-de-los-placeres.raw.mock.ts
@@ -251,9 +251,10 @@ export const elTratadoRawStory: NonNullable<StoryBySlugQueryResult> = {
 	publishedAt: '1981-01-01T00:00:00Z',
 	updatedAt: '1981-01-01T00:00:00Z',
 	approximateReadingTime: 10,
-	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
-	// TODO(#1681): reemplazar el cast por una ref de imagen real de Sanity; el imagery de los raws se resuelve de una vez en el follow-up.
-	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	coverImage: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-ff13dcee67b52bc4bbd78c2c7900f466f335badd-236x328-png' },
+	},
 	mediaSources: [],
 	resources: [],
 	tags: [],

--- a/src/api/_mocks/onoff/geometria.raw.mock.ts
+++ b/src/api/_mocks/onoff/geometria.raw.mock.ts
@@ -249,9 +249,10 @@ export const geometriaRawStory: NonNullable<StoryBySlugQueryResult> = {
 	publishedAt: '1974-01-01T00:00:00Z',
 	updatedAt: '1974-01-01T00:00:00Z',
 	approximateReadingTime: 7,
-	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
-	// TODO(#1681): reemplazar el cast por una ref de imagen real de Sanity; el imagery de los raws se resuelve de una vez en el follow-up.
-	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	coverImage: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-9e1eab984fbe94e19101c7aa4fc2e99a88f71736-236x328-png' },
+	},
 	mediaSources: [],
 	resources: [],
 	tags: [],

--- a/src/api/_mocks/onoff/geometrias-del-desvelo.collection.raw.mock.ts
+++ b/src/api/_mocks/onoff/geometrias-del-desvelo.collection.raw.mock.ts
@@ -3,16 +3,16 @@ import { onoffRawNavTeasersMock } from '../onoff-raw-stories.mock';
 
 // Collection cruda Onoff — "Geometrías del desvelo" (obsesión por el orden y el tiempo).
 // Forma cruda de `storylistQuery` (StorylistQueryResult), para testear `fetchStorylistBySlug`.
-// TODO(#1681): `featuredImage` queda en null (imagery 'sample') hasta contar con la ref de Sanity
-// de `src/assets/img/mocks/collections/geometrias-del-desvelo.png`; junto con `storyCoverImages`,
-// se resuelve el tema imagery de los raws de una sola vez en el follow-up.
 export const geometriasDelDesveloRawCollection: NonNullable<StorylistQueryResult> = {
 	_id: 'onoff-geometrias-del-desvelo',
 	slug: 'geometrias-del-desvelo',
 	title: 'Geometrías del desvelo',
 	description: [],
-	featuredImage: null,
-	storyCoverImages: [],
+	featuredImage: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-6efd3e53eec8dfab23e1c0109027be9f58a01f8c-236x328-png' },
+	},
+	storyCoverImages: onoffRawNavTeasersMock.slice(0, 3).map((story) => story.coverImage),
 	tags: [],
 	stories: onoffRawNavTeasersMock,
 	count: onoffRawNavTeasersMock.length,

--- a/src/api/_mocks/onoff/las-dos-antorchas.raw.mock.ts
+++ b/src/api/_mocks/onoff/las-dos-antorchas.raw.mock.ts
@@ -260,9 +260,10 @@ export const lasDosAntorchasRawStory: NonNullable<StoryBySlugQueryResult> = {
 	publishedAt: '1987-01-01T00:00:00Z',
 	updatedAt: '1987-01-01T00:00:00Z',
 	approximateReadingTime: 8,
-	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
-	// TODO(#1681): reemplazar el cast por una ref de imagen real de Sanity; el imagery de los raws se resuelve de una vez en el follow-up.
-	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	coverImage: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-83ad8511a47107773b70ff339edd8b43c29dcf3e-236x328-png' },
+	},
 	mediaSources: [],
 	resources: [],
 	tags: [],

--- a/src/api/_mocks/onoff/las-escaleras.raw.mock.ts
+++ b/src/api/_mocks/onoff/las-escaleras.raw.mock.ts
@@ -236,9 +236,10 @@ export const lasEscalerasRawStory: NonNullable<StoryBySlugQueryResult> = {
 	publishedAt: '1979-01-01T00:00:00Z',
 	updatedAt: '1979-01-01T00:00:00Z',
 	approximateReadingTime: 9,
-	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
-	// TODO(#1681): reemplazar el cast por una ref de imagen real de Sanity; el imagery de los raws se resuelve de una vez en el follow-up.
-	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	coverImage: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-ad5639283bf3d3e927b5b0eb79ef2ba098b707e8-236x328-png' },
+	},
 	mediaSources: [],
 	resources: [],
 	tags: [],

--- a/src/api/_mocks/onoff/los-peldanos.raw.mock.ts
+++ b/src/api/_mocks/onoff/los-peldanos.raw.mock.ts
@@ -239,9 +239,10 @@ export const losPeldanosRawStory: NonNullable<StoryBySlugQueryResult> = {
 	publishedAt: '1977-01-01T00:00:00Z',
 	updatedAt: '1977-01-01T00:00:00Z',
 	approximateReadingTime: 8,
-	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
-	// TODO(#1681): reemplazar el cast por una ref de imagen real de Sanity; el imagery de los raws se resuelve de una vez en el follow-up.
-	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	coverImage: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-27fb05f42b38f0ba9ba21aeb566e25abe670b213-236x328-png' },
+	},
 	mediaSources: [],
 	resources: [],
 	tags: [],

--- a/src/api/_mocks/onoff/neron.raw.mock.ts
+++ b/src/api/_mocks/onoff/neron.raw.mock.ts
@@ -262,9 +262,10 @@ export const neronRawStory: NonNullable<StoryBySlugQueryResult> = {
 	publishedAt: '1988-01-01T00:00:00Z',
 	updatedAt: '1988-01-01T00:00:00Z',
 	approximateReadingTime: 7,
-	// REASON: GROQ devuelve null para stories sin imagen; el typegen lo declara non-nullable.
-	// TODO(#1681): reemplazar el cast por una ref de imagen real de Sanity; el imagery de los raws se resuelve de una vez en el follow-up.
-	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
+	coverImage: {
+		_type: 'image',
+		asset: { _type: 'reference', _ref: 'image-9642ca580d43168d6965f428e65df5ca6ec34cdc-236x328-png' },
+	},
 	mediaSources: [],
 	resources: [],
 	tags: [],

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -1,4 +1,11 @@
-import { mapStoryNavigationTeaser, mapStoryNavigationTeaserWithAuthor, mapStoryTeaser, mapTags } from './functions';
+import type { SanityImageSource } from '@sanity/image-url';
+import {
+	mapStoryNavigationTeaser,
+	mapStoryNavigationTeaserWithAuthor,
+	mapStoryTeaser,
+	mapTags,
+	urlFor,
+} from './functions';
 import { elOdioRawTeaser, onoffRawNavTeasersMock } from '../_mocks/onoff-raw-stories.mock';
 
 describe('mapTags (ACL)', () => {
@@ -97,5 +104,15 @@ describe('mapStoryNavigationTeaserWithAuthor (ACL)', () => {
 		const result = mapStoryNavigationTeaserWithAuthor([onoffRawNavTeasersMock[0]]);
 
 		expect(result[0].tags).toEqual([]);
+	});
+});
+
+describe('urlFor (ACL)', () => {
+	it('returns an empty string when the source is null or undefined', () => {
+		// REASON: urlFor es una función de propósito general invocada desde varios mappers; su tipo
+		// SanityImageSource no incluye null/undefined, pero el guard defensivo es real (llamadores
+		// externos al tipo pueden pasar un valor vacío) y se ejercita acotado, con el único cast del corpus.
+		expect(urlFor(null as unknown as SanityImageSource)).toBe('');
+		expect(urlFor(undefined as unknown as SanityImageSource)).toBe('');
 	});
 });

--- a/src/api/modules/story/story.service.spec.ts
+++ b/src/api/modules/story/story.service.spec.ts
@@ -1,11 +1,11 @@
 import { clearAllMocks, type Mock } from '@test-utils';
 import * as storyRepository from './story.repository';
 import * as storyService from './story.service';
-import type { StoriesByAuthorSlugQueryResult, StoryBySlugQueryResult } from '../../sanity/types';
+import type { StoriesByAuthorSlugQueryResult } from '../../sanity/types';
 import { elOdioRawStory } from '../../_mocks/onoff/el-odio.raw.mock';
 import { elOdioRawTeaser } from '../../_mocks/onoff-raw-stories.mock';
 
-/* eslint-disable no-restricted-syntax -- vi.mock/vi.fn: mock de módulo del repository; se migra a inyección de dependencias en #1503 */
+/* eslint-disable no-restricted-syntax -- vi.mock/vi.fn: mock de módulo del repository y del builder de imágenes; se migra a inyección de dependencias en #1503 */
 vi.mock('./story.repository', () => ({
 	fetchStoriesByAuthorSlug: vi.fn(),
 	fetchNavigationTeasersByAuthorSlug: vi.fn(),
@@ -13,23 +13,16 @@ vi.mock('./story.repository', () => ({
 	fetchStoriesBySlugs: vi.fn(),
 	fetchStoryBySlug: vi.fn(),
 }));
+vi.mock('@sanity/image-url', () => ({
+	createImageUrlBuilder: () => ({
+		image: (source: unknown) => ({ url: () => `https://cdn.test/${JSON.stringify(source)}` }),
+	}),
+}));
 /* eslint-enable no-restricted-syntax */
-
-// REASON: GROQ devuelve null para stories sin imagen; el typegen declara coverImage non-nullable.
-const rawTeaserNoCover: StoriesByAuthorSlugQueryResult[0] = {
-	...elOdioRawTeaser,
-	coverImage: null as unknown as StoriesByAuthorSlugQueryResult[0]['coverImage'],
-};
 
 const rawTeaserWithCover: StoriesByAuthorSlugQueryResult[0] = {
 	...elOdioRawTeaser,
 	coverImage: { _type: 'image', asset: { _type: 'reference', _ref: 'image-abc-100x100-jpg' } },
-};
-
-// REASON: GROQ devuelve null para stories sin imagen; el typegen declara coverImage non-nullable.
-const rawContentNoCover: NonNullable<StoryBySlugQueryResult> = {
-	...elOdioRawStory,
-	coverImage: null as unknown as NonNullable<StoryBySlugQueryResult>['coverImage'],
 };
 
 describe('StoryService', () => {
@@ -38,14 +31,6 @@ describe('StoryService', () => {
 	});
 
 	describe('getStoriesByAuthorSlug — mapeo de coverImage', () => {
-		it('should map coverImage to an empty string when the story has no image', async () => {
-			(storyRepository.fetchStoriesByAuthorSlug as Mock).mockResolvedValue([rawTeaserNoCover]);
-
-			const [story] = await storyService.getStoriesByAuthorSlug({ slug: 'francois-onoff', limit: 10, offset: 0 });
-
-			expect(story.coverImage).toBe('');
-		});
-
 		it('should expose coverImage as a string, never the raw Sanity image object', async () => {
 			(storyRepository.fetchStoriesByAuthorSlug as Mock).mockResolvedValue([rawTeaserWithCover]);
 
@@ -57,12 +42,13 @@ describe('StoryService', () => {
 	});
 
 	describe('getStoryBySlug — mapeo de coverImage', () => {
-		it('should map coverImage to an empty string when the story has no image', async () => {
-			(storyRepository.fetchStoryBySlug as Mock).mockResolvedValue(rawContentNoCover);
+		it('should expose coverImage as a URL string built from the raw Sanity image', async () => {
+			(storyRepository.fetchStoryBySlug as Mock).mockResolvedValue(elOdioRawStory);
 
 			const story = await storyService.getStoryBySlug('el-odio');
 
-			expect(story.coverImage).toBe('');
+			expect(typeof story.coverImage).toBe('string');
+			expect(story.coverImage).not.toBe('');
 		});
 	});
 });

--- a/src/api/modules/storylist/storylist.repository.spec.ts
+++ b/src/api/modules/storylist/storylist.repository.spec.ts
@@ -1,4 +1,3 @@
-import type { SanityImageSource } from '@sanity/image-url';
 import { clearAllMocks, type Mock } from '@test-utils';
 import { client } from '../../_helpers/sanity-connector';
 import { geometriasDelDesveloRawCollection } from '../../_mocks/onoff/geometrias-del-desvelo.collection.raw.mock';
@@ -16,9 +15,13 @@ vi.mock('@sanity/image-url', () => ({
 }));
 /* eslint-enable no-restricted-syntax */
 
-// Portadas explícitas para los casos de imagery: el corpus crudo tiene featuredImage/coverImage en null
-// hasta el follow-up #1681, así que los refs de imagen se inyectan por caso sobre las collections crudas.
-const img = (ref: string): SanityImageSource => ({ _type: 'image', asset: { _type: 'reference', _ref: ref } });
+// Fragmentos de los `_ref` reales del corpus: la collection (featuredImage) y las 3 primeras
+// stories de `onoffRawNavTeasersMock` (el-palacio, geometria, los-peldanos), que alimentan `storyCoverImages`.
+const geometriasFeaturedRef = '6efd3e53eec8dfab23e1c0109027be9f58a01f8c';
+const inventarioFeaturedRef = 'b02ff4ca997e7b8d5244cae72b704f59a4855fb1';
+const elPalacioCoverRef = '3f8774ea01abc54483829d982035a810667240e1';
+const geometriaCoverRef = '9e1eab984fbe94e19101c7aa4fc2e99a88f71736';
+const losPeldanosCoverRef = '27fb05f42b38f0ba9ba21aeb566e25abe670b213';
 
 describe('storylist.repository', () => {
 	beforeEach(() => {
@@ -27,32 +30,26 @@ describe('storylist.repository', () => {
 
 	describe('fetchStorylistBySlug', () => {
 		it('maps a present featuredImage to representative imagery', async () => {
-			(client.fetch as Mock).mockResolvedValue({
-				...geometriasDelDesveloRawCollection,
-				featuredImage: img('geometrias-del-desvelo'),
-			});
+			(client.fetch as Mock).mockResolvedValue(geometriasDelDesveloRawCollection);
 
 			const result = await fetchStorylistBySlug('geometrias-del-desvelo');
 
 			expect(result.imagery.kind).toBe('representative');
 			if (result.imagery.kind === 'representative') {
-				expect(result.imagery.image).toContain('geometrias-del-desvelo');
+				expect(result.imagery.image).toContain(geometriasFeaturedRef);
 			}
 		});
 
 		it('falls back to sample imagery (story covers) when featuredImage is null', async () => {
-			(client.fetch as Mock).mockResolvedValue({
-				...geometriasDelDesveloRawCollection,
-				storyCoverImages: [img('c1'), img('c2'), img('c3')],
-			});
+			(client.fetch as Mock).mockResolvedValue({ ...geometriasDelDesveloRawCollection, featuredImage: null });
 
 			const result = await fetchStorylistBySlug('geometrias-del-desvelo');
 
 			expect(result.imagery.kind).toBe('sample');
 			if (result.imagery.kind === 'sample') {
-				expect(result.imagery.images[0]).toContain('c1');
-				expect(result.imagery.images[1]).toContain('c2');
-				expect(result.imagery.images[2]).toContain('c3');
+				expect(result.imagery.images[0]).toContain(elPalacioCoverRef);
+				expect(result.imagery.images[1]).toContain(geometriaCoverRef);
+				expect(result.imagery.images[2]).toContain(losPeldanosCoverRef);
 			}
 		});
 	});
@@ -61,32 +58,26 @@ describe('storylist.repository', () => {
 		const params = { slug: 'inventario-de-las-pasiones', start: 0, end: 10 };
 
 		it('maps a present featuredImage to representative imagery', async () => {
-			(client.fetch as Mock).mockResolvedValue({
-				...elInventarioDeLasPasionesRawNavCollection,
-				featuredImage: img('el-inventario-de-las-pasiones'),
-			});
+			(client.fetch as Mock).mockResolvedValue(elInventarioDeLasPasionesRawNavCollection);
 
 			const result = await fetchStorylistStoriesNavigationTeaserByStorylistSlug(params);
 
 			expect(result.imagery.kind).toBe('representative');
 			if (result.imagery.kind === 'representative') {
-				expect(result.imagery.image).toContain('el-inventario-de-las-pasiones');
+				expect(result.imagery.image).toContain(inventarioFeaturedRef);
 			}
 		});
 
 		it('falls back to sample imagery (story covers) when featuredImage is null', async () => {
-			(client.fetch as Mock).mockResolvedValue({
-				...elInventarioDeLasPasionesRawNavCollection,
-				storyCoverImages: [img('c1'), img('c2'), img('c3')],
-			});
+			(client.fetch as Mock).mockResolvedValue({ ...elInventarioDeLasPasionesRawNavCollection, featuredImage: null });
 
 			const result = await fetchStorylistStoriesNavigationTeaserByStorylistSlug(params);
 
 			expect(result.imagery.kind).toBe('sample');
 			if (result.imagery.kind === 'sample') {
-				expect(result.imagery.images[0]).toContain('c1');
-				expect(result.imagery.images[1]).toContain('c2');
-				expect(result.imagery.images[2]).toContain('c3');
+				expect(result.imagery.images[0]).toContain(elPalacioCoverRef);
+				expect(result.imagery.images[1]).toContain(geometriaCoverRef);
+				expect(result.imagery.images[2]).toContain(losPeldanosCoverRef);
 			}
 		});
 	});

--- a/src/app/mocks/storylist.mock.ts
+++ b/src/app/mocks/storylist.mock.ts
@@ -2,11 +2,11 @@ import { Storylist, StorylistStoriesNavigationTeasers, StorylistTeaser } from '@
 import { tagMock } from './tag.mocks';
 import { storyNavigationTeaserWithAuthor } from './story.mock';
 
-// Colección — los espacios imposibles de Onoff (palacios, escaleras, peldaños).
+// Colección — la obsesión de Onoff por el orden y el tiempo (Geometría, el desvelo). Proyección completa (Storylist).
 export const storylistMock: Storylist = {
-	_id: 'onoff-arquitecturas-laberinto',
-	title: 'Arquitecturas del laberinto',
-	slug: 'arquitecturas-del-laberinto',
+	_id: 'onoff-geometrias-del-desvelo',
+	title: 'Geometrías del desvelo',
+	slug: 'geometrias-del-desvelo',
 	count: 1,
 	media: [],
 	tabs: [],
@@ -14,21 +14,21 @@ export const storylistMock: Storylist = {
 		{
 			_type: 'block',
 			style: 'normal',
-			_key: 'arquitecturas-desc',
+			_key: 'geometrias-desc',
 			markDefs: [],
 			children: [
 				{
 					_type: 'span',
 					marks: [],
-					text: 'Los relatos en los que François Onoff convierte la arquitectura en metafísica: palacios de nueve fronteras, escaleras que no terminan, peldaños que se multiplican al ser contados. Espacios que se recorren como demostraciones y se habitan como preguntas.',
-					_key: 'arquitecturas-span',
+					text: 'Onoff lleva la precisión del compás al territorio de lo humano: insomnios que se vuelven una geometría del tiempo, vidas reducidas a coordenadas, figuras que prometen un orden perfecto y terminan revelando, en algún vértice, su grieta.',
+					_key: 'geometrias-span',
 				},
 			],
 		},
 	],
 	imagery: {
 		kind: 'representative',
-		image: 'assets/img/mocks/stories/el-palacio-de-las-nueve-fronteras.png',
+		image: 'assets/img/mocks/collections/geometrias-del-desvelo.png',
 	},
 	tags: [tagMock],
 	config: {

--- a/src/app/mocks/storylist.mock.ts
+++ b/src/app/mocks/storylist.mock.ts
@@ -26,10 +26,9 @@ export const storylistMock: Storylist = {
 			],
 		},
 	],
-	// TODO: #1681 - por una ref de imagen real de Sanity en base a las imágenes mock provistas
 	imagery: {
 		kind: 'representative',
-		image: 'https://cdn.sanity.io/images/s4dbqkc5/production/edd62a3131bd1f46e796e473d0b2b12d1c63c229-1024x1536.png',
+		image: 'assets/img/mocks/stories/el-palacio-de-las-nueve-fronteras.png',
 	},
 	tags: [tagMock],
 	config: {

--- a/src/app/pages/storylist/storylist.schema.spec.ts
+++ b/src/app/pages/storylist/storylist.schema.spec.ts
@@ -11,8 +11,8 @@ describe('buildStorylistCollectionSchema', () => {
 		expect(schema).toMatchObject({
 			'@context': 'https://schema.org',
 			'@type': 'CollectionPage',
-			name: 'Arquitecturas del laberinto',
-			url: 'https://www.cuentoneta.ar/storylist/arquitecturas-del-laberinto',
+			name: 'Geometrías del desvelo',
+			url: 'https://www.cuentoneta.ar/storylist/geometrias-del-desvelo',
 			inLanguage: 'es-AR',
 			mainEntity: {
 				'@type': 'ItemList',
@@ -39,8 +39,8 @@ describe('buildStorylistBreadcrumb', () => {
 			{
 				'@type': 'ListItem',
 				position: 2,
-				name: 'Arquitecturas del laberinto',
-				item: 'https://www.cuentoneta.ar/storylist/arquitecturas-del-laberinto',
+				name: 'Geometrías del desvelo',
+				item: 'https://www.cuentoneta.ar/storylist/geometrias-del-desvelo',
 			},
 		]);
 	});


### PR DESCRIPTION
## Descripción

- Reemplaza los `null as unknown as *QueryResult['coverImage']` de los 8 raws de story del corpus Onoff (`src/api/_mocks/onoff/*.raw.mock.ts`) por objetos `SanityImageSource` reales con `_ref` sintético determinista (`image-<sha1>-236x328-png`), alineando los fixtures con el contrato real de imagen post-#1648 (`story.coverImage` requerido).
- Puebla `featuredImage` y `storyCoverImages` con refs reales en los 2 raws de collection, ejercitando imagery `representative`/`sample` desde el propio fixture; simplifica `storylist.repository.spec.ts` (quita el helper `img()` y las inyecciones por caso).
- Descarta los tests de "coverImage vacío" (input ya imposible) y preserva la cobertura del null-handling defensivo como un unit test acotado de `urlFor` en `functions.spec.ts` — el único `as unknown as` remanente, justificado inline.
- Cierra el `TODO: #1681` huérfano en `src/app/mocks/storylist.mock.ts`: `storylistMock` deja de usar una URL de Sanity CDN hardcodeada y pasa a representar la collection **"Geometrías del desvelo"** (título/slug/`_id`/descripción) con su portada de `assets/img/mocks/collections/geometrias-del-desvelo.png`, en paridad con el raw backend homónimo (`geometriasDelDesveloRawCollection`). Ajusta los literales de `storylist.schema.spec.ts`.

Closes #1681.

Parte de #1651.

## Plan de pruebas

- [x] `pnpm test` — verde
- [x] `pnpm lint` — verde
- [x] `pnpm stylelint` — verde
- [x] `pnpm build` — verde
- [x] `pnpm storybook:build` — verde
- [x] Sin `as unknown as` en el corpus/specs del ACL salvo el cast justificado de `urlFor`, y sin `TODO(#1681)` / `TODO: #1681` pendientes en el repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
