### PR TITLE
[#1810] - [DS V3] Componente Story Hero Header (portada de fondo + meta del cuento)

### DIFF
--- a/src/app/components/story-hero-header/story-hero-header-skeleton.component.ts
+++ b/src/app/components/story-hero-header/story-hero-header-skeleton.component.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+
+import { SkeletonComponent } from '@components/skeleton/skeleton.component';
+import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton.component';
+
+/**
+ * Estado de carga (esqueleto) de StoryHeroHeaderComponent. Replica la banda oscura del hero y la
+ * grilla portada + metadatos con placeholders de cuentoneta-skeleton para evitar saltos de layout
+ * mientras la story carga. Los placeholders usan neutral-700 para contrastar sobre el fondo oscuro.
+ */
+@Component({
+	selector: 'cuentoneta-story-hero-header-skeleton',
+	imports: [SkeletonComponent, CoverImageSkeletonComponent],
+	host: { class: 'relative block overflow-hidden bg-neutral-900' },
+	template: `
+		<div class="relative z-10 px-6 pt-28 pb-10">
+			<div class="mx-auto flex w-full max-w-180 items-center gap-8">
+				<cuentoneta-cover-image-skeleton />
+				<div class="flex min-w-0 flex-1 flex-col items-start gap-2.5">
+					<cuentoneta-skeleton appearance="line" class="h-5.5 w-24 rounded-sm bg-neutral-700" />
+					<div class="flex items-center gap-2">
+						<cuentoneta-skeleton appearance="circle" class="h-6 w-6 bg-neutral-700" />
+						<cuentoneta-skeleton appearance="line" class="h-5 w-40 bg-neutral-700" />
+					</div>
+					<cuentoneta-skeleton appearance="line" class="h-8 w-full max-w-142 bg-neutral-700" />
+					<cuentoneta-skeleton appearance="line" class="h-5 w-52 bg-neutral-700" />
+				</div>
+			</div>
+		</div>
+	`,
+})
+export class StoryHeroHeaderSkeletonComponent {}

--- a/src/app/components/story-hero-header/story-hero-header.component.spec.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.spec.ts
@@ -8,18 +8,27 @@ import { palacioNueveFronterasStoryMock } from '../../mocks/onoff/el-palacio-de-
 describe('StoryHeroHeaderComponent', () => {
 	const genre: Tag = { title: 'Ciencia ficción', slug: 'ciencia-ficcion', shortDescription: '', description: [] };
 	const story: Story = { ...palacioNueveFronterasStoryMock, tags: [genre] };
-	const avatarName = `Retrato de ${story.author.name}`;
 
 	it('should render the story title as the heading', async () => {
 		await render(StoryHeroHeaderComponent, { inputs: { story } });
 		expect(screen.getByRole('heading', { name: story.title })).toBeInTheDocument();
 	});
 
-	it('should render the author name and avatar linking to the author profile', async () => {
+	it('should link the author block to the author profile, exposing just the author name', async () => {
 		await render(StoryHeroHeaderComponent, { inputs: { story } });
-		expect(screen.getByText(story.author.name)).toBeInTheDocument();
-		expect(screen.getByRole('img', { name: avatarName })).toBeInTheDocument();
-		expect(screen.getByRole('link')).toHaveAttribute('href', expect.stringContaining(`/author/${story.author.slug}`));
+		// El avatar es decorativo (alt vacío): el único nombre accesible del enlace es el del autor.
+		const link = screen.getByRole('link', { name: story.author.name });
+		expect(link).toHaveAttribute('href', expect.stringContaining(`/author/${story.author.slug}`));
+	});
+
+	it('should render the blurred background from the cover requested at 1920px width', async () => {
+		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		expect(screen.getByTestId('hero-background')).toHaveAttribute('src', expect.stringContaining('w=1920'));
+	});
+
+	it('should not render the background when the story has no cover', async () => {
+		await render(StoryHeroHeaderComponent, { inputs: { story: { ...story, coverImage: '' } } });
+		expect(screen.queryByTestId('hero-background')).not.toBeInTheDocument();
 	});
 
 	it('should render the original publication with its prefix', async () => {

--- a/src/app/components/story-hero-header/story-hero-header.component.spec.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.spec.ts
@@ -6,8 +6,8 @@ import { StoryHeroHeaderComponent } from './story-hero-header.component';
 import { palacioNueveFronterasStoryMock } from '../../mocks/onoff/el-palacio-de-las-nueve-fronteras.mock';
 
 describe('StoryHeroHeaderComponent', () => {
-	const genre: Tag = { title: 'Ciencia ficción', slug: 'ciencia-ficcion', shortDescription: '', description: [] };
-	const story: Story = { ...palacioNueveFronterasStoryMock, tags: [genre] };
+	const literaryType: Tag = { title: 'Novela', slug: 'novela', shortDescription: '', description: [] };
+	const story: Story = { ...palacioNueveFronterasStoryMock, tags: [literaryType] };
 
 	it('should render the story title as the heading', async () => {
 		await render(StoryHeroHeaderComponent, { inputs: { story } });
@@ -36,14 +36,14 @@ describe('StoryHeroHeaderComponent', () => {
 		expect(screen.getByTestId('publication')).toHaveTextContent(`Publicado en: ${story.originalPublication}`);
 	});
 
-	it('should render the genre tag from the first tag', async () => {
+	it('should render the literary type tag from the first tag', async () => {
 		await render(StoryHeroHeaderComponent, { inputs: { story } });
-		expect(screen.getByTestId('genre')).toHaveTextContent(genre.title);
+		expect(screen.getByTestId('literary-type')).toHaveTextContent(literaryType.title);
 	});
 
-	it('should not render the genre tag when the story has no tags', async () => {
+	it('should not render the literary type tag when the story has no tags', async () => {
 		await render(StoryHeroHeaderComponent, { inputs: { story: { ...story, tags: [] } } });
-		expect(screen.queryByTestId('genre')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('literary-type')).not.toBeInTheDocument();
 	});
 
 	it('should render the foreground cover image when the story has a cover', async () => {

--- a/src/app/components/story-hero-header/story-hero-header.component.spec.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.spec.ts
@@ -6,8 +6,11 @@ import { StoryHeroHeaderComponent } from './story-hero-header.component';
 import { palacioNueveFronterasStoryMock } from '../../mocks/onoff/el-palacio-de-las-nueve-fronteras.mock';
 
 describe('StoryHeroHeaderComponent', () => {
-	const literaryType: Tag = { title: 'Novela', slug: 'novela', shortDescription: '', description: [] };
-	const story: Story = { ...palacioNueveFronterasStoryMock, tags: [literaryType] };
+	const tags: Tag[] = [
+		{ title: 'Novela', slug: 'novela', shortDescription: '', description: [] },
+		{ title: 'Metaficción', slug: 'metaficcion', shortDescription: '', description: [] },
+	];
+	const story: Story = { ...palacioNueveFronterasStoryMock, tags };
 
 	it('should render the story title as the heading', async () => {
 		await render(StoryHeroHeaderComponent, { inputs: { story } });
@@ -36,14 +39,16 @@ describe('StoryHeroHeaderComponent', () => {
 		expect(screen.getByTestId('publication')).toHaveTextContent(`Publicado en: ${story.originalPublication}`);
 	});
 
-	it('should render the literary type tag from the first tag', async () => {
+	it('should render all the story tags', async () => {
 		await render(StoryHeroHeaderComponent, { inputs: { story } });
-		expect(screen.getByTestId('literary-type')).toHaveTextContent(literaryType.title);
+		for (const tag of tags) {
+			expect(screen.getByText(tag.title)).toBeInTheDocument();
+		}
 	});
 
-	it('should not render the literary type tag when the story has no tags', async () => {
+	it('should not render the tags list when the story has no tags', async () => {
 		await render(StoryHeroHeaderComponent, { inputs: { story: { ...story, tags: [] } } });
-		expect(screen.queryByTestId('literary-type')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('tags')).not.toBeInTheDocument();
 	});
 
 	it('should render the foreground cover image when the story has a cover', async () => {

--- a/src/app/components/story-hero-header/story-hero-header.component.spec.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.spec.ts
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/angular';
+
+import type { Story } from '@models/story.model';
+import type { Tag } from '@models/tag.model';
+import { StoryHeroHeaderComponent } from './story-hero-header.component';
+import { palacioNueveFronterasStoryMock } from '../../mocks/onoff/el-palacio-de-las-nueve-fronteras.mock';
+
+describe('StoryHeroHeaderComponent', () => {
+	const genre: Tag = { title: 'Ciencia ficción', slug: 'ciencia-ficcion', shortDescription: '', description: [] };
+	const story: Story = { ...palacioNueveFronterasStoryMock, tags: [genre] };
+	const avatarName = `Retrato de ${story.author.name}`;
+
+	it('should render the story title as the heading', async () => {
+		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		expect(screen.getByRole('heading', { name: story.title })).toBeInTheDocument();
+	});
+
+	it('should render the author name and avatar linking to the author profile', async () => {
+		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		expect(screen.getByText(story.author.name)).toBeInTheDocument();
+		expect(screen.getByRole('img', { name: avatarName })).toBeInTheDocument();
+		expect(screen.getByRole('link')).toHaveAttribute('href', expect.stringContaining(`/author/${story.author.slug}`));
+	});
+
+	it('should render the original publication with its prefix', async () => {
+		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		expect(screen.getByTestId('publication')).toHaveTextContent(`Publicado en: ${story.originalPublication}`);
+	});
+
+	it('should render the genre tag from the first tag', async () => {
+		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		expect(screen.getByTestId('genre')).toHaveTextContent(genre.title);
+	});
+
+	it('should not render the genre tag when the story has no tags', async () => {
+		await render(StoryHeroHeaderComponent, { inputs: { story: { ...story, tags: [] } } });
+		expect(screen.queryByTestId('genre')).not.toBeInTheDocument();
+	});
+
+	it('should render the foreground cover image when the story has a cover', async () => {
+		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		expect(screen.getByTestId('cover-image')).toBeInTheDocument();
+	});
+
+	it('should render the cover placeholder when the story has no cover', async () => {
+		await render(StoryHeroHeaderComponent, { inputs: { story: { ...story, coverImage: '' } } });
+		expect(screen.getByTestId('cover-placeholder')).toBeInTheDocument();
+	});
+
+	it('should render the skeleton when no story is provided', async () => {
+		await render(StoryHeroHeaderComponent);
+		expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+	});
+
+	it('should not render the skeleton once a story is provided', async () => {
+		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument();
+	});
+});

--- a/src/app/components/story-hero-header/story-hero-header.component.stories.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.stories.ts
@@ -19,7 +19,7 @@ const meta: Meta<StoryHeroHeaderComponent> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>Banda superior (hero) de la página de una historia. Usa la misma portada del cuento como fondo difuminado con una capa de opacidad y, en primer plano, presenta la portada nítida, el tipo literario, el autor, el título y la colección/año de publicación originales.</p><p>Recibe el <code>Story</code> completo como único input; cuando no se provee, renderiza su propio estado de carga (skeleton).</p><p>Se compone de <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> (portada en primer plano), <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> (tipo literario, variante <code>gray</code>) e <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar del autor).</p></div>`,
+				component: `<div><p>Banda superior (hero) de la página de una historia. Usa la misma portada del cuento como fondo difuminado con una capa de opacidad y, en primer plano, presenta la portada nítida, los tags, el autor, el título y la colección/año de publicación originales.</p><p>Recibe el <code>Story</code> completo como único input; cuando no se provee, renderiza su propio estado de carga (skeleton).</p><p>Se compone de <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> (portada en primer plano), <a href="./?path=/docs/componentes-v3-tagslist--docs" target="_top"><strong>TagsList</strong></a> (tags de la obra, variante <code>gray</code>) e <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar del autor).</p></div>`,
 			},
 		},
 		layout: 'fullscreen',
@@ -27,8 +27,7 @@ const meta: Meta<StoryHeroHeaderComponent> = {
 	argTypes: {
 		story: {
 			control: { type: 'object' },
-			description:
-				'Historia completa a partir de la cual se derivan portada, tipo literario, autor, título y publicación',
+			description: 'Historia completa a partir de la cual se derivan portada, tags, autor, título y publicación',
 			table: { type: { summary: 'Story' }, defaultValue: { summary: 'undefined' } },
 		},
 	},
@@ -69,7 +68,7 @@ export const Default: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Estado principal del hero con portada, tipo literario, autor, título y publicación.',
+				story: 'Estado principal del hero con portada, tags, autor, título y publicación.',
 			},
 		},
 	},
@@ -84,7 +83,7 @@ export const SinGenero: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Cuando la historia no tiene tags, el Tag de tipo literario se omite y el resto del bloque se mantiene.',
+				story: 'Cuando la historia no tiene tags, la lista de tags se omite y el resto del bloque se mantiene.',
 			},
 		},
 	},

--- a/src/app/components/story-hero-header/story-hero-header.component.stories.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.stories.ts
@@ -1,0 +1,123 @@
+import { applicationConfig, argsToTemplate, Meta, StoryObj } from '@storybook/angular';
+import { provideRouter } from '@angular/router';
+
+import type { Story as StoryModel } from '@models/story.model';
+import type { Tag } from '@models/tag.model';
+import { StoryHeroHeaderComponent } from './story-hero-header.component';
+import { onoffStoriesMock } from '../../mocks/onoff-stories.mock';
+import { palacioNueveFronterasStoryMock } from '../../mocks/onoff/el-palacio-de-las-nueve-fronteras.mock';
+import { literaryWorkSelectArgType } from '../../mocks/onoff-corpus.storybook';
+
+// Género de muestra: los mocks del corpus Onoff traen `tags: []` (deuda de #1593), así que se superpone
+// un tag localmente —sin tocar los mocks compartidos— para poder visualizar el Tag de género del hero.
+const genreTag: Tag = { title: 'Ciencia ficción', slug: 'ciencia-ficcion', shortDescription: '', description: [] };
+const withGenre = (story: StoryModel): StoryModel => ({ ...story, tags: [genreTag] });
+
+// Las descripciones de la doc van en una sola línea: el renderer de Markdown de los autodocs
+// interpreta como bloque de código cualquier línea con indentación, así que un HTML multilínea
+// indentado se mostraría dentro de un recuadro de código.
+const meta: Meta<StoryHeroHeaderComponent> = {
+	component: StoryHeroHeaderComponent,
+	title: 'Componentes V3/StoryHeroHeader',
+	tags: ['autodocs'],
+	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
+	],
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>Banda superior (hero) de la página de una historia. Usa la misma portada del cuento como fondo difuminado con una capa de opacidad y, en primer plano, presenta la portada nítida, el género, el autor, el título y la colección/año de publicación originales.</p><p>Recibe el <code>Story</code> completo como único input; cuando no se provee, renderiza su propio estado de carga (skeleton).</p><p>Se compone de <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> (portada en primer plano), <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> (género, variante <code>gray</code>) e <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar del autor).</p></div>`,
+			},
+		},
+		layout: 'fullscreen',
+	},
+	argTypes: {
+		story: {
+			control: { type: 'object' },
+			description: 'Historia completa a partir de la cual se derivan portada, género, autor, título y publicación',
+			table: { type: { summary: 'Story' }, defaultValue: { summary: 'undefined' } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<StoryHeroHeaderComponent>;
+
+// Playground interactivo: un único selector de Obra; portada de fondo, título, autor y publicación cambian juntos.
+export const Interactiva: StoryObj<StoryHeroHeaderComponent & { storyIndex: number }> = {
+	argTypes: {
+		storyIndex: {
+			...literaryWorkSelectArgType,
+			description:
+				'Obra del corpus de François Onoff; su portada, título, autor y publicación cambian de forma conjunta',
+		},
+	},
+	render: (args) => ({
+		props: { ...args, stories: onoffStoriesMock.map(withGenre) },
+		template: `<cuentoneta-story-hero-header [story]="stories[storyIndex]" />`,
+	}),
+	args: { storyIndex: 0 },
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Playground interactivo. Elegí la <strong>Obra</strong> del corpus: su portada de fondo, título, autor y publicación cambian de forma conjunta.',
+			},
+		},
+	},
+};
+
+// Estado principal documentado: un cuento fijo del corpus con género.
+export const Default: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-story-hero-header ${argsToTemplate(args)} />`,
+	}),
+	args: { story: withGenre(palacioNueveFronterasStoryMock) },
+	parameters: {
+		docs: {
+			description: {
+				story: 'Estado principal del hero con portada, género, autor, título y publicación.',
+			},
+		},
+	},
+};
+
+// Sin género: el estado real de los mocks base (`tags: []`); el Tag se oculta sin romper el layout.
+export const SinGenero: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-story-hero-header ${argsToTemplate(args)} />`,
+	}),
+	args: { story: palacioNueveFronterasStoryMock },
+	parameters: {
+		docs: {
+			description: {
+				story: 'Cuando la historia no tiene tags, el Tag de género se omite y el resto del bloque se mantiene.',
+			},
+		},
+	},
+};
+
+// Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
+// El hero renderiza su propio skeleton cuando no recibe story.
+export const Estados: StoryObj<StoryHeroHeaderComponent & { loading: boolean }> = {
+	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
+	render: (args) => ({
+		props: args,
+		template: `
+			@if (loading) {
+				<cuentoneta-story-hero-header />
+			} @else {
+				<cuentoneta-story-hero-header [story]="story" />
+			}
+		`,
+	}),
+	args: { loading: true, story: withGenre(palacioNueveFronterasStoryMock) },
+	parameters: {
+		docs: { description: { story: 'Activá/desactivá "Cargando" para alternar entre el estado real y el skeleton.' } },
+	},
+};

--- a/src/app/components/story-hero-header/story-hero-header.component.stories.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.stories.ts
@@ -10,12 +10,11 @@ import { literaryWorkSelectArgType } from '../../mocks/onoff-corpus.storybook';
 
 // Género de muestra: los mocks del corpus Onoff traen `tags: []` (deuda de #1593), así que se superpone
 // un tag localmente —sin tocar los mocks compartidos— para poder visualizar el Tag de género del hero.
-const genreTag: Tag = { title: 'Ciencia ficción', slug: 'ciencia-ficcion', shortDescription: '', description: [] };
-const withGenre = (story: StoryModel): StoryModel => ({ ...story, tags: [genreTag] });
+const withGenre = (story: StoryModel): StoryModel => {
+	const genreTag: Tag = { title: 'Ciencia ficción', slug: 'ciencia-ficcion', shortDescription: '', description: [] };
+	return { ...story, tags: [genreTag] };
+};
 
-// Las descripciones de la doc van en una sola línea: el renderer de Markdown de los autodocs
-// interpreta como bloque de código cualquier línea con indentación, así que un HTML multilínea
-// indentado se mostraría dentro de un recuadro de código.
 const meta: Meta<StoryHeroHeaderComponent> = {
 	component: StoryHeroHeaderComponent,
 	title: 'Componentes V3/StoryHeroHeader',
@@ -103,18 +102,12 @@ export const SinGenero: Story = {
 };
 
 // Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
-// El hero renderiza su propio skeleton cuando no recibe story.
+// El hero renderiza su propio skeleton cuando no recibe story, así que basta una única instancia.
 export const Estados: StoryObj<StoryHeroHeaderComponent & { loading: boolean }> = {
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
 	render: (args) => ({
 		props: args,
-		template: `
-			@if (loading) {
-				<cuentoneta-story-hero-header />
-			} @else {
-				<cuentoneta-story-hero-header [story]="story" />
-			}
-		`,
+		template: `<cuentoneta-story-hero-header [story]="loading ? undefined : story" />`,
 	}),
 	args: { loading: true, story: withGenre(palacioNueveFronterasStoryMock) },
 	parameters: {

--- a/src/app/components/story-hero-header/story-hero-header.component.stories.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.stories.ts
@@ -45,7 +45,6 @@ const meta: Meta<StoryHeroHeaderComponent> = {
 export default meta;
 type Story = StoryObj<StoryHeroHeaderComponent>;
 
-// Playground interactivo: un único selector de Obra; portada de fondo, título, autor y publicación cambian juntos.
 export const Interactiva: StoryObj<StoryHeroHeaderComponent & { storyIndex: number }> = {
 	argTypes: {
 		storyIndex: {
@@ -69,7 +68,6 @@ export const Interactiva: StoryObj<StoryHeroHeaderComponent & { storyIndex: numb
 	},
 };
 
-// Estado principal documentado: un cuento fijo del corpus con género.
 export const Default: Story = {
 	render: (args) => ({
 		props: args,
@@ -85,7 +83,6 @@ export const Default: Story = {
 	},
 };
 
-// Sin género: el estado real de los mocks base (`tags: []`); el Tag se oculta sin romper el layout.
 export const SinGenero: Story = {
 	render: (args) => ({
 		props: args,
@@ -101,7 +98,6 @@ export const SinGenero: Story = {
 	},
 };
 
-// Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
 // El hero renderiza su propio skeleton cuando no recibe story, así que basta una única instancia.
 export const Estados: StoryObj<StoryHeroHeaderComponent & { loading: boolean }> = {
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },

--- a/src/app/components/story-hero-header/story-hero-header.component.stories.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.stories.ts
@@ -1,19 +1,10 @@
 import { applicationConfig, argsToTemplate, Meta, StoryObj } from '@storybook/angular';
 import { provideRouter } from '@angular/router';
 
-import type { Story as StoryModel } from '@models/story.model';
-import type { Tag } from '@models/tag.model';
 import { StoryHeroHeaderComponent } from './story-hero-header.component';
 import { onoffStoriesMock } from '../../mocks/onoff-stories.mock';
 import { palacioNueveFronterasStoryMock } from '../../mocks/onoff/el-palacio-de-las-nueve-fronteras.mock';
 import { literaryWorkSelectArgType } from '../../mocks/onoff-corpus.storybook';
-
-// Género de muestra: los mocks del corpus Onoff traen `tags: []` (deuda de #1593), así que se superpone
-// un tag localmente —sin tocar los mocks compartidos— para poder visualizar el Tag de género del hero.
-const withGenre = (story: StoryModel): StoryModel => {
-	const genreTag: Tag = { title: 'Ciencia ficción', slug: 'ciencia-ficcion', shortDescription: '', description: [] };
-	return { ...story, tags: [genreTag] };
-};
 
 const meta: Meta<StoryHeroHeaderComponent> = {
 	component: StoryHeroHeaderComponent,
@@ -28,7 +19,7 @@ const meta: Meta<StoryHeroHeaderComponent> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>Banda superior (hero) de la página de una historia. Usa la misma portada del cuento como fondo difuminado con una capa de opacidad y, en primer plano, presenta la portada nítida, el género, el autor, el título y la colección/año de publicación originales.</p><p>Recibe el <code>Story</code> completo como único input; cuando no se provee, renderiza su propio estado de carga (skeleton).</p><p>Se compone de <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> (portada en primer plano), <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> (género, variante <code>gray</code>) e <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar del autor).</p></div>`,
+				component: `<div><p>Banda superior (hero) de la página de una historia. Usa la misma portada del cuento como fondo difuminado con una capa de opacidad y, en primer plano, presenta la portada nítida, el tipo literario, el autor, el título y la colección/año de publicación originales.</p><p>Recibe el <code>Story</code> completo como único input; cuando no se provee, renderiza su propio estado de carga (skeleton).</p><p>Se compone de <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> (portada en primer plano), <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> (tipo literario, variante <code>gray</code>) e <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar del autor).</p></div>`,
 			},
 		},
 		layout: 'fullscreen',
@@ -36,7 +27,8 @@ const meta: Meta<StoryHeroHeaderComponent> = {
 	argTypes: {
 		story: {
 			control: { type: 'object' },
-			description: 'Historia completa a partir de la cual se derivan portada, género, autor, título y publicación',
+			description:
+				'Historia completa a partir de la cual se derivan portada, tipo literario, autor, título y publicación',
 			table: { type: { summary: 'Story' }, defaultValue: { summary: 'undefined' } },
 		},
 	},
@@ -54,7 +46,7 @@ export const Interactiva: StoryObj<StoryHeroHeaderComponent & { storyIndex: numb
 		},
 	},
 	render: (args) => ({
-		props: { ...args, stories: onoffStoriesMock.map(withGenre) },
+		props: { ...args, stories: onoffStoriesMock },
 		template: `<cuentoneta-story-hero-header [story]="stories[storyIndex]" />`,
 	}),
 	args: { storyIndex: 0 },
@@ -73,11 +65,11 @@ export const Default: Story = {
 		props: args,
 		template: `<cuentoneta-story-hero-header ${argsToTemplate(args)} />`,
 	}),
-	args: { story: withGenre(palacioNueveFronterasStoryMock) },
+	args: { story: palacioNueveFronterasStoryMock },
 	parameters: {
 		docs: {
 			description: {
-				story: 'Estado principal del hero con portada, género, autor, título y publicación.',
+				story: 'Estado principal del hero con portada, tipo literario, autor, título y publicación.',
 			},
 		},
 	},
@@ -88,11 +80,11 @@ export const SinGenero: Story = {
 		props: args,
 		template: `<cuentoneta-story-hero-header ${argsToTemplate(args)} />`,
 	}),
-	args: { story: palacioNueveFronterasStoryMock },
+	args: { story: { ...palacioNueveFronterasStoryMock, tags: [] } },
 	parameters: {
 		docs: {
 			description: {
-				story: 'Cuando la historia no tiene tags, el Tag de género se omite y el resto del bloque se mantiene.',
+				story: 'Cuando la historia no tiene tags, el Tag de tipo literario se omite y el resto del bloque se mantiene.',
 			},
 		},
 	},
@@ -105,7 +97,7 @@ export const Estados: StoryObj<StoryHeroHeaderComponent & { loading: boolean }> 
 		props: args,
 		template: `<cuentoneta-story-hero-header [story]="loading ? undefined : story" />`,
 	}),
-	args: { loading: true, story: withGenre(palacioNueveFronterasStoryMock) },
+	args: { loading: true, story: palacioNueveFronterasStoryMock },
 	parameters: {
 		docs: { description: { story: 'Activá/desactivá "Cargando" para alternar entre el estado real y el skeleton.' } },
 	},

--- a/src/app/components/story-hero-header/story-hero-header.component.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.ts
@@ -31,7 +31,15 @@ import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.c
 	template: `
 		@if (story(); as story) {
 			@if (backgroundImageUrl(); as backgroundImageUrl) {
-				<img [ngSrc]="backgroundImageUrl" fill priority sizes="100vw" alt="" class="scale-105 object-cover blur-xl" />
+				<img
+					[ngSrc]="backgroundImageUrl"
+					fill
+					priority
+					sizes="100vw"
+					alt=""
+					class="scale-105 object-cover blur-xl"
+					data-testid="hero-background"
+				/>
 			}
 			<div class="absolute inset-0 bg-neutral-950-70" data-testid="hero-overlay"></div>
 
@@ -47,12 +55,7 @@ import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.c
 							class="group flex items-center gap-2"
 							data-testid="author"
 						>
-							<cuentoneta-image-profile
-								[src]="story.author.imageUrl"
-								[alt]="'Retrato de ' + story.author.name"
-								size="small"
-								class="shrink-0"
-							/>
+							<cuentoneta-image-profile [src]="story.author.imageUrl" size="small" class="shrink-0" />
 							<span class="font-inter text-sm font-medium text-neutral-50 group-hover:underline">{{
 								story.author.name
 							}}</span>

--- a/src/app/components/story-hero-header/story-hero-header.component.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.ts
@@ -1,0 +1,83 @@
+import { Component, computed, input } from '@angular/core';
+import { NgOptimizedImage } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+import type { Story } from '@models/story.model';
+import { withSanityImageParams } from '@utils/sanity-image.utils';
+import { AppRoutes } from '../../app.routes';
+import { CoverImageComponent } from '../cover-image/cover-image.component';
+import { ImageProfileComponent } from '../image-profile/image-profile.component';
+import { TagComponent } from '../tag/tag.component';
+import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.component';
+
+/**
+ * Hero de la página Story (Design System v3): banda superior del cuento con la MISMA portada de fondo
+ * difuminada + capa de opacidad, y en primer plano la portada nítida (`CoverImage`), el género (`Tag`),
+ * el autor (`ImageProfile` + nombre, enlace al perfil), el título y "Publicado en: <colección> (<año>)".
+ *
+ * Recibe el `Story` completo como único input; ausente ⇒ renderiza su propio skeleton.
+ */
+@Component({
+	selector: 'cuentoneta-story-hero-header',
+	imports: [
+		NgOptimizedImage,
+		RouterLink,
+		CoverImageComponent,
+		ImageProfileComponent,
+		TagComponent,
+		StoryHeroHeaderSkeletonComponent,
+	],
+	host: { class: 'relative block overflow-hidden bg-neutral-900' },
+	template: `
+		@if (story(); as story) {
+			@if (backgroundImageUrl(); as backgroundImageUrl) {
+				<img [ngSrc]="backgroundImageUrl" fill priority sizes="100vw" alt="" class="scale-105 object-cover blur-xl" />
+			}
+			<div class="absolute inset-0 bg-neutral-950-70" data-testid="hero-overlay"></div>
+
+			<div class="relative z-10 px-6 pt-28 pb-10">
+				<div class="mx-auto flex w-full max-w-180 items-center gap-8">
+					<cuentoneta-cover-image [src]="story.coverImage" [priority]="true" />
+					<div class="flex min-w-0 flex-col items-start gap-2.5">
+						@if (genre(); as genre) {
+							<cuentoneta-tag [label]="genre.title" variant="gray" data-testid="genre" />
+						}
+						<a
+							[routerLink]="['/', appRoutes.Author, story.author.slug]"
+							class="group flex items-center gap-2"
+							data-testid="author"
+						>
+							<cuentoneta-image-profile
+								[src]="story.author.imageUrl"
+								[alt]="'Retrato de ' + story.author.name"
+								size="small"
+								class="shrink-0"
+							/>
+							<span class="font-inter text-sm font-medium text-neutral-50 group-hover:underline">{{
+								story.author.name
+							}}</span>
+						</a>
+						<h1 class="w-full font-inter text-2xl font-bold text-neutral-50">{{ story.title }}</h1>
+						<p class="font-inter text-sm font-medium text-neutral-50" data-testid="publication">
+							Publicado en: {{ story.originalPublication }}
+						</p>
+					</div>
+				</div>
+			</div>
+		} @else {
+			<cuentoneta-story-hero-header-skeleton data-testid="skeleton" />
+		}
+	`,
+})
+export class StoryHeroHeaderComponent {
+	protected readonly appRoutes = AppRoutes;
+
+	public readonly story = input<Story>();
+
+	protected readonly genre = computed(() => this.story()?.tags[0]);
+
+	// La misma coverImage pedida al CDN en una talla mayor para el fondo full-bleed (no es otra imagen).
+	protected readonly backgroundImageUrl = computed(() =>
+		withSanityImageParams(this.story()?.coverImage ?? '', { w: 1920 }),
+	);
+}

--- a/src/app/components/story-hero-header/story-hero-header.component.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.ts
@@ -8,11 +8,12 @@ import { AppRoutes } from '../../app.routes';
 import { CoverImageComponent } from '../cover-image/cover-image.component';
 import { ImageProfileComponent } from '../image-profile/image-profile.component';
 import { TagComponent } from '../tag/tag.component';
+import { TagsListComponent } from '../tags-list/tags-list.component';
 import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.component';
 
 /**
  * Hero de la página Story (Design System v3): banda superior del cuento con la MISMA portada de fondo
- * difuminada + capa de opacidad, y en primer plano la portada nítida (`CoverImage`), el tipo literario (`Tag`),
+ * difuminada + capa de opacidad, y en primer plano la portada nítida (`CoverImage`), los tags (`TagsList`),
  * el autor (`ImageProfile` + nombre, enlace al perfil), el título y "Publicado en: <colección> (<año>)".
  *
  * Recibe el `Story` completo como único input; ausente ⇒ renderiza su propio skeleton.
@@ -25,6 +26,7 @@ import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.c
 		CoverImageComponent,
 		ImageProfileComponent,
 		TagComponent,
+		TagsListComponent,
 		StoryHeroHeaderSkeletonComponent,
 	],
 	host: { class: 'relative block overflow-hidden bg-neutral-900' },
@@ -47,8 +49,12 @@ import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.c
 				<div class="mx-auto flex w-full max-w-180 items-center gap-8">
 					<cuentoneta-cover-image [src]="story.coverImage" [priority]="true" />
 					<div class="flex min-w-0 flex-col items-start gap-2.5">
-						@if (literaryType(); as literaryType) {
-							<cuentoneta-tag [label]="literaryType.title" variant="gray" data-testid="literary-type" />
+						@if (tags().length) {
+							<cuentoneta-tags-list data-testid="tags">
+								@for (tag of tags(); track tag.slug) {
+									<cuentoneta-tag [label]="tag.title" variant="gray" />
+								}
+							</cuentoneta-tags-list>
 						}
 						<a
 							[routerLink]="['/', appRoutes.Author, story.author.slug]"
@@ -77,7 +83,7 @@ export class StoryHeroHeaderComponent {
 
 	public readonly story = input<Story>();
 
-	protected readonly literaryType = computed(() => this.story()?.tags[0]);
+	protected readonly tags = computed(() => this.story()?.tags ?? []);
 
 	// La misma coverImage pedida al CDN en una talla mayor para el fondo full-bleed (no es otra imagen).
 	protected readonly backgroundImageUrl = computed(() =>

--- a/src/app/components/story-hero-header/story-hero-header.component.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.ts
@@ -12,7 +12,7 @@ import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.c
 
 /**
  * Hero de la página Story (Design System v3): banda superior del cuento con la MISMA portada de fondo
- * difuminada + capa de opacidad, y en primer plano la portada nítida (`CoverImage`), el género (`Tag`),
+ * difuminada + capa de opacidad, y en primer plano la portada nítida (`CoverImage`), el tipo literario (`Tag`),
  * el autor (`ImageProfile` + nombre, enlace al perfil), el título y "Publicado en: <colección> (<año>)".
  *
  * Recibe el `Story` completo como único input; ausente ⇒ renderiza su propio skeleton.
@@ -47,8 +47,8 @@ import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.c
 				<div class="mx-auto flex w-full max-w-180 items-center gap-8">
 					<cuentoneta-cover-image [src]="story.coverImage" [priority]="true" />
 					<div class="flex min-w-0 flex-col items-start gap-2.5">
-						@if (genre(); as genre) {
-							<cuentoneta-tag [label]="genre.title" variant="gray" data-testid="genre" />
+						@if (literaryType(); as literaryType) {
+							<cuentoneta-tag [label]="literaryType.title" variant="gray" data-testid="literary-type" />
 						}
 						<a
 							[routerLink]="['/', appRoutes.Author, story.author.slug]"
@@ -77,7 +77,7 @@ export class StoryHeroHeaderComponent {
 
 	public readonly story = input<Story>();
 
-	protected readonly genre = computed(() => this.story()?.tags[0]);
+	protected readonly literaryType = computed(() => this.story()?.tags[0]);
 
 	// La misma coverImage pedida al CDN en una talla mayor para el fondo full-bleed (no es otra imagen).
 	protected readonly backgroundImageUrl = computed(() =>

--- a/src/app/mocks/onoff-tags.mock.ts
+++ b/src/app/mocks/onoff-tags.mock.ts
@@ -1,0 +1,66 @@
+import type { Tag } from '@models/tag.model';
+
+// Arma el bloque de Portable Text de `description` a partir del texto corto, que es lo único que varía entre
+// los tags del corpus.
+function createTag(title: string, slug: string, shortDescription: string): Tag {
+	return {
+		title,
+		slug,
+		shortDescription,
+		description: [
+			{
+				_type: 'block',
+				style: 'normal',
+				_key: `${slug}-desc`,
+				markDefs: [],
+				children: [{ _type: 'span', _key: `${slug}-desc-s`, text: shortDescription, marks: [] }],
+			},
+		],
+	};
+}
+
+// Tipo literario de la obra. Va primero en `tags` de cada Story: los componentes que muestran un único tag
+// —el hero de la página de story, entre otros— toman `tags[0]` y lo presentan como etiqueta principal.
+export const cuentoTagMock = createTag('Cuento', 'cuento', 'Relato breve de ficción.');
+export const novelaTagMock = createTag('Novela', 'novela', 'Narrativa extensa de ficción.');
+export const ensayoTagMock = createTag('Ensayo', 'ensayo', 'Prosa reflexiva que argumenta en torno a un tema.');
+export const teatroTagMock = createTag('Teatro', 'teatro', 'Obra escrita para ser representada en escena.');
+
+// Género de la obra. Acompañan al tipo literario como tags adicionales.
+export const dramaPsicologicoTagMock = createTag(
+	'Drama psicológico',
+	'drama-psicologico',
+	'Conflicto centrado en la vida interior de los personajes.',
+);
+export const metaficcionTagMock = createTag(
+	'Metaficción',
+	'metaficcion',
+	'Obras que se vuelven sobre su propia escritura y la exhiben como tema.',
+);
+export const absurdoTagMock = createTag(
+	'Absurdo',
+	'absurdo',
+	'Rutinas y gestos cotidianos llevados hasta perder todo sentido.',
+);
+export const surrealismoTagMock = createTag(
+	'Surrealismo',
+	'surrealismo',
+	'Imágenes oníricas que desbordan la lógica cotidiana.',
+);
+export const alegoriaTagMock = createTag('Alegoría', 'alegoria', 'Relato cuyo sentido literal remite a otro figurado.');
+export const filosoficoTagMock = createTag(
+	'Filosófico',
+	'filosofico',
+	'Ficción organizada en torno a una pregunta o una idea abstracta.',
+);
+export const experimentalTagMock = createTag(
+	'Experimental',
+	'experimental',
+	'Obras que anteponen el procedimiento formal a la trama.',
+);
+export const tragediaTagMock = createTag('Tragedia', 'tragedia', 'Pieza dramática de desenlace adverso.');
+export const dramaHistoricoTagMock = createTag(
+	'Drama histórico',
+	'drama-historico',
+	'Ficción dramática ambientada en hechos o figuras del pasado.',
+);

--- a/src/app/mocks/onoff/el-odio.mock.ts
+++ b/src/app/mocks/onoff/el-odio.mock.ts
@@ -1,5 +1,6 @@
 import type { Story } from '@models/story.model';
 import { authorMock } from '../author.mock';
+import { dramaPsicologicoTagMock, novelaTagMock } from '../onoff-tags.mock';
 
 export const elOdioStoryMock: Story = {
 	_id: 'onoff-story-el-odio',
@@ -9,7 +10,7 @@ export const elOdioStoryMock: Story = {
 	approximateReadingTime: 6,
 	badLanguage: false,
 	coverImage: 'assets/img/mocks/stories/el-odio.png',
-	tags: [],
+	tags: [novelaTagMock, dramaPsicologicoTagMock],
 	resources: [],
 	media: [],
 	epigraphs: [],

--- a/src/app/mocks/onoff/el-palacio-de-las-nueve-fronteras.mock.ts
+++ b/src/app/mocks/onoff/el-palacio-de-las-nueve-fronteras.mock.ts
@@ -1,5 +1,6 @@
 import type { Story } from '@models/story.model';
 import { authorMock } from '../author.mock';
+import { dramaPsicologicoTagMock, metaficcionTagMock, novelaTagMock } from '../onoff-tags.mock';
 
 export const palacioNueveFronterasStoryMock: Story = {
 	_id: 'onoff-story-el-palacio-de-las-nueve-fronteras',
@@ -9,7 +10,7 @@ export const palacioNueveFronterasStoryMock: Story = {
 	approximateReadingTime: 11,
 	badLanguage: false,
 	coverImage: 'assets/img/mocks/stories/el-palacio-de-las-nueve-fronteras.png',
-	tags: [],
+	tags: [novelaTagMock, dramaPsicologicoTagMock, metaficcionTagMock],
 	resources: [],
 	media: [],
 	epigraphs: [],

--- a/src/app/mocks/onoff/el-tratado-de-los-placeres.mock.ts
+++ b/src/app/mocks/onoff/el-tratado-de-los-placeres.mock.ts
@@ -1,5 +1,6 @@
 import type { Story } from '@models/story.model';
 import { authorMock } from '../author.mock';
+import { ensayoTagMock, filosoficoTagMock, metaficcionTagMock } from '../onoff-tags.mock';
 
 export const elTratadoDeLosPlaceresStoryMock: Story = {
 	_id: 'onoff-story-el-tratado-de-los-placeres',
@@ -9,7 +10,7 @@ export const elTratadoDeLosPlaceresStoryMock: Story = {
 	approximateReadingTime: 10,
 	badLanguage: false,
 	coverImage: 'assets/img/mocks/stories/el-tratado-de-los-placeres.png',
-	tags: [],
+	tags: [ensayoTagMock, filosoficoTagMock, metaficcionTagMock],
 	resources: [],
 	media: [],
 	epigraphs: [],

--- a/src/app/mocks/onoff/geometria.mock.ts
+++ b/src/app/mocks/onoff/geometria.mock.ts
@@ -1,5 +1,6 @@
 import type { Story } from '@models/story.model';
 import { authorMock } from '../author.mock';
+import { cuentoTagMock, dramaPsicologicoTagMock, filosoficoTagMock } from '../onoff-tags.mock';
 
 export const geometriaStoryMock: Story = {
 	_id: 'onoff-story-geometria',
@@ -9,7 +10,7 @@ export const geometriaStoryMock: Story = {
 	approximateReadingTime: 7,
 	badLanguage: false,
 	coverImage: 'assets/img/mocks/stories/geometria.png',
-	tags: [],
+	tags: [cuentoTagMock, dramaPsicologicoTagMock, filosoficoTagMock],
 	resources: [],
 	media: [],
 	epigraphs: [],

--- a/src/app/mocks/onoff/las-dos-antorchas.mock.ts
+++ b/src/app/mocks/onoff/las-dos-antorchas.mock.ts
@@ -1,5 +1,6 @@
 import type { Story } from '@models/story.model';
 import { authorMock } from '../author.mock';
+import { experimentalTagMock, metaficcionTagMock, novelaTagMock } from '../onoff-tags.mock';
 
 export const lasDosAntorchasStoryMock: Story = {
 	_id: 'onoff-story-las-dos-antorchas',
@@ -9,7 +10,7 @@ export const lasDosAntorchasStoryMock: Story = {
 	approximateReadingTime: 8,
 	badLanguage: false,
 	coverImage: 'assets/img/mocks/stories/las-dos-antorchas.png',
-	tags: [],
+	tags: [novelaTagMock, metaficcionTagMock, experimentalTagMock],
 	resources: [],
 	media: [],
 	epigraphs: [],

--- a/src/app/mocks/onoff/las-escaleras.mock.ts
+++ b/src/app/mocks/onoff/las-escaleras.mock.ts
@@ -1,5 +1,6 @@
 import type { Story } from '@models/story.model';
 import { authorMock } from '../author.mock';
+import { absurdoTagMock, alegoriaTagMock, novelaTagMock } from '../onoff-tags.mock';
 
 export const lasEscalerasStoryMock: Story = {
 	_id: 'onoff-story-las-escaleras',
@@ -9,7 +10,7 @@ export const lasEscalerasStoryMock: Story = {
 	approximateReadingTime: 9,
 	badLanguage: false,
 	coverImage: 'assets/img/mocks/stories/las-escaleras.png',
-	tags: [],
+	tags: [novelaTagMock, absurdoTagMock, alegoriaTagMock],
 	resources: [],
 	media: [],
 	epigraphs: [],

--- a/src/app/mocks/onoff/los-peldanos.mock.ts
+++ b/src/app/mocks/onoff/los-peldanos.mock.ts
@@ -1,5 +1,6 @@
 import type { Story } from '@models/story.model';
 import { authorMock } from '../author.mock';
+import { absurdoTagMock, cuentoTagMock, surrealismoTagMock } from '../onoff-tags.mock';
 
 export const losPeldanosStoryMock: Story = {
 	_id: 'onoff-story-los-peldanos',
@@ -9,7 +10,7 @@ export const losPeldanosStoryMock: Story = {
 	approximateReadingTime: 8,
 	badLanguage: false,
 	coverImage: 'assets/img/mocks/stories/los-peldanos.png',
-	tags: [],
+	tags: [cuentoTagMock, absurdoTagMock, surrealismoTagMock],
 	resources: [],
 	media: [],
 	epigraphs: [],

--- a/src/app/mocks/onoff/neron.mock.ts
+++ b/src/app/mocks/onoff/neron.mock.ts
@@ -1,5 +1,6 @@
 import type { Story } from '@models/story.model';
 import { authorMock } from '../author.mock';
+import { dramaHistoricoTagMock, teatroTagMock, tragediaTagMock } from '../onoff-tags.mock';
 
 export const neronStoryMock: Story = {
 	_id: 'onoff-story-neron',
@@ -9,7 +10,7 @@ export const neronStoryMock: Story = {
 	approximateReadingTime: 7,
 	badLanguage: false,
 	coverImage: 'assets/img/mocks/stories/neron.png',
-	tags: [],
+	tags: [teatroTagMock, tragediaTagMock, dramaHistoricoTagMock],
 	resources: [],
 	media: [],
 	epigraphs: [],


### PR DESCRIPTION
## Descripción

- Nuevo componente V3 `StoryHeroHeaderComponent`: banda superior (hero) de la página Story, con la **misma portada del cuento** como fondo difuminado + capa de opacidad y, en primer plano, la portada nítida (`CoverImage`), los **tags de la obra** (`TagsList`, variante `gray`), el autor (`ImageProfile` + nombre, con enlace a `/author/:slug`), el título (`<h1>`) y "Publicado en: `<colección> (<año>)`".
- El hero lista **todos** los tags de la historia vía `TagsList` (recorte por ancho + `+N`). Una historia siempre expone al menos un tag, así que el bloque de tags no tiene caso vacío.
- Reutiliza los átomos V3 existentes (`cover-image`, `tag`, `tags-list`, `image-profile`); deriva todos los datos del `Story` completo (input único opcional → self-skeleton).
- Corpus de mocks Onoff con tags reutilizables (`src/app/mocks/onoff-tags.mock.ts`): catálogo de tipos literarios (Cuento, Novela, Ensayo, Teatro) y géneros (Drama psicológico, Metaficción, Absurdo, Surrealismo, Alegoría, Filosófico, Experimental, Tragedia, Drama histórico), asignados a cada una de las 8 obras según su descripción.
- Tokens y medidas extraídos de Figma (nodo `Header` 4488:5780) y mapeados a tokens V3 existentes (`blur-xl`, `neutral-950-70`, `text-2xl`) — sin declarar tokens nuevos.
- Storybook bajo `Componentes V3/StoryHeroHeader`: `Interactiva` (select de las 8 obras del corpus Onoff), `Default` y `Estados` (toggle real↔skeleton). El detalle de por qué el fondo no es otra imagen (misma `coverImage` pedida al CDN a 1920px) se documenta en la descripción de autodocs, no como comentario inline.

Closes #1810.

Parte de #1471.

## Plan de pruebas

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm stylelint` — verde
- [x] `pnpm test` — spec del componente 10/10 (título, enlace de autor con nombre accesible exacto, publicación, todos los tags renderizados, portada/placeholder, fondo difuminado presente/ausente, skeleton presente/ausente)
- [x] `pnpm build` y `pnpm storybook:build` — verde
- [x] Verificación visual en Storybook (Default y skeleton) fiel al diseño de Figma

## Notas

- No integra el hero en `pages/story` (fuera del alcance del AC de #1810; follow-up del epic #1471). Al integrarlo habrá que quitar el `<h1>` actual de `story.component.html` para evitar dos `<h1>` en la misma página.
- El fondo difuminado y la portada nítida se marcan ambos `priority`: se difiere evaluar si el fondo puede cargar sin prioridad hasta poder medir CWV sobre la página integrada (ver `workspace/CODE_REVIEW.md`, sugerencia #6).
