### PR TITLE
[#1703] - Unificar el host de sitemap.xml y robots.txt a www.cuentoneta.ar

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,4 +8,4 @@ Disallow: /api/
 Allow: /api/og/
 
 # Referencia al sitemap
-Sitemap: https://cuentoneta.ar/sitemap.xml
+Sitemap: https://www.cuentoneta.ar/sitemap.xml

--- a/src/api/modules/sitemap/sitemap.service.spec.ts
+++ b/src/api/modules/sitemap/sitemap.service.spec.ts
@@ -166,7 +166,7 @@ describe('SitemapService', () => {
 
 			const urls = await getSitemapUrls();
 
-			expect(urls[0].loc).toBe('https://cuentoneta.ar');
+			expect(urls[0].loc).toBe('https://www.cuentoneta.ar');
 		});
 	});
 

--- a/src/api/modules/sitemap/sitemap.service.ts
+++ b/src/api/modules/sitemap/sitemap.service.ts
@@ -13,7 +13,7 @@ interface SitemapUrl {
  */
 export async function getSitemapUrls(): Promise<SitemapUrl[]> {
 	const { stories, authors, storylists } = await fetchSitemapSlugs();
-	const BASE_URL = process.env['BASE_URL'] || 'https://cuentoneta.ar';
+	const BASE_URL = process.env['BASE_URL'] || 'https://www.cuentoneta.ar';
 
 	return [
 		// Páginas estáticas


### PR DESCRIPTION
## Descripción

- Unifica el host de `sitemap.xml` y `robots.txt` a **`https://www.cuentoneta.ar`** (antes `https://cuentoneta.ar`, sin `www`, que Vercel 308-redirige → cada URL del sitemap terminaba redirigiendo, señal débil para Google).
- Cambia el fallback de `BASE_URL` en `sitemap.service.ts`, la línea `Sitemap:` de `public/robots.txt`, y el test del default en `sitemap.service.spec.ts`. La env var `BASE_URL` sigue teniendo prioridad; los tests del override (`BASE_URL=https://test.cuentoneta.ar`) no cambian.

Closes #1703.
Parte de #1525.

## Plan de pruebas

- [x] `pnpm test` — verde (incluye `sitemap.service.spec.ts`)
- [x] `pnpm lint` · `pnpm typecheck` · `pnpm build` — verdes
- [ ] **Acción manual fuera del repo:** confirmar en Vercel que el dominio primario de producción es `www.cuentoneta.ar`, para que `environment.website` (canónicas/og, generado de `VERCEL_PROJECT_PRODUCTION_URL`) coincida con el host que ahora declaran sitemap/robots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
