### PR TITLE
[HF] - Correcciones en lineado de `CollectionTeaser`

### DIFF
--- a/src/app/components/collection-teaser/collection-teaser.ts
+++ b/src/app/components/collection-teaser/collection-teaser.ts
@@ -32,7 +32,9 @@ import { CoverImageComponent } from '../cover-image/cover-image.component';
 						}
 					</section>
 					<section class="flex flex-1 flex-col gap-1 overflow-hidden">
-						<header class="hover:text-interactive-500 line-clamp-2 cursor-pointer font-inter text-lg font-bold">
+						<header
+							class="hover:text-interactive-500 line-clamp-2 cursor-pointer font-inter text-lg leading-6 font-bold"
+						>
 							{{ storylist.title }}
 						</header>
 						<cuentoneta-portable-text-parser

--- a/src/app/components/collection-teaser/collection-teaser.ts
+++ b/src/app/components/collection-teaser/collection-teaser.ts
@@ -32,13 +32,11 @@ import { CoverImageComponent } from '../cover-image/cover-image.component';
 						}
 					</section>
 					<section class="flex flex-1 flex-col gap-1 overflow-hidden">
-						<header
-							class="hover:text-interactive-500 line-clamp-2 cursor-pointer font-inter text-lg font-bold sm:line-clamp-1"
-						>
+						<header class="hover:text-interactive-500 line-clamp-2 cursor-pointer font-inter text-lg font-bold">
 							{{ storylist.title }}
 						</header>
 						<cuentoneta-portable-text-parser
-							[classes]="'line-clamp-4 sm:line-clamp-3'"
+							[classes]="'line-clamp-4'"
 							[paragraphs]="[storylist.description[0]]"
 							class="font-inter text-sm text-ellipsis text-neutral-700"
 						/>


### PR DESCRIPTION
## Resumen
- Ajustado título de `CollectionTeaser` para ocupar dos líneas antes de ser truncado en todos los viewports.
- Ajustado cuerpo de `CollectionTeaser` para ocupar cuatro líneas antes de ser truncado en todos los viewports.
- Ajustado el `line-height` del título para, conservando el tamaño de fuente `text-lg`, usar un `line-height` de `24px/1.5rem` en todos los viewports.