### PR TITLE
[#1704] - [SEO] Bloquear el SSR hasta resolver los recursos async de las páginas (ssrBlockingRxResource)

### DIFF
--- a/.claude/references/angular-state.md
+++ b/.claude/references/angular-state.md
@@ -28,11 +28,11 @@ Dónde viven los servicios de estado:
 **Prohibido** `firstValueFrom`, `lastValueFrom`, `toPromise` y `async/await` sobre observables en el frontend (restricción dura de `CLAUDE.md`). Se compone con **operadores RxJS** y se cruza a signals con `rxResource` / `toSignal`.
 
 ```typescript
-// ✅ Correcto — el HTTP queda como Observable y se consume vía rxResource (story.component.ts)
-readonly storyResource = rxResource({
+// ✅ Correcto — el HTTP queda como Observable y se consume vía un rxResource (story.component.ts).
+// En componentes de página se usa el wrapper `ssrBlockingRxResource` (ver §7), no `rxResource` crudo.
+readonly storyResource = ssrBlockingRxResource({
 	params: this.slug,
-	stream: ({ params }) =>
-		this.storyService.getBySlug(params).pipe(tap((story) => this.updateMetaTags(story))),
+	stream: ({ params }) => this.storyService.getBySlug(params),
 	defaultValue: undefined,
 });
 
@@ -137,6 +137,28 @@ Preferir un estado de error **por operación** a un único `string | null` compa
 
 > El detalle de **manejo de errores** (preservar la causa, loguear con contexto) está en `CLAUDE.md` → _Manejo de errores_ y en [`maintainability.md`](maintainability.md).
 
+### 7. Recursos de página: bloquear el SSR con `ssrBlockingRxResource`
+
+En **componentes de página** (`src/app/pages/**`), los recursos que alimentan contenido indexable o meta tags por página se declaran con **`ssrBlockingRxResource`** (de [`@utils/ssr-resource`](../../src/app/utils/ssr-resource.ts)), no con `rxResource` crudo. El helper pipea el stream por `pendingUntilEvent`: registra una `PendingTask` que hace esperar la serialización del SSR (`ApplicationRef.whenStable()`) hasta que el fetch emite, completa o falla. Sin él, el server emite el skeleton con meta genérico y Google indexa una página vacía (#1704). En el browser no afecta el render, solo retrasa `isStable`, así que la carga progresiva in-app se conserva.
+
+Para **datos secundarios o no indexables** que deben seguir cargando progresivamente (p. ej. el listado de cuentos de un autor, o los frames de navegación), usar **`progressiveRxResource`** — un alias explícito de `rxResource` que documenta que el no-bloqueo es una decisión, no un olvido.
+
+```typescript
+// ✅ Página: el perfil bloquea el SSR; el listado secundario carga progresivamente (author.component.ts)
+readonly authorResource = ssrBlockingRxResource({
+	params: this.slug,
+	stream: ({ params }) => this.authorService.getBySlug(params),
+	defaultValue: undefined,
+});
+readonly storiesResource = progressiveRxResource({
+	params: this.slug,
+	stream: ({ params }) => this.stories$(params),
+	defaultValue: [],
+});
+```
+
+Cuándo **bloquear**: rutas cuyo HTML server-rendered debe traer contenido/meta reales — `RenderMode.Server` indexables y `Prerender` con contenido (el prerender de build gana contenido real en vez de skeleton). Cuándo **no**: rutas `noindex` servidas por request con meta estáticos (bloquear solo agrega latencia sin ganar indexación → `progressiveRxResource`), y datos secundarios.
+
 ---
 
 ## Checklist rápido
@@ -148,6 +170,7 @@ Preferir un estado de error **por operación** a un único `string | null` compa
 - [ ] ¿El aplanado por defecto es `switchMap` (y cualquier otro está justificado)?
 - [ ] ¿El debounce/throttle/coordinación está en el servicio, no en el componente?
 - [ ] ¿Los errores están tipados por operación, no en un `string | null` global?
+- [ ] ¿Los recursos de página que alimentan contenido/meta indexable usan `ssrBlockingRxResource`, y los secundarios/`noindex` usan `progressiveRxResource` (nunca `rxResource` crudo en `pages/**`)?
 
 ---
 

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
@@ -10,7 +10,7 @@ import { StoryApi } from '../../providers/story-api.interface';
 // Componentes
 import { NavigationFrameComponent } from '@models/navigation-frame.component';
 import { NavigableStoryTeaserComponent } from '../navigable-story-teaser/navigable-story-teaser.component';
-import { rxResource } from '@angular/core/rxjs-interop';
+import { progressiveRxResource } from '@utils/ssr-resource';
 
 @Component({
 	selector: 'cuentoneta-author-navigation-frame',
@@ -35,7 +35,7 @@ export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
 	private storyService = inject(StoryApi);
 
 	// Recursos
-	private readonly storiesResource = rxResource({
+	private readonly storiesResource = progressiveRxResource({
 		params: () => this.navigationSlug(),
 		stream: ({ params: slug }) => this.storyService.getNavigationTeasersByAuthorSlug(slug),
 		defaultValue: [],

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
@@ -12,7 +12,7 @@ import { NavigationFrameComponent } from '@models/navigation-frame.component';
 import { StorylistApi } from '../../providers/storylist-api.interface';
 
 // Componentes
-import { rxResource } from '@angular/core/rxjs-interop';
+import { progressiveRxResource } from '@utils/ssr-resource';
 import { NavigableStorylistStoryTeaserComponent } from '@components/navigable-storylist-story-teaser/navigable-storylist-story-teaser.component';
 import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 
@@ -54,7 +54,7 @@ export class StorylistNavigationFrameComponent extends NavigationFrameComponent 
 	private storylistService = inject(StorylistApi);
 
 	// Recursos
-	private readonly storylistResource = rxResource({
+	private readonly storylistResource = progressiveRxResource({
 		params: () => this.navigationSlug(),
 		stream: ({ params }) => this.storylistService.getStorylistNavigationTeasers(params),
 		defaultValue: undefined,

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -1,10 +1,10 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
-import { rxResource } from '@angular/core/rxjs-interop';
 
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { environment } from '../../environments/environment';
 import { ContributorApi } from '../../providers/contributor-api.interface';
+import { ssrBlockingRxResource } from '@utils/ssr-resource';
 
 @Component({
 	selector: 'cuentoneta-about',
@@ -29,7 +29,7 @@ export default class AboutComponent {
 	private metaTagsDirective = inject(HeadMetadataDirective);
 	private contributorService = inject(ContributorApi);
 
-	private readonly contributorsResource = rxResource({
+	private readonly contributorsResource = ssrBlockingRxResource({
 		stream: () => this.contributorService.getAllByArea(),
 		defaultValue: [],
 	});

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -29,8 +29,7 @@ export default class AboutComponent {
 	private metaTagsDirective = inject(HeadMetadataDirective);
 	private contributorService = inject(ContributorApi);
 
-	// Ruta Server + `noindex, nofollow` con meta tags estáticos: bloquear el SSR solo agregaría latencia
-	// por request sin beneficio de indexación. La grilla de colaboradores carga progresivamente en cliente.
+	// Ruta Server + `noindex, nofollow`: se maneja con carga progresiva.
 	private readonly contributorsResource = progressiveRxResource({
 		stream: () => this.contributorService.getAllByArea(),
 		defaultValue: [],

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -4,7 +4,7 @@ import { NgOptimizedImage } from '@angular/common';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { environment } from '../../environments/environment';
 import { ContributorApi } from '../../providers/contributor-api.interface';
-import { ssrBlockingRxResource } from '@utils/ssr-resource';
+import { progressiveRxResource } from '@utils/ssr-resource';
 
 @Component({
 	selector: 'cuentoneta-about',
@@ -29,7 +29,9 @@ export default class AboutComponent {
 	private metaTagsDirective = inject(HeadMetadataDirective);
 	private contributorService = inject(ContributorApi);
 
-	private readonly contributorsResource = ssrBlockingRxResource({
+	// Ruta Server + `noindex, nofollow` con meta tags estáticos: bloquear el SSR solo agregaría latencia
+	// por request sin beneficio de indexación. La grilla de colaboradores carga progresivamente en cliente.
+	private readonly contributorsResource = progressiveRxResource({
 		stream: () => this.contributorService.getAllByArea(),
 		defaultValue: [],
 	});

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -22,7 +22,7 @@ import { StoryApi } from '../../providers/story-api.interface';
 // Componentes
 import { PortableTextParserComponent } from '@components/portable-text-parser/portable-text-parser.component';
 import { ResourceComponent } from '@components/resource/resource.component';
-import { progressiveRxResource, ssrBlockingRxResource } from '@utils/ssr-resource';
+import { ssrBlockingRxResource } from '@utils/ssr-resource';
 import { StoryCardTeaserComponent } from '@components/story-card-teaser/story-card-teaser.component';
 import Tab from '@components/tabs/tab.component';
 import Tabs from '@components/tabs/tabs.component';
@@ -176,12 +176,8 @@ export default class AuthorComponent implements AuthorHost {
 		stream: ({ params }) => this.authorService.getBySlug(params),
 		defaultValue: undefined,
 	});
-	// Progresivo a propósito: el listado de cuentos es contenido secundario que carga tras el perfil.
-	// El badge "{{ stories().length }} historias" deriva de este recurso; como vive en un @defer que sirve
-	// su placeholder en SSR, el conteo recién se pinta al hidratar y puede mostrar 0 hasta que el listado
-	// resuelve en cliente. Se acepta: el conteo no es contenido indexable y bloquearlo anularía la carga
-	// progresiva (el agregado Author tampoco expone un conteo del que derivarlo).
-	protected readonly storiesResource = progressiveRxResource({
+
+	protected readonly storiesResource = ssrBlockingRxResource({
 		params: this.slug,
 		stream: ({ params }) => this.stories$(params),
 		defaultValue: [],

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -22,7 +22,7 @@ import { StoryApi } from '../../providers/story-api.interface';
 // Componentes
 import { PortableTextParserComponent } from '@components/portable-text-parser/portable-text-parser.component';
 import { ResourceComponent } from '@components/resource/resource.component';
-import { rxResource } from '@angular/core/rxjs-interop';
+import { progressiveRxResource, ssrBlockingRxResource } from '@utils/ssr-resource';
 import { StoryCardTeaserComponent } from '@components/story-card-teaser/story-card-teaser.component';
 import Tab from '@components/tabs/tab.component';
 import Tabs from '@components/tabs/tabs.component';
@@ -171,12 +171,12 @@ export default class AuthorComponent implements AuthorHost {
 	private router = inject(Router);
 
 	// Recursos
-	protected readonly authorResource = rxResource({
+	protected readonly authorResource = ssrBlockingRxResource({
 		params: this.slug,
 		stream: ({ params }) => this.authorService.getBySlug(params),
 		defaultValue: undefined,
 	});
-	protected readonly storiesResource = rxResource({
+	protected readonly storiesResource = progressiveRxResource({
 		params: this.slug,
 		stream: ({ params }) => this.stories$(params),
 		defaultValue: [],

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -176,6 +176,11 @@ export default class AuthorComponent implements AuthorHost {
 		stream: ({ params }) => this.authorService.getBySlug(params),
 		defaultValue: undefined,
 	});
+	// Progresivo a propósito: el listado de cuentos es contenido secundario que carga tras el perfil.
+	// El badge "{{ stories().length }} historias" deriva de este recurso; como vive en un @defer que sirve
+	// su placeholder en SSR, el conteo recién se pinta al hidratar y puede mostrar 0 hasta que el listado
+	// resuelve en cliente. Se acepta: el conteo no es contenido indexable y bloquearlo anularía la carga
+	// progresiva (el agregado Author tampoco expone un conteo del que derivarlo).
 	protected readonly storiesResource = progressiveRxResource({
 		params: this.slug,
 		stream: ({ params }) => this.stories$(params),

--- a/src/app/pages/authors/authors.component.ts
+++ b/src/app/pages/authors/authors.component.ts
@@ -1,7 +1,7 @@
 import { Component, computed, inject } from '@angular/core';
 
 import { AuthorApi } from '../../providers/author-api.interface';
-import { rxResource } from '@angular/core/rxjs-interop';
+import { ssrBlockingRxResource } from '@utils/ssr-resource';
 import { RouterLink } from '@angular/router';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { environment } from '../../environments/environment';
@@ -26,7 +26,7 @@ export default class AuthorsComponent {
 	private authorService = inject(AuthorApi);
 	private metaTagsDirective = inject(HeadMetadataDirective);
 
-	private authorsResource = rxResource({
+	private authorsResource = ssrBlockingRxResource({
 		stream: () => this.authorService.getAll(),
 		defaultValue: [],
 	});

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,9 +1,9 @@
 // Core
 import { Component, computed, inject } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
 
 // Services
 import { ContentApi } from '../../providers/content-api.interface';
+import { ssrBlockingRxResource } from '@utils/ssr-resource';
 
 // SEO
 import { HomeMetaTagsDirective } from './home-meta-tags.directive';
@@ -33,7 +33,7 @@ export default class HomeComponent {
 	private contentService = inject(ContentApi);
 
 	// Recursos
-	private readonly landingPageResource = rxResource({
+	private readonly landingPageResource = ssrBlockingRxResource({
 		stream: () => this.contentService.getLandingPageContent(),
 		defaultValue: undefined,
 	});

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -3,6 +3,8 @@ import { Component, computed, inject } from '@angular/core';
 
 // Services
 import { ContentApi } from '../../providers/content-api.interface';
+
+// Utils
 import { ssrBlockingRxResource } from '@utils/ssr-resource';
 
 // SEO

--- a/src/app/pages/stories/stories.component.ts
+++ b/src/app/pages/stories/stories.component.ts
@@ -5,6 +5,8 @@ import { RouterLink } from '@angular/router';
 
 // Services
 import { StoryApi } from '../../providers/story-api.interface';
+
+// Utils
 import { ssrBlockingRxResource } from '@utils/ssr-resource';
 
 // Directives

--- a/src/app/pages/stories/stories.component.ts
+++ b/src/app/pages/stories/stories.component.ts
@@ -2,10 +2,10 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 
 import { RouterLink } from '@angular/router';
-import { rxResource } from '@angular/core/rxjs-interop';
 
 // Services
 import { StoryApi } from '../../providers/story-api.interface';
+import { ssrBlockingRxResource } from '@utils/ssr-resource';
 
 // Directives
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
@@ -76,7 +76,7 @@ export default class StoriesComponent {
 	private metaTagsDirective = inject(HeadMetadataDirective);
 
 	// TODO: Implementar tamaño de página variable
-	private readonly storiesResource = rxResource({
+	private readonly storiesResource = ssrBlockingRxResource({
 		stream: () => this.storyService.get(0, 2000),
 		defaultValue: [],
 	});

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -2,10 +2,11 @@
 import { Component, computed, forwardRef, inject, signal, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 // Router
 import { AppRoutes } from '../../app.routes';
+import { ssrBlockingRxResource } from '@utils/ssr-resource';
 
 // Services
 import { StoryApi } from '../../providers/story-api.interface';
@@ -74,7 +75,7 @@ export default class StoryComponent implements StoryHost {
 
 	// Recursos
 	protected readonly dummyList = Array(10);
-	private readonly storyResource = rxResource({
+	private readonly storyResource = ssrBlockingRxResource({
 		params: this.slug,
 		stream: ({ params }) => this.storyService.getBySlug(params),
 		defaultValue: undefined,

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -6,6 +6,8 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 // Router
 import { AppRoutes } from '../../app.routes';
+
+// Utils
 import { ssrBlockingRxResource } from '@utils/ssr-resource';
 
 // Services

--- a/src/app/pages/storylist/storylist.component.ts
+++ b/src/app/pages/storylist/storylist.component.ts
@@ -3,6 +3,8 @@ import { Component, computed, forwardRef, inject, input } from '@angular/core';
 
 // Services
 import { StorylistApi } from '../../providers/storylist-api.interface';
+
+// Utils
 import { ssrBlockingRxResource } from '@utils/ssr-resource';
 
 // SEO

--- a/src/app/pages/storylist/storylist.component.ts
+++ b/src/app/pages/storylist/storylist.component.ts
@@ -1,9 +1,9 @@
 // Core
 import { Component, computed, forwardRef, inject, input } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
 
 // Services
 import { StorylistApi } from '../../providers/storylist-api.interface';
+import { ssrBlockingRxResource } from '@utils/ssr-resource';
 
 // SEO
 import { StorylistMetaTagsDirective } from './storylist-meta-tags.directive';
@@ -48,7 +48,7 @@ export default class StorylistComponent implements StorylistHost {
 	private storylistService = inject(StorylistApi);
 
 	// Recursos
-	protected readonly storylistResource = rxResource({
+	protected readonly storylistResource = ssrBlockingRxResource({
 		params: this.slug,
 		stream: ({ params }) => this.storylistService.get(params, 60, 'asc'),
 		defaultValue: undefined,

--- a/src/app/utils/ssr-resource.spec.ts
+++ b/src/app/utils/ssr-resource.spec.ts
@@ -1,0 +1,66 @@
+import { ApplicationRef } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { TestBed } from '@angular/core/testing';
+import { NEVER, Subject } from 'rxjs';
+
+import { progressiveRxResource, ssrBlockingRxResource } from './ssr-resource';
+
+// Deja correr las tasks pendientes (scheduler zoneless + resolución de `whenStable`) sin fake timers.
+const flushTasks = (): Promise<void> => new Promise((resolve) => setTimeout(resolve));
+
+describe('ssrBlockingRxResource', () => {
+	it('mantiene la app inestable (whenStable no resuelve) hasta el primer emit del stream', async () => {
+		const emitter = new Subject<string>();
+		const resource = TestBed.runInInjectionContext(() =>
+			ssrBlockingRxResource({ stream: () => emitter.asObservable(), defaultValue: undefined }),
+		);
+		const appRef = TestBed.inject(ApplicationRef);
+
+		// Corre el effect de carga del resource: se suscribe al stream y `pendingUntilEvent` registra la PendingTask.
+		TestBed.tick();
+
+		let stable = false;
+		appRef.whenStable().then(() => (stable = true));
+		await flushTasks();
+		expect(stable).toBe(false);
+		expect(resource.isLoading()).toBe(true);
+
+		emitter.next('el-aleph');
+		emitter.complete();
+		await appRef.whenStable();
+		TestBed.tick();
+
+		expect(stable).toBe(true);
+		expect(resource.value()).toBe('el-aleph');
+	});
+
+	it('no deja PendingTasks colgadas tras el emit (whenStable vuelve a resolver)', async () => {
+		const emitter = new Subject<string>();
+		TestBed.runInInjectionContext(() =>
+			ssrBlockingRxResource({ stream: () => emitter.asObservable(), defaultValue: '' }),
+		);
+		const appRef = TestBed.inject(ApplicationRef);
+		TestBed.tick();
+
+		emitter.next('primero');
+		emitter.next('segundo');
+		emitter.complete();
+
+		// Si `pendingUntilEvent` no limpiara su task al primer emit, esto quedaría pendiente para siempre.
+		await appRef.whenStable();
+		expect(true).toBe(true);
+	});
+
+	it('respeta el overload sin defaultValue (valor inicial undefined)', () => {
+		const resource = TestBed.runInInjectionContext(() => ssrBlockingRxResource({ stream: () => NEVER }));
+		expect(resource.value()).toBeUndefined();
+	});
+});
+
+describe('progressiveRxResource', () => {
+	// Es `rxResource` por identidad: no agrega ningún comportamiento (ni bloqueo de SSR) que testear
+	// aparte del que ya cubre Angular. Contrasta con `ssrBlockingRxResource`, que sí bloquea `whenStable`.
+	it('es un alias directo de rxResource', () => {
+		expect(progressiveRxResource).toBe(rxResource);
+	});
+});

--- a/src/app/utils/ssr-resource.spec.ts
+++ b/src/app/utils/ssr-resource.spec.ts
@@ -51,6 +51,22 @@ describe('ssrBlockingRxResource', () => {
 		expect(true).toBe(true);
 	});
 
+	it('libera el bloqueo si el stream falla (whenStable resuelve y el error queda seteado)', async () => {
+		const emitter = new Subject<string>();
+		const resource = TestBed.runInInjectionContext(() =>
+			ssrBlockingRxResource({ stream: () => emitter.asObservable(), defaultValue: undefined }),
+		);
+		const appRef = TestBed.inject(ApplicationRef);
+		TestBed.tick();
+
+		emitter.error(new Error('fetch de Sanity falló'));
+
+		// El SSR no debe colgarse ante un fetch fallido: `pendingUntilEvent` libera la task también en error.
+		await appRef.whenStable();
+		TestBed.tick();
+		expect(resource.error()).toBeTruthy();
+	});
+
 	it('respeta el overload sin defaultValue (valor inicial undefined)', () => {
 		const resource = TestBed.runInInjectionContext(() => ssrBlockingRxResource({ stream: () => NEVER }));
 		expect(resource.value()).toBeUndefined();

--- a/src/app/utils/ssr-resource.ts
+++ b/src/app/utils/ssr-resource.ts
@@ -1,0 +1,35 @@
+import { inject, Injector, type ResourceRef } from '@angular/core';
+import { pendingUntilEvent, rxResource, type RxResourceOptions } from '@angular/core/rxjs-interop';
+
+/**
+ * `rxResource` cuyo stream se pipea por `pendingUntilEvent`: registra una `PendingTask` que hace
+ * esperar a `ApplicationRef.whenStable()` (lo que `@angular/ssr` aguarda antes de serializar) hasta
+ * el primer emit del fetch. Así el SSR y el prerender de build sirven contenido + meta tags reales
+ * en vez del skeleton genérico. En el browser no bloquea el render, solo retrasa `isStable`, por lo
+ * que la carga progresiva in-app se conserva.
+ *
+ * Reemplazo zoneless de `FetchContentDirective` → `MacroTaskWrapperService` (macrotask de Zone.js),
+ * perdido en la migración a signals/zoneless (#1144).
+ *
+ * El `Injector` se captura acá y se pasa explícito a `pendingUntilEvent`: el callback `stream()`
+ * corre fuera del contexto de inyección (se invoca al disparar el fetch, no en el field initializer),
+ * donde un `pendingUntilEvent()` sin argumento fallaría con NG0203.
+ */
+export function ssrBlockingRxResource<T, R>(
+	options: RxResourceOptions<T, R> & { defaultValue: NoInfer<T> },
+): ResourceRef<T>;
+export function ssrBlockingRxResource<T, R>(options: RxResourceOptions<T, R>): ResourceRef<T | undefined>;
+export function ssrBlockingRxResource<T, R>(options: RxResourceOptions<T, R>): ResourceRef<T | undefined> {
+	const injector = inject(Injector);
+	return rxResource<T, R>({
+		...options,
+		stream: (params) => options.stream(params).pipe(pendingUntilEvent(injector)),
+	});
+}
+
+/**
+ * Opt-out explícito del bloqueo de SSR: alias directo de `rxResource` para datos secundarios o no
+ * indexables (p. ej. el listado de cuentos de un autor), que se sirven como skeleton y resuelven en
+ * el cliente.
+ */
+export const progressiveRxResource = rxResource;

--- a/src/app/utils/ssr-resource.ts
+++ b/src/app/utils/ssr-resource.ts
@@ -4,9 +4,10 @@ import { pendingUntilEvent, rxResource, type RxResourceOptions } from '@angular/
 /**
  * `rxResource` cuyo stream se pipea por `pendingUntilEvent`: registra una `PendingTask` que hace
  * esperar a `ApplicationRef.whenStable()` (lo que `@angular/ssr` aguarda antes de serializar) hasta
- * el primer emit del fetch. Así el SSR y el prerender de build sirven contenido + meta tags reales
- * en vez del skeleton genérico. En el browser no bloquea el render, solo retrasa `isStable`, por lo
- * que la carga progresiva in-app se conserva.
+ * que el stream emite, completa, falla o se desuscribe. Así el SSR y el prerender de build sirven
+ * contenido + meta tags reales en vez del skeleton genérico, y un fetch que falla libera el bloqueo
+ * en vez de colgar la serialización. En el browser no bloquea el render, solo retrasa `isStable`,
+ * por lo que la carga progresiva in-app se conserva.
  *
  * Reemplazo zoneless de `FetchContentDirective` → `MacroTaskWrapperService` (macrotask de Zone.js),
  * perdido en la migración a signals/zoneless (#1144).
@@ -20,7 +21,7 @@ export function ssrBlockingRxResource<T, R>(
 ): ResourceRef<T>;
 export function ssrBlockingRxResource<T, R>(options: RxResourceOptions<T, R>): ResourceRef<T | undefined>;
 export function ssrBlockingRxResource<T, R>(options: RxResourceOptions<T, R>): ResourceRef<T | undefined> {
-	const injector = inject(Injector);
+	const injector = options.injector ?? inject(Injector);
 	return rxResource<T, R>({
 		...options,
 		stream: (params) => options.stream(params).pipe(pendingUntilEvent(injector)),


### PR DESCRIPTION
## Descripción

Habilitador de la serie SEO (causa raíz de #1697): introduce `ssrBlockingRxResource()` en `src/app/utils/ssr-resource.ts`, que pipea el stream de un `rxResource` por `pendingUntilEvent` (registra una `PendingTask` que hace esperar la serialización del SSR — `ApplicationRef.whenStable()` — hasta que el fetch emite, completa o falla). Así las rutas `RenderMode.Server`/`Prerender` sirven contenido + meta tags reales en el HTML server-rendered, en vez del skeleton genérico con meta genérico que hoy captura Google Search Console. Es el reemplazo zoneless del viejo `FetchContentDirective` → `MacroTaskWrapperService`, perdido en #1144.

- Nuevo helper `ssrBlockingRxResource` (bloqueante) + `progressiveRxResource` (alias explícito de `rxResource`, opt-out para datos secundarios/no indexables).
- Migradas las páginas con fetch: `home`, `story`, `storylist`, `stories`, `authors` → `ssrBlockingRxResource`; `author` → perfil bloqueante + listado de cuentos progresivo.
- `about` (Server + `noindex, nofollow`, meta estáticos) y los frames de navegación (`author`/`storylist`) usan `progressiveRxResource`: bloquear ahí solo agregaría latencia por request sin beneficio de indexación.
- Documentado el patrón en `.claude/references/angular-state.md` (§7 + checklist).

Decisión: bloqueo **universal** (no `isPlatformServer`) — en cliente solo afecta `isStable`, no el render, y no hay consumidor de `isStable`/`whenStable`/`networkidle` en el repo. El `Injector` se captura dentro del helper (el callback `stream()` corre fuera de contexto de inyección; un `pendingUntilEvent()` sin argumento fallaría con NG0203).

Closes #1704.

Parte de #1697.

## Plan de pruebas

- [x] `pnpm lint` · `pnpm stylelint` · `pnpm typecheck` · `pnpm test` (600 pass, 3 skip preexistentes; incluye `ssr-resource.spec.ts` 5/5 con el camino de error) · `pnpm build` (prerender OK) · `pnpm storybook:build` — todos verdes.
- [x] Verificación SSR por `curl` sobre el build de producción: `story/:slug` y `author/:slug` sirven title/description/canonical/JSON-LD reales; `home` sirve título + contenido; `about` responde 200 con meta estático sin bloquear.
- [ ] `pnpm test:e2e` (`e2e/seo/*`): no corrible localmente por un error de carga de `playwright.config.ts` (`require()` de ESM `@nx/devkit`), ajeno a este cambio; corre en CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
