### PR TITLE
[#1751] - Adopta numeración ISO-8601 para el slug de las landing pages

### DIFF
--- a/cms/schemas/landingPage.ts
+++ b/cms/schemas/landingPage.ts
@@ -31,6 +31,8 @@ export default defineType({
 			name: 'config',
 			title: 'Configuración',
 			type: 'string',
+			description:
+				'Formato YYYY-WW, numeración de semana ISO-8601 (lunes = día 1). Ver docs/CONTENT_UPDATE_STRATEGIES.md.',
 			validation: (Rule) => Rule.required(),
 		}),
 		defineField({

--- a/docs/CONTENT_UPDATE_STRATEGIES.md
+++ b/docs/CONTENT_UPDATE_STRATEGIES.md
@@ -119,15 +119,18 @@ Este proceso garantiza que:
 
 ### Nomenclatura de Slugs
 
-Las landing pages se identifican mediante slugs en formato **`YYYY-SS`**:
+Las landing pages se identifican mediante slugs en formato **`YYYY-SS`**, con numeración de semana **ISO-8601**:
 
-- **YYYY**: Año de cuatro dígitos (`getWeekYear`, el año de la semana, no el calendario)
-- **SS**: Número de semana (01-53), con relleno cero a dos dígitos
+- **YYYY**: Año de cuatro dígitos (`getISOWeekYear`, el año ISO de la semana, no el calendario)
+- **SS**: Número de semana ISO (01-53), con relleno cero a dos dígitos
+- **Convención ISO-8601**: la semana empieza el **lunes** y la semana 1 es la que contiene el **primer jueves** del año (equivalente: la que contiene el 4 de enero). No es la convención local por defecto de `date-fns` (domingo = día 1, semana del 1° de enero).
 - **Ejemplos**: `2025-46`, `2026-01`, `2024-52`
 
 El año va primero para que el **orden lexicográfico del slug coincida con el orden cronológico** (`"2025-52" < "2026-01"`). Esto es lo que permite ordenar las semanas cronológicamente en Sanity Studio y acotar la query de la configuración base a `config <= semana actual`.
 
-> **Migración (#1749):** el formato anterior era `SS-YYYY` (p. ej. `46-2025`), que no ordenaba cronológicamente. Los documentos existentes se migraron a `YYYY-SS` con `scripts/migrate-landing-page-config-to-yyyy-ww.ts`, un reordenamiento de string puro que **no recalcula** el número de semana ya asignado.
+> **Migración (#1749):** el formato original era `SS-YYYY` (p. ej. `46-2025`), que no ordenaba cronológicamente. Se migró a `YYYY-SS` con `scripts/migrate-landing-page-config-to-yyyy-ww.ts` (reordenamiento de string puro, sin recalcular la semana).
+>
+> **Migración (#1751):** la numeración pasó de la convención local (domingo) a **ISO-8601** (lunes). Se migró con `scripts/migrate-landing-page-config-to-iso-week.ts`, que reconstruye el jueves de cada semana local y recalcula la semana/año ISO (dry-run por defecto + manejo de colisiones de borde de año). Para el rango 2025-2026 ambas convenciones coinciden, así que la migración fue un no-op sobre esos datos.
 
 ### Ubicación en el Código
 
@@ -152,7 +155,7 @@ El año va primero para que el **orden lexicográfico del slug coincida con el o
 La función `addNextWeeksLandingPageContent(weeksInTheFuture)` ejecuta el siguiente algoritmo:
 
 ```
-1. Calcular fecha actual y slug de la semana actual (formato YYYY-WW vía getWeekYear + getWeek)
+1. Calcular fecha actual y slug de la semana actual (formato YYYY-WW vía getISOWeekYear + getISOWeek)
 2. Generar slugs para las próximas N semanas (ej: weeksInTheFuture = 4)
 3. Consultar Sanity para obtener landing pages existentes con esos slugs
 4. Si TODAS las próximas N semanas ya existen → retornar vacío (sin cambios)

--- a/docs/CONTENT_UPDATE_STRATEGIES.md
+++ b/docs/CONTENT_UPDATE_STRATEGIES.md
@@ -179,6 +179,8 @@ La definición para la ejecución de este cronjob se encuentra en el archivo `ve
 - **Día y hora**: Domingos a las 03:30 am (GMT -3)
 - **Tolerancia**: Puede también ejecutarse de manera manual en cualquier momento antes de que se necesite
 
+> **Interacción con la numeración ISO-8601 (#1751):** las semanas ISO empiezan el **lunes**, y el cron corre el **domingo** — el último día de la semana ISO en curso. Por eso, el domingo la home todavía sirve la semana que termina ese día, y recién el lunes rota a la siguiente. Esto es **continuo, sin huecos**: cada domingo el cron pre-genera las próximas 4 semanas (`semana_actual + 1 … + 4`), así que la semana que la home pedirá de lunes a sábado siempre existe. (La corrida del domingo genera desde la semana _siguiente_; la semana que la home pide ese mismo domingo fue creada por la corrida del domingo anterior.)
+
 ### Ejemplo de Ejecución
 
 **Escenario**: Domingo 16 de noviembre de 2025, último día de la semana 46, a las 3:30 am (GMT -3). Se ejecuta el cronjob con el queryParam de "semanas hacia adelante" `weeksInTheFuture` predeterminado de 4.

--- a/scripts/iso-week-mapping.spec.ts
+++ b/scripts/iso-week-mapping.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { collisionLosers, toIsoSlug } from './iso-week-mapping';
+import type { MappedDoc } from './iso-week-mapping';
+
+describe('iso-week-mapping', () => {
+	describe('toIsoSlug', () => {
+		it('mantiene el número cuando ISO y locale coinciden (rango 2025-2026)', () => {
+			expect(toIsoSlug('2025-46')).toBe('2025-46');
+			expect(toIsoSlug('2026-03')).toBe('2026-03');
+		});
+
+		it('recalcula la semana en los bordes de año donde ISO diverge del locale', () => {
+			// 2021-01 (locale, domingo) cae en la semana ISO 53 de 2020; 2022-52 → ISO 2022-51.
+			expect(toIsoSlug('2021-01')).toBe('2020-53');
+			expect(toIsoSlug('2022-52')).toBe('2022-51');
+		});
+
+		it('devuelve null si el config no tiene formato YYYY-WW', () => {
+			expect(toIsoSlug('nope')).toBeNull();
+			expect(toIsoSlug('46-2025')).toBeNull();
+		});
+	});
+
+	describe('collisionLosers', () => {
+		const mapped = (id: string, config: string, iso: string): MappedDoc => ({
+			id,
+			logical: id.replace(/^drafts\./, ''),
+			config,
+			iso,
+		});
+
+		it('no reporta perdedores sin colisión (un solo doc lógico)', () => {
+			expect(collisionLosers([mapped('a', '2026-03', '2026-03')])).toEqual([]);
+		});
+
+		it('no cuenta como colisión a un draft y su published del mismo documento', () => {
+			const group = [mapped('a', '2021-01', '2020-53'), mapped('drafts.a', '2021-01', '2020-53')];
+			expect(collisionLosers(group)).toEqual([]);
+		});
+
+		it('ante colisión gana el config locale mayor; el menor es el perdedor', () => {
+			// 2020-53 y 2021-01 mapean ambos a 2020-53: gana 2021-01 (b), pierde 2020-53 (a).
+			const group = [mapped('a', '2020-53', '2020-53'), mapped('b', '2021-01', '2020-53')];
+			expect(collisionLosers(group)).toEqual(['a']);
+		});
+	});
+});

--- a/scripts/iso-week-mapping.ts
+++ b/scripts/iso-week-mapping.ts
@@ -1,0 +1,65 @@
+// Funciones puras del mapeo de semanas locale → ISO-8601 para la migración #1751.
+// Separadas del script de I/O (`migrate-landing-page-config-to-iso-week.ts`) para poder testearlas
+// sin tocar Sanity.
+import { addDays, getISOWeek, getISOWeekYear, setWeek, setWeekYear, startOfWeek } from 'date-fns';
+
+export type LandingPageDocument = { _id: string; config: string };
+export type MappedDoc = { id: string; logical: string; config: string; iso: string };
+
+// Un draft (`drafts.<id>`) y su published son el mismo documento lógico: no cuentan como colisión.
+export const logicalId = (id: string): string => id.replace(/^drafts\./, '');
+
+export const distinctLogicals = (group: MappedDoc[]): string[] => [...new Set(group.map((m) => m.logical))];
+
+// Supuesto: un draft y su published comparten `config` (misma semana); el primero que matchea alcanza.
+export const configOf = (group: MappedDoc[], logical: string): string =>
+	group.find((m) => m.logical === logical)?.config ?? '';
+
+// Mapea un slug locale YYYY-WW a su equivalente ISO-8601, anclando en el jueves de la semana locale.
+export function toIsoSlug(config: string): string | null {
+	const localeOptions = { weekStartsOn: 0, firstWeekContainsDate: 1 } as const;
+	const localeSlug = /^(\d{4})-(\d{2})$/;
+	const match = config?.match(localeSlug);
+	if (!match) {
+		return null;
+	}
+	const [, year, week] = match;
+	// La fecha base es irrelevante: setWeekYear/setWeek la reemplazan por completo.
+	const inWeek = setWeek(setWeekYear(new Date(2025, 5, 15), Number(year), localeOptions), Number(week), localeOptions);
+	const thursday = addDays(startOfWeek(inWeek, { weekStartsOn: 0 }), 4);
+	return `${getISOWeekYear(thursday)}-${getISOWeek(thursday).toString().padStart(2, '0')}`;
+}
+
+export function mapDocuments(docs: LandingPageDocument[]): { items: MappedDoc[]; skipped: LandingPageDocument[] } {
+	const items: MappedDoc[] = [];
+	const skipped: LandingPageDocument[] = [];
+	for (const doc of docs) {
+		const iso = toIsoSlug(doc.config);
+		if (iso) {
+			items.push({ id: doc._id, logical: logicalId(doc._id), config: doc.config, iso });
+		} else {
+			skipped.push(doc);
+		}
+	}
+	return { items, skipped };
+}
+
+export function groupByIso(items: MappedDoc[]): Map<string, MappedDoc[]> {
+	const groups = new Map<string, MappedDoc[]>();
+	for (const item of items) {
+		const group = groups.get(item.iso) ?? [];
+		group.push(item);
+		groups.set(item.iso, group);
+	}
+	return groups;
+}
+
+// Ante colisión (>1 doc lógico → mismo ISO), gana el config locale mayor (YYYY-WW ordena cronológico).
+export function collisionLosers(group: MappedDoc[]): string[] {
+	const logicals = distinctLogicals(group);
+	if (logicals.length <= 1) {
+		return [];
+	}
+	const winner = logicals.reduce((a, b) => (configOf(group, a) >= configOf(group, b) ? a : b));
+	return logicals.filter((l) => l !== winner);
+}

--- a/scripts/iso-week-mapping.ts
+++ b/scripts/iso-week-mapping.ts
@@ -1,6 +1,7 @@
 // Funciones puras del mapeo de semanas locale → ISO-8601 para la migración #1751.
 // Separadas del script de I/O (`migrate-landing-page-config-to-iso-week.ts`) para poder testearlas
 // sin tocar Sanity.
+// 🗑️ Programado para eliminación en el milestone 2.9.0 (#1754), junto con su migración y su spec.
 import { addDays, getISOWeek, getISOWeekYear, setWeek, setWeekYear, startOfWeek } from 'date-fns';
 
 export type LandingPageDocument = { _id: string; config: string };

--- a/scripts/migrate-landing-page-config-to-iso-week.ts
+++ b/scripts/migrate-landing-page-config-to-iso-week.ts
@@ -1,0 +1,162 @@
+/**
+ * Migración única (#1751): re-sluggea `config` y `slug.current` de TODOS los documentos landingPage
+ * de numeración de semana LOCAL (default de date-fns: domingo = día 1, semana del 1° de enero) a
+ * ISO-8601 (lunes = día 1, semana del primer jueves). El slug no guarda la fecha, así que por cada
+ * semana locale se reconstruye una fecha representativa, se ancla en su JUEVES (el criterio con el
+ * que ISO decide a qué semana/año pertenece) y se recalcula la semana/año ISO.
+ *
+ * Para casi toda semana el número no cambia; solo diverge en algunos bordes de año, donde además
+ * dos semanas locale pueden mapear al mismo destino ISO (colisión).
+ *
+ * ⚠️ EJECUTAR UNA SOLA VEZ. No es idempotente: el formato viejo (locale YYYY-WW) y el nuevo
+ * (ISO YYYY-WW) son indistinguibles, así que re-aplicar volvería a desplazar las semanas de borde
+ * de año. Correr SIEMPRE el dry-run primero y revisar el reporte.
+ *
+ * Uso:
+ *   node --import tsx --env-file=.env ./scripts/migrate-landing-page-config-to-iso-week.ts                       # dry-run
+ *   node --import tsx --env-file=.env ./scripts/migrate-landing-page-config-to-iso-week.ts --apply
+ *   node --import tsx --env-file=.env ./scripts/migrate-landing-page-config-to-iso-week.ts --apply --resolve=latest-wins
+ */
+import { client } from '../src/api/_helpers/sanity-connector';
+import { addDays, getISOWeek, getISOWeekYear, setWeek, setWeekYear, startOfWeek } from 'date-fns';
+
+type LandingPageDocument = { _id: string; config: string };
+type MappedDoc = { id: string; logical: string; config: string; iso: string };
+
+const LOCALE_OPTIONS = { weekStartsOn: 0, firstWeekContainsDate: 1 } as const;
+const LOCALE_SLUG = /^(\d{4})-(\d{2})$/;
+
+const pad = (n: number) => n.toString().padStart(2, '0');
+// Un draft (`drafts.<id>`) y su published son el mismo documento lógico: no cuentan como colisión.
+const logicalId = (id: string) => id.replace(/^drafts\./, '');
+const configOf = (group: MappedDoc[], logical: string): string =>
+	group.find((m) => m.logical === logical)?.config ?? '';
+const distinctLogicals = (group: MappedDoc[]): string[] => [...new Set(group.map((m) => m.logical))];
+
+// Mapea un slug locale YYYY-WW a su equivalente ISO-8601, anclando en el jueves de la semana locale.
+function toIsoSlug(config: string): string | null {
+	const match = config?.match(LOCALE_SLUG);
+	if (!match) {
+		return null;
+	}
+	const [, year, week] = match;
+	const inWeek = setWeek(
+		setWeekYear(new Date(2025, 5, 15), Number(year), LOCALE_OPTIONS),
+		Number(week),
+		LOCALE_OPTIONS,
+	);
+	const thursday = addDays(startOfWeek(inWeek, { weekStartsOn: 0 }), 4);
+	return `${getISOWeekYear(thursday)}-${pad(getISOWeek(thursday))}`;
+}
+
+function mapDocuments(docs: LandingPageDocument[]): { items: MappedDoc[]; skipped: LandingPageDocument[] } {
+	const items: MappedDoc[] = [];
+	const skipped: LandingPageDocument[] = [];
+	for (const doc of docs) {
+		const iso = toIsoSlug(doc.config);
+		if (iso) {
+			items.push({ id: doc._id, logical: logicalId(doc._id), config: doc.config, iso });
+		} else {
+			skipped.push(doc);
+		}
+	}
+	return { items, skipped };
+}
+
+function groupByIso(items: MappedDoc[]): Map<string, MappedDoc[]> {
+	const groups = new Map<string, MappedDoc[]>();
+	for (const item of items) {
+		const group = groups.get(item.iso) ?? [];
+		group.push(item);
+		groups.set(item.iso, group);
+	}
+	return groups;
+}
+
+// Ante colisión (>1 doc lógico → mismo ISO), gana el config locale mayor (YYYY-WW ordena cronológico).
+function collisionLosers(group: MappedDoc[]): string[] {
+	const logicals = distinctLogicals(group);
+	if (logicals.length <= 1) {
+		return [];
+	}
+	const winner = logicals.reduce((a, b) => (configOf(group, a) >= configOf(group, b) ? a : b));
+	return logicals.filter((l) => l !== winner);
+}
+
+function printReport(
+	total: number,
+	items: MappedDoc[],
+	skipped: LandingPageDocument[],
+	groups: Map<string, MappedDoc[]>,
+): void {
+	console.log(`Documentos: ${total} (mapeables: ${items.length}, sin formato locale: ${skipped.length})`);
+	skipped.forEach((d) => console.log(`  ⊘ ${d._id}: config "${d.config}" no matchea YYYY-WW`));
+
+	const changed = items.filter((m) => m.config !== m.iso);
+	console.log(`\nCambian: ${changed.length} · sin cambio: ${items.length - changed.length}`);
+	changed.forEach((m) => console.log(`  ~ ${m.id}: ${m.config} → ${m.iso}`));
+
+	const collisions = [...groups].filter(([, group]) => distinctLogicals(group).length > 1);
+	if (collisions.length === 0) {
+		console.log('\nSin colisiones.');
+		return;
+	}
+	console.log(`\n⚠️  COLISIONES: ${collisions.length}`);
+	collisions.forEach(([iso, group]) =>
+		console.log(
+			`  ${iso} ← ${distinctLogicals(group)
+				.map((l) => `${l} (${configOf(group, l)})`)
+				.join(', ')}`,
+		),
+	);
+}
+
+async function applyMigration(groups: Map<string, MappedDoc[]>, resolveLatest: boolean): Promise<void> {
+	const hasCollisions = [...groups.values()].some((group) => distinctLogicals(group).length > 1);
+	if (hasCollisions && !resolveLatest) {
+		console.error('\n✗ Hay colisiones y no se pasó --resolve=latest-wins. Abortando sin escribir.');
+		process.exit(1);
+	}
+
+	const transaction = client.transaction();
+	for (const [iso, group] of groups) {
+		const losers = collisionLosers(group);
+		for (const item of group) {
+			if (losers.includes(item.logical)) {
+				console.log(`  ✗ borra ${item.id} (colisión en ${iso})`);
+				transaction.delete(item.id);
+			} else if (item.config !== item.iso) {
+				console.log(`  ✓ ${item.id}: ${item.config} → ${item.iso}`);
+				transaction.patch(item.id, { set: { config: item.iso, 'slug.current': item.iso } });
+			}
+		}
+	}
+	await transaction.commit();
+	console.log('\n✓ Migración aplicada.');
+}
+
+async function runMigration(): Promise<void> {
+	const apply = process.argv.includes('--apply');
+	const resolveLatest = process.argv.includes('--resolve=latest-wins');
+
+	const docs = await client.fetch<LandingPageDocument[]>(`*[_type == 'landingPage']{ _id, config }`);
+	if (docs.length === 0) {
+		console.log('No hay documentos landingPage.');
+		return;
+	}
+
+	const { items, skipped } = mapDocuments(docs);
+	const groups = groupByIso(items);
+	printReport(docs.length, items, skipped, groups);
+
+	if (!apply) {
+		console.log('\n[DRY-RUN] No se escribió nada. Re-correr con --apply para aplicar.');
+		return;
+	}
+	await applyMigration(groups, resolveLatest);
+}
+
+runMigration().catch((err) => {
+	console.error('\nLa migración falló:', err);
+	process.exit(1);
+});

--- a/scripts/migrate-landing-page-config-to-iso-week.ts
+++ b/scripts/migrate-landing-page-config-to-iso-week.ts
@@ -11,6 +11,9 @@
  * (ISO YYYY-WW) son indistinguibles, así que re-aplicar volvería a desplazar las semanas de borde
  * de año. Correr SIEMPRE el dry-run primero y revisar el reporte (incluido el respaldo de colisiones).
  *
+ * 🗑️ Programado para eliminación en el milestone 2.9.0 (#1754), junto con `iso-week-mapping.ts` y su
+ * spec, una vez confirmada la corrida contra producción.
+ *
  * Uso:
  *   node --import tsx --env-file=.env ./scripts/migrate-landing-page-config-to-iso-week.ts                       # dry-run
  *   node --import tsx --env-file=.env ./scripts/migrate-landing-page-config-to-iso-week.ts --apply

--- a/scripts/migrate-landing-page-config-to-iso-week.ts
+++ b/scripts/migrate-landing-page-config-to-iso-week.ts
@@ -1,16 +1,15 @@
 /**
  * Migración única (#1751): re-sluggea `config` y `slug.current` de TODOS los documentos landingPage
  * de numeración de semana LOCAL (default de date-fns: domingo = día 1, semana del 1° de enero) a
- * ISO-8601 (lunes = día 1, semana del primer jueves). El slug no guarda la fecha, así que por cada
- * semana locale se reconstruye una fecha representativa, se ancla en su JUEVES (el criterio con el
- * que ISO decide a qué semana/año pertenece) y se recalcula la semana/año ISO.
+ * ISO-8601 (lunes = día 1, semana del primer jueves). La lógica pura del mapeo vive en
+ * `iso-week-mapping.ts`; acá solo el I/O contra Sanity.
  *
  * Para casi toda semana el número no cambia; solo diverge en algunos bordes de año, donde además
  * dos semanas locale pueden mapear al mismo destino ISO (colisión).
  *
  * ⚠️ EJECUTAR UNA SOLA VEZ. No es idempotente: el formato viejo (locale YYYY-WW) y el nuevo
  * (ISO YYYY-WW) son indistinguibles, así que re-aplicar volvería a desplazar las semanas de borde
- * de año. Correr SIEMPRE el dry-run primero y revisar el reporte.
+ * de año. Correr SIEMPRE el dry-run primero y revisar el reporte (incluido el respaldo de colisiones).
  *
  * Uso:
  *   node --import tsx --env-file=.env ./scripts/migrate-landing-page-config-to-iso-week.ts                       # dry-run
@@ -18,70 +17,9 @@
  *   node --import tsx --env-file=.env ./scripts/migrate-landing-page-config-to-iso-week.ts --apply --resolve=latest-wins
  */
 import { client } from '../src/api/_helpers/sanity-connector';
-import { addDays, getISOWeek, getISOWeekYear, setWeek, setWeekYear, startOfWeek } from 'date-fns';
-
-type LandingPageDocument = { _id: string; config: string };
-type MappedDoc = { id: string; logical: string; config: string; iso: string };
-
-const LOCALE_OPTIONS = { weekStartsOn: 0, firstWeekContainsDate: 1 } as const;
-const LOCALE_SLUG = /^(\d{4})-(\d{2})$/;
-
-const pad = (n: number) => n.toString().padStart(2, '0');
-// Un draft (`drafts.<id>`) y su published son el mismo documento lógico: no cuentan como colisión.
-const logicalId = (id: string) => id.replace(/^drafts\./, '');
-const configOf = (group: MappedDoc[], logical: string): string =>
-	group.find((m) => m.logical === logical)?.config ?? '';
-const distinctLogicals = (group: MappedDoc[]): string[] => [...new Set(group.map((m) => m.logical))];
-
-// Mapea un slug locale YYYY-WW a su equivalente ISO-8601, anclando en el jueves de la semana locale.
-function toIsoSlug(config: string): string | null {
-	const match = config?.match(LOCALE_SLUG);
-	if (!match) {
-		return null;
-	}
-	const [, year, week] = match;
-	const inWeek = setWeek(
-		setWeekYear(new Date(2025, 5, 15), Number(year), LOCALE_OPTIONS),
-		Number(week),
-		LOCALE_OPTIONS,
-	);
-	const thursday = addDays(startOfWeek(inWeek, { weekStartsOn: 0 }), 4);
-	return `${getISOWeekYear(thursday)}-${pad(getISOWeek(thursday))}`;
-}
-
-function mapDocuments(docs: LandingPageDocument[]): { items: MappedDoc[]; skipped: LandingPageDocument[] } {
-	const items: MappedDoc[] = [];
-	const skipped: LandingPageDocument[] = [];
-	for (const doc of docs) {
-		const iso = toIsoSlug(doc.config);
-		if (iso) {
-			items.push({ id: doc._id, logical: logicalId(doc._id), config: doc.config, iso });
-		} else {
-			skipped.push(doc);
-		}
-	}
-	return { items, skipped };
-}
-
-function groupByIso(items: MappedDoc[]): Map<string, MappedDoc[]> {
-	const groups = new Map<string, MappedDoc[]>();
-	for (const item of items) {
-		const group = groups.get(item.iso) ?? [];
-		group.push(item);
-		groups.set(item.iso, group);
-	}
-	return groups;
-}
-
-// Ante colisión (>1 doc lógico → mismo ISO), gana el config locale mayor (YYYY-WW ordena cronológico).
-function collisionLosers(group: MappedDoc[]): string[] {
-	const logicals = distinctLogicals(group);
-	if (logicals.length <= 1) {
-		return [];
-	}
-	const winner = logicals.reduce((a, b) => (configOf(group, a) >= configOf(group, b) ? a : b));
-	return logicals.filter((l) => l !== winner);
-}
+import type { Transaction } from '@sanity/client';
+import type { LandingPageDocument, MappedDoc } from './iso-week-mapping';
+import { collisionLosers, configOf, distinctLogicals, groupByIso, mapDocuments } from './iso-week-mapping';
 
 function printReport(
 	total: number,
@@ -111,6 +49,16 @@ function printReport(
 	);
 }
 
+// Antes de borrar un perdedor de colisión, vuelca su contenido completo para poder recuperarlo.
+async function backupAndDelete(transaction: Transaction, ids: string[]): Promise<void> {
+	const docs = await client.fetch<unknown[]>(`*[_id in $ids]`, { ids });
+	console.log(`\n⚠️  Se borran ${ids.length} documento(s) por colisión. Respaldo (revisar antes de confirmar):`);
+	console.log(JSON.stringify(docs, null, 2));
+	for (const id of ids) {
+		transaction.delete(id);
+	}
+}
+
 async function applyMigration(groups: Map<string, MappedDoc[]>, resolveLatest: boolean): Promise<void> {
 	const hasCollisions = [...groups.values()].some((group) => distinctLogicals(group).length > 1);
 	if (hasCollisions && !resolveLatest) {
@@ -119,17 +67,21 @@ async function applyMigration(groups: Map<string, MappedDoc[]>, resolveLatest: b
 	}
 
 	const transaction = client.transaction();
-	for (const [iso, group] of groups) {
+	const toDelete: string[] = [];
+	for (const [, group] of groups) {
 		const losers = collisionLosers(group);
 		for (const item of group) {
 			if (losers.includes(item.logical)) {
-				console.log(`  ✗ borra ${item.id} (colisión en ${iso})`);
-				transaction.delete(item.id);
+				toDelete.push(item.id);
 			} else if (item.config !== item.iso) {
 				console.log(`  ✓ ${item.id}: ${item.config} → ${item.iso}`);
 				transaction.patch(item.id, { set: { config: item.iso, 'slug.current': item.iso } });
 			}
 		}
+	}
+
+	if (toDelete.length > 0) {
+		await backupAndDelete(transaction, toDelete);
 	}
 	await transaction.commit();
 	console.log('\n✓ Migración aplicada.');

--- a/src/api/modules/content/content.service.spec.ts
+++ b/src/api/modules/content/content.service.spec.ts
@@ -1,4 +1,4 @@
-import { addWeeks, getWeek, getWeekYear } from 'date-fns';
+import { addWeeks, getISOWeek, getISOWeekYear } from 'date-fns';
 import {
 	clearAllMocks,
 	runOnlyPendingTimers,
@@ -34,7 +34,7 @@ describe('ContentService', () => {
 
 	describe('addNextWeeksLandingPageContent', () => {
 		const currentDate = new Date('2025-11-14');
-		const buildSlug = (date: Date) => `${getWeekYear(date)}-${getWeek(date).toString().padStart(2, '0')}`;
+		const buildSlug = (date: Date) => `${getISOWeekYear(date)}-${getISOWeek(date).toString().padStart(2, '0')}`;
 		const currentSlug = buildSlug(currentDate);
 
 		const mockLandingPage = {
@@ -78,9 +78,9 @@ describe('ContentService', () => {
 			expect(contentRepository.fetchLatestLandingPageReferences).toHaveBeenCalledWith(currentSlug);
 		});
 
-		it('should build the slug from the week-year (getWeekYear), not the calendar year, across the Dec/Jan boundary', async () => {
-			// 2025-12-29 cae en la semana 01 de 2026: getWeekYear → "2026-01"; getYear daría "2025-01",
-			// rompiendo el orden lexicográfico = cronológico. Fija getWeekYear para que un refactor no lo revierta.
+		it('should label the week with its ISO week-year, not the calendar year, across the Dec/Jan boundary', async () => {
+			// 2025-12-29 (lunes) es la semana ISO 01 de 2026: getISOWeekYear la etiqueta 2026, no 2025,
+			// preservando el orden lexicográfico = cronológico en el cruce dic/ene.
 			setSystemTime(new Date(2025, 11, 29));
 
 			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
@@ -90,6 +90,20 @@ describe('ContentService', () => {
 			await contentService.addNextWeeksLandingPageContent(4);
 
 			expect(contentRepository.fetchLatestLandingPageReferences).toHaveBeenCalledWith('2026-01');
+		});
+
+		it('should use ISO-8601 week numbering (Monday-start), not the locale default — decision pinned in #1751', async () => {
+			// 2026-07-05 es domingo: en ISO (lunes = día 1) pertenece a la semana 27; el default locale
+			// de date-fns (domingo = día 1) lo pondría en la 28. Fija ISO para que un refactor no lo revierta.
+			setSystemTime(new Date(2026, 6, 5));
+
+			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
+			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(mockLandingPage);
+			(contentRepository.createLandingPages as Mock).mockResolvedValue([]);
+
+			await contentService.addNextWeeksLandingPageContent(4);
+
+			expect(contentRepository.fetchLatestLandingPageReferences).toHaveBeenCalledWith('2026-27');
 		});
 
 		it('should clone the base returned by the repository verbatim, without leaking its _id', async () => {

--- a/src/api/modules/content/content.service.spec.ts
+++ b/src/api/modules/content/content.service.spec.ts
@@ -107,7 +107,7 @@ describe('ContentService', () => {
 		});
 
 		it('generates contiguous ISO weeks with no gap when the cron runs on a Sunday', async () => {
-			// El cron corre en domingo (vercel.json "* * 0"). Bajo ISO el domingo es el último día de su
+			// El cron corre en domingo. Bajo ISO el domingo es el último día de su
 			// semana, así que la home la pide ese domingo y pide la SIGUIENTE de lunes a sábado. Este test
 			// fija que ambas quedan cubiertas: la base se pide para la semana del domingo (2026-26) y se
 			// generan las 4 siguientes contiguas (2026-27..2026-30), incluida la que la home leerá el lunes.

--- a/src/api/modules/content/content.service.spec.ts
+++ b/src/api/modules/content/content.service.spec.ts
@@ -106,6 +106,30 @@ describe('ContentService', () => {
 			expect(contentRepository.fetchLatestLandingPageReferences).toHaveBeenCalledWith('2026-27');
 		});
 
+		it('generates contiguous ISO weeks with no gap when the cron runs on a Sunday', async () => {
+			// El cron corre en domingo (vercel.json "* * 0"). Bajo ISO el domingo es el último día de su
+			// semana, así que la home la pide ese domingo y pide la SIGUIENTE de lunes a sábado. Este test
+			// fija que ambas quedan cubiertas: la base se pide para la semana del domingo (2026-26) y se
+			// generan las 4 siguientes contiguas (2026-27..2026-30), incluida la que la home leerá el lunes.
+			setSystemTime(new Date(2026, 5, 28)); // domingo, semana ISO 2026-26
+			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
+			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(mockLandingPage);
+			(contentRepository.createLandingPages as Mock).mockResolvedValue([]);
+
+			await contentService.addNextWeeksLandingPageContent(4);
+
+			expect(contentRepository.fetchLatestLandingPageReferences).toHaveBeenCalledWith('2026-26');
+			expect(contentRepository.fetchLandingPagesList).toHaveBeenCalledWith([
+				'2026-27',
+				'2026-28',
+				'2026-29',
+				'2026-30',
+			]);
+			// La semana que la home leerá de lunes a sábado (lunes 29/jun → 2026-27) está entre las generadas.
+			const generatedSlugs = (contentRepository.fetchLandingPagesList as Mock).mock.calls[0][0];
+			expect(generatedSlugs).toContain(buildSlug(new Date(2026, 5, 29)));
+		});
+
 		it('should clone the base returned by the repository verbatim, without leaking its _id', async () => {
 			const weeksInTheFuture = 2;
 

--- a/src/api/modules/content/content.service.ts
+++ b/src/api/modules/content/content.service.ts
@@ -15,9 +15,8 @@ import { addWeeks, getISOWeek, getISOWeekYear } from 'date-fns';
 import slugify from 'slugify';
 
 // Formato YYYY-WW con numeración ISO-8601 (lunes = día 1; la semana 1 es la que contiene el primer
-// jueves del año). Elegido en #1751 en vez del default de locale de date-fns (domingo). El orden
-// lexicográfico sigue coincidiendo con el cronológico: getISOWeekYear etiqueta la semana con su año
-// ISO, no con el calendario, así que el cruce dic/ene no rompe el orden.
+// jueves del año). El orden lexicográfico sigue coincidiendo con el cronológico: getISOWeekYear
+// etiqueta la semana con su año ISO, no con el calendario, así que el cruce dic/ene no rompe el orden.
 function buildWeekSlug(date: Date): string {
 	return `${getISOWeekYear(date)}-${getISOWeek(date).toString().padStart(2, '0')}`;
 }

--- a/src/api/modules/content/content.service.ts
+++ b/src/api/modules/content/content.service.ts
@@ -11,14 +11,15 @@ import {
 import { LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
 
 // Utils
-import { addWeeks, getWeek, getWeekYear } from 'date-fns';
+import { addWeeks, getISOWeek, getISOWeekYear } from 'date-fns';
 import slugify from 'slugify';
 
-// Formato YYYY-WW para que el orden lexicográfico del slug/config coincida con el cronológico.
-// Se usa getWeekYear (no getYear): en el cruce dic/ene el año calendario puede diferir del año de
-// la semana, y etiquetar la semana con el año calendario rompería ese orden.
+// Formato YYYY-WW con numeración ISO-8601 (lunes = día 1; la semana 1 es la que contiene el primer
+// jueves del año). Elegido en #1751 en vez del default de locale de date-fns (domingo). El orden
+// lexicográfico sigue coincidiendo con el cronológico: getISOWeekYear etiqueta la semana con su año
+// ISO, no con el calendario, así que el cruce dic/ene no rompe el orden.
 function buildWeekSlug(date: Date): string {
-	return `${getWeekYear(date)}-${getWeek(date).toString().padStart(2, '0')}`;
+	return `${getISOWeekYear(date)}-${getISOWeek(date).toString().padStart(2, '0')}`;
 }
 
 export async function getLandingPageContent(): Promise<LandingPageContent> {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 		globals: true,
 		environment: 'happy-dom',
 		setupFiles: ['src/test-setup.ts'],
-		include: ['src/**/*.{test,spec}.ts'],
+		include: ['src/**/*.{test,spec}.ts', 'scripts/**/*.{test,spec}.ts'],
 		// @sanity y los bundles fesm de Angular se inlinan para que Vite los transforme.
 		server: {
 			deps: {


### PR DESCRIPTION
## Descripción

Adopta numeración de semana **ISO-8601** (lunes = día 1, semana del primer jueves) para el slug/`config` de las landing pages, en vez del default de locale de `date-fns` (domingo), que nadie eligió deliberadamente. Cierra la deuda de evaluación diferida por #1749. Es la **Opción A** del plan (aprobada), no la de solo documentar el esquema locale.

- **`buildWeekSlug`** pasa de `getWeek`/`getWeekYear` a `getISOWeek`/`getISOWeekYear`. El orden lexicográfico del slug sigue coincidiendo con el cronológico.
- **Migración de datos** (`scripts/migrate-landing-page-config-to-iso-week.ts`): re-sluggea **todos** los registros reconstruyendo el jueves de cada semana local y recalculando la semana/año ISO. Dry-run por defecto + detección de colisiones de borde de año (`--apply`, `--resolve=latest-wins`, respaldo del doc antes de borrar). La lógica pura vive en `scripts/iso-week-mapping.ts` y está cubierta por tests.
- **Docs + schema del Studio** documentan la convención ISO-8601 y la continuidad cron-domingo / semana-ISO-lunes.

Closes #1751.

## Nota sobre ISO ≡ locale en 2025-2026

Para el rango de fechas actual, la semana ISO y la locale **coinciden** (Jan 1 2026 cae jueves), así que la migración es un **no-op** sobre los datos vigentes. Las convenciones solo divergen en ciertos bordes de año (p. ej. 2021), donde el script recalcula y maneja las colisiones. El cambio funcional real (semanas Monday-start) es correcto y está fijado por tests.

## Cutover de producción

El código lee/genera slugs con numeración ISO. Antes de desplegar, correr el dry-run de la migración contra producción y aplicarlo:

```
node --import tsx --env-file=.env ./scripts/migrate-landing-page-config-to-iso-week.ts            # dry-run
node --import tsx --env-file=.env ./scripts/migrate-landing-page-config-to-iso-week.ts --apply
```

Prerrequisito: los datos deben estar en formato `YYYY-WW` (la migración de #1749). Si producción sigue en `WW-YYYY`, correr primero `migrate-landing-page-config-to-yyyy-ww.ts`. Registrado en el issue de release #1752.

> **Ojo (observado en dev):** el dataset `development` revirtió de `YYYY-WW` a `WW-YYYY` durante el desarrollo de este PR (posible reseed/reset automático del entorno). Si producción tiene un mecanismo análogo, coordinar la ventana de cutover en consecuencia para que el formato de datos no se deshaga tras migrar.

## Plan de pruebas

- [x] `pnpm lint` · `pnpm stylelint` · `pnpm typecheck` · `pnpm test` (10 specs de content + 6 del mapeo puro) · `pnpm build` · `pnpm storybook:build` — verdes.
- [x] `pnpm test:e2e` — 40/40 verde (tras restaurar dev a `YYYY-WW`).
- [x] Mapeo locale→ISO validado empíricamente: identidad 2025-2026, divergencia y colisión de borde de año (2020-53/2021-01).
- [x] Continuidad cron(domingo)/home simulada sobre un año: 0 días sin cobertura.
