### PR TITLE
[#1572] - Página de listado de autores /authors/

### DIFF
--- a/src/app/pages/authors/authors.component.spec.ts
+++ b/src/app/pages/authors/authors.component.spec.ts
@@ -1,22 +1,75 @@
-import { render } from '@testing-library/angular';
-import { restoreAllMocks, spyOn } from '@test-utils';
+import { DeferBlockState } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { render, screen } from '@testing-library/angular';
+import { of } from 'rxjs';
 
+import { restoreAllMocks, spyOn } from '@test-utils';
 import AuthorsComponent from './authors.component';
-import { provideAuthorApiMock } from '../../providers/author.mock';
+import { InMemoryAuthorApi, provideAuthorApiMock } from '../../providers/author.mock';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
+import { authorTeaserMock } from '@mocks/author.mock';
+import { AppRoutes } from '../../app.routes';
 
 describe('AuthorsComponent', () => {
 	afterEach(() => restoreAllMocks());
+
+	const defaultProviders = [provideRouter([]), provideAuthorApiMock()];
 
 	it('should set the canonical URL for /authors via buildCanonicalUrl', async () => {
 		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
 
 		await render(AuthorsComponent, {
-			providers: [provideRouter([]), provideAuthorApiMock()],
+			providers: defaultProviders,
 		});
 
-		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl('authors'));
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(AppRoutes.Authors));
+	});
+
+	it('should display the page title and subtitle', async () => {
+		await render(AuthorsComponent, {
+			providers: defaultProviders,
+		});
+
+		expect(screen.getByRole('heading', { name: 'Autores/as' })).toBeInTheDocument();
+		expect(screen.getByText('Explorá el catálogo completo de autores y autoras de La Cuentoneta')).toBeInTheDocument();
+	});
+
+	it('should render author teasers when data is available', async () => {
+		const { fixture } = await render(AuthorsComponent, {
+			providers: defaultProviders,
+		});
+
+		const deferBlockFixture = (await fixture.getDeferBlocks())[0];
+		await deferBlockFixture.render(DeferBlockState.Complete);
+
+		expect(screen.getByTestId('author-teaser')).toBeInTheDocument();
+		expect(screen.getByText(authorTeaserMock.name)).toBeInTheDocument();
+	});
+
+	it('should render skeletons in loading state', async () => {
+		const { fixture } = await render(AuthorsComponent, {
+			providers: defaultProviders,
+		});
+
+		const deferBlockFixture = (await fixture.getDeferBlocks())[0];
+		await deferBlockFixture.render(DeferBlockState.Loading);
+
+		expect(screen.getAllByTestId('skeleton')).toHaveLength(6);
+	});
+
+	it('should show the header without teasers when the list is empty', async () => {
+		class EmptyAuthorApi extends InMemoryAuthorApi {
+			public override getAll() {
+				return of([]);
+			}
+		}
+
+		await render(AuthorsComponent, {
+			providers: [provideRouter([]), provideAuthorApiMock(new EmptyAuthorApi())],
+		});
+
+		expect(screen.getByRole('heading', { name: 'Autores/as' })).toBeInTheDocument();
+		expect(screen.queryByTestId('author-teaser')).not.toBeInTheDocument();
 	});
 });

--- a/src/app/pages/authors/authors.component.ts
+++ b/src/app/pages/authors/authors.component.ts
@@ -1,46 +1,65 @@
-import { Component, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 
 import { AuthorApi } from '../../providers/author-api.interface';
 import { ssrBlockingRxResource } from '@utils/ssr-resource';
-import { RouterLink } from '@angular/router';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
+import { AppRoutes } from '../../app.routes';
+import { AuthorTeaserV3Component } from '@components/author-teaser-v3/author-teaser-v3.component';
+import { AuthorTeaserV3SkeletonComponent } from '@components/author-teaser-v3/author-teaser-v3-skeleton.component';
 
 @Component({
-	imports: [RouterLink],
+	selector: 'cuentoneta-authors',
+	imports: [AuthorTeaserV3Component, AuthorTeaserV3SkeletonComponent],
 	hostDirectives: [HeadMetadataDirective],
-	template: `<main class="content horizontal-layout-spacing vertical-layout-spacing">
-		<ul class="list-inside list-disc">
-			@for (author of authors(); track author.slug) {
-				<li>
-					<span>
-						<a [routerLink]="['/', 'author', author.slug]" class="underline">{{ author.name }}</a>
-					</span>
-				</li>
-			}
-		</ul>
-	</main>`,
-	styles: ``,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<main class="content horizontal-layout-spacing vertical-layout-spacing">
+			<section class="flex flex-col gap-8">
+				<header class="flex flex-col gap-1">
+					<h1 class="font-inter text-2xl font-bold text-neutral-900">Autores/as</h1>
+					<p class="font-inter text-sm font-medium text-neutral-600">
+						Explorá el catálogo completo de autores y autoras de La Cuentoneta
+					</p>
+				</header>
+
+				<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+					@defer (when authors().length > 0) {
+						@for (author of authors(); track author._id) {
+							<cuentoneta-author-teaser-v3 [author]="author" data-testid="author-teaser" />
+						}
+					} @loading (minimum 500ms) {
+						@for (_ of skeletons; track $index) {
+							<cuentoneta-author-teaser-v3-skeleton data-testid="skeleton" />
+						}
+					}
+				</section>
+			</section>
+		</main>
+	`,
 })
 export default class AuthorsComponent {
-	private authorService = inject(AuthorApi);
-	private metaTagsDirective = inject(HeadMetadataDirective);
+	private readonly authorService = inject(AuthorApi);
+	private readonly metaTagsDirective = inject(HeadMetadataDirective);
 
-	private authorsResource = ssrBlockingRxResource({
+	private readonly authorsResource = ssrBlockingRxResource({
 		stream: () => this.authorService.getAll(),
 		defaultValue: [],
 	});
 
 	protected readonly authors = computed(() => this.authorsResource.value());
+	protected readonly skeletons = Array.from({ length: 6 });
 
 	constructor() {
 		this.updateMetaTags();
 	}
 
 	private updateMetaTags() {
-		this.metaTagsDirective.setTitle('Índice de Autores');
-		this.metaTagsDirective.setDefaultDescription();
-		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl('authors'));
+		this.metaTagsDirective.setTitle('Autores/as');
+		this.metaTagsDirective.setDescription(
+			'Explorá el catálogo completo de autores y autoras publicados en La Cuentoneta',
+		);
+		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl(AppRoutes.Authors));
 		this.metaTagsDirective.setRobots('noindex, follow');
 	}
 }


### PR DESCRIPTION
## Descripción

- Rediseña `/authors` como catálogo v3: cabecera + grilla responsive de `AuthorTeaserV3` + skeleton/`@defer`.
- Mantiene `ssrBlockingRxResource` + `AuthorApi.getAll()` (A–Z) y prerender SSR.
- Mejora meta (título, description, canonical) con `noindex, follow` (mismo criterio que el índice de historias).
- Amplía tests ATL (header, teasers, loading, vacío, canonical).

Closes #1572.

Parte de #1568.

## Orden de merge (epic #1568)

```
#1569 (tags) ✅
    ↓
#1570 contrato highlightedAuthors  →  PR #1767 (draft)
    ↓
#1571 HighlightedAuthors en home   →  PR #1766
    ↓
#1572 catálogo /authors            →  este PR (draft)
```

1. **#1570** primero — contrato API real.
2. **#1571** después — sección home; deja `showViewAll = false` hasta que exista este destino.
3. **#1572** (este) — habilita el destino de “Ver todo”.
4. **Follow-up de 1 línea** tras merge de #1571+#1572: `showViewAll = true` en `HighlightedAuthors` (no incluido aquí porque el componente aún no está en `develop`).

Este PR **no depende** de #1570/#1571 para el catálogo en sí; el orden solo importa para el botón “Ver todo” de la home.

## Plan de pruebas

- [x] `pnpm test` (authors.component.spec)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] Verificar `/authors` en local (grilla + SSR)
- [ ] Tras merge de #1571: habilitar “Ver todo” y verificar navegación home → `/authors`