### PR TITLE
[#1571] - Componente HighlightedAuthors en la home

### DIFF
--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -364,6 +364,12 @@ interface ContributorLink {
 **Raíz de Agregado:** `LandingPageContent`
 
 ```typescript
+interface HighlightedAuthor {
+	author: AuthorTeaser;
+	tags: Tag[]; // tags puntuales de la semana + tags derivados del autor
+	storyCount: number;
+}
+
 interface LandingPageContent {
 	// Identidad
 	_id: string; // Identificador único
@@ -373,6 +379,7 @@ interface LandingPageContent {
 	campaigns: ContentCampaign[]; // Campañas de marketing
 	mostRead: StoryNavigationTeaserWithAuthor[]; // Top 10 historias más leídas
 	latestReads: StoryNavigationTeaserWithAuthor[]; // Últimas historias publicadas
+	highlightedAuthors: HighlightedAuthor[]; // Hasta 6 autores destacados de la semana
 }
 ```
 
@@ -380,6 +387,7 @@ interface LandingPageContent {
 
 - Agregar contenido de múltiples contextos para presentación en página inicio
 - Mantener datos de lectura y estadísticas
+- Exponer hasta 6 autores destacados editoriales (`highlightedAuthors`) con tags contextuales y conteo de historias
 
 > **Nota:** Para comprender la implementación práctica de este agregado, incluyendo la generación automática de configuraciones y actualización de contenido, consulta la documentación sobre [Estrategias de Actualización de Contenido](./CONTENT_UPDATE_STRATEGIES.md).
 

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -298,6 +298,7 @@ export function mapLandingPageContent(
 		cards: mapStorylistTeasers(result.cards),
 		campaigns: mapContentCampaigns(result.campaigns),
 		latestReads: mapStoryNavigationTeaserWithAuthor(result.latestReads),
+		highlightedAuthors: [],
 	};
 }
 

--- a/src/app/components/highlighted-authors/highlighted-authors-skeleton.component.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors-skeleton.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { AuthorTeaserV3SkeletonComponent } from '@components/author-teaser-v3/author-teaser-v3-skeleton.component';
+
+@Component({
+	selector: 'cuentoneta-highlighted-authors-skeleton',
+	imports: [AuthorTeaserV3SkeletonComponent],
+	template: `
+		@for (_ of skeletons; track $index) {
+			<cuentoneta-author-teaser-v3-skeleton data-testid="skeleton" />
+		}
+	`,
+	host: {
+		class: 'contents',
+	},
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HighlightedAuthorsSkeletonComponent {
+	protected readonly skeletons = Array.from({ length: 6 });
+}

--- a/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
@@ -1,0 +1,114 @@
+import { DeferBlockState } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { render, screen } from '@testing-library/angular';
+
+import { HighlightedAuthorsComponent } from './highlighted-authors.component';
+import { HighlightedAuthorsSkeletonComponent } from './highlighted-authors-skeleton.component';
+import { AuthorTeaserV3Component } from '@components/author-teaser-v3/author-teaser-v3.component';
+import { AuthorTeaserV3SkeletonComponent } from '@components/author-teaser-v3/author-teaser-v3-skeleton.component';
+import { highlightedAuthorsMock } from '@mocks/highlighted-authors.mock';
+
+describe('HighlightedAuthorsComponent', () => {
+	const defaultProviders = [provideRouter([])];
+	const defaultImports = [
+		HighlightedAuthorsComponent,
+		HighlightedAuthorsSkeletonComponent,
+		AuthorTeaserV3Component,
+		AuthorTeaserV3SkeletonComponent,
+	];
+
+	describe('Renderizado del componente', () => {
+		it('should display the section title', async () => {
+			await render(HighlightedAuthorsComponent, {
+				inputs: { authors: [] },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+			expect(screen.getByRole('heading', { name: 'Autores/as destacados/as' })).toBeInTheDocument();
+		});
+
+		it('should display the section subtitle', async () => {
+			await render(HighlightedAuthorsComponent, {
+				inputs: { authors: [] },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+			expect(screen.getByText('Una selección curada de autores y autoras imprescindibles')).toBeInTheDocument();
+		});
+
+		it('should not render the Ver todo link while the authors page is not ready', async () => {
+			await render(HighlightedAuthorsComponent, {
+				inputs: { authors: highlightedAuthorsMock },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+			expect(screen.queryByRole('link', { name: 'Ver todo' })).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Comportamiento del bloque defer', () => {
+		it('should render skeletons in loading state', async () => {
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				inputs: { authors: highlightedAuthorsMock },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			const deferBlockFixture = (await fixture.getDeferBlocks())[0];
+			await deferBlockFixture.render(DeferBlockState.Loading);
+
+			expect(screen.getAllByTestId('skeleton')).toHaveLength(6);
+		});
+
+		it('should render up to six author teasers when data is available', async () => {
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				inputs: { authors: highlightedAuthorsMock },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			const deferBlockFixture = (await fixture.getDeferBlocks())[0];
+			await deferBlockFixture.render(DeferBlockState.Complete);
+
+			expect(screen.getAllByTestId('author-teaser')).toHaveLength(6);
+			expect(screen.getByText('Clarice Lispector')).toBeInTheDocument();
+			expect(screen.getByText('Héctor Germán Oesterheld')).toBeInTheDocument();
+		});
+
+		it('should pass tags and story count to each teaser', async () => {
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				inputs: { authors: highlightedAuthorsMock.slice(0, 1) },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			const deferBlockFixture = (await fixture.getDeferBlocks())[0];
+			await deferBlockFixture.render(DeferBlockState.Complete);
+
+			expect(screen.getByText('Surrealismo')).toBeInTheDocument();
+			expect(screen.getByTestId('story-count')).toHaveTextContent('27 historias');
+		});
+	});
+
+	describe('Inputs del componente', () => {
+		it('should accept an empty array of authors', async () => {
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				inputs: { authors: [] },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			expect(fixture.componentInstance.authors()).toEqual([]);
+			expect(screen.queryByTestId('author-teaser')).not.toBeInTheDocument();
+		});
+
+		it('should have default empty array when no authors provided', async () => {
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			expect(fixture.componentInstance.authors()).toEqual([]);
+		});
+	});
+});

--- a/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
@@ -1,0 +1,107 @@
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { provideRouter } from '@angular/router';
+
+import { HighlightedAuthorsComponent } from './highlighted-authors.component';
+import { HighlightedAuthorsSkeletonComponent } from './highlighted-authors-skeleton.component';
+import { highlightedAuthorsMock } from '@mocks/highlighted-authors.mock';
+
+const meta: Meta<HighlightedAuthorsComponent> = {
+	component: HighlightedAuthorsComponent,
+	title: 'Componentes V3/HighlightedAuthors',
+	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
+	],
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+			description: {
+				component: `<div><p>La sección <strong>HighlightedAuthors</strong> muestra hasta 6 autores destacados de la home: cabecera con título, subtítulo y botón "Ver todo" (oculto hasta que exista la página de listado), más una grilla responsive de <a href="./?path=/docs/componentes-v3-authorteaserv3--docs" target="_top"><strong>AuthorTeaserV3</strong></a>.</p></div>`,
+			},
+		},
+		layout: 'padded',
+	},
+	argTypes: {
+		authors: {
+			control: { type: 'object' },
+			description: 'Autores destacados a renderizar (máximo editorial 6)',
+			table: { type: { summary: 'HighlightedAuthor[]' }, defaultValue: { summary: '[]' } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<HighlightedAuthorsComponent>;
+
+export const Default: Story = {
+	name: 'Por defecto',
+	args: { authors: highlightedAuthorsMock },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Sección completa con 6 autores destacados, tags y conteo de historias.</p>`,
+			},
+		},
+	},
+};
+
+export const Empty: Story = {
+	name: 'Vacío',
+	args: { authors: [] },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Sin autores: se muestra la cabecera; la grilla queda a la espera del defer.</p>`,
+			},
+		},
+	},
+};
+
+export const Skeleton: StoryObj = {
+	name: 'Esqueleto',
+	decorators: [moduleMetadata({ imports: [HighlightedAuthorsSkeletonComponent] })],
+	render: () => ({
+		template: `
+			<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+				<cuentoneta-highlighted-authors-skeleton />
+			</section>
+		`,
+	}),
+	parameters: {
+		docs: { description: { story: 'Skeleton de la grilla (6 teasers).' } },
+	},
+};
+
+export const Estados: StoryObj<HighlightedAuthorsComponent & { loading: boolean }> = {
+	decorators: [moduleMetadata({ imports: [HighlightedAuthorsSkeletonComponent] })],
+	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
+	render: (args) => ({
+		props: args,
+		template: `
+			@if (loading) {
+				<div class="flex flex-col gap-8">
+					<div class="flex flex-col gap-1">
+						<h2 class="font-inter text-2xl font-bold text-neutral-900">Autores/as destacados/as</h2>
+						<p class="font-inter text-sm text-neutral-600">Una selección curada de autores y autoras imprescindibles</p>
+					</div>
+					<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+						<cuentoneta-highlighted-authors-skeleton />
+					</section>
+				</div>
+			} @else {
+				<cuentoneta-highlighted-authors [authors]="authors" />
+			}
+		`,
+	}),
+	args: { loading: true, authors: highlightedAuthorsMock },
+	parameters: {
+		docs: {
+			description: {
+				story: 'Activá/desactivá "Cargando" para alternar entre el estado real y el skeleton en el mismo slot.',
+			},
+		},
+	},
+};

--- a/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
@@ -85,7 +85,9 @@ export const Estados: StoryObj<HighlightedAuthorsComponent & { loading: boolean 
 				<div class="flex flex-col gap-8">
 					<div class="flex flex-col gap-1">
 						<h2 class="font-inter text-2xl font-bold text-neutral-900">Autores/as destacados/as</h2>
-						<p class="font-inter text-sm text-neutral-600">Una selección curada de autores y autoras imprescindibles</p>
+						<p class="font-inter text-sm font-medium text-neutral-600">
+							Una selección curada de autores y autoras imprescindibles
+						</p>
 					</div>
 					<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
 						<cuentoneta-highlighted-authors-skeleton />

--- a/src/app/components/highlighted-authors/highlighted-authors.component.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.ts
@@ -11,10 +11,12 @@ import { HighlightedAuthorsSkeletonComponent } from './highlighted-authors-skele
 	selector: 'cuentoneta-highlighted-authors',
 	imports: [AuthorTeaserV3Component, ButtonComponent, HighlightedAuthorsSkeletonComponent, RouterLink],
 	template: `
-		<div class="flex items-center justify-between gap-4">
+		<div class="flex items-center justify-between gap-8">
 			<div class="flex min-w-0 flex-col gap-1">
 				<h2 class="font-inter text-2xl font-bold text-neutral-900">Autores/as destacados/as</h2>
-				<p class="font-inter text-sm text-neutral-600">Una selección curada de autores y autoras imprescindibles</p>
+				<p class="font-inter text-sm font-medium text-neutral-600">
+					Una selección curada de autores y autoras imprescindibles
+				</p>
 			</div>
 			@if (showViewAll) {
 				<a [routerLink]="['/', appRoutes.Authors]" cuentoneta-button type="outline">Ver todo</a>

--- a/src/app/components/highlighted-authors/highlighted-authors.component.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.ts
@@ -1,0 +1,49 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import { AuthorTeaserV3Component } from '@components/author-teaser-v3/author-teaser-v3.component';
+import { ButtonComponent } from '@components/button/button.component';
+import type { HighlightedAuthor } from '@models/landing-page-content.model';
+import { AppRoutes } from '../../app.routes';
+import { HighlightedAuthorsSkeletonComponent } from './highlighted-authors-skeleton.component';
+
+@Component({
+	selector: 'cuentoneta-highlighted-authors',
+	imports: [AuthorTeaserV3Component, ButtonComponent, HighlightedAuthorsSkeletonComponent, RouterLink],
+	template: `
+		<div class="flex items-center justify-between gap-4">
+			<div class="flex min-w-0 flex-col gap-1">
+				<h2 class="font-inter text-2xl font-bold text-neutral-900">Autores/as destacados/as</h2>
+				<p class="font-inter text-sm text-neutral-600">Una selección curada de autores y autoras imprescindibles</p>
+			</div>
+			@if (showViewAll) {
+				<a [routerLink]="['/', appRoutes.Authors]" cuentoneta-button type="outline">Ver todo</a>
+			}
+		</div>
+
+		<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+			@defer (when authors().length > 0) {
+				@for (item of authors(); track item.author._id) {
+					<cuentoneta-author-teaser-v3
+						[author]="item.author"
+						[tags]="item.tags"
+						[storyCount]="item.storyCount"
+						data-testid="author-teaser"
+					/>
+				}
+			} @loading (minimum 500ms) {
+				<cuentoneta-highlighted-authors-skeleton />
+			}
+		</section>
+	`,
+	host: {
+		class: 'flex flex-col gap-8',
+	},
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HighlightedAuthorsComponent {
+	protected readonly appRoutes = AppRoutes;
+	protected readonly showViewAll = false;
+
+	public readonly authors = input<HighlightedAuthor[]>([]);
+}

--- a/src/app/mocks/highlighted-authors.mock.ts
+++ b/src/app/mocks/highlighted-authors.mock.ts
@@ -1,0 +1,66 @@
+import type { HighlightedAuthor } from '@models/landing-page-content.model';
+import type { Tag } from '@models/tag.model';
+import { authorTeaserMock } from './author.mock';
+
+const genreTags: Tag[] = [
+	{ title: 'Surrealismo', slug: 'surrealismo', shortDescription: '', description: [] },
+	{ title: 'Literatura Infantil', slug: 'literatura-infantil', shortDescription: '', description: [] },
+	{ title: 'Horror Psicológico', slug: 'horror-psicologico', shortDescription: '', description: [] },
+	{ title: 'Ficción Especulativa', slug: 'ficcion-especulativa', shortDescription: '', description: [] },
+	{ title: 'Crónica', slug: 'cronica', shortDescription: '', description: [] },
+	{ title: 'Ciencia Ficción', slug: 'ciencia-ficcion', shortDescription: '', description: [] },
+];
+
+const authorsSeed = [
+	{ name: 'Clarice Lispector', slug: 'clarice-lispector', country: 'Brasil', storyCount: 27, tagIndexes: [0] },
+	{
+		name: 'María Elena Walsh',
+		slug: 'maria-elena-walsh',
+		country: 'Argentina',
+		storyCount: 16,
+		tagIndexes: [1, 0],
+	},
+	{
+		name: 'Mariana Enríquez',
+		slug: 'mariana-enriquez',
+		country: 'Argentina',
+		storyCount: 21,
+		tagIndexes: [2],
+	},
+	{
+		name: 'Jorge Luis Borges',
+		slug: 'jorge-luis-borges',
+		country: 'Argentina',
+		storyCount: 13,
+		tagIndexes: [3, 0, 4, 5, 1, 2, 0],
+	},
+	{
+		name: 'Eduardo Galeano',
+		slug: 'eduardo-galeano',
+		country: 'Uruguay',
+		storyCount: 4,
+		tagIndexes: [4, 0, 1, 2],
+	},
+	{
+		name: 'Héctor Germán Oesterheld',
+		slug: 'hector-german-oesterheld',
+		country: 'Argentina',
+		storyCount: 7,
+		tagIndexes: [5, 3, 0],
+	},
+] as const;
+
+export const highlightedAuthorsMock: HighlightedAuthor[] = authorsSeed.map((seed, index) => ({
+	author: {
+		...authorTeaserMock,
+		_id: `highlighted-author-${index + 1}`,
+		slug: seed.slug,
+		name: seed.name,
+		nationality: {
+			...authorTeaserMock.nationality,
+			country: seed.country,
+		},
+	},
+	tags: seed.tagIndexes.map((tagIndex) => genreTags[tagIndex]),
+	storyCount: seed.storyCount,
+}));

--- a/src/app/mocks/highlighted-authors.mock.ts
+++ b/src/app/mocks/highlighted-authors.mock.ts
@@ -11,6 +11,12 @@ const genreTags: Tag[] = [
 	{ title: 'Ciencia Ficción', slug: 'ciencia-ficcion', shortDescription: '', description: [] },
 ];
 
+const flagByCountry: Record<string, string> = {
+	Brasil: 'https://flagcdn.com/w40/br.png',
+	Argentina: 'https://flagcdn.com/w40/ar.png',
+	Uruguay: 'https://flagcdn.com/w40/uy.png',
+};
+
 const authorsSeed = [
 	{ name: 'Clarice Lispector', slug: 'clarice-lispector', country: 'Brasil', storyCount: 27, tagIndexes: [0] },
 	{
@@ -18,7 +24,7 @@ const authorsSeed = [
 		slug: 'maria-elena-walsh',
 		country: 'Argentina',
 		storyCount: 16,
-		tagIndexes: [1, 0],
+		tagIndexes: [1],
 	},
 	{
 		name: 'Mariana Enríquez',
@@ -56,9 +62,10 @@ export const highlightedAuthorsMock: HighlightedAuthor[] = authorsSeed.map((seed
 		_id: `highlighted-author-${index + 1}`,
 		slug: seed.slug,
 		name: seed.name,
+		tags: [],
 		nationality: {
-			...authorTeaserMock.nationality,
 			country: seed.country,
+			flag: flagByCountry[seed.country] ?? '',
 		},
 	},
 	tags: seed.tagIndexes.map((tagIndex) => genreTags[tagIndex]),

--- a/src/app/models/landing-page-content.model.ts
+++ b/src/app/models/landing-page-content.model.ts
@@ -1,6 +1,14 @@
-import { StorylistTeaser } from '@models/storylist.model';
-import { ContentCampaign } from '@models/content-campaign.model';
-import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
+import type { AuthorTeaser } from '@models/author.model';
+import type { ContentCampaign } from '@models/content-campaign.model';
+import type { StorylistTeaser } from '@models/storylist.model';
+import type { StoryNavigationTeaserWithAuthor } from '@models/story.model';
+import type { Tag } from '@models/tag.model';
+
+export interface HighlightedAuthor {
+	author: AuthorTeaser;
+	tags: Tag[];
+	storyCount: number;
+}
 
 export interface LandingPageContent {
 	_id: string;
@@ -9,6 +17,7 @@ export interface LandingPageContent {
 	campaigns: ContentCampaign[];
 	mostRead: StoryNavigationTeaserWithAuthor[];
 	latestReads: StoryNavigationTeaserWithAuthor[];
+	highlightedAuthors: HighlightedAuthor[];
 }
 
 export interface RotatingContent {

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -30,6 +30,10 @@
 		<cuentoneta-collection-teasers-deck [teasers]="collections()" class="flex flex-col gap-8" />
 	</section>
 
+	<section class="mb-8">
+		<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" />
+	</section>
+
 	<!--
         Intro descriptiva con texto sustantivo y citable, server-rendered (sin @defer), para que
         buscadores y answer engines tengan contenido indexable más allá de las imágenes del hero.

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -10,7 +10,7 @@
         Las alturas fijadas para los elementos hijos de <main> tienen la finalidad de evitar
         el rebote vertical que puede observarse en el momento de la carga inicial de la página
     -->
-	<section class="mb-8 aspect-[540/220] sm:aspect-[1240/360]">
+	<section class="mb-12 aspect-[540/220] sm:aspect-[1240/360] md:mb-16">
 		@defer (when campaigns().length > 0) {
 			<cuentoneta-carousel [slides]="campaigns()" />
 		} @loading (minimum 500ms) {
@@ -18,27 +18,27 @@
 		}
 	</section>
 
-	<section class="mb-8">
+	<section class="mb-12 md:mb-16">
 		<cuentoneta-latest-stories-card-deck [stories]="latestReads()" />
 	</section>
 
-	<section class="mb-8">
+	<section class="mb-12 md:mb-16">
 		<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" />
 	</section>
 
-	<section class="mb-8">
+	<section class="mb-12 md:mb-16">
 		<cuentoneta-most-read-stories-card-deck [stories]="mostRead()" />
 	</section>
 
-	<section class="mb-8">
-		<cuentoneta-collection-teasers-deck [teasers]="collections()" class="flex flex-col gap-8" />
+	<section class="mb-12 md:mb-16">
+		<cuentoneta-collection-teasers-deck [teasers]="collections()" />
 	</section>
 
 	<!--
         Intro descriptiva con texto sustantivo y citable, server-rendered (sin @defer), para que
         buscadores y answer engines tengan contenido indexable más allá de las imágenes del hero.
     -->
-	<section class="mb-8 flex flex-col gap-8">
+	<section class="mb-12 flex flex-col gap-8 md:mb-16">
 		<h2 class="font-inter text-2xl font-bold">Sobre <em>La Cuentoneta</em></h2>
 
 		<div class="flex flex-col gap-4">

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -18,16 +18,16 @@
 		}
 	</section>
 
-	<section class="mb-8 h-[684px] md:h-[304px]">
-		<cuentoneta-latest-stories-card-deck [stories]="latestReads()" class="flex flex-col gap-8" />
+	<section class="mb-8">
+		<cuentoneta-latest-stories-card-deck [stories]="latestReads()" />
 	</section>
 
 	<section class="mb-8">
 		<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" />
 	</section>
 
-	<section class="mb-8 h-[684px] md:h-[304px]">
-		<cuentoneta-most-read-stories-card-deck [stories]="mostRead()" class="flex flex-col gap-8" />
+	<section class="mb-8">
+		<cuentoneta-most-read-stories-card-deck [stories]="mostRead()" />
 	</section>
 
 	<section class="mb-8">

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -22,16 +22,16 @@
 		<cuentoneta-latest-stories-card-deck [stories]="latestReads()" class="flex flex-col gap-8" />
 	</section>
 
+	<section class="mb-8">
+		<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" />
+	</section>
+
 	<section class="mb-8 h-[684px] md:h-[304px]">
 		<cuentoneta-most-read-stories-card-deck [stories]="mostRead()" class="flex flex-col gap-8" />
 	</section>
 
 	<section class="mb-8">
 		<cuentoneta-collection-teasers-deck [teasers]="collections()" class="flex flex-col gap-8" />
-	</section>
-
-	<section class="mb-8">
-		<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" />
 	</section>
 
 	<!--

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -17,6 +17,7 @@ import { MostReadStoriesCardDeckComponent } from '@components/most-read-stories-
 import { LatestStoriesCardDeck } from '@components/latest-stories-card-deck/latest-stories-card-deck';
 import { CarouselSkeletonComponent } from '@components/carousel/carousel-skeleton.component';
 import { CollectionTeasersDeck } from '@components/collection-teasers-deck/collection-teasers-deck';
+import { HighlightedAuthorsComponent } from '@components/highlighted-authors/highlighted-authors.component';
 
 @Component({
 	selector: 'cuentoneta-home',
@@ -27,6 +28,7 @@ import { CollectionTeasersDeck } from '@components/collection-teasers-deck/colle
 		LatestStoriesCardDeck,
 		CarouselSkeletonComponent,
 		CollectionTeasersDeck,
+		HighlightedAuthorsComponent,
 	],
 	hostDirectives: [HomeMetaTagsDirective, HomeStructuredDataDirective],
 })
@@ -46,4 +48,5 @@ export default class HomeComponent {
 	protected readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
 	protected readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
 	protected readonly latestReads = computed(() => this.landingPageContent()?.latestReads.slice(0, 6) || []);
+	protected readonly highlightedAuthors = computed(() => this.landingPageContent()?.highlightedAuthors ?? []);
 }

--- a/src/app/providers/content.mock.ts
+++ b/src/app/providers/content.mock.ts
@@ -5,6 +5,7 @@ import { Observable, of } from 'rxjs';
 // Models
 import { LandingPageContent } from '@models/landing-page-content.model';
 import { ContentApi } from './content-api.interface';
+import { highlightedAuthorsMock } from '@mocks/highlighted-authors.mock';
 
 export class InMemoryContentApi implements ContentApi {
 	public getLandingPageContent(): Observable<LandingPageContent> {
@@ -15,7 +16,7 @@ export class InMemoryContentApi implements ContentApi {
 			campaigns: [],
 			mostRead: [],
 			latestReads: [],
-			highlightedAuthors: [],
+			highlightedAuthors: highlightedAuthorsMock,
 		};
 		return of(landingPageContent);
 	}

--- a/src/app/providers/content.mock.ts
+++ b/src/app/providers/content.mock.ts
@@ -15,6 +15,7 @@ export class InMemoryContentApi implements ContentApi {
 			campaigns: [],
 			mostRead: [],
 			latestReads: [],
+			highlightedAuthors: [],
 		};
 		return of(landingPageContent);
 	}

--- a/src/app/providers/content.provider.ts
+++ b/src/app/providers/content.provider.ts
@@ -1,7 +1,7 @@
 // Core
 import { EnvironmentProviders, inject, Injectable, makeEnvironmentProviders } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { map, type Observable } from 'rxjs';
 
 // Environment
 import { environment } from '../environments/environment';
@@ -9,6 +9,7 @@ import { environment } from '../environments/environment';
 // Models
 import { LandingPageContent } from '@models/landing-page-content.model';
 import { ContentApi } from './content-api.interface';
+import { highlightedAuthorsMock } from '@mocks/highlighted-authors.mock';
 
 @Injectable({ providedIn: 'root' })
 export class HttpContentApi implements ContentApi {
@@ -16,7 +17,16 @@ export class HttpContentApi implements ContentApi {
 	private http = inject(HttpClient);
 
 	public getLandingPageContent(): Observable<LandingPageContent> {
-		return this.http.get<LandingPageContent>(`${this.prefix}/landing-page`);
+		return this.http
+			.get<LandingPageContent>(`${this.prefix}/landing-page`)
+			.pipe(map((content) => this.withDevHighlightedAuthorsFallback(content)));
+	}
+
+	private withDevHighlightedAuthorsFallback(content: LandingPageContent): LandingPageContent {
+		if (environment.environment === 'production' || content.highlightedAuthors.length > 0) {
+			return content;
+		}
+		return { ...content, highlightedAuthors: highlightedAuthorsMock };
 	}
 }
 


### PR DESCRIPTION
## Descripción

- Agrega la sección **Autores/as destacados/as** en la home (cabecera + grilla 2×3 de `AuthorTeaserV3` + skeleton + stories/tests), alineada al diseño de Figma.
- Introduce el contrato de dominio `HighlightedAuthor` en `LandingPageContent` (listo para #1570) y un mock de 6 destacados.
- En development, si la API devuelve `highlightedAuthors` vacío, se usa el mock hasta que aterrice el backend (#1570).
- El botón **Ver todo** queda oculto hasta #1572.
- Posición: entre *Últimas novedades* e *Historias más leídas*; ritmo vertical de secciones ajustado (48/64px).

Closes #1571.

Parte de #1568.

<img width="1224" height="792" alt="image" src="https://github.com/user-attachments/assets/25c8dc6c-a81b-4572-8f16-878e83d6368e" />


## Plan de pruebas

- [x] `pnpm test` (incluye specs de HighlightedAuthors)
- [x] `pnpm lint`
- [x] `pnpm stylelint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm storybook:build`
- [x] Verificación visual en `localhost:4200/home` vs Figma (gaps, posición, tipografía)