### PR TITLE
[#1705] - Regla ESLint: forzar ssrBlockingRxResource/progressiveRxResource en páginas

### DIFF
--- a/.claude/references/angular-state.md
+++ b/.claude/references/angular-state.md
@@ -159,6 +159,8 @@ readonly storiesResource = progressiveRxResource({
 
 Cuándo **bloquear**: rutas cuyo HTML server-rendered debe traer contenido/meta reales — `RenderMode.Server` indexables y `Prerender` con contenido (el prerender de build gana contenido real en vez de skeleton). Cuándo **no**: rutas `noindex` servidas por request con meta estáticos (bloquear solo agrega latencia sin ganar indexación → `progressiveRxResource`), y datos secundarios.
 
+**Enforced por lint:** en `src/app/pages/**` está prohibido `rxResource`/`httpResource` crudo — el gate `lint` obliga a elegir `ssrBlockingRxResource` o `progressiveRxResource` (`no-restricted-syntax`, bloque `ssr-fetch-must-decide-blocking` de `eslint.config.mjs`; #1705).
+
 ---
 
 ## Checklist rápido

--- a/.claude/references/typescript.md
+++ b/.claude/references/typescript.md
@@ -92,3 +92,16 @@ const DEFAULT_INTERVAL = 24 * 60 * 60 * 1000;
 - **Global:** solo tras confirmar reuso entre varios archivos.
 
 **Rationale:** una constante declarada 50 líneas lejos de su único uso obliga al lector a saltar entre dos lugares. Co-locarla con su uso (cuando es único) hace el código autocontenido.
+
+## `eslint.config.mjs`: reglas por-scope reemplazan, no mergean
+
+En ESLint flat config, cuando **dos config objects aplican al mismo archivo** y ambos setean la **misma** regla (p. ej. `no-restricted-syntax`), el bloque que matchea **último gana por completo**: su array de opciones **reemplaza** el del bloque anterior, no lo concatena. Un bloque acotado (`files: ['src/app/pages/**/*.ts']`) que redeclara `no-restricted-syntax` con solo sus restricciones nuevas **pierde silenciosamente** las del bloque global (`files: ['**/*.ts']`) para esos archivos.
+
+**Regla:** al acotar `no-restricted-syntax` (u otra regla de array) a un scope, **recomponer** las restricciones base en vez de redeclarar solo las nuevas — típicamente esparciendo la constante común:
+
+```js
+// ✅ el bloque de páginas conserva commonRestrictedSyntax (enum, lifecycle hooks, estáticas, CommonJS)
+'no-restricted-syntax': ['error', ...commonRestrictedSyntax, ...pageFetchRestrictedSyntax],
+```
+
+Precedentes en el propio archivo: `test-utils-vi-exception` (recompone `commonRestrictedSyntax` al soltar `viRestrictedSyntax` para `src/test-utils.ts`) y `ssr-fetch-must-decide-blocking` (recompone `commonRestrictedSyntax` al sumar las restricciones de fetch de página; #1705). La única parte que **sí** se puede soltar sin recomponer es la que no aplica al scope (`viRestrictedSyntax` en un bloque que ya `ignores: ['**/*.spec.ts']`, porque `vi.*` solo aparece en specs).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -75,6 +75,22 @@ const viRestrictedSyntax = [
 	},
 ];
 
+// Prohíbe rxResource/httpResource crudos en páginas: todo fetch de página debe decidir explícitamente
+// su estrategia de SSR con ssrBlockingRxResource()/progressiveRxResource(), para no repetir la
+// regresión de SEO de #1697 (un fetch sin pendingUntilEvent sirve el skeleton al SSR sin bloquear).
+const pageFetchRestrictedSyntax = [
+	{
+		selector: "CallExpression[callee.name='rxResource']",
+		message:
+			'En páginas usá ssrBlockingRxResource() o progressiveRxResource() de @utils/ssr-resource en vez de rxResource crudo — rxResource omite pendingUntilEvent y puede reproducir la regresión de SEO de #1697.',
+	},
+	{
+		selector: "CallExpression[callee.name='httpResource']",
+		message:
+			'En páginas usá ssrBlockingRxResource() o progressiveRxResource() de @utils/ssr-resource en vez de httpResource crudo — httpResource omite el bloqueo explícito del SSR y puede reproducir la regresión de SEO de #1697.',
+	},
+];
+
 export default [
 	{
 		name: 'ignores',
@@ -147,6 +163,17 @@ export default [
 			'@stylistic/js/no-extra-semi': 'off',
 			'no-barrel-files/no-barrel-files': 'error',
 			'preserve-caught-error': 'error',
+		},
+	},
+	{
+		// Compone commonRestrictedSyntax con las restricciones de fetch de página: en flat config, un
+		// bloque posterior que setea la misma regla REEMPLAZA el array del bloque `nx`, no lo mergea —
+		// recomponer commonRestrictedSyntax evita perder su cobertura (enum/lifecycle/estáticas) en páginas.
+		name: 'ssr-fetch-must-decide-blocking',
+		files: ['src/app/pages/**/*.ts'],
+		ignores: ['**/*.spec.ts'],
+		rules: {
+			'no-restricted-syntax': ['error', ...commonRestrictedSyntax, ...pageFetchRestrictedSyntax],
 		},
 	},
 	{


### PR DESCRIPTION
## Descripción

- Agrega la regla ESLint `ssr-fetch-must-decide-blocking` (`no-restricted-syntax`, scope `src/app/pages/**/*.ts`, ignora specs) que prohíbe `rxResource`/`httpResource` crudos en páginas: todo fetch de página debe elegir explícitamente su estrategia de SSR con `ssrBlockingRxResource()` (bloquea el SSR para SEO) o `progressiveRxResource()` (opt-out progresivo). Hace estructuralmente imposible repetir la regresión de #1697.
- El bloque **recompone** `commonRestrictedSyntax` (`['error', ...commonRestrictedSyntax, ...pageFetchRestrictedSyntax]`) porque en flat config un bloque posterior que setea la misma regla reemplaza el array del bloque `nx`, no lo mergea — así las páginas no pierden la cobertura de enum/lifecycle hooks/propiedades estáticas/CommonJS. Sigue el precedente de `test-utils-vi-exception`. (Este es el único cambio sustantivo respecto del spike #1700, que redeclaraba la regla sin recomponer.)
- Documenta el enforcement en `angular-state.md` §7 ("Enforced por lint") y el gotcha de flat config (reemplazo vs. merge de reglas por-scope) en `typescript.md`, para que futuros cambios de `eslint.config.mjs` no reintroduzcan el bug.

Closes #1705.
Parte de #1697.

## Plan de pruebas

- [x] `pnpm lint` — verde (todas las páginas ya migradas a los helpers en #1704 pasan la regla)
- [x] `pnpm typecheck` — verde
- [x] `pnpm stylelint` — verde
- [x] `pnpm test` — verde
- [x] `pnpm build` — verde
- [x] `pnpm storybook:build` — verde
- [x] Verificación manual descartable (archivo probe en `src/app/pages/`, nunca commiteado): confirma que las 4 categorías disparan simultáneamente — `enum` y `OnInit` de `commonRestrictedSyntax` (preservadas) + `rxResource`/`httpResource` de la regla nueva. Prueba en concreto el punto reemplazo-vs-merge de flat config.

## Notas

- Scope opcional a `src/app/components/**`: no se extiende ahora (YAGNI). Grep confirma cero usos crudos hoy; los dos componentes con fetch propio (`author-navigation-frame`, `storylist-navigation-frame`) ya usan `progressiveRxResource`. Extenderlo es un cambio de una línea cuando aparezca la necesidad.
- Limitación conocida (aceptada, no específica de este cambio): los selectores son por nombre de identificador, así que un import con alias evadiría la regla — mismo blind spot que enum/lifecycle/CommonJS en este archivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
