### PR TITLE
[#1570] - landingPage.highlightedAuthors: schema, query y contrato de dominio

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -763,6 +763,53 @@
 				},
 				"optional": false
 			},
+			"coverImage": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "object",
+					"attributes": {
+						"asset": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageAsset.reference"
+							},
+							"optional": true
+						},
+						"media": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "unknown"
+							},
+							"optional": true
+						},
+						"hotspot": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageHotspot"
+							},
+							"optional": true
+						},
+						"crop": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageCrop"
+							},
+							"optional": true
+						},
+						"_type": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "string",
+								"value": "image"
+							}
+						}
+					}
+				},
+				"optional": false
+			},
 			"mediaSources": {
 				"type": "objectAttribute",
 				"value": {
@@ -1205,346 +1252,6 @@
 		}
 	},
 	{
-		"type": "type",
-		"name": "nationality.reference",
-		"value": {
-			"type": "object",
-			"attributes": {
-				"_ref": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string"
-					}
-				},
-				"_type": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string",
-						"value": "reference"
-					}
-				},
-				"_weak": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "boolean"
-					},
-					"optional": true
-				}
-			},
-			"dereferencesTo": "nationality"
-		}
-	},
-	{
-		"name": "author",
-		"type": "document",
-		"attributes": {
-			"_id": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_type": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string",
-					"value": "author"
-				}
-			},
-			"_createdAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_updatedAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_rev": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"name": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": false
-			},
-			"slug": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "slug"
-				},
-				"optional": false
-			},
-			"image": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "object",
-					"attributes": {
-						"asset": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageAsset.reference"
-							},
-							"optional": true
-						},
-						"media": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "unknown"
-							},
-							"optional": true
-						},
-						"hotspot": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageHotspot"
-							},
-							"optional": true
-						},
-						"crop": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageCrop"
-							},
-							"optional": true
-						},
-						"_type": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "string",
-								"value": "image"
-							}
-						}
-					}
-				},
-				"optional": false
-			},
-			"nationality": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "nationality.reference"
-				},
-				"optional": false
-			},
-			"bornOn": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": true
-			},
-			"bornOnYear": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "computedNumber"
-				},
-				"optional": true
-			},
-			"diedOn": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": true
-			},
-			"diedOnYear": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "computedNumber"
-				},
-				"optional": true
-			},
-			"biography": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "blockContent"
-				},
-				"optional": false
-			},
-			"resources": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "array",
-					"of": {
-						"type": "object",
-						"attributes": {
-							"title": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string"
-								},
-								"optional": false
-							},
-							"url": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string"
-								},
-								"optional": false
-							},
-							"resourceType": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "inline",
-									"name": "resourceType.reference"
-								},
-								"optional": false
-							},
-							"_type": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string",
-									"value": "resource"
-								}
-							}
-						},
-						"rest": {
-							"type": "object",
-							"attributes": {
-								"_key": {
-									"type": "objectAttribute",
-									"value": {
-										"type": "string"
-									}
-								}
-							}
-						}
-					}
-				},
-				"optional": true
-			},
-			"tags": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "array",
-					"of": {
-						"type": "object",
-						"attributes": {
-							"_key": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string"
-								}
-							}
-						},
-						"rest": {
-							"type": "inline",
-							"name": "tag.reference"
-						}
-					}
-				},
-				"optional": true
-			}
-		}
-	},
-	{
-		"name": "nationality",
-		"type": "document",
-		"attributes": {
-			"_id": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_type": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string",
-					"value": "nationality"
-				}
-			},
-			"_createdAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_updatedAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_rev": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"country": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": false
-			},
-			"flag": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "object",
-					"attributes": {
-						"asset": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageAsset.reference"
-							},
-							"optional": true
-						},
-						"media": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "unknown"
-							},
-							"optional": true
-						},
-						"hotspot": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageHotspot"
-							},
-							"optional": true
-						},
-						"crop": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageCrop"
-							},
-							"optional": true
-						},
-						"_type": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "string",
-								"value": "image"
-							}
-						}
-					}
-				},
-				"optional": false
-			}
-		}
-	},
-	{
 		"name": "sanity.imageCrop",
 		"type": "type",
 		"value": {
@@ -1735,7 +1442,7 @@
 						}
 					}
 				},
-				"optional": false
+				"optional": true
 			},
 			"tags": {
 				"type": "objectAttribute",
@@ -2489,6 +2196,406 @@
 					}
 				},
 				"optional": true
+			},
+			"highlightedAuthors": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "array",
+					"of": {
+						"type": "object",
+						"attributes": {
+							"author": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "inline",
+									"name": "author.reference"
+								},
+								"optional": false
+							},
+							"additionalTags": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "array",
+									"of": {
+										"type": "object",
+										"attributes": {
+											"_key": {
+												"type": "objectAttribute",
+												"value": {
+													"type": "string"
+												}
+											}
+										},
+										"rest": {
+											"type": "inline",
+											"name": "tag.reference"
+										}
+									}
+								},
+								"optional": true
+							},
+							"_type": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string",
+									"value": "highlightedAuthor"
+								}
+							}
+						},
+						"rest": {
+							"type": "object",
+							"attributes": {
+								"_key": {
+									"type": "objectAttribute",
+									"value": {
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				},
+				"optional": true
+			}
+		}
+	},
+	{
+		"type": "type",
+		"name": "nationality.reference",
+		"value": {
+			"type": "object",
+			"attributes": {
+				"_ref": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string"
+					}
+				},
+				"_type": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string",
+						"value": "reference"
+					}
+				},
+				"_weak": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "boolean"
+					},
+					"optional": true
+				}
+			},
+			"dereferencesTo": "nationality"
+		}
+	},
+	{
+		"name": "author",
+		"type": "document",
+		"attributes": {
+			"_id": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_type": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string",
+					"value": "author"
+				}
+			},
+			"_createdAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_updatedAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_rev": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"name": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": false
+			},
+			"slug": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "slug"
+				},
+				"optional": false
+			},
+			"image": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "object",
+					"attributes": {
+						"asset": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageAsset.reference"
+							},
+							"optional": true
+						},
+						"media": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "unknown"
+							},
+							"optional": true
+						},
+						"hotspot": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageHotspot"
+							},
+							"optional": true
+						},
+						"crop": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageCrop"
+							},
+							"optional": true
+						},
+						"_type": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "string",
+								"value": "image"
+							}
+						}
+					}
+				},
+				"optional": false
+			},
+			"nationality": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "nationality.reference"
+				},
+				"optional": false
+			},
+			"bornOn": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"bornOnYear": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "computedNumber"
+				},
+				"optional": true
+			},
+			"diedOn": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"diedOnYear": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "computedNumber"
+				},
+				"optional": true
+			},
+			"biography": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "blockContent"
+				},
+				"optional": false
+			},
+			"resources": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "array",
+					"of": {
+						"type": "object",
+						"attributes": {
+							"title": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								},
+								"optional": false
+							},
+							"url": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								},
+								"optional": false
+							},
+							"resourceType": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "inline",
+									"name": "resourceType.reference"
+								},
+								"optional": false
+							},
+							"_type": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string",
+									"value": "resource"
+								}
+							}
+						},
+						"rest": {
+							"type": "object",
+							"attributes": {
+								"_key": {
+									"type": "objectAttribute",
+									"value": {
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				},
+				"optional": true
+			},
+			"tags": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "array",
+					"of": {
+						"type": "object",
+						"attributes": {
+							"_key": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								}
+							}
+						},
+						"rest": {
+							"type": "inline",
+							"name": "tag.reference"
+						}
+					}
+				},
+				"optional": true
+			}
+		}
+	},
+	{
+		"name": "nationality",
+		"type": "document",
+		"attributes": {
+			"_id": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_type": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string",
+					"value": "nationality"
+				}
+			},
+			"_createdAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_updatedAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_rev": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"country": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": false
+			},
+			"flag": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "object",
+					"attributes": {
+						"asset": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageAsset.reference"
+							},
+							"optional": true
+						},
+						"media": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "unknown"
+							},
+							"optional": true
+						},
+						"hotspot": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageHotspot"
+							},
+							"optional": true
+						},
+						"crop": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageCrop"
+							},
+							"optional": true
+						},
+						"_type": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "string",
+								"value": "image"
+							}
+						}
+					}
+				},
+				"optional": false
 			}
 		}
 	},

--- a/cms/schemas/landingPage.ts
+++ b/cms/schemas/landingPage.ts
@@ -85,5 +85,53 @@ export default defineType({
 				}),
 			],
 		}),
+		defineField({
+			name: 'highlightedAuthors',
+			title: 'Autores/as destacados/as',
+			description:
+				'Hasta 6 autores destacados de la semana. Las etiquetas adicionales se suman a las del autor y se muestran primero.',
+			type: 'array',
+			validation: (Rule) => Rule.max(6),
+			of: [
+				defineArrayMember({
+					name: 'highlightedAuthor',
+					title: 'Autor/a destacado/a',
+					type: 'object',
+					preview: {
+						select: {
+							title: 'author.name',
+							media: 'author.image',
+						},
+						prepare({ title, media }) {
+							return {
+								title: title ?? 'Sin autor',
+								media,
+							};
+						},
+					},
+					fields: [
+						defineField({
+							name: 'author',
+							title: 'Autor/a',
+							type: 'reference',
+							to: [{ type: 'author' }],
+							validation: (Rule) => Rule.required(),
+						}),
+						defineField({
+							name: 'additionalTags',
+							title: 'Etiquetas adicionales',
+							description: 'Etiquetas puntuales de la semana (p. ej. Cumpleaños). Se muestran antes que las del autor.',
+							type: 'array',
+							of: [
+								defineArrayMember({
+									type: 'reference',
+									to: [{ type: 'tag' }],
+								}),
+							],
+						}),
+					],
+				}),
+			],
+		}),
 	],
 });

--- a/docs/CONTENT_UPDATE_STRATEGIES.md
+++ b/docs/CONTENT_UPDATE_STRATEGIES.md
@@ -113,9 +113,15 @@ Este proceso garantiza que:
   },
   campaigns: Array<CampaignReference>,     // Campañas a mostrar
   cards: Array<CardReference>,             // Tarjetas de contenido
-  latestReads: Array<StoryReference>       // Historias destacadas
+  latestReads: Array<StoryReference>,      // Historias destacadas
+  highlightedAuthors: Array<{              // Hasta 6 autores destacados de la semana
+    author: AuthorReference,
+    additionalTags?: Array<TagReference>
+  }>
 }
 ```
+
+El campo `highlightedAuthors` se clona en crudo junto con `campaigns`, `cards` y `latestReads` vía `latestLandingPageReferencesQuery`. Sin incluirlo en esa query, el cron semanal lo perdería.
 
 ### Nomenclatura de Slugs
 

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -364,6 +364,12 @@ interface ContributorLink {
 **Raíz de Agregado:** `LandingPageContent`
 
 ```typescript
+interface HighlightedAuthor {
+	author: AuthorTeaser;
+	tags: Tag[]; // additionalTags de la semana (primero) + tags derivados del autor
+	storyCount: number;
+}
+
 interface LandingPageContent {
 	// Identidad
 	_id: string; // Identificador único
@@ -373,6 +379,7 @@ interface LandingPageContent {
 	campaigns: ContentCampaign[]; // Campañas de marketing
 	mostRead: StoryNavigationTeaserWithAuthor[]; // Top 10 historias más leídas
 	latestReads: StoryNavigationTeaserWithAuthor[]; // Últimas historias publicadas
+	highlightedAuthors: HighlightedAuthor[]; // Hasta 6 autores destacados de la semana
 }
 ```
 
@@ -380,6 +387,7 @@ interface LandingPageContent {
 
 - Agregar contenido de múltiples contextos para presentación en página inicio
 - Mantener datos de lectura y estadísticas
+- Exponer hasta 6 autores destacados editoriales (`highlightedAuthors`) con tags contextuales y conteo de historias
 
 > **Nota:** Para comprender la implementación práctica de este agregado, incluyendo la generación automática de configuraciones y actualización de contenido, consulta la documentación sobre [Estrategias de Actualización de Contenido](./CONTENT_UPDATE_STRATEGIES.md).
 

--- a/src/api/_queries/content.query.ts
+++ b/src/api/_queries/content.query.ts
@@ -47,6 +47,7 @@ export const latestLandingPageReferencesQuery = defineQuery(`
     'cards': coalesce(cards[],[]),
     'campaigns': coalesce(campaigns[],[]),
     'latestReads': coalesce(latestReads,[]),
+    'highlightedAuthors': coalesce(highlightedAuthors[],[]),
 } | order(config desc, _createdAt desc)[0]
 `);
 
@@ -118,4 +119,38 @@ export const landingPageContentQuery = defineQuery(`
             'resources': [],
         }
     },[]),
+    'highlightedAuthors': coalesce(highlightedAuthors[]{
+        'author': author->{
+            _id,
+            'slug': slug.current,
+            name,
+            image,
+            nationality->,
+            'biography': [],
+            bornOn,
+            bornOnYear,
+            diedOn,
+            diedOnYear,
+            'resources': [],
+            'tags': coalesce(tags[]->{
+                title,
+                'slug': slug.current,
+                shortDescription,
+                description,
+                icon
+            }, [])
+        },
+        'additionalTags': coalesce(additionalTags[]->{
+            title,
+            'slug': slug.current,
+            shortDescription,
+            description,
+            icon
+        }, []),
+        'storyCount': count(*[
+            _type == 'story'
+            && author._ref == ^.author._ref
+            && !(_id in path('drafts.**'))
+        ])
+    }, []),
 }`);

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -1,5 +1,6 @@
 import type { SanityImageSource } from '@sanity/image-url';
 import {
+	mapHighlightedAuthors,
 	mapStoryNavigationTeaser,
 	mapStoryNavigationTeaserWithAuthor,
 	mapStoryTeaser,
@@ -79,6 +80,116 @@ describe('mapTags (ACL)', () => {
 
 	it('returns an empty array when there are no tags', () => {
 		expect(mapTags([])).toEqual([]);
+	});
+});
+
+describe('mapHighlightedAuthors (ACL)', () => {
+	const rawTag = (title: string, slug: string) => ({
+		title,
+		slug,
+		shortDescription: title,
+		description: [] as never[],
+		icon: { _type: 'iconPicker' as const, provider: 'mdi', name: 'tag' },
+	});
+
+	const rawAuthor = (overrides: { tags?: ReturnType<typeof rawTag>[] } = {}) => ({
+		_id: 'author_1',
+		slug: 'clarice-lispector',
+		name: 'Clarice Lispector',
+		image: { _type: 'image' as const },
+		nationality: {
+			_id: 'nat_1',
+			_type: 'nationality' as const,
+			_createdAt: '2020-01-01T00:00:00Z',
+			_updatedAt: '2020-01-01T00:00:00Z',
+			_rev: 'rev',
+			country: 'Brasil',
+			flag: { _type: 'image' as const },
+		},
+		biography: [] as never[],
+		bornOn: null,
+		bornOnYear: null,
+		diedOn: null,
+		diedOnYear: null,
+		resources: [] as never[],
+		tags: overrides.tags ?? [],
+	});
+
+	it('concatenates additionalTags before author tags', () => {
+		const result = mapHighlightedAuthors([
+			{
+				author: rawAuthor({ tags: [rawTag('Surrealismo', 'surrealismo')] }),
+				additionalTags: [rawTag('Cumpleaños', 'cumpleanos')],
+				storyCount: 12,
+			},
+		]);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].tags.map((tag) => tag.slug)).toEqual(['cumpleanos', 'surrealismo']);
+		expect(result[0].storyCount).toBe(12);
+	});
+
+	it('returns empty tags when both sources are empty', () => {
+		const result = mapHighlightedAuthors([
+			{
+				author: rawAuthor({ tags: [] }),
+				additionalTags: [],
+				storyCount: 0,
+			},
+		]);
+
+		expect(result[0].tags).toEqual([]);
+		expect(result[0].storyCount).toBe(0);
+	});
+
+	it('keeps only additionalTags when the author has none', () => {
+		const result = mapHighlightedAuthors([
+			{
+				author: rawAuthor({ tags: [] }),
+				additionalTags: [rawTag('Cumpleaños', 'cumpleanos')],
+				storyCount: 3,
+			},
+		]);
+
+		expect(result[0].tags.map((tag) => tag.slug)).toEqual(['cumpleanos']);
+	});
+
+	it('keeps only author tags when additionalTags are empty', () => {
+		const result = mapHighlightedAuthors([
+			{
+				author: rawAuthor({ tags: [rawTag('Crónica', 'cronica'), rawTag('Ensayo', 'ensayo')] }),
+				additionalTags: [],
+				storyCount: 7,
+			},
+		]);
+
+		expect(result[0].tags.map((tag) => tag.slug)).toEqual(['cronica', 'ensayo']);
+	});
+
+	it('maps the author through the teaser ACL with empty tags on the teaser', () => {
+		const result = mapHighlightedAuthors([
+			{
+				author: rawAuthor({ tags: [rawTag('Surrealismo', 'surrealismo')] }),
+				additionalTags: [],
+				storyCount: 5,
+			},
+		]);
+
+		expect(result[0].author).toMatchObject({
+			_id: 'author_1',
+			slug: 'clarice-lispector',
+			name: 'Clarice Lispector',
+			tags: [],
+			biography: [],
+			resources: [],
+		});
+		expect(result[0].author.imageUrl).toBeDefined();
+	});
+
+	it('returns an empty array when the input is empty or missing', () => {
+		expect(mapHighlightedAuthors([])).toEqual([]);
+		expect(mapHighlightedAuthors(undefined)).toEqual([]);
+		expect(mapHighlightedAuthors(null)).toEqual([]);
 	});
 });
 

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -13,7 +13,7 @@ import { createImageUrlBuilder, SanityImageSource } from '@sanity/image-url';
 // Modelos
 import { Author, AuthorProfile, AuthorTeaser } from '@models/author.model';
 import { ContentCampaign, viewportElementSizes } from '@models/content-campaign.model';
-import { LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
+import { HighlightedAuthor, LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
 import { StorylistTeaser } from '@models/storylist.model';
 import { Resource } from '@models/resource.model';
 import {
@@ -83,8 +83,11 @@ export function mapAuthorProfile(rawAuthorData: NonNullable<AuthorBySlugQueryRes
 }
 type AuthorTeaserForStoriesSubQuery = NonNullable<StorylistQueryResult>['stories'][0]['author'];
 type AuthorTeaserForListSubQuery = UnwrapArray<AuthorsQueryResult>;
+type AuthorTeaserForHighlightedSubQuery = UnwrapArray<
+	NonNullable<LandingPageContentQueryResult>['highlightedAuthors']
+>['author'];
 export function mapAuthorTeaser(
-	rawAuthorData: AuthorTeaserForStoriesSubQuery | AuthorTeaserForListSubQuery,
+	rawAuthorData: AuthorTeaserForStoriesSubQuery | AuthorTeaserForListSubQuery | AuthorTeaserForHighlightedSubQuery,
 ): AuthorTeaser {
 	return {
 		_id: rawAuthorData._id,
@@ -165,10 +168,13 @@ export function mapResources(resources: ResourcesSubQuery): Resource[] {
 	);
 }
 
+type HighlightedAuthorRaw = UnwrapArray<NonNullable<LandingPageContentQueryResult>['highlightedAuthors']>;
 type TagsSubQuery =
 	| NonNullable<StoryBySlugQueryResult>['tags']
 	| NonNullable<AuthorBySlugQueryResult>['tags']
-	| NonNullable<StorylistTeasersQueryResult>[0]['tags'];
+	| NonNullable<StorylistTeasersQueryResult>[0]['tags']
+	| HighlightedAuthorRaw['author']['tags']
+	| HighlightedAuthorRaw['additionalTags'];
 export function mapTags(tags: TagsSubQuery): Tag[] {
 	return tags.map((tag) => ({
 		...tag,
@@ -290,6 +296,20 @@ export function mapStoryNavigationTeaserWithAuthor(
 	return stories;
 }
 
+export function mapHighlightedAuthors(
+	raw: NonNullable<LandingPageContentQueryResult>['highlightedAuthors'] | null | undefined,
+): HighlightedAuthor[] {
+	if (!raw || raw.length === 0) {
+		return [];
+	}
+
+	return raw.map((item) => ({
+		author: mapAuthorTeaser(item.author),
+		tags: [...mapTags(item.additionalTags), ...mapTags(item.author.tags)],
+		storyCount: item.storyCount,
+	}));
+}
+
 export function mapLandingPageContent(
 	result: NonNullable<LandingPageContentQueryResult> & RotatingContent,
 ): LandingPageContent {
@@ -298,6 +318,7 @@ export function mapLandingPageContent(
 		cards: mapStorylistTeasers(result.cards),
 		campaigns: mapContentCampaigns(result.campaigns),
 		latestReads: mapStoryNavigationTeaserWithAuthor(result.latestReads),
+		highlightedAuthors: mapHighlightedAuthors(result.highlightedAuthors),
 	};
 }
 

--- a/src/api/modules/content/content.repository.ts
+++ b/src/api/modules/content/content.repository.ts
@@ -47,6 +47,12 @@ export async function createLandingPages(
 		campaigns: Array<{ _key: string; _type: string; _ref: string }>;
 		cards: Array<{ _key: string; _type: string; _ref: string }>;
 		latestReads: Array<{ _key: string; _type: string; _ref: string }>;
+		highlightedAuthors: Array<{
+			_key: string;
+			_type: string;
+			author: { _type: string; _ref: string };
+			additionalTags?: Array<{ _key: string; _type: string; _ref: string }>;
+		}>;
 	}>,
 ) {
 	return Promise.all(landingPageObjects.map((object) => client.create(object)));

--- a/src/api/modules/content/content.service.spec.ts
+++ b/src/api/modules/content/content.service.spec.ts
@@ -42,6 +42,14 @@ describe('ContentService', () => {
 			campaigns: [{ _id: 'campaign-1' }, { _id: 'campaign-2' }],
 			cards: [{ _id: 'card-1' }],
 			latestReads: [{ _id: 'story-1' }, { _id: 'story-2' }],
+			highlightedAuthors: [
+				{
+					_key: 'ha-1',
+					_type: 'highlightedAuthor',
+					author: { _type: 'reference', _ref: 'author-1' },
+					additionalTags: [{ _key: 't1', _type: 'reference', _ref: 'tag-1' }],
+				},
+			],
 		};
 
 		beforeEach(() => {
@@ -150,6 +158,7 @@ describe('ContentService', () => {
 				expect(obj.campaigns).toEqual(mockLandingPage.campaigns);
 				expect(obj.cards).toEqual(mockLandingPage.cards);
 				expect(obj.latestReads).toEqual(mockLandingPage.latestReads);
+				expect(obj.highlightedAuthors).toEqual(mockLandingPage.highlightedAuthors);
 				expect(obj).not.toHaveProperty('_id');
 			});
 		});
@@ -216,6 +225,7 @@ describe('ContentService', () => {
 				expect(obj).toHaveProperty('campaigns');
 				expect(obj).toHaveProperty('cards');
 				expect(obj).toHaveProperty('latestReads');
+				expect(obj).toHaveProperty('highlightedAuthors');
 			});
 		});
 

--- a/src/api/sanity/types.ts
+++ b/src/api/sanity/types.ts
@@ -241,64 +241,6 @@ export type SanityImageHotspot = {
 	width: number;
 };
 
-export type NationalityReference = {
-	_ref: string;
-	_type: 'reference';
-	_weak?: boolean;
-	[internalGroqTypeReferenceTo]?: 'nationality';
-};
-
-export type Author = {
-	_id: string;
-	_type: 'author';
-	_createdAt: string;
-	_updatedAt: string;
-	_rev: string;
-	name: string;
-	slug: Slug;
-	image: {
-		asset?: SanityImageAssetReference;
-		media?: unknown;
-		hotspot?: SanityImageHotspot;
-		crop?: SanityImageCrop;
-		_type: 'image';
-	};
-	nationality: NationalityReference;
-	bornOn?: string;
-	bornOnYear?: ComputedNumber;
-	diedOn?: string;
-	diedOnYear?: ComputedNumber;
-	biography: BlockContent;
-	resources?: Array<{
-		title: string;
-		url: string;
-		resourceType: ResourceTypeReference;
-		_type: 'resource';
-		_key: string;
-	}>;
-	tags?: Array<
-		{
-			_key: string;
-		} & TagReference
-	>;
-};
-
-export type Nationality = {
-	_id: string;
-	_type: 'nationality';
-	_createdAt: string;
-	_updatedAt: string;
-	_rev: string;
-	country: string;
-	flag: {
-		asset?: SanityImageAssetReference;
-		media?: unknown;
-		hotspot?: SanityImageHotspot;
-		crop?: SanityImageCrop;
-		_type: 'image';
-	};
-};
-
 export type Storylist = {
 	_id: string;
 	_type: 'storylist';
@@ -448,6 +390,74 @@ export type LandingPage = {
 			_key: string;
 		} & StoryReference
 	>;
+	highlightedAuthors?: Array<{
+		author: AuthorReference;
+		additionalTags?: Array<
+			{
+				_key: string;
+			} & TagReference
+		>;
+		_type: 'highlightedAuthor';
+		_key: string;
+	}>;
+};
+
+export type NationalityReference = {
+	_ref: string;
+	_type: 'reference';
+	_weak?: boolean;
+	[internalGroqTypeReferenceTo]?: 'nationality';
+};
+
+export type Author = {
+	_id: string;
+	_type: 'author';
+	_createdAt: string;
+	_updatedAt: string;
+	_rev: string;
+	name: string;
+	slug: Slug;
+	image: {
+		asset?: SanityImageAssetReference;
+		media?: unknown;
+		hotspot?: SanityImageHotspot;
+		crop?: SanityImageCrop;
+		_type: 'image';
+	};
+	nationality: NationalityReference;
+	bornOn?: string;
+	bornOnYear?: ComputedNumber;
+	diedOn?: string;
+	diedOnYear?: ComputedNumber;
+	biography: BlockContent;
+	resources?: Array<{
+		title: string;
+		url: string;
+		resourceType: ResourceTypeReference;
+		_type: 'resource';
+		_key: string;
+	}>;
+	tags?: Array<
+		{
+			_key: string;
+		} & TagReference
+	>;
+};
+
+export type Nationality = {
+	_id: string;
+	_type: 'nationality';
+	_createdAt: string;
+	_updatedAt: string;
+	_rev: string;
+	country: string;
+	flag: {
+		asset?: SanityImageAssetReference;
+		media?: unknown;
+		hotspot?: SanityImageHotspot;
+		crop?: SanityImageCrop;
+		_type: 'image';
+	};
 };
 
 export type Resource = {
@@ -607,14 +617,14 @@ export type AllSanitySchemaTypes =
 	| ComputedNumber
 	| SanityImageCrop
 	| SanityImageHotspot
-	| NationalityReference
-	| Author
-	| Nationality
 	| Storylist
 	| ContentCampaign
 	| ContentCampaignReference
 	| StorylistReference
 	| LandingPage
+	| NationalityReference
+	| Author
+	| Nationality
 	| Resource
 	| ResourceType
 	| Contributor
@@ -841,7 +851,7 @@ export type LandingPageListQueryResult = Array<{
 
 // Source: ../src/api/_queries/content.query.ts
 // Variable: latestLandingPageReferencesQuery
-// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{    _id,    _type,    'slug': slug.current,    config,    'cards': coalesce(cards[],[]),    'campaigns': coalesce(campaigns[],[]),    'latestReads': coalesce(latestReads,[]),} | order(config desc, _createdAt desc)[0]
+// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{    _id,    _type,    'slug': slug.current,    config,    'cards': coalesce(cards[],[]),    'campaigns': coalesce(campaigns[],[]),    'latestReads': coalesce(latestReads,[]),    'highlightedAuthors': coalesce(highlightedAuthors[],[]),} | order(config desc, _createdAt desc)[0]
 export type LatestLandingPageReferencesQueryResult = {
 	_id: string;
 	_type: 'landingPage';
@@ -868,11 +878,23 @@ export type LatestLandingPageReferencesQueryResult = {
 				} & StoryReference
 		  >
 		| Array<never>;
+	highlightedAuthors:
+		| Array<{
+				author: AuthorReference;
+				additionalTags?: Array<
+					{
+						_key: string;
+					} & TagReference
+				>;
+				_type: 'highlightedAuthor';
+				_key: string;
+		  }>
+		| Array<never>;
 } | null;
 
 // Source: ../src/api/_queries/content.query.ts
 // Variable: landingPageContentQuery
-// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{    _id,    'slug': slug.current,    config,    'cards': coalesce(cards[]->{        _id,        title,        'slug': slug.current,        description,        featuredImage,        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            shortDescription,            description,            icon        }, []),        'storyCoverImages': coalesce(stories[]->coverImage, []),        'count': coalesce(count(stories), 0),				config,				'tabs': [],	      'mediaSources': coalesce(mediaSources[], []),    },[]),    'campaigns': coalesce(campaigns[]->{        _id,        'title': coalesce(title, ''),        'slug': coalesce(slug.current, ''),        'description': coalesce(description, []),        'url': coalesce(url, ''),        'contents': {            'xs': {                'title': coalesce(contents.xs.title, []),                'subtitle': coalesce(contents.xs.subtitle, []),                'image': contents.xs.image            },            'md': {                'title': coalesce(contents.md.title, []),                'subtitle': coalesce(contents.md.subtitle, []),                'image': contents.md.image            }        }    },[]),    'latestReads': coalesce(latestReads[]->{        _id,        'slug': slug.current,        title,        badLanguage,        'body': [],        originalPublication,        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {             _id,            'slug': slug.current,            name,            image,            nationality->,            'biography': [],						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[]),}
+// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{    _id,    'slug': slug.current,    config,    'cards': coalesce(cards[]->{        _id,        title,        'slug': slug.current,        description,        featuredImage,        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            shortDescription,            description,            icon        }, []),        'storyCoverImages': coalesce(stories[]->coverImage, []),        'count': coalesce(count(stories), 0),				config,				'tabs': [],	      'mediaSources': coalesce(mediaSources[], []),    },[]),    'campaigns': coalesce(campaigns[]->{        _id,        'title': coalesce(title, ''),        'slug': coalesce(slug.current, ''),        'description': coalesce(description, []),        'url': coalesce(url, ''),        'contents': {            'xs': {                'title': coalesce(contents.xs.title, []),                'subtitle': coalesce(contents.xs.subtitle, []),                'image': contents.xs.image            },            'md': {                'title': coalesce(contents.md.title, []),                'subtitle': coalesce(contents.md.subtitle, []),                'image': contents.md.image            }        }    },[]),    'latestReads': coalesce(latestReads[]->{        _id,        'slug': slug.current,        title,        badLanguage,        'body': [],        originalPublication,        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {             _id,            'slug': slug.current,            name,            image,            nationality->,            'biography': [],						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[]),    'highlightedAuthors': coalesce(highlightedAuthors[]{        'author': author->{            _id,            'slug': slug.current,            name,            image,            nationality->,            'biography': [],            bornOn,            bornOnYear,            diedOn,            diedOnYear,            'resources': [],            'tags': coalesce(tags[]->{                title,                'slug': slug.current,                shortDescription,                description,                icon            }, [])        },        'additionalTags': coalesce(additionalTags[]->{            title,            'slug': slug.current,            shortDescription,            description,            icon        }, []),        'storyCount': count(*[            _type == 'story'            && author._ref == ^.author._ref            && !(_id in path('drafts.**'))        ])    }, []),}
 export type LandingPageContentQueryResult = {
 	_id: string;
 	slug: string;
@@ -1084,6 +1106,62 @@ export type LandingPageContentQueryResult = {
 					diedOnYear: ComputedNumber | null;
 					resources: Array<never>;
 				};
+		  }>
+		| Array<never>;
+	highlightedAuthors:
+		| Array<{
+				author: {
+					_id: string;
+					slug: string;
+					name: string;
+					image: {
+						asset?: SanityImageAssetReference;
+						media?: unknown;
+						hotspot?: SanityImageHotspot;
+						crop?: SanityImageCrop;
+						_type: 'image';
+					};
+					nationality: {
+						_id: string;
+						_type: 'nationality';
+						_createdAt: string;
+						_updatedAt: string;
+						_rev: string;
+						country: string;
+						flag: {
+							asset?: SanityImageAssetReference;
+							media?: unknown;
+							hotspot?: SanityImageHotspot;
+							crop?: SanityImageCrop;
+							_type: 'image';
+						};
+					};
+					biography: Array<never>;
+					bornOn: string | null;
+					bornOnYear: ComputedNumber | null;
+					diedOn: string | null;
+					diedOnYear: ComputedNumber | null;
+					resources: Array<never>;
+					tags:
+						| Array<{
+								title: string;
+								slug: string;
+								shortDescription: string;
+								description: BlockContent;
+								icon: IconPicker;
+						  }>
+						| Array<never>;
+				};
+				additionalTags:
+					| Array<{
+							title: string;
+							slug: string;
+							shortDescription: string;
+							description: BlockContent;
+							icon: IconPicker;
+					  }>
+					| Array<never>;
+				storyCount: number;
 		  }>
 		| Array<never>;
 } | null;
@@ -2092,8 +2170,8 @@ declare module '@sanity/client' {
 		"\n*[_type == 'author' && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    name,\n    image,\n    nationality->,\n    'biography': [],\n    bornOn,\n \t\tbornOnYear,\n    diedOn,\n    diedOnYear,\n    'resources': []\n}|order(name asc)": AuthorsQueryResult;
 		"\n*[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{\n    _id,\n    name,\n    'mostRead': coalesce(mostRead[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        badLanguage,\n        'body': [],\n        originalPublication,\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            'biography': [],\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[])\n}": RotatingContentQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current in $slugs]{\n\t\t_id,\n\t\t'slug': slug.current,\n\t\tconfig,\n}": LandingPageListQueryResult;
-		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{\n    _id,\n    _type,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[],[]),\n    'campaigns': coalesce(campaigns[],[]),\n    'latestReads': coalesce(latestReads,[]),\n} | order(config desc, _createdAt desc)[0]\n": LatestLandingPageReferencesQueryResult;
-		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{\n    _id,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[]->{\n        _id,\n        title,\n        'slug': slug.current,\n        description,\n        featuredImage,\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            shortDescription,\n            description,\n            icon\n        }, []),\n        'storyCoverImages': coalesce(stories[]->coverImage, []),\n        'count': coalesce(count(stories), 0),\n\t\t\t\tconfig,\n\t\t\t\t'tabs': [],\n\t      'mediaSources': coalesce(mediaSources[], []),\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'description': coalesce(description, []),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'title': coalesce(contents.xs.title, []),\n                'subtitle': coalesce(contents.xs.subtitle, []),\n                'image': contents.xs.image\n            },\n            'md': {\n                'title': coalesce(contents.md.title, []),\n                'subtitle': coalesce(contents.md.subtitle, []),\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'latestReads': coalesce(latestReads[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        badLanguage,\n        'body': [],\n        originalPublication,\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> { \n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            'biography': [],\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[]),\n}": LandingPageContentQueryResult;
+		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{\n    _id,\n    _type,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[],[]),\n    'campaigns': coalesce(campaigns[],[]),\n    'latestReads': coalesce(latestReads,[]),\n    'highlightedAuthors': coalesce(highlightedAuthors[],[]),\n} | order(config desc, _createdAt desc)[0]\n": LatestLandingPageReferencesQueryResult;
+		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{\n    _id,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[]->{\n        _id,\n        title,\n        'slug': slug.current,\n        description,\n        featuredImage,\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            shortDescription,\n            description,\n            icon\n        }, []),\n        'storyCoverImages': coalesce(stories[]->coverImage, []),\n        'count': coalesce(count(stories), 0),\n\t\t\t\tconfig,\n\t\t\t\t'tabs': [],\n\t      'mediaSources': coalesce(mediaSources[], []),\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'description': coalesce(description, []),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'title': coalesce(contents.xs.title, []),\n                'subtitle': coalesce(contents.xs.subtitle, []),\n                'image': contents.xs.image\n            },\n            'md': {\n                'title': coalesce(contents.md.title, []),\n                'subtitle': coalesce(contents.md.subtitle, []),\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'latestReads': coalesce(latestReads[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        badLanguage,\n        'body': [],\n        originalPublication,\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> { \n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            'biography': [],\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[]),\n    'highlightedAuthors': coalesce(highlightedAuthors[]{\n        'author': author->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            'biography': [],\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear,\n            'resources': [],\n            'tags': coalesce(tags[]->{\n                title,\n                'slug': slug.current,\n                shortDescription,\n                description,\n                icon\n            }, [])\n        },\n        'additionalTags': coalesce(additionalTags[]->{\n            title,\n            'slug': slug.current,\n            shortDescription,\n            description,\n            icon\n        }, []),\n        'storyCount': count(*[\n            _type == 'story'\n            && author._ref == ^.author._ref\n            && !(_id in path('drafts.**'))\n        ])\n    }, []),\n}": LandingPageContentQueryResult;
 		"\n*[_type == 'contributor' && !(_id in path('drafts.**'))]\n{\n\tname,\n\t'slug': slug.current,\n\tarea,\n\tlink {\n\t\thandle,\n\t\turl\n\t},\n\tnotes\n}|order(name asc)\n": AllContributorsQueryResult;
 		'{\n\t"stories": *[_type == "story" && !(_id in path(\'drafts.**\'))]{ "slug": slug.current, "lastmod": _updatedAt },\n\t"authors": *[_type == "author" && !(_id in path(\'drafts.**\'))]{ "slug": slug.current, "lastmod": _updatedAt },\n\t"storylists": *[_type == "storylist" && !(_id in path(\'drafts.**\'))]{ "slug": slug.current, "lastmod": _updatedAt }\n}': SitemapSlugsQueryResult;
 		"\n*[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))][$start...$end]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'badLanguage': coalesce(badLanguage, false),\n    'body': coalesce(body[0...3], []),\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription,\n            description,\n            icon\n        }\n    }, []),\n}|order(title asc)": StoriesByAuthorSlugQueryResult;

--- a/src/app/models/landing-page-content.model.ts
+++ b/src/app/models/landing-page-content.model.ts
@@ -1,6 +1,14 @@
-import { StorylistTeaser } from '@models/storylist.model';
-import { ContentCampaign } from '@models/content-campaign.model';
-import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
+import type { AuthorTeaser } from '@models/author.model';
+import type { ContentCampaign } from '@models/content-campaign.model';
+import type { StorylistTeaser } from '@models/storylist.model';
+import type { StoryNavigationTeaserWithAuthor } from '@models/story.model';
+import type { Tag } from '@models/tag.model';
+
+export interface HighlightedAuthor {
+	author: AuthorTeaser;
+	tags: Tag[];
+	storyCount: number;
+}
 
 export interface LandingPageContent {
 	_id: string;
@@ -9,6 +17,7 @@ export interface LandingPageContent {
 	campaigns: ContentCampaign[];
 	mostRead: StoryNavigationTeaserWithAuthor[];
 	latestReads: StoryNavigationTeaserWithAuthor[];
+	highlightedAuthors: HighlightedAuthor[];
 }
 
 export interface RotatingContent {

--- a/src/app/providers/content.mock.ts
+++ b/src/app/providers/content.mock.ts
@@ -15,6 +15,7 @@ export class InMemoryContentApi implements ContentApi {
 			campaigns: [],
 			mostRead: [],
 			latestReads: [],
+			highlightedAuthors: [],
 		};
 		return of(landingPageContent);
 	}


### PR DESCRIPTION
## Descripción

- Agrega el campo CMS `highlightedAuthors[]` (máx. 6) como objetos `{ author, additionalTags }` en `landingPage`.
- Proyecta el campo en GROQ de lectura (`landingPageContentQuery` con tags + `storyCount`) y en el clonado semanal (`latestLandingPageReferencesQuery`).
- Expone el contrato de dominio `HighlightedAuthor` y el mapper ACL `mapHighlightedAuthors` (tags = additionalTags primero + author.tags).
- Tests del mapper (concatenación, vacíos, teaser) y del clone semanal.

Closes #1570.

Parte de #1568.

## Plan de pruebas

- [x] `pnpm test` (functions.spec + content.service.spec)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] Poblar `highlightedAuthors` en Sanity Studio y verificar `GET /api/content/landing-page`
- [ ] Verificar que el cron/clone preserve el campo

## Notas

- Draft a la espera de aprobación / review.
- Coordinar merge con #1571 (PR #1766): preferible mergear este PR primero (contrato real); #1571 puede quitar el fallback de mock en development.