### PR TITLE
[#1799] - Sumar el build del Studio (sanity build) como gate de CI

### DIFF
--- a/.claude/references/coding-agent-policies.md
+++ b/.claude/references/coding-agent-policies.md
@@ -181,7 +181,7 @@ El principio: **el documento es canónico; la memoria es refuerzo**. Si los dos 
 
 ### Gates de CI
 
-Independientemente de lo anterior, todo PR debe dejar verdes los gates de CI definidos en `CLAUDE.md`: `test`, `lint`, `stylelint`, `typecheck`, `e2e`, `build`, `storybook`. Que un gate sea "molesto" o "lento" no es justificación para saltearlo o deshabilitarlo.
+Independientemente de lo anterior, todo PR debe dejar verdes los gates de CI definidos en `CLAUDE.md`: `test`, `lint`, `stylelint`, `typecheck`, `e2e`, `build`, `storybook`, `studio-build`. Que un gate sea "molesto" o "lento" no es justificación para saltearlo o deshabilitarlo.
 
 ### Enmiendas
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,9 +349,7 @@ jobs:
     # Checkout propio, sin `needs: setup`: cms/ es un proyecto pnpm aparte (lockfile
     # propio, fuera del workspace de la raíz) y además referencia el árbol `src/` de la
     # raíz vía import relativo (schemas/contentCampaign.ts). El workspace.tar de `setup`
-    # no instala cms/node_modules, así que reusarlo no ahorra nada. Es el gate que
-    # faltaba: `pnpm build`/`typecheck` no compilan cms/, así que un bump roto de una
-    # dep del Studio (como @sanity/icons 3→5 en #1759/#1800) llegaba a develop sin señal.
+    # no instala cms/node_modules, así que reusarlo no ahorra nada.
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,3 +342,48 @@ jobs:
         run: bash .github/scripts/nx-run.sh nx run @cuentoneta/app:build-storybook
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+  studio-build:
+    name: 'Studio build (sanity build)'
+    runs-on: ubuntu-latest
+    # Checkout propio, sin `needs: setup`: cms/ es un proyecto pnpm aparte (lockfile
+    # propio, fuera del workspace de la raíz) y además referencia el árbol `src/` de la
+    # raíz vía import relativo (schemas/contentCampaign.ts). El workspace.tar de `setup`
+    # no instala cms/node_modules, así que reusarlo no ahorra nada. Es el gate que
+    # faltaba: `pnpm build`/`typecheck` no compilan cms/, así que un bump roto de una
+    # dep del Studio (como @sanity/icons 3→5 en #1759/#1800) llegaba a develop sin señal.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+
+      - name: Select pnpm as package manager
+        uses: pnpm/action-setup@v6.0.9
+        with:
+          version: 10.12.1
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 22.22.3
+          cache: 'pnpm'
+          cache-dependency-path: cms/pnpm-lock.yaml
+
+      - name: Install CMS dependencies
+        working-directory: cms
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      # `sanity build` (bundler Vite/Rollup) es el gate autoritativo del Studio: un
+      # `tsc --noEmit` sobre cms/ no sirve (ruido de moduleResolution sobre node_modules,
+      # sin relación con errores reales de bundling). `--ignore-scripts` en el install
+      # saltea el postinstall que genera cms/.env (set-environment.ts), así que las vars
+      # que lee sanity.cli.ts se pasan acá explícitas, con fallback a los valores públicos
+      # por defecto (s4dbqkc5/development) para que corra igual en PRs de forks sin secrets.
+      - name: Build Sanity Studio
+        working-directory: cms
+        run: pnpm exec sanity build
+        env:
+          SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID || 's4dbqkc5' }}
+          SANITY_STUDIO_DATASET: ${{ secrets.SANITY_STUDIO_DATASET || 'development' }}
+          # El CLI de Sanity corre desatendido cuando CI=true (Actions ya lo setea;
+          # explícito por robustez, mismo patrón que el job deploy-studio de release.yml).
+          CI: 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Usar **siempre `pnpm`** para instalar y ejecutar scripts. Los scripts envuelven 
 | `pnpm test:e2e`                           | E2E (Playwright)                                                                                                                     |
 | `pnpm storybook` / `pnpm storybook:build` | Storybook dev / build                                                                                                                |
 | `pnpm sanity:dev`                         | Studio de Sanity (`@cuentoneta/cms`)                                                                                                 |
+| `pnpm sanity:build`                       | Build del Studio (`sanity build`) — reproduce en local el gate de CI `studio-build`                                                  |
 | `pnpm sanity:extract-schema`              | Extrae el schema de Sanity                                                                                                           |
 | `pnpm sanity:run-typegen-generator`       | Genera tipos a partir del schema                                                                                                     |
 | `pnpm sanity migration run <slug>`        | Corre una migración de datos (desde `cms/`; dry-run por defecto) → [`sanity-migrations.md`](.claude/references/sanity-migrations.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,11 @@ Usar **siempre `pnpm`** para instalar y ejecutar scripts. Los scripts envuelven 
 | `pnpm sanity:run-typegen-generator`       | Genera tipos a partir del schema                                                                                                     |
 | `pnpm sanity migration run <slug>`        | Corre una migración de datos (desde `cms/`; dry-run por defecto) → [`sanity-migrations.md`](.claude/references/sanity-migrations.md) |
 
-**Gates de CI** (deben quedar verdes en cada PR): `test`, `lint`, `stylelint`, `typecheck`, `e2e`, `build`, `storybook`.
+**Gates de CI** (deben quedar verdes en cada PR): `test`, `lint`, `stylelint`, `typecheck`, `e2e`, `build`, `storybook`, `studio-build`.
 
 > El gate `typecheck` (`pnpm typecheck` → `tsc --noEmit` estricto) cubre el **TS puro** de la app (`src/**`, incluidos `*.spec.ts` y `*.stories.ts`) y `scripts/`. **No** valida plantillas Angular (eso lo hacen `build`/`storybook` vía `ngtsc`) ni el proyecto `cms/`.
+>
+> El build del Studio de Sanity (`cms/`) lo cubre el gate **`studio-build`** (`pnpm -C cms exec sanity build`, el bundler Vite/Rollup real del Studio), no `typecheck` ni `build`. Corre en un job aparte con install propio de `cms/` (proyecto pnpm standalone). Cierra el punto ciego por el que un bump roto de una dependencia del Studio podía llegar a `develop` sin señal de CI.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"test:ui": "nx test --ui",
 		"test:e2e": "nx run @cuentoneta/app:e2e",
 		"sanity:dev": "nx run @cuentoneta/cms:dev",
+		"sanity:build": "nx run @cuentoneta/cms:build --skip-nx-cache",
 		"sanity:extract-schema": "nx run @cuentoneta/cms:extract-schema",
 		"sanity:run-typegen-generator": "nx run @cuentoneta/cms:typegen",
 		"prepare": "husky"


### PR DESCRIPTION
## Descripción

- Agrega el gate de CI **`studio-build`** a `.github/workflows/ci.yml`: corre `sanity build` sobre `cms/` en cada PR/push, cerrando el punto ciego por el que un bump roto de una dependencia del Studio (como `@sanity/icons` 3→5 en #1759/#1800) llegaba a `develop` sin señal de CI (ni `pnpm build` ni `pnpm typecheck` compilan `cms/`).
- Job propio con checkout e install standalone de `cms/` (proyecto pnpm aparte), replicando el patrón ya probado de `deploy-studio` en `release.yml`. Corre siempre (sin path filter) para cubrir también los PRs de Dependabot sobre `cms/`.
- Suma un script `pnpm sanity:build` (envuelve el target Nx `@cuentoneta/cms:build`, antes huérfano) para reproducir el gate en local, y documenta el gate nuevo en `CLAUDE.md` y `coding-agent-policies.md`.

Closes #1799.

## Plan de pruebas

- [x] `sanity build` de `cms/` verificado en local (exit 0) con las mismas env vars que usa el job (`SANITY_STUDIO_PROJECT_ID=s4dbqkc5 SANITY_STUDIO_DATASET=development CI=true`).
- [x] `pnpm sanity:build` (script nuevo) verificado en local (exit 0).
- [x] YAML de `ci.yml` validado (9 jobs, `studio-build` bien formado, sin `needs`).
- [x] Gates de la app en verde (`lint`, `stylelint`, `typecheck`, `test`, `build`, `storybook:build`) — sin regresión (el diff es aditivo, solo tooling de CI + Markdown).
- [ ] Validación final: la corrida real de `ci.yml` en este PR ejercita el job `studio-build` end-to-end.

## Fuera de alcance (follow-up)

- #1803 — Exigir todos los gates documentados (incluido `studio-build`) como required status checks de `develop`. Gap operativo preexistente de branch protection detectado en la review; requiere permisos de admin del repo, fuera del alcance de este PR.
