### PR TITLE
[#1731] - El gate de lint (eslint:lint) no cubre e2e/**

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Usar **siempre `pnpm`** para instalar y ejecutar scripts. Los scripts envuelven 
 | `pnpm install`                            | Instala dependencias                 |
 | `pnpm dev`                                | Dev server (SSR) en desarrollo       |
 | `pnpm build`                              | Build de producción                  |
-| `pnpm lint`                               | ESLint sobre `src`                   |
+| `pnpm lint`                               | ESLint sobre `src` y `e2e`           |
 | `pnpm stylelint`                          | Stylelint sobre CSS                  |
 | `pnpm typecheck`                          | Type-check estricto (`tsc --noEmit`) |
 | `pnpm test`                               | Tests unitarios (Vitest)             |

--- a/e2e/dmca.component.spec.ts
+++ b/e2e/dmca.component.spec.ts
@@ -2,25 +2,23 @@ import { test, expect } from '@playwright/test';
 
 test.describe('DMCA Component', () => {
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/dmca'); // Asegúrate de que esta ruta sea correcta para tu aplicación
+		await page.goto('/dmca');
 	});
 
 	test('should render the DmcaComponent page', async ({ page }) => {
-		const mainElement = await page.locator('main');
+		const mainElement = page.locator('main');
 		await expect(mainElement).toBeVisible();
 	});
 
 	test('should have all instances of "contacto@cuentoneta.ar" as clickable links', async ({ page }) => {
-		const links = await page.locator('a:has-text("contacto@cuentoneta.ar")');
-		const elements = await page.locator(':text("contacto@cuentoneta.ar")');
+		const links = page.locator('a:has-text("contacto@cuentoneta.ar")');
+		const elements = page.locator(':text("contacto@cuentoneta.ar")');
 
 		const elementsCount = await elements.count();
-		const linksCount = await elements.count();
+		const linksCount = await links.count();
 
-		// Verifica que haya al menos un enlace
 		expect(elementsCount).toEqual(linksCount);
 
-		// Verifica que cada enlace sea clickeable y tenga el atributo href correcto
 		for (let i = 0; i < linksCount; i++) {
 			const link = links.nth(i);
 			await expect(link).toHaveAttribute('href', 'mailto:contacto@cuentoneta.ar');

--- a/e2e/dmca.component.spec.ts
+++ b/e2e/dmca.component.spec.ts
@@ -15,11 +15,9 @@ test.describe('DMCA Component', () => {
 		const elements = page.locator(':text("contacto@cuentoneta.ar")');
 
 		const elementsCount = await elements.count();
-		const linksCount = await links.count();
+		await expect(links).toHaveCount(elementsCount);
 
-		expect(elementsCount).toEqual(linksCount);
-
-		for (let i = 0; i < linksCount; i++) {
+		for (let i = 0; i < elementsCount; i++) {
 			const link = links.nth(i);
 			await expect(link).toHaveAttribute('href', 'mailto:contacto@cuentoneta.ar');
 			await expect(link).toBeVisible();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -116,13 +116,8 @@ export default [
 	},
 	{
 		name: 'playwright',
+		...playwright.configs['flat/recommended'],
 		files: ['**/e2e/**/?(*.)+(spec|test).ts'],
-		plugins: {
-			playwright,
-		},
-		rules: {
-			...playwright.configs['flat/recommended'],
-		},
 	},
 	{
 		name: 'nx',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -116,8 +116,16 @@ export default [
 	},
 	{
 		name: 'playwright',
-		...playwright.configs['flat/recommended'],
 		files: ['**/e2e/**/?(*.)+(spec|test).ts'],
+		plugins: {
+			playwright,
+		},
+		languageOptions: {
+			...playwright.configs['flat/recommended'].languageOptions,
+		},
+		rules: {
+			...playwright.configs['flat/recommended'].rules,
+		},
 	},
 	{
 		name: 'nx',

--- a/project.json
+++ b/project.json
@@ -113,6 +113,9 @@
 			"defaultConfiguration": "development",
 			"continuous": true
 		},
+		"eslint:lint": {
+			"command": "eslint ./src ./e2e"
+		},
 		"stylelint": {
 			"executor": "nx-stylelint:lint",
 			"outputs": ["{options.outputFile}"],


### PR DESCRIPTION
## Descripción

- Extiende el target `eslint:lint` para lintear `./src` y `./e2e` (override del comando inferido por `@nx/eslint/plugin`, que solo cubría `./src`).
- Corrige el bloque Playwright de `eslint.config.mjs` para aplicar `flat/recommended` correctamente (el spread previo era inválido y rompía al lintear e2e).
- Ajusta `e2e/dmca.component.spec.ts` para cumplir las reglas de Playwright y corrige el conteo de enlaces.

Closes #1731.

## Plan de pruebas

- [x] `pnpm lint` verde con `eslint ./src ./e2e`
- [x] `nx show project` confirma el comando del target
- [x] `pnpm typecheck` / `pnpm stylelint` / `pnpm test` verdes