### PR TITLE
[#1562] - Auditar autores y cuentos con ficha incompleta en Sanity (structured data)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ Thumbs.db
 # Generated reference material (re-create with `pnpm exec tsx --env-file=.env scripts/audit/export-authors-bios.ts`)
 /tools/author-bios/
 
+# Auditoría de fichas incompletas para structured data (re-create with audit-structured-data-completeness.ts)
+/tools/structured-data-audit/
+
 # Exportaciones de dataset de Sanity
 /cms/*.tar.gz
 

--- a/scripts/audit/README.md
+++ b/scripts/audit/README.md
@@ -15,11 +15,12 @@ pnpm exec tsx --env-file=.env scripts/audit/<script>.ts
 
 ## Scripts disponibles
 
-| Script                     | Tipo                                                  | Qué hace                                                                                                                                                                                                                                                                                    |
-| -------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `audit-bold-names.ts`      | **Read-only** ✅                                      | Audita qué autores publicados no tienen su `name` en negrita dentro de su biografía. Reporta **Grupo A** (sin ninguna negrita) y **Grupo B** (hay negrita, pero el `name` no aparece como subcadena contigua).                                                                              |
-| `export-authors-bios.ts`   | **Read-only** de Sanity ✅ (escribe archivos locales) | Exporta la biografía de cada autor publicado a un `.md` en `tools/author-bios/` (carpeta _gitignored_), como material de referencia estilística.                                                                                                                                            |
-| `bold-author-pen-names.ts` | **⚠️ Escribe en Sanity (producción)**                 | Aplica negrita al nombre del autor dentro de su biografía, según una **lista curada** de operaciones (`in_place` / `prepend` / `skip`). Deja los cambios como **borradores (`drafts.*`), sin publicar**, para revisión en Studio. Es **idempotente** (saltea drafts que ya tienen negrita). |
+| Script                                  | Tipo                                                  | Qué hace                                                                                                                                                                                                                                                                                    |
+| --------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `audit-bold-names.ts`                   | **Read-only** ✅                                      | Audita qué autores publicados no tienen su `name` en negrita dentro de su biografía. Reporta **Grupo A** (sin ninguna negrita) y **Grupo B** (hay negrita, pero el `name` no aparece como subcadena contigua).                                                                              |
+| `export-authors-bios.ts`                | **Read-only** de Sanity ✅ (escribe archivos locales) | Exporta la biografía de cada autor publicado a un `.md` en `tools/author-bios/` (carpeta _gitignored_), como material de referencia estilística.                                                                                                                                            |
+| `bold-author-pen-names.ts`              | **⚠️ Escribe en Sanity (producción)**                 | Aplica negrita al nombre del autor dentro de su biografía, según una **lista curada** de operaciones (`in_place` / `prepend` / `skip`). Deja los cambios como **borradores (`drafts.*`), sin publicar**, para revisión en Studio. Es **idempotente** (saltea drafts que ya tienen negrita). |
+| `audit-structured-data-completeness.ts` | **Read-only** ✅ (escribe reporte local)              | Detecta autores y cuentos con ficha incompleta para datos estructurados (`Person` / `Article`). Emite Markdown + CSV en `tools/structured-data-audit/` (gitignored), con score de incompleteness y sección dedicada a cuentos sin `publishedAt` editorial (fallback `_createdAt`).          |
 
 ### Comandos
 
@@ -29,6 +30,9 @@ pnpm exec tsx --env-file=.env scripts/audit/audit-bold-names.ts
 
 # Export de biografías a Markdown (solo lectura; salida en tools/author-bios/)
 pnpm exec tsx --env-file=.env scripts/audit/export-authors-bios.ts
+
+# Completitud de fichas para structured data (solo lectura; salida en tools/structured-data-audit/)
+pnpm exec tsx --env-file=.env scripts/audit/audit-structured-data-completeness.ts
 
 # Negrita de nombres — ⚠️ crea drafts en el dataset de .env (producción)
 pnpm exec tsx --env-file=.env scripts/audit/bold-author-pen-names.ts
@@ -65,6 +69,23 @@ Mapeo `blockContent` → Markdown:
 | Bloque `image`            | `![](image-ref)` (referencia, no descarga) |
 
 Salida: un archivo `tools/author-bios/<slug>.md` por autor, encabezado `# {name}` + cuerpo. Idempotente (sobrescribe). La carpeta está _gitignored_.
+
+## Detalle: `audit-structured-data-completeness.ts`
+
+Read-only sobre el dataset de `.env`. Evalúa campos que alimentan JSON-LD:
+
+| Entidad            | Campos (gaps)                                                                                                                                   | Score         |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| Autor (`Person`)   | `slug`, `image`, `sameAs` (resources con URL), `nationality`, `biography` (≥ 80 chars), `bornOn`; `diedOn` se lista pero no entra al score core | core gaps / 6 |
+| Cuento (`Article`) | `title`, `slug`, `author`, `publishedAt` editorial, `originalPublication`, `review`                                                             | gaps / 6      |
+
+Salida (idempotente, sobrescribe):
+
+- `tools/structured-data-audit/report.md` — resumen, conteos por campo, ranking y lista de cuentos con fallback `_createdAt`.
+- `tools/structured-data-audit/authors-incomplete.csv`
+- `tools/structured-data-audit/stories-incomplete.csv`
+
+La lógica pura vive en `structured-data-completeness.ts` (tests en `*.spec.ts`).
 
 ## Convención
 

--- a/scripts/audit/audit-structured-data-completeness.ts
+++ b/scripts/audit/audit-structured-data-completeness.ts
@@ -1,0 +1,295 @@
+/**
+ * Auditoría read-only: autores y cuentos con ficha incompleta que debilita
+ * los datos estructurados (Person / Article). Emite un reporte Markdown
+ * (y CSV) en `tools/structured-data-audit/` (gitignored).
+ *
+ * Uso:
+ *   pnpm exec tsx --env-file=.env scripts/audit/audit-structured-data-completeness.ts
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { client } from '../../src/api/_helpers/sanity-connector';
+import {
+	AUTHOR_CORE_GAPS,
+	BIOGRAPHY_MIN_CHARS,
+	evaluateAuthor,
+	evaluateStory,
+	groupByGap,
+	STORY_GAPS,
+	type AuthorAuditInput,
+	type AuthorAuditResult,
+	type AuthorGap,
+	type StoryAuditInput,
+	type StoryAuditResult,
+	type StoryGap,
+} from './structured-data-completeness';
+
+interface AuthorRow {
+	name: string;
+	slug: string | null;
+	hasImage: boolean;
+	resourceUrls: Array<string | null> | null;
+	hasNationality: boolean;
+	biographyText: string | null;
+	bornOn: string | null;
+	diedOn: string | null;
+}
+
+interface StoryRow {
+	title: string | null;
+	slug: string | null;
+	hasAuthor: boolean;
+	hasPublishedAt: boolean;
+	originalPublication: string | null;
+	reviewText: string | null;
+}
+
+const AUTHOR_GAP_LABEL: Record<AuthorGap, string> = {
+	slug: 'slug (rompe URL del Person)',
+	image: 'image → Person.image',
+	sameAs: 'resources[].url → Person.sameAs',
+	nationality: 'nationality',
+	biography: `biography vacía o < ${BIOGRAPHY_MIN_CHARS} chars`,
+	bornOn: 'bornOn → birthDate',
+	diedOn: 'diedOn → deathDate (opcional si el autor vive)',
+};
+
+const STORY_GAP_LABEL: Record<StoryGap, string> = {
+	title: 'title',
+	slug: 'slug',
+	author: 'author (rompe Person anidado)',
+	publishedAt: 'publishedAt editorial (usa fallback _createdAt)',
+	originalPublication: 'originalPublication',
+	review: 'review / summary',
+};
+
+const fetchAuthors = (): Promise<AuthorRow[]> =>
+	client.fetch(`*[_type == "author" && !(_id in path("drafts.**"))] | order(name asc) {
+		name,
+		"slug": slug.current,
+		"hasImage": defined(image.asset),
+		"resourceUrls": resources[].url,
+		"hasNationality": defined(nationality),
+		"biographyText": pt::text(biography),
+		bornOn,
+		diedOn
+	}`);
+
+const fetchStories = (): Promise<StoryRow[]> =>
+	client.fetch(`*[_type == "story" && !(_id in path("drafts.**"))] | order(title asc) {
+		title,
+		"slug": slug.current,
+		"hasAuthor": defined(author),
+		"hasPublishedAt": defined(publishedAt),
+		originalPublication,
+		"reviewText": pt::text(review)
+	}`);
+
+const label = (item: { slug: string | null; name?: string; title?: string | null }): string => {
+	const id = item.slug?.trim() || '(sin-slug)';
+	const name = item.name ?? item.title ?? '';
+	return name ? `${id} — ${name}` : id;
+};
+
+const renderAuthorSection = (results: AuthorAuditResult[]): string => {
+	const incomplete = results.filter((r) => r.coreGaps.length > 0);
+	const byGap = groupByGap(
+		incomplete.map((r) => ({ gaps: r.coreGaps })),
+		AUTHOR_CORE_GAPS,
+	);
+	const lines: string[] = [
+		`## Autores`,
+		``,
+		`- Total publicados: **${results.length}**`,
+		`- Con al menos un gap core: **${incomplete.length}**`,
+		`- Completos (core): **${results.length - incomplete.length}**`,
+		``,
+		`### Conteo por campo faltante (core)`,
+		``,
+	];
+	for (const g of AUTHOR_CORE_GAPS) {
+		lines.push(`- \`${g}\` (${AUTHOR_GAP_LABEL[g]}): **${byGap[g]}**`);
+	}
+	lines.push(``, `### Por campo (detalle)`, ``);
+	for (const g of AUTHOR_CORE_GAPS) {
+		const hit = incomplete.filter((r) => r.coreGaps.includes(g));
+		if (hit.length === 0) continue;
+		lines.push(`#### ${g} (${hit.length})`, ``);
+		for (const r of hit) lines.push(`- ${label(r)}`);
+		lines.push(``);
+	}
+	lines.push(`### Ranking por incompleteness (core)`, ``);
+	lines.push(`| slug | name | gaps core | incompleteness |`);
+	lines.push(`| --- | --- | --- | ---: |`);
+	const ranked = [...incomplete].sort(
+		(a, b) => b.incompleteness - a.incompleteness || (a.slug ?? '').localeCompare(b.slug ?? ''),
+	);
+	for (const r of ranked) {
+		lines.push(
+			`| ${r.slug ?? '—'} | ${r.name.replace(/\|/g, '\\|')} | ${r.coreGaps.join(', ')} | ${(r.incompleteness * 100).toFixed(0)}% |`,
+		);
+	}
+	const withBornWithoutDied = results.filter((r) => !r.gaps.includes('bornOn') && r.gaps.includes('diedOn')).length;
+	lines.push(``, `### Nota: diedOn`, ``);
+	lines.push(
+		`\`diedOn\` es enriquecimiento opcional (no entra en el score core). Autores con \`bornOn\` y sin \`diedOn\`: **${withBornWithoutDied}** (puede ser intencional si el autor vive).`,
+	);
+	lines.push(``);
+	return lines.join('\n');
+};
+
+const renderStorySection = (results: StoryAuditResult[]): string => {
+	const incomplete = results.filter((r) => r.gaps.length > 0);
+	const fallback = results.filter((r) => r.usesCreatedAtFallback);
+	const byGap = groupByGap(incomplete, STORY_GAPS);
+	const lines: string[] = [
+		`## Cuentos`,
+		``,
+		`- Total publicados: **${results.length}**`,
+		`- Con al menos un gap: **${incomplete.length}**`,
+		`- Completos: **${results.length - incomplete.length}**`,
+		`- Usan fallback \`_createdAt\` (sin \`publishedAt\` editorial): **${fallback.length}**`,
+		``,
+		`### Conteo por campo faltante`,
+		``,
+	];
+	for (const g of STORY_GAPS) {
+		lines.push(`- \`${g}\` (${STORY_GAP_LABEL[g]}): **${byGap[g]}**`);
+	}
+	lines.push(``, `### publishedAt → fallback _createdAt (${fallback.length})`, ``);
+	for (const r of fallback) lines.push(`- ${label({ slug: r.slug, title: r.title })}`);
+	lines.push(``, `### Por campo (detalle)`, ``);
+	for (const g of STORY_GAPS) {
+		if (g === 'publishedAt') continue;
+		const hit = incomplete.filter((r) => r.gaps.includes(g));
+		if (hit.length === 0) continue;
+		lines.push(`#### ${g} (${hit.length})`, ``);
+		for (const r of hit) lines.push(`- ${label({ slug: r.slug, title: r.title })}`);
+		lines.push(``);
+	}
+	lines.push(`### Ranking por incompleteness`, ``);
+	lines.push(`| slug | title | gaps | incompleteness |`);
+	lines.push(`| --- | --- | --- | ---: |`);
+	const ranked = [...incomplete].sort(
+		(a, b) => b.incompleteness - a.incompleteness || (a.slug ?? '').localeCompare(b.slug ?? ''),
+	);
+	for (const r of ranked) {
+		const title = (r.title ?? '').replace(/\|/g, '\\|');
+		lines.push(`| ${r.slug ?? '—'} | ${title} | ${r.gaps.join(', ')} | ${(r.incompleteness * 100).toFixed(0)}% |`);
+	}
+	return lines.join('\n');
+};
+
+const toCsv = (headers: string[], rows: string[][]): string => {
+	const esc = (c: string) => {
+		if (/[",\n]/.test(c)) return `"${c.replace(/"/g, '""')}"`;
+		return c;
+	};
+	return [headers.map(esc).join(','), ...rows.map((r) => r.map(esc).join(','))].join('\n') + '\n';
+};
+
+const mapAuthors = (rows: AuthorRow[]): AuthorAuditResult[] =>
+	rows.map((row) =>
+		evaluateAuthor({
+			name: row.name,
+			slug: row.slug,
+			hasImage: row.hasImage,
+			resourceUrls: row.resourceUrls,
+			hasNationality: row.hasNationality,
+			biographyText: row.biographyText,
+			bornOn: row.bornOn,
+			diedOn: row.diedOn,
+		} satisfies AuthorAuditInput),
+	);
+
+const mapStories = (rows: StoryRow[]): StoryAuditResult[] =>
+	rows.map((row) =>
+		evaluateStory({
+			title: row.title,
+			slug: row.slug,
+			hasAuthor: row.hasAuthor,
+			hasPublishedAt: row.hasPublishedAt,
+			originalPublication: row.originalPublication,
+			reviewText: row.reviewText,
+		} satisfies StoryAuditInput),
+	);
+
+const buildReport = (authors: AuthorAuditResult[], stories: StoryAuditResult[]): string => {
+	const generatedAt = new Date().toISOString();
+	const dataset = process.env['SANITY_STUDIO_DATASET'] ?? '(desconocido)';
+	return [
+		`# Auditoría de completitud de fichas (structured data)`,
+		``,
+		`- Generado: \`${generatedAt}\``,
+		`- Dataset: \`${dataset}\``,
+		`- Criterio biografía corta: < ${BIOGRAPHY_MIN_CHARS} caracteres de texto plano`,
+		`- Score de autor: gaps **core** / ${AUTHOR_CORE_GAPS.length} (sin \`diedOn\`)`,
+		`- Score de cuento: gaps / ${STORY_GAPS.length}`,
+		``,
+		renderAuthorSection(authors),
+		``,
+		renderStorySection(stories),
+		``,
+	].join('\n');
+};
+
+const writeOutputs = async (
+	outDir: string,
+	report: string,
+	authors: AuthorAuditResult[],
+	stories: StoryAuditResult[],
+): Promise<string> => {
+	await mkdir(outDir, { recursive: true });
+	const reportPath = join(outDir, 'report.md');
+	await writeFile(reportPath, report, 'utf8');
+	const authorsCsv = toCsv(
+		['slug', 'name', 'core_gaps', 'all_gaps', 'incompleteness'],
+		authors
+			.filter((a) => a.coreGaps.length > 0)
+			.map((a) => [a.slug ?? '', a.name, a.coreGaps.join('|'), a.gaps.join('|'), a.incompleteness.toFixed(3)]),
+	);
+	await writeFile(join(outDir, 'authors-incomplete.csv'), authorsCsv, 'utf8');
+	const storiesCsv = toCsv(
+		['slug', 'title', 'gaps', 'uses_created_at_fallback', 'incompleteness'],
+		stories
+			.filter((s) => s.gaps.length > 0)
+			.map((s) => [
+				s.slug ?? '',
+				s.title ?? '',
+				s.gaps.join('|'),
+				s.usesCreatedAtFallback ? 'true' : 'false',
+				s.incompleteness.toFixed(3),
+			]),
+	);
+	await writeFile(join(outDir, 'stories-incomplete.csv'), storiesCsv, 'utf8');
+	return reportPath;
+};
+
+const logSummary = (authors: AuthorAuditResult[], stories: StoryAuditResult[], reportPath: string, outDir: string) => {
+	const authorIncomplete = authors.filter((a) => a.coreGaps.length > 0).length;
+	const storyIncomplete = stories.filter((s) => s.gaps.length > 0).length;
+	const storyFallback = stories.filter((s) => s.usesCreatedAtFallback).length;
+	console.log(`\nAutores: ${authors.length} (${authorIncomplete} incompletos core)`);
+	console.log(
+		`Cuentos: ${stories.length} (${storyIncomplete} incompletos; ${storyFallback} sin publishedAt editorial)`,
+	);
+	console.log(`\n✓ Reporte: ${reportPath}`);
+	console.log(`  CSV:     ${join(outDir, 'authors-incomplete.csv')}`);
+	console.log(`  CSV:     ${join(outDir, 'stories-incomplete.csv')}`);
+};
+
+const run = async () => {
+	console.log('Consultando autores y cuentos en Sanity…');
+	const [authorRows, storyRows] = await Promise.all([fetchAuthors(), fetchStories()]);
+	const authors = mapAuthors(authorRows);
+	const stories = mapStories(storyRows);
+	const report = buildReport(authors, stories);
+	const outDir = join(process.cwd(), 'tools', 'structured-data-audit');
+	const reportPath = await writeOutputs(outDir, report, authors, stories);
+	logSummary(authors, stories, reportPath, outDir);
+};
+
+run().catch((err) => {
+	console.error('\nLa auditoría falló:', err);
+	process.exit(1);
+});

--- a/scripts/audit/structured-data-completeness.spec.ts
+++ b/scripts/audit/structured-data-completeness.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+	AUTHOR_CORE_GAPS,
+	BIOGRAPHY_MIN_CHARS,
+	evaluateAuthor,
+	evaluateStory,
+	groupByGap,
+	STORY_GAPS,
+	type AuthorAuditInput,
+	type StoryAuditInput,
+} from './structured-data-completeness';
+
+const completeAuthor = (): AuthorAuditInput => ({
+	name: 'Ada Lovelace',
+	slug: 'ada-lovelace',
+	hasImage: true,
+	resourceUrls: ['https://es.wikipedia.org/wiki/Ada_Lovelace'],
+	hasNationality: true,
+	biographyText: 'x'.repeat(BIOGRAPHY_MIN_CHARS),
+	bornOn: '1815-12-10',
+	diedOn: '1852-11-27',
+});
+
+const completeStory = (): StoryAuditInput => ({
+	title: 'Un cuento',
+	slug: 'un-cuento',
+	hasAuthor: true,
+	hasPublishedAt: true,
+	originalPublication: 'Revista X, 1920',
+	reviewText: 'Resumen del cuento.',
+});
+
+describe('evaluateAuthor', () => {
+	it('returns no core gaps for a complete author', () => {
+		const result = evaluateAuthor(completeAuthor());
+		expect(result.coreGaps).toEqual([]);
+		expect(result.incompleteness).toBe(0);
+	});
+
+	it('flags each missing core field and computes incompleteness', () => {
+		const result = evaluateAuthor({
+			name: 'Sin ficha',
+			slug: null,
+			hasImage: false,
+			resourceUrls: [],
+			hasNationality: false,
+			biographyText: '',
+			bornOn: null,
+			diedOn: null,
+		});
+		expect(result.coreGaps).toEqual([...AUTHOR_CORE_GAPS]);
+		expect(result.gaps).toContain('diedOn');
+		expect(result.incompleteness).toBe(1);
+	});
+
+	it('treats empty resource urls as missing sameAs', () => {
+		const result = evaluateAuthor({
+			...completeAuthor(),
+			resourceUrls: ['', null, '   '],
+		});
+		expect(result.coreGaps).toContain('sameAs');
+	});
+
+	it('flags short biography under the min length', () => {
+		const result = evaluateAuthor({
+			...completeAuthor(),
+			biographyText: 'corta',
+		});
+		expect(result.coreGaps).toContain('biography');
+	});
+});
+
+describe('evaluateStory', () => {
+	it('returns no gaps for a complete story', () => {
+		const result = evaluateStory(completeStory());
+		expect(result.gaps).toEqual([]);
+		expect(result.usesCreatedAtFallback).toBe(false);
+		expect(result.incompleteness).toBe(0);
+	});
+
+	it('marks publishedAt fallback when editorial date is missing', () => {
+		const result = evaluateStory({
+			...completeStory(),
+			hasPublishedAt: false,
+		});
+		expect(result.usesCreatedAtFallback).toBe(true);
+		expect(result.gaps).toContain('publishedAt');
+	});
+
+	it('flags missing author, originalPublication and review', () => {
+		const result = evaluateStory({
+			title: 'T',
+			slug: 't',
+			hasAuthor: false,
+			hasPublishedAt: true,
+			originalPublication: null,
+			reviewText: null,
+		});
+		expect(result.gaps).toEqual(expect.arrayContaining(['author', 'originalPublication', 'review']));
+	});
+});
+
+describe('groupByGap', () => {
+	it('counts items per gap', () => {
+		const counts = groupByGap([{ gaps: ['slug', 'image'] as const }, { gaps: ['slug'] as const }], [
+			'slug',
+			'image',
+			'sameAs',
+		] as const);
+		expect(counts.slug).toBe(2);
+		expect(counts.image).toBe(1);
+		expect(counts.sameAs).toBe(0);
+	});
+
+	it('covers all story gap keys', () => {
+		const counts = groupByGap([{ gaps: [...STORY_GAPS] }], STORY_GAPS);
+		for (const g of STORY_GAPS) {
+			expect(counts[g]).toBe(1);
+		}
+	});
+});

--- a/scripts/audit/structured-data-completeness.ts
+++ b/scripts/audit/structured-data-completeness.ts
@@ -1,0 +1,117 @@
+/**
+ * Lógica pura de completitud de fichas para datos estructurados (SEO/AEO).
+ * Separada del I/O de Sanity para poder testearla sin red.
+ */
+export const BIOGRAPHY_MIN_CHARS = 80;
+
+export type AuthorGap = 'slug' | 'image' | 'sameAs' | 'nationality' | 'biography' | 'bornOn' | 'diedOn';
+
+/** Gaps que alimentan Person / URL de perfil; `diedOn` es enriquecimiento opcional (autores vivos). */
+export const AUTHOR_CORE_GAPS: readonly AuthorGap[] = Object.freeze([
+	'slug',
+	'image',
+	'sameAs',
+	'nationality',
+	'biography',
+	'bornOn',
+] as const);
+
+export type StoryGap = 'title' | 'slug' | 'author' | 'publishedAt' | 'originalPublication' | 'review';
+
+export const STORY_GAPS: readonly StoryGap[] = Object.freeze([
+	'title',
+	'slug',
+	'author',
+	'publishedAt',
+	'originalPublication',
+	'review',
+] as const);
+
+export interface AuthorAuditInput {
+	name: string;
+	slug: string | null;
+	hasImage: boolean;
+	resourceUrls: Array<string | null> | null;
+	hasNationality: boolean;
+	biographyText: string | null;
+	bornOn: string | null;
+	diedOn: string | null;
+}
+
+export interface StoryAuditInput {
+	title: string | null;
+	slug: string | null;
+	hasAuthor: boolean;
+	hasPublishedAt: boolean;
+	originalPublication: string | null;
+	reviewText: string | null;
+}
+
+export interface AuthorAuditResult {
+	name: string;
+	slug: string | null;
+	gaps: AuthorGap[];
+	coreGaps: AuthorGap[];
+	/** 0 = completa (core); 1 = todos los core faltan. */
+	incompleteness: number;
+}
+
+export interface StoryAuditResult {
+	title: string | null;
+	slug: string | null;
+	gaps: StoryGap[];
+	usesCreatedAtFallback: boolean;
+	incompleteness: number;
+}
+
+export function evaluateAuthor(input: AuthorAuditInput): AuthorAuditResult {
+	const gaps: AuthorGap[] = [];
+	if (!input.slug?.trim()) gaps.push('slug');
+	if (!input.hasImage) gaps.push('image');
+	const urls = (input.resourceUrls ?? []).filter((u): u is string => typeof u === 'string' && u.trim().length > 0);
+	if (urls.length === 0) gaps.push('sameAs');
+	if (!input.hasNationality) gaps.push('nationality');
+	const bio = (input.biographyText ?? '').trim();
+	if (bio.length < BIOGRAPHY_MIN_CHARS) gaps.push('biography');
+	if (!input.bornOn?.trim()) gaps.push('bornOn');
+	if (!input.diedOn?.trim()) gaps.push('diedOn');
+
+	const coreGaps = gaps.filter((g): g is AuthorGap => (AUTHOR_CORE_GAPS as readonly string[]).includes(g));
+	return {
+		name: input.name,
+		slug: input.slug,
+		gaps,
+		coreGaps,
+		incompleteness: coreGaps.length / AUTHOR_CORE_GAPS.length,
+	};
+}
+
+export function evaluateStory(input: StoryAuditInput): StoryAuditResult {
+	const gaps: StoryGap[] = [];
+	if (!input.title?.trim()) gaps.push('title');
+	if (!input.slug?.trim()) gaps.push('slug');
+	if (!input.hasAuthor) gaps.push('author');
+	const usesCreatedAtFallback = !input.hasPublishedAt;
+	if (usesCreatedAtFallback) gaps.push('publishedAt');
+	if (!input.originalPublication?.trim()) gaps.push('originalPublication');
+	const review = (input.reviewText ?? '').trim();
+	if (review.length === 0) gaps.push('review');
+
+	return {
+		title: input.title,
+		slug: input.slug,
+		gaps,
+		usesCreatedAtFallback,
+		incompleteness: gaps.length / STORY_GAPS.length,
+	};
+}
+
+export function groupByGap<T extends string>(items: Array<{ gaps: T[] }>, allGaps: readonly T[]): Record<T, number> {
+	const counts = Object.fromEntries(allGaps.map((g) => [g, 0])) as Record<T, number>;
+	for (const item of items) {
+		for (const g of item.gaps) {
+			if (g in counts) counts[g]++;
+		}
+	}
+	return counts;
+}

--- a/scripts/audit/structured-data-completeness.ts
+++ b/scripts/audit/structured-data-completeness.ts
@@ -1,31 +1,15 @@
 /**
  * Lógica pura de completitud de fichas para datos estructurados (SEO/AEO).
  * Separada del I/O de Sanity para poder testearla sin red.
+ *
+ * Cada campo se define como una regla `{ gap, missing }` — agregar un campo
+ * es una fila en la tabla, no un nuevo `if`.
  */
 export const BIOGRAPHY_MIN_CHARS = 80;
 
 export type AuthorGap = 'slug' | 'image' | 'sameAs' | 'nationality' | 'biography' | 'bornOn' | 'diedOn';
 
-/** Gaps que alimentan Person / URL de perfil; `diedOn` es enriquecimiento opcional (autores vivos). */
-export const AUTHOR_CORE_GAPS: readonly AuthorGap[] = Object.freeze([
-	'slug',
-	'image',
-	'sameAs',
-	'nationality',
-	'biography',
-	'bornOn',
-] as const);
-
 export type StoryGap = 'title' | 'slug' | 'author' | 'publishedAt' | 'originalPublication' | 'review';
-
-export const STORY_GAPS: readonly StoryGap[] = Object.freeze([
-	'title',
-	'slug',
-	'author',
-	'publishedAt',
-	'originalPublication',
-	'review',
-] as const);
 
 export interface AuthorAuditInput {
 	name: string;
@@ -64,19 +48,56 @@ export interface StoryAuditResult {
 	incompleteness: number;
 }
 
-export function evaluateAuthor(input: AuthorAuditInput): AuthorAuditResult {
-	const gaps: AuthorGap[] = [];
-	if (!input.slug?.trim()) gaps.push('slug');
-	if (!input.hasImage) gaps.push('image');
-	const urls = (input.resourceUrls ?? []).filter((u): u is string => typeof u === 'string' && u.trim().length > 0);
-	if (urls.length === 0) gaps.push('sameAs');
-	if (!input.hasNationality) gaps.push('nationality');
-	const bio = (input.biographyText ?? '').trim();
-	if (bio.length < BIOGRAPHY_MIN_CHARS) gaps.push('biography');
-	if (!input.bornOn?.trim()) gaps.push('bornOn');
-	if (!input.diedOn?.trim()) gaps.push('diedOn');
+interface FieldRule<TGap extends string, TInput> {
+	gap: TGap;
+	/** true ⇒ el campo falta / debilita structured data. */
+	missing: (input: TInput) => boolean;
+	/** false ⇒ no entra al score (p. ej. diedOn en autores vivos). Default true. */
+	core?: boolean;
+}
 
-	const coreGaps = gaps.filter((g): g is AuthorGap => (AUTHOR_CORE_GAPS as readonly string[]).includes(g));
+const hasNonEmptyUrl = (urls: Array<string | null> | null): boolean =>
+	(urls ?? []).some((u) => typeof u === 'string' && u.trim().length > 0);
+
+const AUTHOR_RULES: readonly FieldRule<AuthorGap, AuthorAuditInput>[] = Object.freeze([
+	{ gap: 'slug', missing: (i) => !i.slug?.trim() },
+	{ gap: 'image', missing: (i) => !i.hasImage },
+	{ gap: 'sameAs', missing: (i) => !hasNonEmptyUrl(i.resourceUrls) },
+	{ gap: 'nationality', missing: (i) => !i.hasNationality },
+	{ gap: 'biography', missing: (i) => (i.biographyText ?? '').trim().length < BIOGRAPHY_MIN_CHARS },
+	{ gap: 'bornOn', missing: (i) => !i.bornOn?.trim() },
+	{ gap: 'diedOn', missing: (i) => !i.diedOn?.trim(), core: false },
+]);
+
+const STORY_RULES: readonly FieldRule<StoryGap, StoryAuditInput>[] = Object.freeze([
+	{ gap: 'title', missing: (i) => !i.title?.trim() },
+	{ gap: 'slug', missing: (i) => !i.slug?.trim() },
+	{ gap: 'author', missing: (i) => !i.hasAuthor },
+	{ gap: 'publishedAt', missing: (i) => !i.hasPublishedAt },
+	{ gap: 'originalPublication', missing: (i) => !i.originalPublication?.trim() },
+	{ gap: 'review', missing: (i) => !(i.reviewText ?? '').trim() },
+]);
+
+export const AUTHOR_CORE_GAPS: readonly AuthorGap[] = Object.freeze(
+	AUTHOR_RULES.filter((r) => r.core !== false).map((r) => r.gap),
+);
+
+export const STORY_GAPS: readonly StoryGap[] = Object.freeze(STORY_RULES.map((r) => r.gap));
+
+const collectGaps = <TGap extends string, TInput>(rules: readonly FieldRule<TGap, TInput>[], input: TInput): TGap[] =>
+	rules.filter((r) => r.missing(input)).map((r) => r.gap);
+
+const coreGapsOf = <TGap extends string, TInput>(
+	rules: readonly FieldRule<TGap, TInput>[],
+	gaps: readonly TGap[],
+): TGap[] => {
+	const core = new Set(rules.filter((r) => r.core !== false).map((r) => r.gap));
+	return gaps.filter((g) => core.has(g));
+};
+
+export function evaluateAuthor(input: AuthorAuditInput): AuthorAuditResult {
+	const gaps = collectGaps(AUTHOR_RULES, input);
+	const coreGaps = coreGapsOf(AUTHOR_RULES, gaps);
 	return {
 		name: input.name,
 		slug: input.slug,
@@ -87,31 +108,24 @@ export function evaluateAuthor(input: AuthorAuditInput): AuthorAuditResult {
 }
 
 export function evaluateStory(input: StoryAuditInput): StoryAuditResult {
-	const gaps: StoryGap[] = [];
-	if (!input.title?.trim()) gaps.push('title');
-	if (!input.slug?.trim()) gaps.push('slug');
-	if (!input.hasAuthor) gaps.push('author');
-	const usesCreatedAtFallback = !input.hasPublishedAt;
-	if (usesCreatedAtFallback) gaps.push('publishedAt');
-	if (!input.originalPublication?.trim()) gaps.push('originalPublication');
-	const review = (input.reviewText ?? '').trim();
-	if (review.length === 0) gaps.push('review');
-
+	const gaps = collectGaps(STORY_RULES, input);
 	return {
 		title: input.title,
 		slug: input.slug,
 		gaps,
-		usesCreatedAtFallback,
+		usesCreatedAtFallback: !input.hasPublishedAt,
 		incompleteness: gaps.length / STORY_GAPS.length,
 	};
 }
 
-export function groupByGap<T extends string>(items: Array<{ gaps: T[] }>, allGaps: readonly T[]): Record<T, number> {
+/** Cuenta cuántos ítems reportan cada gap (una pasada sobre flatMap). */
+export function groupByGap<T extends string>(
+	items: Array<{ gaps: readonly T[] }>,
+	allGaps: readonly T[],
+): Record<T, number> {
 	const counts = Object.fromEntries(allGaps.map((g) => [g, 0])) as Record<T, number>;
-	for (const item of items) {
-		for (const g of item.gaps) {
-			if (g in counts) counts[g]++;
-		}
+	for (const gap of items.flatMap((item) => item.gaps)) {
+		if (gap in counts) counts[gap] += 1;
 	}
 	return counts;
 }


### PR DESCRIPTION
## Descripción

- Agrega un script de auditoría **read-only** en `scripts/audit/` que detecta autores y cuentos con ficha incompleta para datos estructurados (`Person` / `Article`).
- Emite un reporte accionable en `tools/structured-data-audit/` (gitignored): Markdown con conteos por campo, ranking por incompleteness y sección dedicada a cuentos sin `publishedAt` editorial (fallback `_createdAt`), más CSV de incompletos.
- La lógica pura vive en `structured-data-completeness.ts` con tests unitarios; documentado en `scripts/audit/README.md`.

Closes #1562.

## Plan de pruebas

- [x] `pnpm exec vitest run scripts/audit/structured-data-completeness.spec.ts` — 9 tests verdes
- [x] `pnpm typecheck` verde
- [ ] Correr contra el dataset real: `pnpm exec tsx --env-file=.env scripts/audit/audit-structured-data-completeness.ts` y revisar `tools/structured-data-audit/report.md`

## Uso

```bash
pnpm exec tsx --env-file=.env scripts/audit/audit-structured-data-completeness.ts
```