### PR TITLE
[#1706] - Estandarizar URLs canónicas con buildCanonicalUrl (corrige doble slash)

### DIFF
--- a/src/app/pages/author/author-meta-tags.directive.spec.ts
+++ b/src/app/pages/author/author-meta-tags.directive.spec.ts
@@ -5,6 +5,8 @@ import { Title } from '@angular/platform-browser';
 
 import { authorMock } from '@mocks/author.mock';
 import { type AuthorProfile } from '@models/author.model';
+import { AppRoutes } from '../../app.routes';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { AuthorMetaTagsDirective } from './author-meta-tags.directive';
 import { AUTHOR_HOST } from './author-host';
@@ -45,6 +47,16 @@ describe('AuthorMetaTagsDirective', () => {
 		TestBed.tick();
 
 		expect(titleSpy).toHaveBeenCalledWith(expect.stringContaining(authorMock.name));
+	});
+
+	it('should set the canonical URL from the author slug via buildCanonicalUrl', () => {
+		authorSignal.set(authorMock);
+		const canonicalSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setCanonicalUrl');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(`${AppRoutes.Author}/${authorMock.slug}`));
 	});
 
 	it('should re-apply the meta tags when the author signal changes', () => {

--- a/src/app/pages/author/author-meta-tags.directive.ts
+++ b/src/app/pages/author/author-meta-tags.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, inject, untracked } from '@angular/core';
 
 import { AppRoutes } from '../../app.routes';
-import { environment } from '../../environments/environment';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { AbstractMetaTagsDirective } from '../../directives/abstract-meta-tags.directive';
 import { AUTHOR_HOST } from './author-host';
@@ -21,7 +21,7 @@ export class AuthorMetaTagsDirective extends AbstractMetaTagsDirective {
 		untracked(() => {
 			this.head.setTitle(author.name);
 			this.head.setDescription(`Perfil y obras de ${author.name} para leer en La Cuentoneta.`);
-			this.head.setCanonicalUrl(`${environment.website}/${AppRoutes.Author}/${author.slug}`);
+			this.head.setCanonicalUrl(buildCanonicalUrl(`${AppRoutes.Author}/${author.slug}`));
 			this.head.setRobots('index, follow');
 			this.head.setKeywords(['escritor', 'poemas', 'cuentos', 'autor', author.name.toLowerCase()]);
 		});

--- a/src/app/pages/story/story-meta-tags.directive.spec.ts
+++ b/src/app/pages/story/story-meta-tags.directive.spec.ts
@@ -5,6 +5,8 @@ import { Title } from '@angular/platform-browser';
 
 import { storyMock } from '@mocks/story.mock';
 import { type Story } from '@models/story.model';
+import { AppRoutes } from '../../app.routes';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { StoryMetaTagsDirective } from './story-meta-tags.directive';
 import { STORY_HOST } from './story-host';
@@ -45,6 +47,16 @@ describe('StoryMetaTagsDirective', () => {
 		TestBed.tick();
 
 		expect(titleSpy).toHaveBeenCalledWith(expect.stringContaining(`${storyMock.title} - ${storyMock.author.name}`));
+	});
+
+	it('should set the canonical URL from the story slug via buildCanonicalUrl', () => {
+		storySignal.set(storyMock);
+		const canonicalSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setCanonicalUrl');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(`${AppRoutes.Story}/${storyMock.slug}`));
 	});
 
 	it('should re-apply the meta tags when the story signal changes', () => {

--- a/src/app/pages/story/story-meta-tags.directive.ts
+++ b/src/app/pages/story/story-meta-tags.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, inject, untracked } from '@angular/core';
 
 import { AppRoutes } from '../../app.routes';
-import { environment } from '../../environments/environment';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { AbstractMetaTagsDirective } from '../../directives/abstract-meta-tags.directive';
 import { STORY_HOST } from './story-host';
@@ -23,7 +23,7 @@ export class StoryMetaTagsDirective extends AbstractMetaTagsDirective {
 			this.head.setDescription(
 				'Una lectura en La Cuentoneta: Una iniciativa que busca fomentar y hacer accesible la lectura digital.',
 			);
-			this.head.setCanonicalUrl(`${environment.website}/${AppRoutes.Story}/${story.slug}`);
+			this.head.setCanonicalUrl(buildCanonicalUrl(`${AppRoutes.Story}/${story.slug}`));
 			this.head.setRobots('index, follow');
 			this.head.setKeywords([
 				'literatura',

--- a/src/app/pages/storylist/storylist-meta-tags.directive.spec.ts
+++ b/src/app/pages/storylist/storylist-meta-tags.directive.spec.ts
@@ -5,6 +5,8 @@ import { Title } from '@angular/platform-browser';
 
 import { storylistMock } from '@mocks/storylist.mock';
 import { type Storylist } from '@models/storylist.model';
+import { AppRoutes } from '../../app.routes';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { StorylistMetaTagsDirective } from './storylist-meta-tags.directive';
 import { STORYLIST_HOST } from './storylist-host';
@@ -45,6 +47,16 @@ describe('StorylistMetaTagsDirective', () => {
 		TestBed.tick();
 
 		expect(titleSpy).toHaveBeenCalledWith(expect.stringContaining(storylistMock.title));
+	});
+
+	it('should set the canonical URL from the storylist slug via buildCanonicalUrl', () => {
+		storylistSignal.set(storylistMock);
+		const canonicalSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setCanonicalUrl');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(`${AppRoutes.StoryList}/${storylistMock.slug}`));
 	});
 
 	it('should re-apply the meta tags when the storylist signal changes', () => {

--- a/src/app/pages/storylist/storylist-meta-tags.directive.ts
+++ b/src/app/pages/storylist/storylist-meta-tags.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, inject, untracked } from '@angular/core';
 
 import { AppRoutes } from '../../app.routes';
-import { environment } from '../../environments/environment';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { AbstractMetaTagsDirective } from '../../directives/abstract-meta-tags.directive';
 import { STORYLIST_HOST } from './storylist-host';
@@ -23,7 +23,7 @@ export class StorylistMetaTagsDirective extends AbstractMetaTagsDirective {
 			this.head.setDescription(
 				'Una storylist en La Cuentoneta: Una iniciativa que busca fomentar y hacer accesible la lectura digital.',
 			);
-			this.head.setCanonicalUrl(`${environment.website}/${AppRoutes.StoryList}/${storylist.slug}`);
+			this.head.setCanonicalUrl(buildCanonicalUrl(`${AppRoutes.StoryList}/${storylist.slug}`));
 			this.head.setRobots('index, follow');
 			this.head.setKeywords(['literatura', 'poemas', 'cuentos', 'textos', storylist.title.toLowerCase()]);
 		});

--- a/src/app/utils/build-canonical-url.util.spec.ts
+++ b/src/app/utils/build-canonical-url.util.spec.ts
@@ -1,4 +1,5 @@
 import { buildCanonicalUrl } from './build-canonical-url.util';
+import { environment } from '../environments/environment';
 
 describe('buildCanonicalUrl', () => {
 	it('should join host and path with a single slash when the host has no trailing slash', () => {
@@ -23,5 +24,13 @@ describe('buildCanonicalUrl', () => {
 		expect(buildCanonicalUrl('//storylist/terror', 'https://www.cuentoneta.ar//')).toBe(
 			'https://www.cuentoneta.ar/storylist/terror',
 		);
+	});
+
+	it('should default the host to environment.website when the website argument is omitted', () => {
+		expect(buildCanonicalUrl('story/el-aleph')).toBe(buildCanonicalUrl('story/el-aleph', environment.website));
+	});
+
+	it('should produce a root-relative URL when the host is just "/" (dev environment.website)', () => {
+		expect(buildCanonicalUrl('story/el-aleph', '/')).toBe('/story/el-aleph');
 	});
 });

--- a/src/app/utils/build-canonical-url.util.spec.ts
+++ b/src/app/utils/build-canonical-url.util.spec.ts
@@ -1,0 +1,27 @@
+import { buildCanonicalUrl } from './build-canonical-url.util';
+
+describe('buildCanonicalUrl', () => {
+	it('should join host and path with a single slash when the host has no trailing slash', () => {
+		expect(buildCanonicalUrl('story/el-aleph', 'https://www.cuentoneta.ar')).toBe(
+			'https://www.cuentoneta.ar/story/el-aleph',
+		);
+	});
+
+	it('should not produce a double slash when the host already has a trailing slash', () => {
+		expect(buildCanonicalUrl('story/el-aleph', 'https://www.cuentoneta.ar/')).toBe(
+			'https://www.cuentoneta.ar/story/el-aleph',
+		);
+	});
+
+	it('should trim a leading slash from the path', () => {
+		expect(buildCanonicalUrl('/author/borges', 'https://www.cuentoneta.ar')).toBe(
+			'https://www.cuentoneta.ar/author/borges',
+		);
+	});
+
+	it('should collapse multiple trailing/leading slashes into a single separator', () => {
+		expect(buildCanonicalUrl('//storylist/terror', 'https://www.cuentoneta.ar//')).toBe(
+			'https://www.cuentoneta.ar/storylist/terror',
+		);
+	});
+});

--- a/src/app/utils/build-canonical-url.util.ts
+++ b/src/app/utils/build-canonical-url.util.ts
@@ -2,11 +2,10 @@ import { environment } from '../environments/environment';
 
 /**
  * Arma una URL canónica uniendo el host del sitio con un path relativo, garantizando un único `/`
- * de separación. En producción `environment.website` viene con `/` final (ver scripts/set-environment.ts),
- * por lo que concatenar `${environment.website}/${path}` producía un doble slash en el canonical.
+ * de separación. Evita el doble slash que producía `${environment.website}/${path}` cuando
+ * `environment.website` trae `/` final en producción (ver scripts/set-environment.ts).
  *
- * El segundo parámetro `website` existe como costura de test para verificar la normalización del host
- * con y sin slash final; en producción se usa el default de `environment`.
+ * `website` es una costura de test; en producción usa el default de `environment`.
  */
 export function buildCanonicalUrl(path: string, website: string = environment.website): string {
 	const base = website.replace(/\/+$/, '');

--- a/src/app/utils/build-canonical-url.util.ts
+++ b/src/app/utils/build-canonical-url.util.ts
@@ -1,0 +1,15 @@
+import { environment } from '../environments/environment';
+
+/**
+ * Arma una URL canónica uniendo el host del sitio con un path relativo, garantizando un único `/`
+ * de separación. En producción `environment.website` viene con `/` final (ver scripts/set-environment.ts),
+ * por lo que concatenar `${environment.website}/${path}` producía un doble slash en el canonical.
+ *
+ * El segundo parámetro `website` existe como costura de test para verificar la normalización del host
+ * con y sin slash final; en producción se usa el default de `environment`.
+ */
+export function buildCanonicalUrl(path: string, website: string = environment.website): string {
+	const base = website.replace(/\/+$/, '');
+	const normalizedPath = path.replace(/^\/+/, '');
+	return `${base}/${normalizedPath}`;
+}


### PR DESCRIPTION
## Descripción

- Estandariza la construcción de URLs canónicas con el helper `buildCanonicalUrl`, que corrige un bug de **doble slash**: `environment.website` trae `/` final en producción, por lo que `${environment.website}/${path}` generaba `https://www.cuentoneta.ar//story/...`.
- Adopta el helper en las directivas de meta de `story`, `author` y `storylist`, y agrega tests de regresión de la canónica (más cobertura del default `environment.website` y del host `"/"`).

Closes #1706.
Parte de #1525.

## Plan de pruebas

- [x] `pnpm test` — verde (spec del util + specs de las 3 directivas)
- [x] `pnpm lint` · `pnpm typecheck` · `pnpm build` — verdes

## Follow-up

- #1709 — extender `buildCanonicalUrl` a `about`/`authors`/`dmca`/`stories` (mismo bug de doble slash, fuera del scope textual de este issue).

## Notas

- En las rutas `RenderMode.Server` (story/author/storylist) la canónica solo aparece en el HTML server-rendered una vez que aterrice el bloqueo SSR (#1704); en las `Prerender` ya rinde. Este PR corrige la construcción de la URL en sí, independiente de eso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
