### PR TITLE
[#1771] - Biografía del autor como description del Person (JSON-LD)

### DIFF
--- a/src/app/pages/author/author.schema.spec.ts
+++ b/src/app/pages/author/author.schema.spec.ts
@@ -4,7 +4,6 @@ import type { IsoDateTime } from '@utils/date.utils';
 
 import { buildAuthorBreadcrumb, buildAuthorProfilePageSchema } from './author.schema';
 
-// Construye un bloque de biografía (PortableText) con un span por texto; sin textos deja children vacío.
 function bioBlock(...texts: string[]): TextBlockContent {
 	return {
 		_type: 'block',
@@ -55,27 +54,31 @@ describe('buildAuthorProfilePageSchema', () => {
 
 		const mainEntity = buildAuthorProfilePageSchema(author, websiteUrl)['mainEntity'] as Record<string, unknown>;
 
-		expect(mainEntity['description']).toBe('Primera oración. Segunda oración.');
+		expect(mainEntity['description'], 'une el texto de cada bloque separándolos con un espacio').toBe(
+			'Primera oración. Segunda oración.',
+		);
 	});
 
 	it('should truncate a long biography description at a word boundary with an ellipsis', () => {
-		// 295 'a' + espacio + palabra que cruza el tope de 300: el corte cae en el espacio (índice 295)
-		// y descarta la palabra parcial, dejando los 295 caracteres previos + elipsis.
-		const author = { ...authorMock, biography: [bioBlock(`${'a'.repeat(295)} palabraDescartada`)] };
+		const fitsBeforeLimit = 'a'.repeat(295);
+		const author = { ...authorMock, biography: [bioBlock(`${fitsBeforeLimit} palabraDescartada`)] };
 
 		const mainEntity = buildAuthorProfilePageSchema(author, websiteUrl)['mainEntity'] as Record<string, unknown>;
 
-		expect(mainEntity['description']).toBe(`${'a'.repeat(295)}…`);
+		expect(mainEntity['description'], 'corta en el espacio previo al tope de 300 y descarta la palabra parcial').toBe(
+			`${fitsBeforeLimit}…`,
+		);
 	});
 
 	it('should hard-cut at the max length when there is no space within the limit', () => {
-		// Una sola "palabra" de 350 caracteres sin espacios: no hay límite de palabra donde cortar,
-		// así que cae al tope duro de 300 caracteres + elipsis.
-		const author = { ...authorMock, biography: [bioBlock('b'.repeat(350))] };
+		const singleLongWord = 'b'.repeat(350);
+		const author = { ...authorMock, biography: [bioBlock(singleLongWord)] };
 
 		const mainEntity = buildAuthorProfilePageSchema(author, websiteUrl)['mainEntity'] as Record<string, unknown>;
 
-		expect(mainEntity['description']).toBe(`${'b'.repeat(300)}…`);
+		expect(mainEntity['description'], 'sin límite de palabra, cae al tope duro de 300 caracteres + elipsis').toBe(
+			`${'b'.repeat(300)}…`,
+		);
 	});
 
 	it('should collapse a block with empty children when flattening the biography', () => {
@@ -83,7 +86,9 @@ describe('buildAuthorProfilePageSchema', () => {
 
 		const mainEntity = buildAuthorProfilePageSchema(author, websiteUrl)['mainEntity'] as Record<string, unknown>;
 
-		expect(mainEntity['description']).toBe('Biografía sin bloque vacío previo.');
+		expect(mainEntity['description'], 'el bloque vacío no agrega espacios ni artefactos al aplanar').toBe(
+			'Biografía sin bloque vacío previo.',
+		);
 	});
 
 	it('should omit the description in mainEntity when the author has no biography', () => {

--- a/src/app/pages/author/author.schema.spec.ts
+++ b/src/app/pages/author/author.schema.spec.ts
@@ -19,10 +19,48 @@ describe('buildAuthorProfilePageSchema', () => {
 				url: 'https://www.cuentoneta.ar/author/francois-onoff',
 				image: 'assets/img/mocks/author/francois-onoff.png',
 				sameAs: ['https://es.wikipedia.org/wiki/Francois_Onoff'],
+				description: expect.any(String),
 				birthDate: '1948-01-01',
 				deathDate: '1994-12-31',
 			},
 		});
+	});
+
+	it('should flatten the biography PortableText into the Person description', () => {
+		const author = {
+			...authorMock,
+			biography: [
+				{
+					...authorMock.biography[0],
+					children: [{ ...authorMock.biography[0].children[0], text: 'Primera oración.' }],
+				},
+				{
+					...authorMock.biography[1],
+					children: [{ ...authorMock.biography[1].children[0], text: 'Segunda oración.' }],
+				},
+			],
+		};
+
+		const mainEntity = buildAuthorProfilePageSchema(author, websiteUrl)['mainEntity'] as Record<string, unknown>;
+
+		expect(mainEntity['description']).toBe('Primera oración. Segunda oración.');
+	});
+
+	it('should truncate a long biography description at a word boundary with an ellipsis', () => {
+		const mainEntity = buildAuthorProfilePageSchema(authorMock, websiteUrl)['mainEntity'] as Record<string, unknown>;
+		const description = mainEntity['description'] as string;
+
+		expect(description.startsWith('François Onoff (Chateauroux, 1948 - París, 1994)')).toBe(true);
+		expect(description.endsWith('…')).toBe(true);
+		expect(description.length).toBeLessThanOrEqual(301);
+	});
+
+	it('should omit the description in mainEntity when the author has no biography', () => {
+		const author = { ...authorMock, biography: [] };
+
+		const mainEntity = buildAuthorProfilePageSchema(author, websiteUrl)['mainEntity'] as Record<string, unknown>;
+
+		expect(mainEntity['description']).toBeUndefined();
 	});
 
 	it('should forward the ISO datetime dates verbatim to dateCreated/dateModified', () => {

--- a/src/app/pages/author/author.schema.spec.ts
+++ b/src/app/pages/author/author.schema.spec.ts
@@ -1,7 +1,19 @@
 import { authorMock } from '@mocks/author.mock';
+import type { TextBlockContent } from '@models/block-content.model';
 import type { IsoDateTime } from '@utils/date.utils';
 
 import { buildAuthorBreadcrumb, buildAuthorProfilePageSchema } from './author.schema';
+
+// Construye un bloque de biografía (PortableText) con un span por texto; sin textos deja children vacío.
+function bioBlock(...texts: string[]): TextBlockContent {
+	return {
+		_type: 'block',
+		_key: `block-${texts.length}`,
+		style: 'normal',
+		markDefs: [],
+		children: texts.map((text, index) => ({ _type: 'span', _key: `span-${index}`, text, marks: [] })),
+	};
+}
 
 describe('buildAuthorProfilePageSchema', () => {
 	const websiteUrl = 'https://www.cuentoneta.ar/';
@@ -47,12 +59,31 @@ describe('buildAuthorProfilePageSchema', () => {
 	});
 
 	it('should truncate a long biography description at a word boundary with an ellipsis', () => {
-		const mainEntity = buildAuthorProfilePageSchema(authorMock, websiteUrl)['mainEntity'] as Record<string, unknown>;
-		const description = mainEntity['description'] as string;
+		// 295 'a' + espacio + palabra que cruza el tope de 300: el corte cae en el espacio (índice 295)
+		// y descarta la palabra parcial, dejando los 295 caracteres previos + elipsis.
+		const author = { ...authorMock, biography: [bioBlock(`${'a'.repeat(295)} palabraDescartada`)] };
 
-		expect(description.startsWith('François Onoff (Chateauroux, 1948 - París, 1994)')).toBe(true);
-		expect(description.endsWith('…')).toBe(true);
-		expect(description.length).toBeLessThanOrEqual(301);
+		const mainEntity = buildAuthorProfilePageSchema(author, websiteUrl)['mainEntity'] as Record<string, unknown>;
+
+		expect(mainEntity['description']).toBe(`${'a'.repeat(295)}…`);
+	});
+
+	it('should hard-cut at the max length when there is no space within the limit', () => {
+		// Una sola "palabra" de 350 caracteres sin espacios: no hay límite de palabra donde cortar,
+		// así que cae al tope duro de 300 caracteres + elipsis.
+		const author = { ...authorMock, biography: [bioBlock('b'.repeat(350))] };
+
+		const mainEntity = buildAuthorProfilePageSchema(author, websiteUrl)['mainEntity'] as Record<string, unknown>;
+
+		expect(mainEntity['description']).toBe(`${'b'.repeat(300)}…`);
+	});
+
+	it('should collapse a block with empty children when flattening the biography', () => {
+		const author = { ...authorMock, biography: [bioBlock(), bioBlock('Biografía sin bloque vacío previo.')] };
+
+		const mainEntity = buildAuthorProfilePageSchema(author, websiteUrl)['mainEntity'] as Record<string, unknown>;
+
+		expect(mainEntity['description']).toBe('Biografía sin bloque vacío previo.');
 	});
 
 	it('should omit the description in mainEntity when the author has no biography', () => {

--- a/src/app/pages/author/author.schema.ts
+++ b/src/app/pages/author/author.schema.ts
@@ -1,8 +1,34 @@
 import { Location } from '@angular/common';
 
 import { type Author, type AuthorProfile } from '@models/author.model';
+import { type TextBlockContent } from '@models/block-content.model';
 import { buildBreadcrumbSchema, buildPersonSchema } from '@utils/schema-org.builders';
 import { type JsonLdSchema } from '../../providers/schema-org.service';
+
+// Tope del `description` del Person: un resumen citable, no la biografía entera volcada al JSON-LD.
+const MAX_BIOGRAPHY_DESCRIPTION_LENGTH = 300;
+
+/**
+ * Aplana la biografía (PortableText) a texto plano para el `description` del Person, recortado en el
+ * último espacio antes del tope. Da al `Person`/`ProfilePage` una señal de "aboutness" para AEO/rich
+ * results, independiente de que la bio quede en un tab oculto por CSS en la página.
+ */
+function buildBiographyDescription(biography: TextBlockContent[]): string | undefined {
+	const plainText = biography
+		.map((block) => block.children.map((child) => child.text).join(''))
+		.join(' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+	if (!plainText) {
+		return undefined;
+	}
+	if (plainText.length <= MAX_BIOGRAPHY_DESCRIPTION_LENGTH) {
+		return plainText;
+	}
+	const truncated = plainText.slice(0, MAX_BIOGRAPHY_DESCRIPTION_LENGTH);
+	const lastSpace = truncated.lastIndexOf(' ');
+	return `${truncated.slice(0, lastSpace > 0 ? lastSpace : MAX_BIOGRAPHY_DESCRIPTION_LENGTH).trimEnd()}…`;
+}
 
 /**
  * Construye el JSON-LD `ProfilePage` de la página de un autor. Como `Person` no es un `CreativeWork`,
@@ -13,6 +39,10 @@ export function buildAuthorProfilePageSchema(author: AuthorProfile, websiteUrl: 
 	const baseUrl = Location.stripTrailingSlash(websiteUrl);
 	const authorUrl = `${baseUrl}/author/${author.slug}`;
 	const person = buildPersonSchema(author, authorUrl);
+	const description = buildBiographyDescription(author.biography);
+	if (description) {
+		person['description'] = description;
+	}
 	if (author.bornOn) {
 		person['birthDate'] = author.bornOn;
 	}

--- a/src/app/pages/author/author.schema.ts
+++ b/src/app/pages/author/author.schema.ts
@@ -6,12 +6,12 @@ import { buildBreadcrumbSchema, buildPersonSchema } from '@utils/schema-org.buil
 import { type JsonLdSchema } from '../../providers/schema-org.service';
 
 /**
- * Aplana la biografía (PortableText) a texto plano para el `description` del Person, recortado en el
- * último espacio antes del tope. Da al `Person`/`ProfilePage` una señal de "aboutness" para AEO/rich
- * results, independiente de que la bio quede en un tab oculto por CSS en la página.
+ * Aplana y recorta la biografía (PortableText) a texto plano para el `description` del Person, recortado
+ * en el último espacio antes del tope. Da al `Person`/`ProfilePage` texto para resultados enriquecidos
+ * para AEO/SEO en la información expuesta en JSON-LD, independiente de la biografía visible para el
+ * crawler en HTML
  */
 function buildBiographyDescription(biography: TextBlockContent[]): string | undefined {
-	// Tope del `description`: un resumen citable, no la biografía entera volcada al JSON-LD.
 	const maxLength = 300;
 	const plainText = biography
 		.map((block) => block.children.map((child) => child.text).join(''))

--- a/src/app/pages/author/author.schema.ts
+++ b/src/app/pages/author/author.schema.ts
@@ -5,15 +5,14 @@ import { type TextBlockContent } from '@models/block-content.model';
 import { buildBreadcrumbSchema, buildPersonSchema } from '@utils/schema-org.builders';
 import { type JsonLdSchema } from '../../providers/schema-org.service';
 
-// Tope del `description` del Person: un resumen citable, no la biografía entera volcada al JSON-LD.
-const MAX_BIOGRAPHY_DESCRIPTION_LENGTH = 300;
-
 /**
  * Aplana la biografía (PortableText) a texto plano para el `description` del Person, recortado en el
  * último espacio antes del tope. Da al `Person`/`ProfilePage` una señal de "aboutness" para AEO/rich
  * results, independiente de que la bio quede en un tab oculto por CSS en la página.
  */
 function buildBiographyDescription(biography: TextBlockContent[]): string | undefined {
+	// Tope del `description`: un resumen citable, no la biografía entera volcada al JSON-LD.
+	const maxLength = 300;
 	const plainText = biography
 		.map((block) => block.children.map((child) => child.text).join(''))
 		.join(' ')
@@ -22,12 +21,12 @@ function buildBiographyDescription(biography: TextBlockContent[]): string | unde
 	if (!plainText) {
 		return undefined;
 	}
-	if (plainText.length <= MAX_BIOGRAPHY_DESCRIPTION_LENGTH) {
+	if (plainText.length <= maxLength) {
 		return plainText;
 	}
-	const truncated = plainText.slice(0, MAX_BIOGRAPHY_DESCRIPTION_LENGTH);
+	const truncated = plainText.slice(0, maxLength);
 	const lastSpace = truncated.lastIndexOf(' ');
-	return `${truncated.slice(0, lastSpace > 0 ? lastSpace : MAX_BIOGRAPHY_DESCRIPTION_LENGTH).trimEnd()}…`;
+	return `${truncated.slice(0, lastSpace > 0 ? lastSpace : maxLength).trimEnd()}…`;
 }
 
 /**


### PR DESCRIPTION
> Parte de #1771. Follow-up de #1774 (ya mergeado): reforzar la señal semántica del autor de cara a AEO/rich results.

## Contexto

Con #1774, el render-all de `Tabs` dejó la **biografía del autor en el SSR** — pero en un panel `[hidden]` (Google lo indexa, aunque pondera algo menos el contenido oculto por CSS). Este PR complementa: expone la biografía también en el **JSON-LD**, donde no hay ambigüedad de visibilidad y refuerza la "aboutness" del `Person`/`ProfilePage` para motores y respuestas generativas.

## Cambio

`buildAuthorProfilePageSchema` ahora aplana la biografía (PortableText) a texto plano y la agrega como **`Person.description`**, recortada a 300 chars en un límite de palabra con elipsis. Se omite cuando el autor no tiene biografía.

El extractor vive en `author.schema` (no en `buildPersonSchema`, que es compartido y liviano para el autor embebido de la story, que no carga biografía).

## Verificación

Build SSR local + `curl` sobre `/author/velmiro-ayala-gauna` → `profile-page` JSON-LD, `mainEntity.description`:

```
"Velmiro Ayala Gauna (Corrientes, 1905 - Rosario, 1967) fue un docente, músico,
periodista y escritor argentino. … los…"   (299 chars, recorte en palabra + elipsis)
```

Se preservan `name`/`image`/`sameAs`/`birthDate`/`deathDate`.

Gates verdes: `typecheck`, `lint`, `test` (4 tests nuevos: aplanado, recorte con elipsis, omisión sin bio, y `description` en el match del ProfilePage) y `build`.