### PR TITLE
[#1709] - Extender buildCanonicalUrl a about/authors/dmca/stories (corrige doble slash)

### DIFF
--- a/src/app/pages/about/about.component.spec.ts
+++ b/src/app/pages/about/about.component.spec.ts
@@ -1,9 +1,13 @@
 import { render } from '@testing-library/angular';
+import { spyOn } from '@test-utils';
+import { TestBed } from '@angular/core/testing';
 
 import AboutComponent from './about.component';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideContributorApiMock } from '../../providers/contributor.mock';
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 
 describe('AboutComponent', () => {
 	const setup = async () => {
@@ -15,5 +19,15 @@ describe('AboutComponent', () => {
 	it('should create', async () => {
 		const view = setup();
 		expect(view).toBeTruthy();
+	});
+
+	it('should set the canonical URL for /about via buildCanonicalUrl', () => {
+		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
+		TestBed.configureTestingModule({
+			providers: [provideHttpClient(), provideHttpClientTesting(), provideContributorApiMock()],
+		});
+		TestBed.createComponent(AboutComponent);
+
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl('about'));
 	});
 });

--- a/src/app/pages/about/about.component.spec.ts
+++ b/src/app/pages/about/about.component.spec.ts
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/angular';
-import { spyOn } from '@test-utils';
-import { TestBed } from '@angular/core/testing';
+import { restoreAllMocks, spyOn } from '@test-utils';
 
 import AboutComponent from './about.component';
 import { provideHttpClient } from '@angular/common/http';
@@ -16,17 +15,17 @@ describe('AboutComponent', () => {
 		});
 	};
 
+	afterEach(() => restoreAllMocks());
+
 	it('should create', async () => {
 		const view = setup();
 		expect(view).toBeTruthy();
 	});
 
-	it('should set the canonical URL for /about via buildCanonicalUrl', () => {
+	it('should set the canonical URL for /about via buildCanonicalUrl', async () => {
 		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
-		TestBed.configureTestingModule({
-			providers: [provideHttpClient(), provideHttpClientTesting(), provideContributorApiMock()],
-		});
-		TestBed.createComponent(AboutComponent);
+
+		await setup();
 
 		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl('about'));
 	});

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -3,7 +3,7 @@ import { NgOptimizedImage } from '@angular/common';
 import { rxResource } from '@angular/core/rxjs-interop';
 
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
-import { environment } from '../../environments/environment';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 import { ContributorApi } from '../../providers/contributor-api.interface';
 
 @Component({
@@ -43,7 +43,7 @@ export default class AboutComponent {
 	private updateMetaTags() {
 		this.metaTagsDirective.setTitle('Nosotros');
 		this.metaTagsDirective.setDefaultDescription();
-		this.metaTagsDirective.setCanonicalUrl(`${environment.website}/about`);
+		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl('about'));
 		this.metaTagsDirective.setRobots('noindex, nofollow');
 	}
 }

--- a/src/app/pages/authors/authors.component.spec.ts
+++ b/src/app/pages/authors/authors.component.spec.ts
@@ -1,0 +1,21 @@
+import { spyOn } from '@test-utils';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+
+import AuthorsComponent from './authors.component';
+import { provideAuthorApiMock } from '../../providers/author.mock';
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
+
+describe('AuthorsComponent', () => {
+	it('should set the canonical URL for /authors via buildCanonicalUrl', () => {
+		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
+		TestBed.configureTestingModule({
+			providers: [provideHttpClient(), provideHttpClientTesting(), provideAuthorApiMock()],
+		});
+		TestBed.createComponent(AuthorsComponent);
+
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl('authors'));
+	});
+});

--- a/src/app/pages/authors/authors.component.spec.ts
+++ b/src/app/pages/authors/authors.component.spec.ts
@@ -1,7 +1,6 @@
-import { spyOn } from '@test-utils';
-import { TestBed } from '@angular/core/testing';
-import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { render } from '@testing-library/angular';
+import { restoreAllMocks, spyOn } from '@test-utils';
+import { provideRouter } from '@angular/router';
 
 import AuthorsComponent from './authors.component';
 import { provideAuthorApiMock } from '../../providers/author.mock';
@@ -9,12 +8,14 @@ import { HeadMetadataDirective } from '../../directives/head-metadata.directive'
 import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 
 describe('AuthorsComponent', () => {
-	it('should set the canonical URL for /authors via buildCanonicalUrl', () => {
+	afterEach(() => restoreAllMocks());
+
+	it('should set the canonical URL for /authors via buildCanonicalUrl', async () => {
 		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
-		TestBed.configureTestingModule({
-			providers: [provideHttpClient(), provideHttpClientTesting(), provideAuthorApiMock()],
+
+		await render(AuthorsComponent, {
+			providers: [provideRouter([]), provideAuthorApiMock()],
 		});
-		TestBed.createComponent(AuthorsComponent);
 
 		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl('authors'));
 	});

--- a/src/app/pages/authors/authors.component.ts
+++ b/src/app/pages/authors/authors.component.ts
@@ -4,7 +4,7 @@ import { AuthorApi } from '../../providers/author-api.interface';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
-import { environment } from '../../environments/environment';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 
 @Component({
 	imports: [RouterLink],
@@ -40,7 +40,7 @@ export default class AuthorsComponent {
 	private updateMetaTags() {
 		this.metaTagsDirective.setTitle('Índice de Autores');
 		this.metaTagsDirective.setDefaultDescription();
-		this.metaTagsDirective.setCanonicalUrl(`${environment.website}/authors`);
+		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl('authors'));
 		this.metaTagsDirective.setRobots('noindex, follow');
 	}
 }

--- a/src/app/pages/dmca/dmca.component.spec.ts
+++ b/src/app/pages/dmca/dmca.component.spec.ts
@@ -1,0 +1,15 @@
+import { spyOn } from '@test-utils';
+import { TestBed } from '@angular/core/testing';
+
+import DmcaComponent from './dmca.component';
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
+
+describe('DmcaComponent', () => {
+	it('should set the canonical URL for /dmca via buildCanonicalUrl', () => {
+		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
+		TestBed.createComponent(DmcaComponent);
+
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl('dmca'));
+	});
+});

--- a/src/app/pages/dmca/dmca.component.spec.ts
+++ b/src/app/pages/dmca/dmca.component.spec.ts
@@ -1,14 +1,18 @@
-import { spyOn } from '@test-utils';
-import { TestBed } from '@angular/core/testing';
+import { render } from '@testing-library/angular';
+import { restoreAllMocks, spyOn } from '@test-utils';
+import { provideRouter } from '@angular/router';
 
 import DmcaComponent from './dmca.component';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 
 describe('DmcaComponent', () => {
-	it('should set the canonical URL for /dmca via buildCanonicalUrl', () => {
+	afterEach(() => restoreAllMocks());
+
+	it('should set the canonical URL for /dmca via buildCanonicalUrl', async () => {
 		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
-		TestBed.createComponent(DmcaComponent);
+
+		await render(DmcaComponent, { providers: [provideRouter([])] });
 
 		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl('dmca'));
 	});

--- a/src/app/pages/dmca/dmca.component.ts
+++ b/src/app/pages/dmca/dmca.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject } from '@angular/core';
 
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
-import { environment } from '../../environments/environment';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 
 @Component({
 	selector: 'cuentoneta-dmca',
@@ -124,7 +124,7 @@ export default class DmcaComponent {
 	private updateMetaTags() {
 		this.metaTagsDirective.setTitle('DMCA');
 		this.metaTagsDirective.setDefaultDescription();
-		this.metaTagsDirective.setCanonicalUrl(`${environment.website}/dmca`);
+		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl('dmca'));
 		this.metaTagsDirective.setRobots('noindex, nofollow');
 	}
 }

--- a/src/app/pages/stories/stories.component.spec.ts
+++ b/src/app/pages/stories/stories.component.spec.ts
@@ -1,7 +1,6 @@
-import { spyOn } from '@test-utils';
-import { TestBed } from '@angular/core/testing';
-import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { render } from '@testing-library/angular';
+import { restoreAllMocks, spyOn } from '@test-utils';
+import { provideRouter } from '@angular/router';
 
 import StoriesComponent from './stories.component';
 import { AppRoutes } from '../../app.routes';
@@ -10,12 +9,12 @@ import { HeadMetadataDirective } from '../../directives/head-metadata.directive'
 import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 
 describe('StoriesComponent', () => {
-	it('should set the canonical URL for /story via buildCanonicalUrl', () => {
+	afterEach(() => restoreAllMocks());
+
+	it('should set the canonical URL for /story via buildCanonicalUrl', async () => {
 		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
-		TestBed.configureTestingModule({
-			providers: [provideHttpClient(), provideHttpClientTesting(), provideStoryApiMock()],
-		});
-		TestBed.createComponent(StoriesComponent);
+
+		await render(StoriesComponent, { providers: [provideRouter([]), provideStoryApiMock()] });
 
 		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(AppRoutes.Story));
 	});

--- a/src/app/pages/stories/stories.component.spec.ts
+++ b/src/app/pages/stories/stories.component.spec.ts
@@ -1,0 +1,22 @@
+import { spyOn } from '@test-utils';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+
+import StoriesComponent from './stories.component';
+import { AppRoutes } from '../../app.routes';
+import { provideStoryApiMock } from '../../providers/story.mock';
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
+
+describe('StoriesComponent', () => {
+	it('should set the canonical URL for /story via buildCanonicalUrl', () => {
+		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
+		TestBed.configureTestingModule({
+			providers: [provideHttpClient(), provideHttpClientTesting(), provideStoryApiMock()],
+		});
+		TestBed.createComponent(StoriesComponent);
+
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(AppRoutes.Story));
+	});
+});

--- a/src/app/pages/stories/stories.component.ts
+++ b/src/app/pages/stories/stories.component.ts
@@ -10,8 +10,8 @@ import { StoryApi } from '../../providers/story-api.interface';
 // Directives
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 
-// Environment
-import { environment } from '../../environments/environment';
+// Utils
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 
 // Routing
 import { AppRoutes } from '../../app.routes';
@@ -92,7 +92,7 @@ export default class StoriesComponent {
 		this.metaTagsDirective.setDescription(
 			'Explora la colección completa de historias publicadas en La Cuentoneta y descubre nuevos autores y lecturas',
 		);
-		this.metaTagsDirective.setCanonicalUrl(`${environment.website}/${this.appRoutes.Story}`);
+		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl(this.appRoutes.Story));
 		this.metaTagsDirective.setRobots('noindex, follow');
 	}
 }


### PR DESCRIPTION
## Descripción

- Extiende `buildCanonicalUrl` (introducido en #1706, ya en `develop`) a los 4 call sites que todavía armaban la canónica con `${environment.website}/${path}` y sufrían el mismo **bug de doble slash**: `about`, `authors`, `dmca` y `stories`.
- Elimina el import muerto de `environment` en los 4 componentes.
- Agrega un test de regresión de la canónica por página (ATL `render()` + spy sobre `HeadMetadataDirective.prototype.setCanonicalUrl`, con `restoreAllMocks`).

Closes #1709.
Parte de #1525.

## Plan de pruebas

- [x] `pnpm lint` · `pnpm typecheck` · `pnpm test` · `pnpm build` — verdes.

## Notas

- `home-meta-tags.directive.ts` queda fuera: usa `environment.website` sin concatenar path, no tiene el bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
