### PR TITLE
[HF] - Render SSR de la ficha de autor (@if plano en vez de @defer)

### DIFF
--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -51,8 +51,6 @@ import { InitialsPipe } from '../../pipes/initials.pipe';
 	template: `
 		<main class="content vertical-layout-spacing horizontal-layout-spacing">
 			<article class="grid grid-cols-1 gap-8">
-				<!-- Contenido renderizado con @if plano (no @defer): ssrBlockingRxResource ya resuelve el dato en SSR,
-					 pero un @defer serviría el placeholder al crawler → ficha sin H1/biografía/enlaces internos (thin content). -->
 				@if (author(); as author) {
 					<section class="flex items-center gap-4">
 						<img

--- a/src/app/pages/author/author.component.ts
+++ b/src/app/pages/author/author.component.ts
@@ -51,37 +51,37 @@ import { InitialsPipe } from '../../pipes/initials.pipe';
 	template: `
 		<main class="content vertical-layout-spacing horizontal-layout-spacing">
 			<article class="grid grid-cols-1 gap-8">
-				@defer (when authorResource.hasValue()) {
-					@if (author(); as author) {
-						<section class="flex items-center gap-4">
-							<img
-								[ngSrc]="authorImageUrl()"
-								[alt]="'Retrato de ' + author.name"
-								class="h-[88px] rounded-xl"
-								width="88"
-								height="88"
-							/>
-							<div class="flex flex-col gap-2">
-								<h1 class="font-inter text-xl font-bold">
-									<span class="hidden sm:inline">{{ author.name }}</span>
-									<span class="sm:hidden">{{ author.name | initials }}</span>
-								</h1>
-								<span class="flex items-center gap-2 font-inter text-sm font-medium text-neutral-600">
-									<img [ngSrc]="authorFlagUrl()" width="20" height="15" class="h-[15px] w-5 rounded" alt="" />
-									{{ author.nationality.country }}
-								</span>
+				<!-- Contenido renderizado con @if plano (no @defer): ssrBlockingRxResource ya resuelve el dato en SSR,
+					 pero un @defer serviría el placeholder al crawler → ficha sin H1/biografía/enlaces internos (thin content). -->
+				@if (author(); as author) {
+					<section class="flex items-center gap-4">
+						<img
+							[ngSrc]="authorImageUrl()"
+							[alt]="'Retrato de ' + author.name"
+							class="h-[88px] rounded-xl"
+							width="88"
+							height="88"
+						/>
+						<div class="flex flex-col gap-2">
+							<h1 class="font-inter text-xl font-bold">
+								<span class="hidden sm:inline">{{ author.name }}</span>
+								<span class="sm:hidden">{{ author.name | initials }}</span>
+							</h1>
+							<span class="flex items-center gap-2 font-inter text-sm font-medium text-neutral-600">
+								<img [ngSrc]="authorFlagUrl()" width="20" height="15" class="h-[15px] w-5 rounded" alt="" />
+								{{ author.nationality.country }}
+							</span>
 
-								<div class="flex">
-									<div class="rounded bg-neutral-200 px-2 py-0.5 hover:cursor-default">
-										<span class="flex items-center gap-1 font-inter text-xs font-semibold"
-											>{{ stories().length }} historias</span
-										>
-									</div>
+							<div class="flex">
+								<div class="rounded bg-neutral-200 px-2 py-0.5 hover:cursor-default">
+									<span class="flex items-center gap-1 font-inter text-xs font-semibold"
+										>{{ stories().length }} historias</span
+									>
 								</div>
 							</div>
-						</section>
-					}
-				} @placeholder (minimum 500ms) {
+						</div>
+					</section>
+				} @else {
 					<section class="flex items-center gap-4">
 						<cuentoneta-skeleton appearance="square" class="h-[88px] w-[88px] rounded-xl bg-neutral-300" />
 						<div class="flex flex-col gap-2">
@@ -99,7 +99,13 @@ import { InitialsPipe } from '../../pipes/initials.pipe';
 					<cuentoneta-tabs [initialTab]="activeTab()" class="w-full">
 						<cuentoneta-tab title="Textos" name="stories">
 							<div>
-								@defer (when storiesResource.hasValue()) {
+								@if (storiesResource.isLoading()) {
+									<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-8">
+										@for (_ of [].constructor(12); track $index) {
+											<cuentoneta-story-card-teaser-skeleton [order]="$index + 1" data-testid="skeleton" />
+										}
+									</section>
+								} @else {
 									<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-8">
 										@for (story of stories(); track $index) {
 											<cuentoneta-story-card-teaser
@@ -112,41 +118,27 @@ import { InitialsPipe } from '../../pipes/initials.pipe';
 											/>
 										}
 									</section>
-								} @loading (minimum 500ms) {
-									<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-8">
-										@for (_ of [].constructor(12); track $index) {
-											<cuentoneta-story-card-teaser-skeleton [order]="$index + 1" data-testid="skeleton" />
-										}
-									</section>
 								}
 							</div>
 						</cuentoneta-tab>
 						<cuentoneta-tab title="Biografía" name="about">
 							<div>
-								@defer (when authorResource.hasValue()) {
-									<div class="flex flex-col gap-4">
-										<cuentoneta-portable-text-parser
-											[paragraphs]="author.biography"
-											[classes]="'source-serif-xl font-normal leading-8'"
-											class="flex flex-col gap-4"
-										/>
-										@if (author.resources && author.resources.length > 0) {
-											<hr class="text-neutral-500" />
-											<div class="font-inter font-semibold text-neutral-600">Recursos web sobre el autor:</div>
-											<div class="flex justify-start gap-4">
-												@for (resource of author.resources; track $index) {
-													<cuentoneta-resource [resource]="resource" />
-												}
-											</div>
-										}
-									</div>
-								} @loading (minimum 500ms) {
-									<div class="flex flex-col gap-2">
-										@for (line of biographySkeletonLines; track $index) {
-											<cuentoneta-skeleton appearance="line" class="h-[25px] w-full bg-neutral-300" />
-										}
-									</div>
-								}
+								<div class="flex flex-col gap-4">
+									<cuentoneta-portable-text-parser
+										[paragraphs]="author.biography"
+										[classes]="'source-serif-xl font-normal leading-8'"
+										class="flex flex-col gap-4"
+									/>
+									@if (author.resources && author.resources.length > 0) {
+										<hr class="text-neutral-500" />
+										<div class="font-inter font-semibold text-neutral-600">Recursos web sobre el autor:</div>
+										<div class="flex justify-start gap-4">
+											@for (resource of author.resources; track $index) {
+												<cuentoneta-resource [resource]="resource" />
+											}
+										</div>
+									}
+								</div>
 							</div>
 						</cuentoneta-tab>
 					</cuentoneta-tabs>
@@ -161,9 +153,6 @@ export default class AuthorComponent implements AuthorHost {
 	// Route inputs
 	public readonly slug = input.required<string>();
 	public readonly activeTab = input<'stories' | 'about'>('stories');
-
-	// Cantidad de líneas del skeleton de la biografía mientras carga
-	protected readonly biographySkeletonLines = Array.from({ length: 10 });
 
 	// Providers
 	private authorService = inject(AuthorApi);


### PR DESCRIPTION
## Problema

Autores no aparecían indexados en Google (caso reportado: **Velmiro Ayala Gauna**). El diagnóstico, verificado con `curl` contra producción y build SSR local:

- `/author/:slug` estaba en el sitemap y servía SSR con `<head>` correcto (title/canonical/robots/JSON-LD), **pero el `<body>` era todo skeleton**. El template envolvía el contenido primario en bloques `@defer (when …Resource.hasValue())`, y como la app usa `provideClientHydration()` **sin** `withIncrementalHydration()`, un `@defer` renderiza su placeholder en SSR.
- Resultado que veía el crawler: **sin `<h1>`, sin biografía, 0 enlaces internos a `/story/`** → thin content → no indexado. El `ssrBlockingRxResource` (#1704) ya resolvía el dato en SSR, pero el `@defer` del template lo ignoraba y servía el skeleton igual.

## Solución

Reemplazar los `@defer` de `author.component.ts` por `@if` planos (mismo patrón que `/story`, que sí indexa): el dato ya está resuelto en SSR gracias a `ssrBlockingRxResource`, así que el `@if` es `true` al serializar y renderiza el contenido completo; el skeleton queda como `@else` para la carga progresiva en el cliente. Se quitó `biographySkeletonLines` (sin uso).

## Verificación

Build SSR local + `curl` sobre `/author/velmiro-ayala-gauna`:

| | Antes | Después |
|---|---|---|
| `<h1>` | ausente | ✅ presente |
| Enlaces internos `/story/` | **0** | ✅ **8** |
| Skeletons en HTML SSR | 10 | ✅ 0 |
| Conteo "8 historias" | ausente | ✅ presente |
| JSON-LD (org/website/profile-page/breadcrumb) | ✅ | ✅ |

Gates verdes: `typecheck`, `lint`, `build` (valida plantillas vía ngtsc) y `test`.

## Alcance / follow-ups

Este hotfix ataca la causa inmediata. Quedan capturados aparte:
- #1771 — completar el SSR de la ficha de autor: evaluar `withIncrementalHydration()` para recuperar el beneficio del `@defer`, y resolver la **biografía tab-gated** (el `Tabs` solo renderiza el tab activo → la bio no llega al crawler). También auditar storylist/home, que comparten el patrón.
- #1772 — suite de verificación del HTML SSR crudo (curl) para blindar el indexado contra este tipo de regresión.

Relacionado con el epic SEO #1525 y el fix del deopt a CSR #1730.