### PR TITLE
[#1707] - [OpenGraph] Emitir og:url por página en el SSR (hoy estático al home)

### DIFF
--- a/src/app/directives/head-metadata.directive.spec.ts
+++ b/src/app/directives/head-metadata.directive.spec.ts
@@ -3,6 +3,7 @@ import { HeadMetadataDirective } from './head-metadata.directive';
 import { TestBed } from '@angular/core/testing';
 import { Meta, Title } from '@angular/platform-browser';
 import { DOCUMENT } from '@angular/common';
+import { environment } from '../environments/environment';
 
 describe('HeadMetadataDirective', () => {
 	const BASE_URL = 'https://www.cuentoneta.ar';
@@ -147,6 +148,7 @@ describe('HeadMetadataDirective', () => {
 
 	describe('setCanonicalUrl', () => {
 		it('should create and set canonical link element if it does not exist', () => {
+			const metaSpy = spyOn(metaService, 'updateTag');
 			const url = `${BASE_URL}/test`;
 
 			directive.setCanonicalUrl(url);
@@ -157,9 +159,11 @@ describe('HeadMetadataDirective', () => {
 			expect(linkElement).toHaveAttribute('rel', 'canonical');
 			expect(linkElement).toHaveAttribute('href', url);
 			expect(linkElement.parentElement).toBe(document.head);
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:url', content: url });
 		});
 
 		it('should update existing canonical link element', () => {
+			const metaSpy = spyOn(metaService, 'updateTag');
 			const initialUrl = `${BASE_URL}/initial`;
 			const updatedUrl = `${BASE_URL}/updated`;
 
@@ -172,11 +176,13 @@ describe('HeadMetadataDirective', () => {
 			expect(linkElements[0]).toHaveAttribute('rel', 'canonical');
 			expect(linkElements[0]).toHaveAttribute('href', updatedUrl);
 			expect(linkElements[0].parentElement).toBe(document.head);
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:url', content: updatedUrl });
 		});
 	});
 
 	describe('removeCanonicalUrl', () => {
-		it('should remove canonical link element if it exists', () => {
+		it('should remove canonical link element and reset og:url to the home fallback if it exists', () => {
+			const metaSpy = spyOn(metaService, 'updateTag');
 			directive.setCanonicalUrl(`${BASE_URL}/test`);
 
 			let linkElement = document.querySelector('link[rel="canonical"]');
@@ -186,6 +192,15 @@ describe('HeadMetadataDirective', () => {
 
 			linkElement = document.querySelector('link[rel="canonical"]');
 			expect(linkElement).toBeFalsy();
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:url', content: environment.website });
+		});
+
+		it('should reset og:url to the home fallback even when no canonical link exists', () => {
+			const metaSpy = spyOn(metaService, 'updateTag');
+
+			directive.removeCanonicalUrl();
+
+			expect(metaSpy).toHaveBeenCalledWith({ property: 'og:url', content: environment.website });
 		});
 
 		it('should not throw error if canonical link does not exist', () => {
@@ -532,8 +547,9 @@ describe('HeadMetadataDirective', () => {
 			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image', content: 'assets/svg/logo.svg' });
 			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:image:alt', content: 'Logo de La Cuentoneta' });
 			expect(updateSpy).toHaveBeenCalledWith({ name: 'twitter:image', content: 'assets/svg/logo.svg' });
-			// El <link rel="canonical"> se quita del head.
+			// El <link rel="canonical"> se quita del head y og:url se resetea al home (no se elimina).
 			expect(document.querySelector(`link[rel='canonical']`)).toBeNull();
+			expect(updateSpy).toHaveBeenCalledWith({ property: 'og:url', content: environment.website });
 		});
 	});
 });

--- a/src/app/directives/head-metadata.directive.ts
+++ b/src/app/directives/head-metadata.directive.ts
@@ -1,6 +1,7 @@
 import { Directive, effect, inject, PLATFORM_ID, DOCUMENT } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { isPlatformBrowser } from '@angular/common';
+import { environment } from '../environments/environment';
 
 @Directive({
 	selector: '[cuentonetaHeadMetadata]',
@@ -124,6 +125,11 @@ export class HeadMetadataDirective {
 		this.setKeywords(['cuentos', 'literatura', 'poemas', 'podcast', 'narraciones']);
 	}
 
+	// El fallback de og:url es el home. A diferencia del <link rel="canonical"> —que se elimina al
+	// limpiar— og:url se resetea al home para que una página sin canonical propio no arrastre el og:url
+	// de la anterior en la navegación SPA (mismo patrón que og:image con su logo por defecto).
+	private readonly defaultOgUrl = environment.website;
+
 	public setCanonicalUrl(url: string) {
 		const head = this.document.getElementsByTagName('head')[0];
 		let element: HTMLLinkElement | null = this.document.querySelector(`link[rel='canonical']`) || null;
@@ -133,6 +139,7 @@ export class HeadMetadataDirective {
 		}
 		element.setAttribute('rel', 'canonical');
 		element.setAttribute('href', url);
+		this.metaTagService.updateTag({ property: 'og:url', content: url });
 	}
 
 	public removeCanonicalUrl() {
@@ -140,6 +147,7 @@ export class HeadMetadataDirective {
 		if (element) {
 			element.remove();
 		}
+		this.metaTagService.updateTag({ property: 'og:url', content: this.defaultOgUrl });
 	}
 
 	// Para páginas indexables emitimos, además de index/follow, las directivas de vista previa


### PR DESCRIPTION
## Descripción

- El `<meta property="og:url">` era estático al home (`src/indexFile.html`), apuntaba siempre a `https://www.cuentoneta.ar` aunque estuviéramos en `/story/:slug`, `/author/:slug`, etc.
- Ahora `HeadMetadataDirective.setCanonicalUrl(url)` emite también `og:url` con la URL de la página, y `removeCanonicalUrl()` lo resetea a `environment.website` (no lo elimina), imitando el patrón de `removeImage()` con la OG image por defecto, para que una página sin canonical propio no arrastre el `og:url` de la anterior en la navegación SPA.
- `og:url` espeja exactamente al `<link rel="canonical">`: hereda automáticamente la normalización de `buildCanonicalUrl` (#1706) sin lógica propia.

Closes #1707.

Parte de #216.

## Plan de pruebas

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm stylelint` · `pnpm test` · `pnpm build` · `pnpm storybook:build` — todos verdes localmente.
- [x] Tests unitarios en `head-metadata.directive.spec.ts`: emisión de `og:url` al setear el canonical (con y sin canonical previo), reset a `environment.website` al remover (con y sin canonical previo) y reset en la limpieza por `effect(onCleanup)` al destruirse la directiva.
- [x] Verificación SSR con `curl` contra `localhost:4000`: las rutas prerenderizadas/estáticas (`/`, `/about`, `/dmca`, `/authors`) ya emiten `og:url` **por página**, espejando al canonical. Las rutas `RenderMode.Server` (story/author) muestran el `og:url` por página en SSR una vez que el server espera los datos (dependencia de #1704, aún no mergeado) — en cliente ya se actualiza vía el nuevo código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
