### PR TITLE
[#1715] - La barra de navegación del cuento hace un fetch a /author//navigation (404) cuando navigationSlug está vacío

### DIFF
--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
@@ -13,6 +13,7 @@ import { storyMock, storyTeaserMock } from '../../mocks/story.mock';
 
 // Services
 import { StoryApi } from '../../providers/story-api.interface';
+import { NavigationFrameService } from '../../providers/navigation-frame.service';
 
 // 3rd party libs
 import { render, screen } from '@testing-library/angular';
@@ -70,5 +71,35 @@ describe('AuthorNavigationFrameComponent', () => {
 		view.detectChanges();
 
 		expect(getNavigationTeasersByAuthorSlug).not.toHaveBeenCalled();
+	});
+
+	test('should not publish a navigation config when navigationSlug is empty', async () => {
+		const view = await render(AuthorNavigationFrameComponent, {
+			componentImports: [CommonModule, NavigableStoryTeaserComponent],
+			inputs: {
+				selectedStorySlug: storyMock.slug,
+				navigationSlug: '',
+			},
+			providers: [
+				{
+					provide: StoryApi,
+					useValue: {
+						getNavigationTeasersByAuthorSlug: () => of([storyTeaserMock]),
+					},
+				},
+			],
+		});
+		view.detectChanges();
+
+		const navigationFrameService = view.fixture.debugElement.injector.get(NavigationFrameService);
+		expect(navigationFrameService.navigationBarConfig().headerTitle).toBe('');
+	});
+
+	test('should publish the author navigation config when navigationSlug is present', async () => {
+		const view = await setup();
+		view.detectChanges();
+
+		const navigationFrameService = view.fixture.debugElement.injector.get(NavigationFrameService);
+		expect(navigationFrameService.navigationBarConfig().headerTitle).toBe('Más del autor');
 	});
 });

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.spec.ts
@@ -18,6 +18,9 @@ import { StoryApi } from '../../providers/story-api.interface';
 import { render, screen } from '@testing-library/angular';
 import { authorMock } from '../../mocks/author.mock';
 
+// Test utils
+import { fn } from '@test-utils';
+
 describe('AuthorNavigationFrameComponent', () => {
 	const setup = async () => {
 		return await render(AuthorNavigationFrameComponent, {
@@ -50,5 +53,22 @@ describe('AuthorNavigationFrameComponent', () => {
 		expect(screen.getByText(storyTeaserMock.title)).toBeInTheDocument();
 		expect(screen.getByText(storyTeaserMock.originalPublication)).toBeInTheDocument();
 		expect(screen.getByText(`${storyTeaserMock.approximateReadingTime} minutos de lectura`)).toBeInTheDocument();
+	});
+
+	test('should not fetch navigation teasers when navigationSlug is empty', async () => {
+		const getNavigationTeasersByAuthorSlug = fn<(slug: string) => Observable<StoryTeaser[]>>();
+		getNavigationTeasersByAuthorSlug.mockReturnValue(of([storyTeaserMock]));
+
+		const view = await render(AuthorNavigationFrameComponent, {
+			componentImports: [CommonModule, NavigableStoryTeaserComponent],
+			inputs: {
+				selectedStorySlug: storyMock.slug,
+				navigationSlug: '',
+			},
+			providers: [{ provide: StoryApi, useValue: { getNavigationTeasersByAuthorSlug } }],
+		});
+		view.detectChanges();
+
+		expect(getNavigationTeasersByAuthorSlug).not.toHaveBeenCalled();
 	});
 });

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
@@ -36,7 +36,7 @@ export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
 
 	// Recursos
 	private readonly storiesResource = progressiveRxResource({
-		params: () => this.navigationSlug(),
+		params: () => this.navigationSlug() || undefined,
 		stream: ({ params: slug }) => this.storyService.getNavigationTeasersByAuthorSlug(slug),
 		defaultValue: [],
 	});

--- a/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
+++ b/src/app/components/author-navigation-frame/author-navigation-frame.component.ts
@@ -48,10 +48,14 @@ export class AuthorNavigationFrameComponent extends NavigationFrameComponent {
 	constructor() {
 		super();
 		effect(() => {
+			const navigationSlug = this.navigationSlug();
+			if (!navigationSlug) {
+				return;
+			}
 			this.config.set({
 				headerTitle: 'Más del autor',
 				footerTitle: 'Ver más...',
-				navigationRoute: this.router.createUrlTree([this.appRoutes.Author, this.navigationSlug()]),
+				navigationRoute: this.router.createUrlTree([this.appRoutes.Author, navigationSlug]),
 				showFooter: true,
 			});
 		});

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.spec.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.spec.ts
@@ -19,6 +19,9 @@ import { StorylistApi } from '../../providers/storylist-api.interface';
 // 3rd party libs
 import { render, screen } from '@testing-library/angular';
 
+// Test utils
+import { fn } from '@test-utils';
+
 describe('StorylistNavigationFrameComponent', () => {
 	const setup = async () => {
 		return await render(StorylistNavigationFrameComponent, {
@@ -51,6 +54,23 @@ describe('StorylistNavigationFrameComponent', () => {
 		view.detectChanges();
 		expect(screen.getByText(storylistMock.stories[0].title)).toBeInTheDocument();
 		expect(screen.getByText(storylistMock.stories[0].author.name)).toBeInTheDocument();
+	});
+
+	test('should not fetch navigation teasers when navigationSlug is empty', async () => {
+		const getStorylistNavigationTeasers = fn<(slug: string) => Observable<Storylist>>();
+		getStorylistNavigationTeasers.mockReturnValue(of(storylistMock));
+
+		const view = await render(StorylistNavigationFrameComponent, {
+			componentImports: [CommonModule, NavigableStorylistStoryTeaserComponent, SkeletonComponent],
+			inputs: {
+				selectedStorySlug: storyMock.slug,
+				navigationSlug: '',
+			},
+			providers: [DatePipe, { provide: StorylistApi, useValue: { getStorylistNavigationTeasers } }],
+		});
+		view.detectChanges();
+
+		expect(getStorylistNavigationTeasers).not.toHaveBeenCalled();
 	});
 
 	test('should render loading skeletons with role="status" while the storylist resolves', async () => {

--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.ts
@@ -55,7 +55,7 @@ export class StorylistNavigationFrameComponent extends NavigationFrameComponent 
 
 	// Recursos
 	private readonly storylistResource = progressiveRxResource({
-		params: () => this.navigationSlug(),
+		params: () => this.navigationSlug() || undefined,
 		stream: ({ params }) => this.storylistService.getStorylistNavigationTeasers(params),
 		defaultValue: undefined,
 	});


### PR DESCRIPTION
## Descripción

Corrige dos síntomas del mismo escenario —`navigationSlug` vacío (`''`) durante la ventana previa a que la historia resuelva su autor—:

1. **Fetch 404 (bug original #1715):** los frames de navegación pasaban `navigationSlug=''` directo como `params` del `progressiveRxResource`, disparando `GET /api/story/author//navigation` (404). Se gatea con `this.navigationSlug() || undefined` en `AuthorNavigationFrameComponent` y `StorylistNavigationFrameComponent`: con `undefined` el recurso queda idle y no dispara el loader; cuando llega el slug real, refetchea con normalidad.
2. **Link de navegación roto (alcance ampliado, absorbe #1716):** el `effect()` de `AuthorNavigationFrameComponent` construía `createUrlTree(['author', ''])` y publicaba un link roto en el header/footer durante esa misma ventana. Se retorna temprano cuando el slug está vacío, de forma análoga al gating que ya tenía `StorylistNavigationFrameComponent`.

Tests de regresión en ambos specs: espían el método de la API con `fn()` de `@test-utils` (`not.toHaveBeenCalled()` con slug vacío) y verifican que la config de navegación no se publica con slug vacío (y sí se publica con slug válido, para no sobre-gatear).

Closes #1715.
Closes #1716.

## Plan de pruebas

- [x] `pnpm test` — specs de ambos frames verdes (incluye regresión de fetch y de publicación de config)
- [x] `pnpm lint`
- [x] `pnpm stylelint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm storybook:build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
