### PR TITLE
[#1815] - [DS] Nombre accesible duplicado en el enlace de autor (avatar dentro del <a>)

### DIFF
--- a/src/app/components/author-teaser/author-teaser.component.spec.ts
+++ b/src/app/components/author-teaser/author-teaser.component.spec.ts
@@ -36,29 +36,38 @@ describe('AuthorTeaserComponent', () => {
 		expect(screen.getByText(authorTeaserMock.name)).toBeInTheDocument();
 	});
 
-	test("should display the author's image with correct alt text", async () => {
+	test("should display the author's image", async () => {
 		await setup();
-		const img = screen.getByAltText(`Retrato de ${authorTeaserMock.name}`);
+		// El avatar es decorativo (alt vacío), fuera del árbol de accesibilidad: se localiza por su testid.
+		const img = screen.getByTestId('author-avatar');
 		expect(img).toBeInTheDocument();
 		expect(img).toHaveAttribute('src', expect.stringContaining(authorTeaserMock.imageUrl));
 	});
 
 	test('should display the nationality flag and country name if available', async () => {
 		await setup();
-		const flag = screen.getByAltText(`Bandera de ${authorTeaserMock.nationality.country}`);
+		const flag = screen.getByTestId('author-flag');
 		expect(flag).toBeInTheDocument();
 		expect(screen.getByText(authorTeaserMock.nationality.country)).toBeInTheDocument();
 	});
 
+	test('should expose just the author name and country as the accessible name of the link', async () => {
+		await setup();
+		// Avatar y bandera decorativos: el nombre accesible del enlace no incluye "Retrato de …" duplicado.
+		const link = screen.getByRole('link');
+		expect(link).toHaveAccessibleName(expect.stringContaining(authorTeaserMock.name));
+		expect(link).toHaveAccessibleName(expect.not.stringContaining('Retrato de'));
+	});
+
 	test('should apply correct styles for "sm" variant', async () => {
 		await setup('sm');
-		const img = screen.getByAltText(`Retrato de ${authorTeaserMock.name}`);
+		const img = screen.getByTestId('author-avatar');
 		expect(img).toHaveClass('h-[40px] w-[40px] rounded');
 	});
 
 	test('should apply correct styles for "md" variant', async () => {
 		await setup('md');
-		const img = screen.getByAltText(`Retrato de ${authorTeaserMock.name}`);
+		const img = screen.getByTestId('author-avatar');
 		expect(img).toHaveClass('h-[64px] w-[64px] rounded-md');
 	});
 

--- a/src/app/components/author-teaser/author-teaser.component.spec.ts
+++ b/src/app/components/author-teaser/author-teaser.component.spec.ts
@@ -53,10 +53,13 @@ describe('AuthorTeaserComponent', () => {
 
 	test('should expose just the author name and country as the accessible name of the link', async () => {
 		await setup();
-		// Avatar y bandera decorativos: el nombre accesible del enlace no incluye "Retrato de …" duplicado.
+		// Avatar y bandera decorativos: el nombre accesible del enlace es el texto (nombre + país),
+		// sin el "Retrato de …" ni el "Bandera de …" duplicados de los alt descriptivos.
 		const link = screen.getByRole('link');
 		expect(link).toHaveAccessibleName(expect.stringContaining(authorTeaserMock.name));
+		expect(link).toHaveAccessibleName(expect.stringContaining(authorTeaserMock.nationality.country));
 		expect(link).toHaveAccessibleName(expect.not.stringContaining('Retrato de'));
+		expect(link).toHaveAccessibleName(expect.not.stringContaining('Bandera de'));
 	});
 
 	test('should apply correct styles for "sm" variant', async () => {

--- a/src/app/components/author-teaser/author-teaser.component.ts
+++ b/src/app/components/author-teaser/author-teaser.component.ts
@@ -20,7 +20,6 @@ import { withSanityImageParams } from '@utils/sanity-image.utils';
 		class="flex flex-row items-center hover:cursor-pointer"
 	>
 		<img
-			[alt]="'Retrato de ' + author().name"
 			[ngSrc]="authorImageUrl()"
 			[width]="imageSize()"
 			[height]="imageSize()"
@@ -28,6 +27,8 @@ import { withSanityImageParams } from '@utils/sanity-image.utils';
 				'h-[40px] w-[40px] rounded': variant() === 'sm',
 				'h-[64px] w-[64px] rounded-md': variant() === 'md',
 			}"
+			alt=""
+			data-testid="author-avatar"
 		/>
 		<div class="block hover:!cursor-pointer">
 			<h2
@@ -42,11 +43,12 @@ import { withSanityImageParams } from '@utils/sanity-image.utils';
 			@if (author().nationality; as nationality) {
 				<div class="flex items-center gap-2">
 					<img
-						[alt]="'Bandera de ' + nationality.country"
 						[ngSrc]="authorFlagUrl()"
+						alt=""
 						class="h-[15px] w-[20px] rounded"
 						width="20"
 						height="15"
+						data-testid="author-flag"
 					/>
 					<span
 						[ngClass]="{

--- a/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.spec.ts
@@ -4,7 +4,6 @@ import { storyMock } from '@mocks/story.mock';
 import type { Story } from '@models/story.model';
 
 const country = storyMock.author.nationality.country;
-const countryRegex = new RegExp(`\\b${country}\\b`, 'i');
 
 const name = storyMock.author.name;
 const nameRegex = new RegExp(`\\b${name}\\b`, 'iu');
@@ -37,18 +36,15 @@ describe('BioSummaryCardComponent', () => {
 		expect(screen.getByText('(Chateauroux, 1948 - París, 1994) fue un escritor', { exact: false })).toBeInTheDocument();
 	});
 
-	it('should display the country image text', async () => {
+	it('should display the country flag image', async () => {
 		await render(BioSummaryCardComponent, {
 			inputs: {
 				story: storyMock,
 			},
 		});
 
-		const countryImage = screen.getByRole('img', {
-			name: countryRegex,
-		});
-
-		expect(countryImage).toBeInTheDocument();
+		// La bandera es decorativa (alt vacío): se localiza por su testid, no por el nombre accesible.
+		expect(screen.getByTestId('author-flag')).toBeInTheDocument();
 	});
 
 	it('should display the author name', async () => {

--- a/src/app/components/home-story-card/home-story-card.component.spec.ts
+++ b/src/app/components/home-story-card/home-story-card.component.spec.ts
@@ -70,6 +70,14 @@ describe('HomeStoryCardComponent', () => {
 			const link = screen.getAllByRole('link').find((l) => l.getAttribute('href')?.includes('/author/'));
 			expect(link?.getAttribute('href')).toContain(authorUrl);
 		});
+
+		it('should expose the author name as the accessible name of the author link', async () => {
+			await render(HomeStoryCardComponent, {
+				inputs: { story: storyNavigationTeaserWithAuthorMock, navigationParams },
+			});
+			// El avatar es decorativo (alt vacío): el nombre accesible del enlace es solo el nombre del autor.
+			expect(screen.getByRole('link', { name: storyNavigationTeaserWithAuthorMock.author.name })).toBeInTheDocument();
+		});
 	});
 
 	describe('Order', () => {

--- a/src/app/components/home-story-card/home-story-card.component.ts
+++ b/src/app/components/home-story-card/home-story-card.component.ts
@@ -64,12 +64,7 @@ import { HomeStoryCardSkeletonComponent } from './home-story-card-skeleton.compo
 						class="group relative z-10 flex min-w-0 items-center gap-2"
 						data-testid="author"
 					>
-						<cuentoneta-image-profile
-							[src]="story.author.imageUrl"
-							[alt]="'Retrato de ' + story.author.name"
-							size="small"
-							class="shrink-0"
-						/>
+						<cuentoneta-image-profile [src]="story.author.imageUrl" size="small" class="shrink-0" />
 						<span class="truncate font-inter text-sm font-medium text-neutral-900 group-hover:underline">{{
 							story.author.name
 						}}</span>

--- a/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.spec.ts
+++ b/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.spec.ts
@@ -94,6 +94,14 @@ describe('StoryCardTeaserV3Component', () => {
 			expect(link?.getAttribute('href')).toContain(authorUrl);
 		});
 
+		it('should expose the author name as the accessible name of the author link', async () => {
+			await render(StoryCardTeaserV3Component, {
+				inputs: { story: storyNavigationTeaserWithAuthorMock, navigationParams, showAuthor: true },
+			});
+			// El avatar es decorativo (alt vacío): el nombre accesible del enlace es solo el nombre del autor.
+			expect(screen.getByRole('link', { name: storyNavigationTeaserWithAuthorMock.author.name })).toBeInTheDocument();
+		});
+
 		it('should not display the author when showAuthor is false', async () => {
 			await render(StoryCardTeaserV3Component, {
 				inputs: { story: storyNavigationTeaserWithAuthorMock, navigationParams, showAuthor: false },

--- a/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.ts
+++ b/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.ts
@@ -102,12 +102,7 @@ export type StoryCardTeaserV3Variant = 'on-white' | 'on-gray' | 'highlighted';
 				class="group relative z-10 flex min-w-0 items-center gap-2"
 				data-testid="author"
 			>
-				<cuentoneta-image-profile
-					[src]="author.imageUrl"
-					[alt]="'Retrato de ' + author.name"
-					size="small"
-					class="shrink-0"
-				/>
+				<cuentoneta-image-profile [src]="author.imageUrl" size="small" class="shrink-0" />
 				<span class="truncate font-inter text-sm font-medium text-neutral-900 group-hover:underline">{{
 					author.name
 				}}</span>

--- a/src/app/components/story-card-teaser/story-card-teaser.component.spec.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.spec.ts
@@ -96,7 +96,8 @@ describe('StoryCardTeaserComponent', () => {
 			},
 		});
 		const authorName = screen.getByText(storyNavigationTeaserWithAuthorMock.author.name);
-		const authorImage = screen.getByRole('img');
+		// El avatar es decorativo (alt vacío), fuera del árbol de accesibilidad: se localiza por su testid.
+		const authorImage = screen.getByTestId('author-avatar');
 		expect(authorName).toBeInTheDocument();
 		expect(authorImage).toBeInTheDocument();
 	});
@@ -116,6 +117,18 @@ describe('StoryCardTeaserComponent', () => {
 		expect(storyLink.href.includes(storyUrl)).toBeTruthy();
 	});
 
+	it('should expose the author name as the accessible name of the author link', async () => {
+		await render(StoryCardTeaserComponent, {
+			inputs: {
+				story: storyNavigationTeaserWithAuthorMock,
+				navigationParams: navigationParams,
+				showAuthor: true,
+			},
+		});
+		// El avatar decorativo no contamina el nombre accesible del enlace: es solo el nombre del autor.
+		expect(screen.getByRole('link', { name: storyNavigationTeaserWithAuthorMock.author.name })).toBeInTheDocument();
+	});
+
 	it('should not display the author name and avatar', async () => {
 		await render(StoryCardTeaserComponent, {
 			inputs: {
@@ -125,7 +138,7 @@ describe('StoryCardTeaserComponent', () => {
 			},
 		});
 		const authorName = screen.queryByText(storyNavigationTeaserWithAuthorMock.author.name);
-		const authorImage = screen.queryByRole('img');
+		const authorImage = screen.queryByTestId('author-avatar');
 		expect(authorName).not.toBeInTheDocument();
 		expect(authorImage).not.toBeInTheDocument();
 	});

--- a/src/app/components/story-card-teaser/story-card-teaser.component.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.ts
@@ -21,10 +21,11 @@ import { withSanityImageParams } from '@utils/sanity-image.utils';
 						<a [routerLink]="['/', appRoutes.Author, story.author.slug]" class="flex items-center gap-2">
 							<img
 								[ngSrc]="authorImageUrl()"
-								[alt]="'Retrato de ' + story.author.name"
+								alt=""
 								width="20"
 								height="20"
 								class="h-5 w-5 rounded-full"
+								data-testid="author-avatar"
 							/>
 							<span class="font-inter text-sm font-semibold text-neutral-500">{{ story.author.name }}</span>
 						</a>


### PR DESCRIPTION
## Descripción

- Corrige la **duplicación del nombre accesible** del enlace al perfil del autor en 4 componentes: `StoryCardTeaserV3`, `HomeStoryCard`, `StoryCardTeaser` (V2) y `AuthorTeaser` (V2). La imagen decorativa (avatar; en `AuthorTeaser` también la bandera de nacionalidad) llevaba un `alt` descriptivo **dentro** del `<a>` que ya incluye ese mismo texto, produciendo nombres accesibles como "Retrato de X X".
- **Fix:** se dejan esas imágenes decorativas (`alt=""`), tomando como referencia `AuthorTeaserV3` (avatar fuera del `<a>`, ya correcto y **sin tocar**). El nombre accesible del enlace pasa a ser solo el texto (nombre; y país en `AuthorTeaser`).
- Cada componente suma un test de regresión de accesibilidad. Se ajusta además el test del consumidor `BioSummaryCard` (la bandera de `AuthorTeaser`, ahora decorativa, se localiza por `data-testid`).

Closes #1815.

## Plan de pruebas

- [x] Test de regresión por componente (`getByRole('link', { name })` / `toHaveAccessibleName`)
- [x] `pnpm test` — 678 passed / 3 skipped / 0 failed
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm stylelint`, `pnpm build`, `pnpm storybook:build` — verde
- [x] Cambio de accesibilidad puro (sin cambios visuales; `AuthorTeaserV3`, referencia correcta, no se modifica)
