### PR TITLE
[HF] - Confía los proxy headers de Vercel en el SSR para evitar el deopt a CSR

### DIFF
--- a/e2e/seo/ssr-proxy-headers.spec.ts
+++ b/e2e/seo/ssr-proxy-headers.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Test e2e de regresión del deopt-a-CSR por proxy headers (Vercel).
+ *
+ * El hardening SSR de Angular (`AngularAppEngine`) descarta a client-side rendering
+ * (`serveClientSidePage()` → `index.csr.html`, sin contenido ni meta por página) cuando llega
+ * un header `x-forwarded-*` no declarado como confiable. Vercel termina TLS y **siempre** agrega
+ * `x-forwarded-for`, así que sin `trustProxyHeaders` en `src/server.ts` toda request de producción
+ * deopteaba a CSR y los crawlers recibían el shell genérico → desindexación.
+ *
+ * Este test simula ese header y verifica que el SSR igual sirve el HTML por página (título y
+ * canónica del cuento, no el shell genérico de home). Si alguien quita `trustProxyHeaders: true`,
+ * el server deoptea y este test falla.
+ */
+import { test, expect } from '@playwright/test';
+
+import { getTitleText, getCanonicalHref } from '../_utils/seo';
+import { STABLE_SLUGS } from '../_utils/seo-fixtures';
+
+const storyPath = `/story/${STABLE_SLUGS.story}`;
+
+// `x-forwarded-for` es el header que Vercel agrega a toda request y que dispara el deopt si no se
+// confía (no está en el set confiable por default de Angular). Se omite `x-forwarded-proto: https`
+// a propósito: en el dev server (http) forzaría el self-fetch del SSR a `https://localhost` y
+// fallaría por TLS — un artefacto de dev ajeno a lo que este test verifica (el deopt por proxy).
+const proxyHeaders = { 'x-forwarded-for': '66.249.66.1' };
+
+test('SSR con x-forwarded-for sirve el HTML por página, no el shell CSR genérico', async ({ request }) => {
+	const html = await (await request.get(storyPath, { headers: proxyHeaders })).text();
+
+	// Afirma sobre el mecanismo: el deopt sirve el shell CSR (`ng-server-context="ssg"`); el SSR
+	// real lo marca como `"ssr"`.
+	expect(html).toContain('ng-server-context="ssr"');
+	// Y sobre el efecto observable: título y canónica del cuento, no el genérico de home.
+	expect(getTitleText(html)).toMatch(/aleph/i);
+	expect(getCanonicalHref(html)).toContain(storyPath);
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,11 @@ import { getAllowedHosts } from './api/_helpers/environment';
  * Inicializa Hono y exporta la instancia de la aplicación
  */
 export const app = new Hono({ strict: false }).use(requestId()).use(secureHeaders());
-const angularApp = new AngularAppEngine({ allowedHosts: getAllowedHosts() });
+// Vercel termina TLS y siempre agrega headers `x-forwarded-*` (incluido `x-forwarded-for`).
+// Sin declararlos confiables, el hardening SSR de Angular degrada cada request a client-side
+// rendering (sirve `index.csr.html` sin contenido ni meta), dejando las páginas Server sin SSR
+// para los crawlers. `trustProxyHeaders: true` los honra y preserva el render server-side.
+const angularApp = new AngularAppEngine({ allowedHosts: getAllowedHosts(), trustProxyHeaders: true });
 
 // Registra ruta del sitemap en la raíz
 app.route('/sitemap.xml', sitemapController);


### PR DESCRIPTION
## Contexto / problema

Google Search Console mostró una caída de ~66% en páginas indexadas a partir del 11-jun. Causa **confirmada**: en Vercel (serverless), `AngularAppEngine` **deoptea cada request a client-side rendering** porque Vercel termina TLS y **siempre** agrega el header `x-forwarded-for`, que el hardening SSR de Angular 21 no confía por default (`normalizeTrustProxyHeaders` confía solo `x-forwarded-host`/`x-forwarded-proto`). Con `deoptToCSR`, `AngularAppEngine.handle()` sirve `serveClientSidePage()` = `index.csr.html` (shell con `ng-server-context="ssg"`, sin contenido ni meta por página) → los crawlers reciben el shell genérico y desindexan las rutas `RenderMode.Server` (`story/:slug`, `author/:slug`, `storylist/:slug`, `home`). Los usuarios no lo notan: el browser bootea CSR y fetchea `/api` del lado del cliente.

## Fix

`trustProxyHeaders: true` en el `AngularAppEngine` de `src/server.ts`: honra los `x-forwarded-*` de Vercel y preserva el render server-side.

## Verificación

- **A/B en build de prod local** (`node dist/cuentoneta/server/server.mjs` + curl con `x-forwarded-for`): **sin** la opción → `ng-server-context="ssg"`, título genérico, 0 contenido; **con** la opción → `ssr` + título/canónica/contenido por página.
- **Test e2e de regresión** (`e2e/seo/ssr-proxy-headers.spec.ts`): manda `x-forwarded-for` y asevera `ng-server-context="ssr"` + título y canónica del cuento. Verificado que **falla** sin `trustProxyHeaders` y **pasa** con él.

## Seguridad

Confiar los proxy headers es correcto detrás de Vercel (el borde los sobrescribe) y `allowedHosts` sigue validando el host de forma **incondicional**. `x-forwarded-host` ya se confiaba por default; los headers extra que agrega `true` (`x-forwarded-for`/`-port`/`-prefix`) no se consumen en ningún punto de decisión. Se prefiere `true` a una lista explícita para no re-romperse ante futuros `x-forwarded-*` de la plataforma.

## Gates

`lint`, `typecheck`, `stylelint`, `test`, `build`, `storybook:build` — verdes (corridos en la code review, **aprobada sin bloqueantes**).

## Seguimiento (aparte)

La fragilidad del round-trip **self-fetch del SSR a la URL pública** (`environment.apiUrl` = `VERCEL_PROJECT_PRODUCTION_URL`) queda como issue separado — **no confirmada en prod**, porque el deopt cortocircuitaba antes de que el SSR corriera. Post-deploy conviene verificar que las páginas rindan `ssr`+contenido; si aparece `ssr`+genérico, ahí sí atacar el self-fetch.
