### PR TITLE
[#1800] - Arregla el build del Studio con @sanity/icons v5 (imports por subpath + phantom deps)

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -44,6 +44,18 @@
 			"uuid": ">=11.1.1",
 			"ws": ">=8.20.1",
 			"brace-expansion@5": ">=5.0.6"
+		},
+		"packageExtensions": {
+			"sanity-plugin-bulk-actions-table": {
+				"dependencies": {
+					"@sanity/icons": "^3.8.0"
+				}
+			},
+			"sanity-plugin-icon-picker": {
+				"dependencies": {
+					"@sanity/icons": "^3.8.0"
+				}
+			}
 		}
 	}
 }

--- a/cms/pnpm-lock.yaml
+++ b/cms/pnpm-lock.yaml
@@ -9,6 +9,8 @@ overrides:
   ws: '>=8.20.1'
   brace-expansion@5: '>=5.0.6'
 
+packageExtensionsChecksum: sha256-yjaeXrkw/GL9ZkPlL0is7IpiClzrRaTcxEkwpV5+8Vg=
+
 importers:
   .:
     dependencies:
@@ -11917,6 +11919,7 @@ snapshots:
 
   sanity-plugin-bulk-actions-table@1.0.4(react@19.2.7)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.11.14)(@sanity/cli-core@1.3.4(@noble/hashes@2.0.1)(@types/node@22.19.20)(babel-plugin-react-compiler@1.0.0)(lightningcss@1.32.0)(yaml@2.9.0))(@types/node@22.19.20)(@types/react@19.1.8)(babel-plugin-react-compiler@1.0.0)(immer@10.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.27.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.8.3)):
     dependencies:
+      '@sanity/icons': 3.8.0(react@19.2.7)
       classnames: 2.5.1
       lodash.debounce: 4.0.8
       lodash.get: 4.4.2
@@ -11940,6 +11943,7 @@ snapshots:
 
   sanity-plugin-icon-picker@4.0.0(@emotion/is-prop-valid@1.4.0)(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.11.14)(@sanity/cli-core@1.3.4(@noble/hashes@2.0.1)(@types/node@22.19.20)(babel-plugin-react-compiler@1.0.0)(lightningcss@1.32.0)(yaml@2.9.0))(@types/node@22.19.20)(@types/react@19.1.8)(babel-plugin-react-compiler@1.0.0)(immer@10.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(prismjs@1.27.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.8.3)):
     dependencies:
+      '@sanity/icons': 3.8.0(react@19.2.7)
       '@sanity/incompatible-plugin': 1.0.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@sanity/ui': 2.16.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.3(css-to-react-native@3.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       decamelize: 3.2.0

--- a/cms/sanity.config.ts
+++ b/cms/sanity.config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from 'sanity';
 import deskStructure from './deskStructure';
 import schemas from './schemas/schema';
 
-import { LaunchIcon, RobotIcon } from '@sanity/icons';
+import { LaunchIcon } from '@sanity/icons/Launch';
+import { RobotIcon } from '@sanity/icons/Robot';
 
 // Plugins
 import { structureTool } from 'sanity/structure';

--- a/cms/schemas/author.ts
+++ b/cms/schemas/author.ts
@@ -1,4 +1,4 @@
-import { UsersIcon } from '@sanity/icons';
+import { UsersIcon } from '@sanity/icons/Users';
 import { resource } from './resourceType';
 import { defineArrayMember, defineField, defineType } from 'sanity';
 import { validateHistoricalDate } from '../utils/validations';

--- a/cms/schemas/contentCampaign.ts
+++ b/cms/schemas/contentCampaign.ts
@@ -1,5 +1,5 @@
 import { defineField, defineType } from 'sanity';
-import { CalendarIcon } from '@sanity/icons';
+import { CalendarIcon } from '@sanity/icons/Calendar';
 import { localizedRequire } from '../utils/validations';
 
 // Models

--- a/cms/schemas/contributor.ts
+++ b/cms/schemas/contributor.ts
@@ -1,5 +1,5 @@
 import { defineField, defineType } from 'sanity';
-import { UserIcon } from '@sanity/icons';
+import { UserIcon } from '@sanity/icons/User';
 
 export default defineType({
 	name: 'contributor',

--- a/cms/schemas/landingPage.ts
+++ b/cms/schemas/landingPage.ts
@@ -1,4 +1,4 @@
-import { CodeBlockIcon } from '@sanity/icons';
+import { CodeBlockIcon } from '@sanity/icons/CodeBlock';
 import { defineArrayMember, defineField, defineType } from 'sanity';
 
 export default defineType({

--- a/cms/schemas/media-sources.ts
+++ b/cms/schemas/media-sources.ts
@@ -1,4 +1,7 @@
-import { DocumentPdfIcon, DocumentVideoIcon, PlayIcon, TwitterIcon } from '@sanity/icons';
+import { DocumentPdfIcon } from '@sanity/icons/DocumentPdf';
+import { DocumentVideoIcon } from '@sanity/icons/DocumentVideo';
+import { PlayIcon } from '@sanity/icons/Play';
+import { TwitterIcon } from '@sanity/icons/Twitter';
 import { defineField, defineType } from 'sanity';
 
 export const audioRecording = defineType({

--- a/cms/schemas/nationality.ts
+++ b/cms/schemas/nationality.ts
@@ -1,4 +1,4 @@
-import { EarthGlobeIcon } from '@sanity/icons';
+import { EarthGlobeIcon } from '@sanity/icons/EarthGlobe';
 import { defineField, defineType } from 'sanity';
 
 export default defineType({

--- a/cms/schemas/resourceType.ts
+++ b/cms/schemas/resourceType.ts
@@ -1,4 +1,4 @@
-import { LinkIcon } from '@sanity/icons';
+import { LinkIcon } from '@sanity/icons/Link';
 import { preview } from 'sanity-plugin-icon-picker';
 import { defineField, defineType } from 'sanity';
 

--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -1,4 +1,4 @@
-import { DocumentTextIcon } from '@sanity/icons';
+import { DocumentTextIcon } from '@sanity/icons/DocumentText';
 import { resource } from './resourceType';
 import { defineArrayMember, defineField, defineType } from 'sanity';
 import { audioRecording, pdfLink, spaceRecording, spotifyPodcastEpisode, youtubeVideo } from './media-sources';

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -1,4 +1,5 @@
-import { DashboardIcon, DocumentTextIcon } from '@sanity/icons';
+import { DashboardIcon } from '@sanity/icons/Dashboard';
+import { DocumentTextIcon } from '@sanity/icons/DocumentText';
 import { defineArrayMember, defineField, defineType } from 'sanity';
 import { audioRecording, pdfLink, spaceRecording, spotifyPodcastEpisode, youtubeVideo } from './media-sources';
 

--- a/cms/schemas/tag.ts
+++ b/cms/schemas/tag.ts
@@ -1,4 +1,4 @@
-import { TagIcon } from '@sanity/icons';
+import { TagIcon } from '@sanity/icons/Tag';
 import { preview } from 'sanity-plugin-icon-picker';
 import { defineField, defineType } from 'sanity';
 


### PR DESCRIPTION
## Contexto

En `develop`, Dependabot bumpeó `@sanity/icons` de `3.7.4` a `5.0.0` (commit `a68a1054`). La v5 **removió los exports de iconos del root del paquete**: ahora cada icono se importa por subpath (`import { XIcon } from '@sanity/icons/X'`).

Como consecuencia, **el Studio de Sanity (`cms/`) dejó de buildear**. CI no lo detecta porque el gate `build` compila la app de Angular, no el proyecto `cms/`.

Este fix se venía arrastrando dentro de la rama `feat/1759-landing-activa-studio`, pero corresponde tratarlo por separado del trabajo de personalización de la UI del Studio, ya que es una corrección de compatibilidad independiente que afecta a `develop` por sí misma.

## Cambios

- Migra los **11 archivos del `cms/`** que importaban iconos del root de `@sanity/icons` al patrón de subpaths de v5 (`sanity.config.ts` + 10 schemas).
- Agrega `packageExtensions` para los plugins de terceros que importan `@sanity/icons` del root como **phantom dependency** (no lo declaran) y cuyo dist compilado no se puede editar:
  - `sanity-plugin-bulk-actions-table`
  - `sanity-plugin-icon-picker`
  - Se les inyecta `@sanity/icons ^3.8.0` nested (los iconos son SVG sin estado, coexisten con el v5 de nuestro código). `singleton-management` ya declaraba `^3.7.4`.
- Regenera `cms/pnpm-lock.yaml`.

## Fuera de alcance (queda en #1759)

- `LandingPageListPane.tsx` y los structure items de la landing (no existen en `develop`).
- El `SyncIcon` en `rotatingContent.ts` y la dependencia `@sanity/ui` (ambos introducidos por #1759).

## Verificación

- `sanity build` → **EXIT 0** (verde). Es la validación real; `tsc` no detecta este breakage (es resolución de exports del bundler, no de tipos).
- Cero imports del root de `@sanity/icons` en `cms/`.

Closes #1800
