### PR TITLE
[#1771] - Tabs renderiza todos los paneles para exponer la biografía del autor al SSR

### DIFF
--- a/src/app/components/tabs/tabs.component.spec.ts
+++ b/src/app/components/tabs/tabs.component.spec.ts
@@ -107,12 +107,13 @@ describe('TabsComponent', () => {
 		await render(TestHostComponent);
 
 		const buttons = screen.getAllByRole('tab');
-		const tabPanel = screen.getByRole('tabpanel');
 
-		expect(tabPanel).toHaveTextContent('Content 1');
+		expect(screen.getByRole('tabpanel')).toHaveTextContent('Content 1');
 
 		await user.click(buttons[2]);
 
-		expect(tabPanel).toHaveTextContent('Content 3');
+		// Cada tab tiene su propio panel (el inactivo queda [hidden], fuera del árbol de accesibilidad),
+		// por lo que se re-consulta el tabpanel visible en vez de reutilizar la referencia anterior.
+		expect(screen.getByRole('tabpanel')).toHaveTextContent('Content 3');
 	});
 });

--- a/src/app/components/tabs/tabs.component.ts
+++ b/src/app/components/tabs/tabs.component.ts
@@ -23,7 +23,7 @@ import { NgTemplateOutlet } from '@angular/common';
 				</button>
 			}
 		</div>
-		<!-- Todos los paneles se renderizan en el DOM (el inactivo se oculta con [hidden]): así el contenido
+		<!-- Fix temporal pre-Design System V3: Todos los paneles se renderizan en el DOM (el inactivo se oculta con [hidden]): así el contenido
 			 del tab no activo — p. ej. la biografía del autor — llega al HTML SSR y es indexable por buscadores. -->
 		@for (tab of tabs(); track $index) {
 			<div

--- a/src/app/components/tabs/tabs.component.ts
+++ b/src/app/components/tabs/tabs.component.ts
@@ -12,6 +12,7 @@ import { NgTemplateOutlet } from '@angular/common';
 				<button
 					(click)="setActive(tab)"
 					[attr.aria-selected]="tabTitle === activeTabTitle"
+					[attr.aria-controls]="'tabpanel-' + tab.name()"
 					[class]="
 						tabTitle === activeTabTitle ? 'border-brand-400 text-brand-500' : 'border-neutral-200 text-neutral-600'
 					"
@@ -22,9 +23,16 @@ import { NgTemplateOutlet } from '@angular/common';
 				</button>
 			}
 		</div>
-		@if (active()) {
-			<div [attr.aria-labelledby]="active().title()" role="tabpanel">
-				<ng-container [ngTemplateOutlet]="active().content()" />
+		<!-- Todos los paneles se renderizan en el DOM (el inactivo se oculta con [hidden]): así el contenido
+			 del tab no activo — p. ej. la biografía del autor — llega al HTML SSR y es indexable por buscadores. -->
+		@for (tab of tabs(); track $index) {
+			<div
+				[id]="'tabpanel-' + tab.name()"
+				[attr.aria-labelledby]="tab.title()"
+				[hidden]="tab !== active()"
+				role="tabpanel"
+			>
+				<ng-container [ngTemplateOutlet]="tab.content()" />
 			</div>
 		}`,
 	host: {


### PR DESCRIPTION
> Parte de #1771. **Stackeado sobre #1773** (hotfix del `@if`), del que depende: sin ese fix la bio seguiría tras un `@defer`. La base se re-apuntará a `develop` cuando #1773 mergee.

## Problema

El componente `Tabs` renderizaba **solo el panel activo** (`ngTemplateOutlet` de `active().content()`); el contenido del tab no activo vive en un `<ng-template>` y **nunca llega al HTML SSR**. En `/author/:slug` el tab activo por defecto es "Textos" (cuentos), así que la **biografía** — la prosa más rica para indexar y para respaldar el `Person`/`ProfilePage` (JSON-LD/AEO) — quedaba fuera de la vista del crawler.

## Solución

`Tabs` ahora **renderiza todos los paneles** y oculta el inactivo con `[hidden]` (`display:none` por UA + excluido del árbol de accesibilidad). El contenido no activo queda en el DOM/SSR e indexable; el usuario sigue viendo un solo panel. Se agregan `id` + `aria-controls` por panel (ahora hay varios en el DOM).

Aplica a los dos usos de `Tabs` (autor y storylist): en ambos, el contenido de los tabs no activos pasa a ser indexable.

## Verificación

Build SSR local + `curl` sobre `/author/velmiro-ayala-gauna`:

| Señal en SSR | Antes (#1773) | Ahora |
|---|---|---|
| Biografía (párrafos + "Recursos web sobre el autor") | ❌ ausente (tab inactivo) | ✅ presente (panel `[hidden]` pero en el HTML) |
| `role="tabpanel"` en el DOM | 1 | 2 (cuentos + biografía) |
| Enlaces internos `/story/` | 8 | 8 |
| `<h1>` / skeletons | ✅ / 0 | ✅ / 0 |

Gates verdes: `typecheck`, `lint`, `build`, `test` (spec de `Tabs` ajustado: re-consulta el tabpanel visible tras el click, porque cada tab tiene su propio panel).

## Nota de trade-off

La bio queda en el SSR pero **`[hidden]`** (Google la indexa, aunque pondera algo menos el contenido oculto por CSS) — el trade-off elegido para conservar la UX de tabs. Si más adelante se quiere máxima prominencia, se evaluaría sacar la bio de los tabs (alternativa registrada en #1771).