### PR TITLE
[#1691] - Agregar gate de CI de type-checking estricto (tsc --noEmit)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -53,7 +53,7 @@ Cargá todas estas juntas:
 3. **Verificar cobertura de tests** — Confirmá que hay tests para el código nuevo (Vitest + Angular Testing Library + `@test-utils`).
 4. **Correr los gates de CI** — Ejecutá los gates vía `pnpm` para asegurar que nada se rompió. Debés correr esta verificación vos mismo en **cada** invocación; nunca confíes en ni reportes un estado de CI que no observaste directamente.
 
-Los gates que deben quedar verdes en cada PR son: `pnpm lint`, `pnpm test`, `pnpm stylelint`, `pnpm build` y `pnpm storybook:build`. Corré cada uno y reportá el resultado real que observaste.
+Los gates que deben quedar verdes en cada PR son: `pnpm lint`, `pnpm test`, `pnpm stylelint`, `pnpm typecheck`, `pnpm build` y `pnpm storybook:build`. Corré cada uno y reportá el resultado real que observaste.
 
 ## Falsos positivos conocidos — NO marcar
 
@@ -217,6 +217,7 @@ Corré los gates vía `pnpm` vos mismo en cada invocación y reportá el resulta
 | ---------------------- | --------- |
 | `pnpm lint`            | PASS/FAIL |
 | `pnpm stylelint`       | PASS/FAIL |
+| `pnpm typecheck`       | PASS/FAIL |
 | `pnpm test`            | PASS/FAIL |
 | `pnpm build`           | PASS/FAIL |
 | `pnpm storybook:build` | PASS/FAIL |

--- a/.claude/agents/migration-planner.md
+++ b/.claude/agents/migration-planner.md
@@ -107,7 +107,7 @@ pnpm outdated
 
 ### Verificación final (gates de CI)
 
-Todos deben quedar verdes antes de mergear: `pnpm test`, `pnpm lint`, `pnpm stylelint`, `pnpm build`, `pnpm storybook:build`.
+Todos deben quedar verdes antes de mergear: `pnpm test`, `pnpm lint`, `pnpm stylelint`, `pnpm typecheck`, `pnpm build`, `pnpm storybook:build`.
 
 ### Plan de rollback
 

--- a/.claude/agents/plan-writer.md
+++ b/.claude/agents/plan-writer.md
@@ -126,7 +126,7 @@ Escribí el plan en `workspace/PLAN.md` con esta estructura:
 
 ## Gates de CI
 
-Listar los gates que deben quedar verdes para este cambio (vía `pnpm`): `test`, `lint`, `stylelint`, `e2e`, `build`, `storybook`. Indicar cuáles son relevantes al diff.
+Listar los gates que deben quedar verdes para este cambio (vía `pnpm`): `test`, `lint`, `stylelint`, `typecheck`, `e2e`, `build`, `storybook`. Indicar cuáles son relevantes al diff.
 
 ## Convenciones del repo a respetar
 

--- a/.claude/references/coding-agent-policies.md
+++ b/.claude/references/coding-agent-policies.md
@@ -177,7 +177,7 @@ El principio: **el documento es canónico; la memoria es refuerzo**. Si los dos 
 
 ### Gates de CI
 
-Independientemente de lo anterior, todo PR debe dejar verdes los gates de CI definidos en `CLAUDE.md`: `test`, `lint`, `stylelint`, `e2e`, `build`, `storybook`. Que un gate sea "molesto" o "lento" no es justificación para saltearlo o deshabilitarlo.
+Independientemente de lo anterior, todo PR debe dejar verdes los gates de CI definidos en `CLAUDE.md`: `test`, `lint`, `stylelint`, `typecheck`, `e2e`, `build`, `storybook`. Que un gate sea "molesto" o "lento" no es justificación para saltearlo o deshabilitarlo.
 
 ### Enmiendas
 

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -79,7 +79,7 @@ No avanzar a la Fase 3 sin aprobación explícita.
 **Propósito:** verificar que pasen los gates de CI y correr el agente `code-reviewer`.
 
 1. Correr los **gates de CI** localmente (con `pnpm`, nunca `nx` directo):
-   - `pnpm lint` · `pnpm test` · `pnpm stylelint` · `pnpm build` · `pnpm storybook:build` · (`pnpm test:e2e` si el cambio toca flujos E2E).
+   - `pnpm lint` · `pnpm test` · `pnpm stylelint` · `pnpm typecheck` · `pnpm build` · `pnpm storybook:build` · (`pnpm test:e2e` si el cambio toca flujos E2E).
    - Si alguno falla: reportar cuál, diagnosticar, arreglar, commitear el fix (reglas de Fase 3) y re-correr hasta que pasen.
 2. Delegar al agente **`code-reviewer`** para revisar todos los cambios de la rama vs. `develop`.
 3. El code-reviewer escribe los hallazgos en `workspace/CODE_REVIEW.md`.

--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -59,7 +59,7 @@ Formato de commit: `[#<issue>] - <qué cambió>` (español). Cada commit deja el
 
 **Propósito:** confirmar que el release no rompe el pipeline automático.
 
-1. **Gates de CI** (con `pnpm`): `pnpm lint · pnpm stylelint · pnpm test · pnpm build · pnpm storybook:build`. Un bump + CHANGELOG no toca runtime, pero se corren igual por política. El `build` confirma de paso la versión (`@cuentoneta/app@<x>` en el `postbuild`).
+1. **Gates de CI** (con `pnpm`): `pnpm lint · pnpm stylelint · pnpm typecheck · pnpm test · pnpm build · pnpm storybook:build`. Un bump + CHANGELOG no toca runtime, pero se corren igual por política. El `build` confirma de paso la versión (`@cuentoneta/app@<x>` en el `postbuild`).
 2. **Dry-run de la extracción de notas de `release.yml`:** el workflow extrae con `awk` el cuerpo entre `## Versión <x>` y el próximo `## Versión`. Simularlo y confirmar que devuelve una sección **no vacía** (si falta, el job del release falla):
 
    ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,41 @@ jobs:
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
+  typecheck:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Select pnpm as package manager
+        uses: pnpm/action-setup@v6.0.9
+        with:
+          version: 10.12.1
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22.22.3
+
+      - name: Download workspace artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: workspace
+
+      - name: Unpack workspace
+        run: tar -xf workspace.tar
+
+      - name: Cache de Nx local (fallback sin Nx Cloud)
+        uses: actions/cache@v6
+        with:
+          path: .nx/cache
+          key: nx-cache-typecheck-${{ github.sha }}
+          restore-keys: |
+            nx-cache-typecheck-
+
+      - name: Run typecheck
+        run: bash .github/scripts/nx-run.sh nx typecheck
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
   e2e:
     needs: setup
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ Thumbs.db
 # Grabaciones sueltas de referencia en scripts/
 scripts/*.m4a
 scripts/*.mp4
+
+# Info incremental de TypeScript (regenerable por tsc -b)
+*.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Usar **siempre `pnpm`** para instalar y ejecutar scripts. Los scripts envuelven 
 | `pnpm build`                              | Build de producción                  |
 | `pnpm lint`                               | ESLint sobre `src`                   |
 | `pnpm stylelint`                          | Stylelint sobre CSS                  |
+| `pnpm typecheck`                          | Type-check estricto (`tsc --noEmit`) |
 | `pnpm test`                               | Tests unitarios (Vitest)             |
 | `pnpm test:watch`                         | Tests en watch                       |
 | `pnpm test:e2e`                           | E2E (Playwright)                     |
@@ -57,7 +58,9 @@ Usar **siempre `pnpm`** para instalar y ejecutar scripts. Los scripts envuelven 
 | `pnpm sanity:extract-schema`              | Extrae el schema de Sanity           |
 | `pnpm sanity:run-typegen-generator`       | Genera tipos a partir del schema     |
 
-**Gates de CI** (deben quedar verdes en cada PR): `test`, `lint`, `stylelint`, `e2e`, `build`, `storybook`.
+**Gates de CI** (deben quedar verdes en cada PR): `test`, `lint`, `stylelint`, `typecheck`, `e2e`, `build`, `storybook`.
+
+> El gate `typecheck` (`pnpm typecheck` → `tsc --noEmit` estricto) cubre el **TS puro** de la app (`src/**`, incluidos `*.spec.ts` y `*.stories.ts`) y `scripts/`. **No** valida plantillas Angular (eso lo hacen `build`/`storybook` vía `ngtsc`) ni el proyecto `cms/`.
 
 ---
 

--- a/nx.json
+++ b/nx.json
@@ -41,6 +41,10 @@
 		"stylelint": {
 			"inputs": ["default", "{workspaceRoot}/.stylelintrc(.(json|yml|yaml|js))?"],
 			"cache": true
+		},
+		"typecheck": {
+			"inputs": ["default", "^default"],
+			"cache": true
 		}
 	},
 	"namedInputs": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"lint": "nx eslint:lint --skip-nx-cache",
 		"stylelint": "nx stylelint @cuentoneta/app",
 		"test": "nx test --skip-nx-cache",
+		"typecheck": "nx typecheck --skip-nx-cache",
 		"test:watch": "nx test --watch",
 		"test:ui": "nx test --ui",
 		"test:e2e": "nx run @cuentoneta/app:e2e",

--- a/project.json
+++ b/project.json
@@ -120,6 +120,12 @@
 				"lintFilePatterns": ["**/*.css"]
 			}
 		},
+		"typecheck": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "tsc -p tsconfig.typecheck.json --noEmit"
+			}
+		},
 		"test-storybook": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/scripts/add-storylist-config.ts
+++ b/scripts/add-storylist-config.ts
@@ -11,7 +11,7 @@ const runMigration = async () => {
 
 	console.log('\n--- Fetching all storylists without config field ---');
 
-	const documents = await client.fetch(
+	const documents = await client.fetch<Array<{ _id: string; title: string; slug: { current: string } }>>(
 		`*[_type == 'storylist' && !defined(config) && !(_id in path('drafts.**'))] { _id, title, slug }`,
 	);
 

--- a/scripts/delete-day-property-in-story.ts
+++ b/scripts/delete-day-property-in-story.ts
@@ -4,13 +4,17 @@
 
 // Importar cliente de Sanity
 import { client } from '../src/api/_helpers/sanity-connector';
+import type { Transaction } from '@sanity/client';
+
+type StoryDocument = { _id: string; _rev: string };
+type StoryPatch = { id: string; patch: { unset: string[]; ifRevisionID: string } };
 
 const fetchStories = () =>
-	client.fetch(`
+	client.fetch<StoryDocument[]>(`
   *[_type == 'story']
 `);
 
-const buildPatches = (stories) =>
+const buildPatches = (stories: StoryDocument[]): StoryPatch[] =>
 	stories.map((story) => ({
 		id: story._id,
 		patch: {
@@ -19,10 +23,10 @@ const buildPatches = (stories) =>
 		},
 	}));
 
-const createTransaction = (patches) =>
+const createTransaction = (patches: StoryPatch[]) =>
 	patches.reduce((tx, patch) => tx.patch(patch.id, patch.patch), client.transaction());
 
-const commitTransaction = (tx) => tx.commit();
+const commitTransaction = (tx: Transaction) => tx.commit();
 
 const migrateBatch = async () => {
 	const stories = await fetchStories();

--- a/scripts/flatten-author-biography.ts
+++ b/scripts/flatten-author-biography.ts
@@ -12,7 +12,7 @@ const runMigration = async () => {
 
 	console.log('\n--- Fetching all authors with localized biographies ---');
 
-	const documents = await client.fetch(
+	const documents = await client.fetch<Array<{ _id: string; name: string; biography?: { es?: unknown } }>>(
 		`*[_type == 'author' && biography.es != null && !(_id in path('drafts.**'))] { _id, name, biography }`,
 	);
 
@@ -27,7 +27,7 @@ const runMigration = async () => {
 	// Build transaction with all patches
 	const transaction = documents.reduce((tx, doc) => {
 		if (doc.biography?.es) {
-			return tx.patch(doc._id, (patch) => patch.set({ biography: doc.biography.es }));
+			return tx.patch(doc._id, (patch) => patch.set({ biography: doc.biography?.es }));
 		}
 		return tx;
 	}, client.transaction());

--- a/scripts/remove-language-field.ts
+++ b/scripts/remove-language-field.ts
@@ -7,7 +7,7 @@ import { client } from '../src/api/_helpers/sanity-connector';
 const migrateDocType = async (docType: 'story' | 'storylist') => {
 	console.log(`\n--- Fetching all ${docType} documents with language field ---`);
 
-	const documents = await client.fetch(
+	const documents = await client.fetch<Array<{ _id: string; title: string }>>(
 		`*[_type == '${docType}' && defined(language) && !(_id in path('drafts.**'))] { _id, title }`,
 	);
 

--- a/src/app/components/footer/footer.component.spec.ts
+++ b/src/app/components/footer/footer.component.spec.ts
@@ -20,7 +20,7 @@ describe('FooterComponent', () => {
 			providers: [provideRouter([])],
 		});
 
-		view.fixture.componentInstance.navLinks.forEach((link) => {
+		view.fixture.componentInstance['navLinks'].forEach((link) => {
 			const navItem = screen.getByRole('link', { name: link.label });
 			expect(navItem).toBeInTheDocument();
 			expect(screen.getByText(link.label)).toHaveProperty('href', expect.stringMatching(new RegExp(link.path)));
@@ -32,7 +32,7 @@ describe('FooterComponent', () => {
 			providers: [provideRouter([])],
 		});
 
-		view.fixture.componentInstance.socialLinks.forEach((link) => {
+		view.fixture.componentInstance['socialLinks'].forEach((link) => {
 			const socialIcon = screen.getByAltText(link.alt);
 			expect(socialIcon).toBeInTheDocument();
 		});

--- a/src/app/components/media-resource-tag/media-resource-tag.component.spec.ts
+++ b/src/app/components/media-resource-tag/media-resource-tag.component.spec.ts
@@ -7,7 +7,8 @@ describe('MediaResourceTagComponent', () => {
 			inputs: {
 				platform: {
 					title: 'Posee contenido multimedia',
-					icon: 'media',
+					// La plantilla concatena `icon` en el data-testid; el test usa un string como stand-in del Record de ng-icon.
+					icon: 'media' as unknown as Record<string, string>,
 				},
 				size: 'md',
 			},

--- a/src/app/components/media-resource-tag/media-resource-tag.component.spec.ts
+++ b/src/app/components/media-resource-tag/media-resource-tag.component.spec.ts
@@ -7,8 +7,7 @@ describe('MediaResourceTagComponent', () => {
 			inputs: {
 				platform: {
 					title: 'Posee contenido multimedia',
-					// La plantilla concatena `icon` en el data-testid; el test usa un string como stand-in del Record de ng-icon.
-					icon: 'media' as unknown as Record<string, string>,
+					icon: { media: '' },
 				},
 				size: 'md',
 			},
@@ -25,5 +24,18 @@ describe('MediaResourceTagComponent', () => {
 		const icon = screen.getByTestId('icon-media');
 		expect(icon).toBeInTheDocument();
 		expect(icon).toHaveAttribute('aria-label', 'Posee contenido multimedia');
+	});
+
+	// Regresión #1702: el data-testid deriva de la key del ícono, no del objeto crudo (antes daba `icon-[object Object]`).
+	it('should derive the data-testid from the icon key, not the icon object', async () => {
+		await render(MediaResourceTagComponent, {
+			inputs: {
+				platform: { title: 'Contiene videos de YouTube', icon: { faBrandYoutube: '' } },
+				size: 'md',
+			},
+		});
+
+		expect(screen.getByTestId('icon-faBrandYoutube')).toBeInTheDocument();
+		expect(screen.queryByTestId('icon-[object Object]')).toBeNull();
 	});
 });

--- a/src/app/components/media-resource-tag/media-resource-tag.component.spec.ts
+++ b/src/app/components/media-resource-tag/media-resource-tag.component.spec.ts
@@ -26,7 +26,6 @@ describe('MediaResourceTagComponent', () => {
 		expect(icon).toHaveAttribute('aria-label', 'Posee contenido multimedia');
 	});
 
-	// Regresión #1702: el data-testid deriva de la key del ícono, no del objeto crudo (antes daba `icon-[object Object]`).
 	it('should derive the data-testid from the icon key, not the icon object', async () => {
 		await render(MediaResourceTagComponent, {
 			inputs: {

--- a/src/app/components/media-resource-tag/media-resource-tag.component.ts
+++ b/src/app/components/media-resource-tag/media-resource-tag.component.ts
@@ -16,7 +16,7 @@ export interface MediaResourcePlatform {
 			[name]="iconName()"
 			[size]="iconSize()"
 			[attr.aria-label]="platform().title"
-			[attr.data-testid]="'icon-' + platform().icon"
+			[attr.data-testid]="'icon-' + iconName()"
 		/>
 	</div>`,
 })

--- a/src/app/components/media-resource-tags/media-resource-tags.component.spec.ts
+++ b/src/app/components/media-resource-tags/media-resource-tags.component.spec.ts
@@ -46,7 +46,7 @@ describe('MediaResourceTagsComponent', () => {
 		});
 
 		const instance = view.fixture.componentInstance;
-		const platforms = instance.platforms as { [key in MediaTypeKey]: MediaResourcePlatform };
+		const platforms = instance['platforms'] as { [key in MediaTypeKey]: MediaResourcePlatform };
 
 		mockMedia.forEach((media) => {
 			const platformIcon = screen.getByLabelText(platforms[media.type].title);
@@ -64,7 +64,7 @@ describe('MediaResourceTagsComponent', () => {
 			},
 		});
 		const instance = view.fixture.componentInstance;
-		const platforms = instance.platforms as { [key in MediaTypeKey]: MediaResourcePlatform };
+		const platforms = instance['platforms'] as { [key in MediaTypeKey]: MediaResourcePlatform };
 		const expectedPlatforms = ['audioRecording', 'spaceRecording', 'spotifyPodcastEpisode', 'youTubeVideo'];
 		const actualPlatforms = Object.keys(platforms) as MediaTypeKey[];
 		expect(actualPlatforms).toEqual(expectedPlatforms);

--- a/src/app/pages/author/author.schema.spec.ts
+++ b/src/app/pages/author/author.schema.spec.ts
@@ -25,7 +25,11 @@ describe('buildAuthorProfilePageSchema', () => {
 	});
 
 	it('should forward the ISO datetime dates verbatim to dateCreated/dateModified', () => {
-		const author = { ...authorMock, createdAt: '2022-01-25T23:26:34Z', updatedAt: '2026-06-09T00:32:32Z' };
+		const author = {
+			...authorMock,
+			createdAt: '2022-01-25T23:26:34Z' as typeof authorMock.createdAt,
+			updatedAt: '2026-06-09T00:32:32Z' as typeof authorMock.updatedAt,
+		};
 
 		const schema = buildAuthorProfilePageSchema(author, websiteUrl);
 

--- a/src/app/pages/author/author.schema.spec.ts
+++ b/src/app/pages/author/author.schema.spec.ts
@@ -1,4 +1,5 @@
 import { authorMock } from '@mocks/author.mock';
+import type { IsoDateTime } from '@utils/date.utils';
 
 import { buildAuthorBreadcrumb, buildAuthorProfilePageSchema } from './author.schema';
 
@@ -27,8 +28,8 @@ describe('buildAuthorProfilePageSchema', () => {
 	it('should forward the ISO datetime dates verbatim to dateCreated/dateModified', () => {
 		const author = {
 			...authorMock,
-			createdAt: '2022-01-25T23:26:34Z' as typeof authorMock.createdAt,
-			updatedAt: '2026-06-09T00:32:32Z' as typeof authorMock.updatedAt,
+			createdAt: '2022-01-25T23:26:34Z' as IsoDateTime,
+			updatedAt: '2026-06-09T00:32:32Z' as IsoDateTime,
 		};
 
 		const schema = buildAuthorProfilePageSchema(author, websiteUrl);

--- a/src/app/pages/storylist/storylist.component.spec.ts
+++ b/src/app/pages/storylist/storylist.component.spec.ts
@@ -21,7 +21,8 @@ describe.skip('StorylistComponent', () => {
 	const setup = async () => {
 		return await render(StorylistComponent, {
 			componentImports: [CommonModule, HttpClientTestingModule, MockStorylistCardDeckComponent],
-			componentProviders: [provideRouter([]), provideMock(HeadMetadataDirective)],
+			providers: [provideRouter([])],
+			componentProviders: [provideMock(HeadMetadataDirective)],
 		});
 	};
 

--- a/src/app/providers/contributor.provider.spec.ts
+++ b/src/app/providers/contributor.provider.spec.ts
@@ -83,7 +83,7 @@ describe('HttpContributorApi', () => {
 		it('should handle HTTP errors gracefully', () => {
 			service.getAll().subscribe(
 				() => {
-					fail('should have failed');
+					throw new Error('should have failed');
 				},
 				(error) => {
 					expect(error.status).toBe(500);

--- a/src/app/providers/layout.service.spec.ts
+++ b/src/app/providers/layout.service.spec.ts
@@ -24,8 +24,8 @@ describe('LayoutService', () => {
 			dispatchEvent: fn((event: Event) => {
 				if (typeof event === 'object' && event.type) {
 					mockWindow.addEventListener.mock.calls
-						.filter(([type]: ['resize' | 'orientationchange']) => type === event.type)
-						.forEach(([, listener]: [string, Mock]) => listener(event));
+						.filter(([type]) => type === event.type)
+						.forEach(([, listener]) => listener(event));
 				}
 			}),
 		};

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist/out-tsc",
+		"noEmit": true,
+		"types": ["node", "vitest/globals"]
+	},
+	"include": ["src/**/*.ts", "scripts/**/*.ts"],
+	"exclude": ["node_modules", "tmp", "dist"]
+}

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -5,6 +5,6 @@
 		"noEmit": true,
 		"types": ["node", "vitest/globals"]
 	},
-	"include": ["src/**/*.ts", "scripts/**/*.ts"],
+	"include": ["src/**/*.ts", "scripts/**/*.ts", "e2e/**/*.ts", "playwright.config.ts", "vitest.config.ts"],
 	"exclude": ["node_modules", "tmp", "dist"]
 }


### PR DESCRIPTION
## Descripción

- Agrega un gate de CI dedicado de type-checking estricto (`pnpm typecheck` → `tsc --noEmit`) que atrapa errores de tipos como el de #1690 sin depender del gate de Storybook (el más pesado y de feedback tardío). En CI corre en ~6s vs. ~40s de storybook.
- Implementación: `tsconfig.typecheck.json` dedicado (extiende el tsconfig raíz, cubre `src/**` incluidos specs y stories, `scripts/**`, `e2e/**` y los configs raíz de Playwright/Vitest; **no** valida plantillas Angular ni `cms/`), target Nx `typecheck` cacheable, script `pnpm typecheck` y job `typecheck` en `ci.yml` calcado del patrón de `lint`.
- Cierra un hueco real: Vitest y Playwright transpilan sin type-checkear, así que los `*.spec.ts` y specs e2e no los verificaba ningún gate. Corregí los errores de tipos latentes que esto expuso (7 specs: accesos a miembros `protected`, `fail()`→`throw`, casts de mocks, `provideRouter` movido a `providers`) y tipé `client.fetch<T>()` en 4 scripts de migración.
- Documentación de gates actualizada en `CLAUDE.md`, `coding-agent-policies.md`, skills y agentes.

Closes #1691.

## Resuelto en este PR: #1702 (bug destapado por el gate)

Al tipar el spec de `MediaResourceTagComponent`, el gate destapó que el mock pasaba `icon` como `string` cuando el input es `Record<string, string>`. La causa de raíz estaba en el componente: el `data-testid` se construía concatenando el **objeto `icon` crudo** —`'icon-' + platform().icon`—, lo que producía `icon-[object Object]` para íconos reales (p. ej. `{ faBrandYoutube }`).

En vez de sellar el síntoma con un cast en el test, se corrigió el bug de raíz:

- **Componente:** el `data-testid` ahora deriva de la **key** del ícono vía `iconName()` (`'icon-' + iconName()`), consistente con `[name]="iconName()"`.
- **Mock del spec:** pasa un `Record` real (`{ media: '' }`) reflejando el shape verdadero; se eliminó el `as unknown as Record<string, string>`.
- **Test de regresión:** verifica que el `data-testid` se derive de la key (`icon-faBrandYoutube`) y no del objeto (`icon-[object Object]`). Se confirmó que falla con el componente previo y pasa con el fix.

Closes #1702.

## Plan de pruebas

- [x] `pnpm typecheck` — verde sobre `src/**` + `scripts/**` + `e2e/**` + configs.
- [x] **Criterio de aceptación #1690:** con un error inyectado (`const forced: string = maybe` donde `maybe: string | undefined`), `pnpm typecheck` **falla** con `TS2322` y exit ≠ 0; sin el error, verde. Probe revertido, no commiteado.
- [x] **Regresión #1702:** verificado que el nuevo test falla con el componente viejo (`icon-[object Object]`) y pasa con el fix.
- [x] `pnpm lint` · `pnpm stylelint` · `pnpm test` · `pnpm build` · `pnpm storybook:build` — todos verdes (local y CI).

## Fuera de alcance (follow-up)

- El branch protection de `develop` solo exige `lint` y `test` como required status checks. Para que `typecheck` (y el resto de gates ya existentes) bloqueen el merge hace falta actualizar la config de branch protection en GitHub — es settings de repo, no código. Trackeado en #1701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
