### PR TITLE
chore: elimina comentarios redundantes en stories, directiva y specs de backend

### DIFF
--- a/src/api/modules/content/content.service.spec.ts
+++ b/src/api/modules/content/content.service.spec.ts
@@ -51,7 +51,6 @@ describe('ContentService', () => {
 		it('should create missing weeks landing pages when they do not exist', async () => {
 			const weeksInTheFuture = 4;
 
-			// Mock repository responses
 			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
 			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(mockLandingPage);
 			(contentRepository.createLandingPages as Mock).mockResolvedValue([
@@ -63,7 +62,6 @@ describe('ContentService', () => {
 
 			const result = await contentService.addNextWeeksLandingPageContent(weeksInTheFuture);
 
-			// Verify all weeks were created
 			expect(result).toHaveLength(4);
 			expect(contentRepository.fetchLandingPagesList).toHaveBeenCalledWith(
 				expect.arrayContaining([
@@ -203,11 +201,9 @@ describe('ContentService', () => {
 
 			const result = await contentService.addNextWeeksLandingPageContent(weeksInTheFuture);
 
-			// Should create only the 2 missing weeks
 			expect(result).toHaveLength(2);
 			expect(contentRepository.createLandingPages).toHaveBeenCalled();
 
-			// Verify that the created objects have the correct structure
 			const callArgs = (contentRepository.createLandingPages as Mock).mock.calls[0][0];
 			expect(callArgs).toHaveLength(2);
 			callArgs.forEach((obj: LandingPageContentQueryResult) => {

--- a/src/api/modules/sitemap/sitemap.service.spec.ts
+++ b/src/api/modules/sitemap/sitemap.service.spec.ts
@@ -90,7 +90,6 @@ describe('SitemapService', () => {
 		});
 
 		it('should include story URLs', async () => {
-			// Repository returns already-processed data (dates formatted)
 			(sitemapRepository.fetchSitemapSlugs as Mock).mockResolvedValue({
 				stories: [{ slug: 'el-aleph', lastmod: '2025-01-01' }],
 				authors: [],
@@ -142,7 +141,6 @@ describe('SitemapService', () => {
 		});
 
 		it('should handle missing lastmod gracefully', async () => {
-			// Repository returns processed data (undefined lastmod preserved)
 			(sitemapRepository.fetchSitemapSlugs as Mock).mockResolvedValue({
 				stories: [{ slug: 'no-lastmod-story', lastmod: undefined }],
 				authors: [],

--- a/src/app/components/author-teaser-v3/author-teaser-v3.component.stories.ts
+++ b/src/app/components/author-teaser-v3/author-teaser-v3.component.stories.ts
@@ -67,7 +67,6 @@ const meta: Meta<AuthorTeaserV3Component> = {
 export default meta;
 type Story = StoryObj<AuthorTeaserV3Component>;
 
-// Teaser completo: avatar, tags, nombre + bandera y cantidad de historias.
 export const Default: Story = {
 	name: 'Por defecto',
 	render: (args) => ({ props: args, template: `<cuentoneta-author-teaser-v3 ${argsToTemplate(args)} />` }),
@@ -81,8 +80,6 @@ export const Default: Story = {
 	},
 };
 
-// Más de 2 tags en un contenedor acotado: la fila de tags se recorta por ancho y colapsa el excedente
-// tras un contador "+N".
 export const ManyTags: Story = {
 	name: 'Muchos tags',
 	render: (args) => ({ props: args, template: `<cuentoneta-author-teaser-v3 ${argsToTemplate(args)} />` }),
@@ -97,7 +94,6 @@ export const ManyTags: Story = {
 	},
 };
 
-// Sin imagen: el avatar cae al placeholder circular.
 export const WithoutImage: Story = {
 	name: 'Sin imagen',
 	render: (args) => ({ props: args, template: `<cuentoneta-author-teaser-v3 ${argsToTemplate(args)} />` }),
@@ -111,7 +107,6 @@ export const WithoutImage: Story = {
 	},
 };
 
-// Estado de carga (skeleton) del teaser.
 export const Skeleton: StoryObj = {
 	name: 'Esqueleto',
 	decorators: [moduleMetadata({ imports: [AuthorTeaserV3SkeletonComponent] })],
@@ -121,7 +116,6 @@ export const Skeleton: StoryObj = {
 	},
 };
 
-// Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
 export const Estados: StoryObj<AuthorTeaserV3Component & { loading: boolean }> = {
 	decorators: [moduleMetadata({ imports: [AuthorTeaserV3SkeletonComponent] })],
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },

--- a/src/app/components/button/button.component.stories.ts
+++ b/src/app/components/button/button.component.stories.ts
@@ -127,7 +127,6 @@ export const Disabled: Story = {
 	},
 };
 
-// Vitrina con las tres variantes activas en simultáneo.
 export const Showcase: Story = {
 	render: () => ({
 		template: `

--- a/src/app/components/carousel/carousel.component.stories.ts
+++ b/src/app/components/carousel/carousel.component.stories.ts
@@ -56,7 +56,6 @@ const meta: Meta<CarouselComponent> = {
 export default meta;
 type Story = StoryObj<CarouselComponent>;
 
-// Historia principal con documentación
 export const Default: Story = {
 	name: 'Por defecto',
 	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
@@ -73,7 +72,6 @@ export const Default: Story = {
 	},
 };
 
-// Carousel con una sola diapositiva
 export const SingleSlide: Story = {
 	name: 'Diapositiva única',
 	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
@@ -90,7 +88,6 @@ export const SingleSlide: Story = {
 	},
 };
 
-// Carousel con transición rápida
 export const FastTransition: Story = {
 	name: 'Transición rápida',
 	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
@@ -107,7 +104,6 @@ export const FastTransition: Story = {
 	},
 };
 
-// Carousel con transición lenta
 export const SlowTransition: Story = {
 	name: 'Transición lenta',
 	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
@@ -124,7 +120,6 @@ export const SlowTransition: Story = {
 	},
 };
 
-// Múltiples diapositivas de ejemplo
 const extendedSlidesMock: ContentCampaign[] = [
 	...contentCampaignMock,
 	{
@@ -195,7 +190,6 @@ const extendedSlidesMock: ContentCampaign[] = [
 	},
 ];
 
-// Carousel con múltiples diapositivas
 export const MultipleSlides: Story = {
 	name: 'Múltiples diapositivas',
 	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
@@ -212,7 +206,6 @@ export const MultipleSlides: Story = {
 	},
 };
 
-// Historia interactiva para documentación
 export const Interactive: Story = {
 	name: 'Interactivo',
 	render: (args) => ({
@@ -247,14 +240,12 @@ export const Interactive: Story = {
 	},
 };
 
-// Vista comparativa Desktop y Mobile
 export const DesktopAndMobile: Story = {
 	name: 'Escritorio y móvil',
 	render: (args) => ({
 		props: args,
 		template: `
 			<div class="flex flex-col gap-8 p-4">
-				<!-- Desktop View -->
 				<div>
 					<h3 class="text-lg font-semibold text-neutral-700 mb-3">Desktop (960px)</h3>
 					<div style="width: 1240px; max-width: 100%; justify-self: center;">
@@ -262,7 +253,6 @@ export const DesktopAndMobile: Story = {
 					</div>
 				</div>
 
-				<!-- Mobile View -->
 				<div>
 					<h3 class="text-lg font-semibold text-neutral-700 mb-3">Mobile (375px)</h3>
 					<div style="width: 375px; justify-self: center;">
@@ -288,7 +278,6 @@ export const DesktopAndMobile: Story = {
 	},
 };
 
-// Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
 export const Estados: StoryObj<CarouselComponent & { loading: boolean }> = {
 	decorators: [moduleMetadata({ imports: [CarouselSkeletonComponent] })],
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },

--- a/src/app/components/cover-image/cover-image.component.stories.ts
+++ b/src/app/components/cover-image/cover-image.component.stories.ts
@@ -42,7 +42,6 @@ export const WithImage: Story = {
 	parameters: { docs: { description: { story: 'Cover con imagen.' } } },
 };
 
-// Playground: selector de Obra que elige la portada a visualizar entre las covers del corpus en assets.
 export const Interactiva: StoryObj<CoverImageComponent & { coverIndex: number }> = {
 	argTypes: {
 		coverIndex: {
@@ -71,7 +70,6 @@ export const Placeholder: Story = {
 	parameters: { docs: { description: { story: 'Sin `src`: se muestra el placeholder del Design System.' } } },
 };
 
-// Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
 export const Estados: StoryObj<CoverImageComponent & { loading: boolean }> = {
 	decorators: [moduleMetadata({ imports: [CoverImageSkeletonComponent] })],
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },

--- a/src/app/components/home-story-card/home-story-card.component.stories.ts
+++ b/src/app/components/home-story-card/home-story-card.component.stories.ts
@@ -66,7 +66,6 @@ const meta: Meta<HomeStoryCardComponent> = {
 export default meta;
 type Story = StoryObj<HomeStoryCardComponent>;
 
-// Playground interactivo: un único selector de Obra; la portada y el título cambian juntos.
 export const Interactiva: StoryObj<HomeStoryCardComponent & { storyIndex: number }> = {
 	argTypes: {
 		storyIndex: {
@@ -102,7 +101,6 @@ export const Interactiva: StoryObj<HomeStoryCardComponent & { storyIndex: number
 	},
 };
 
-// Tarjeta completa: cover sobre contenedor gris, numeración, multimedia, autor y título.
 export const Default: Story = {
 	render: (args) => ({
 		props: args,
@@ -123,7 +121,6 @@ export const Default: Story = {
 	},
 };
 
-// Estado de carga (skeleton) de la tarjeta.
 export const Skeleton: StoryObj = {
 	decorators: [moduleMetadata({ imports: [HomeStoryCardSkeletonComponent] })],
 	render: () => ({ template: `<cuentoneta-home-story-card-skeleton />` }),
@@ -132,7 +129,6 @@ export const Skeleton: StoryObj = {
 	},
 };
 
-// Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
 // La tarjeta renderiza su propio skeleton cuando no recibe story.
 export const Estados: StoryObj<HomeStoryCardComponent & { loading: boolean }> = {
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },

--- a/src/app/components/image-profile/image-profile.component.stories.ts
+++ b/src/app/components/image-profile/image-profile.component.stories.ts
@@ -53,7 +53,6 @@ const meta: Meta<ImageProfileComponent> = {
 export default meta;
 type Story = StoryObj<ImageProfileComponent>;
 
-// Playground.
 export const Default: Story = {
 	render: (args) => ({ props: args, template: `<cuentoneta-image-profile ${argsToTemplate(args)} />` }),
 	args: { src, alt, size: 'medium', variant: 'profile' },
@@ -66,7 +65,6 @@ export const Default: Story = {
 	},
 };
 
-// Placeholder (sin imagen).
 export const Placeholder: Story = {
 	render: (args) => ({ props: args, template: `<cuentoneta-image-profile ${argsToTemplate(args)} />` }),
 	args: { size: 'medium', variant: 'profile' },
@@ -79,7 +77,6 @@ export const Placeholder: Story = {
 	},
 };
 
-// Variante Collections.
 export const Collection: Story = {
 	render: (args) => ({ props: args, template: `<cuentoneta-image-profile ${argsToTemplate(args)} />` }),
 	args: { size: 'medium', variant: 'collection' },
@@ -92,7 +89,6 @@ export const Collection: Story = {
 	},
 };
 
-// Vitrina de tamaños y estados.
 export const Showcase: Story = {
 	render: (args) => ({
 		props: args,

--- a/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.stories.ts
+++ b/src/app/components/story-card-teaser-v3/story-card-teaser-v3.component.stories.ts
@@ -9,9 +9,6 @@ import {
 } from '../../mocks/onoff-story-teasers.mock';
 import { corpusStories, literaryWorkSelectArgType, withRichMedia } from '../../mocks/onoff-corpus.storybook';
 
-// Las descripciones de la doc van en una sola línea: el renderer de Markdown de los autodocs
-// interpreta como bloque de código cualquier línea con indentación, así que un HTML multilínea
-// indentado se mostraría dentro de un recuadro de código.
 const meta: Meta<StoryCardTeaserV3Component> = {
 	component: StoryCardTeaserV3Component,
 	title: 'Componentes V3/StoryCardTeaserV3',
@@ -84,7 +81,6 @@ const meta: Meta<StoryCardTeaserV3Component> = {
 export default meta;
 type Story = StoryObj<StoryCardTeaserV3Component>;
 
-// Playground interactivo: un único selector de Obra; la portada, el título y el extracto cambian juntos.
 export const Interactiva: StoryObj<StoryCardTeaserV3Component & { storyIndex: number }> = {
 	argTypes: {
 		storyIndex: {
@@ -127,7 +123,6 @@ export const Interactiva: StoryObj<StoryCardTeaserV3Component & { storyIndex: nu
 	},
 };
 
-// Variante OnWhite — imagen a la izquierda, fondo blanco.
 export const OnWhite: Story = {
 	render: (args) => ({
 		props: args,
@@ -152,7 +147,6 @@ export const OnWhite: Story = {
 	},
 };
 
-// Variante OnGray — igual a OnWhite pero pensada para fondos grises (selectores en blanco).
 export const OnGray: Story = {
 	render: (args) => ({
 		props: args,
@@ -177,7 +171,6 @@ export const OnGray: Story = {
 	},
 };
 
-// Variante Highlighted — tarjeta destacada con la imagen a la derecha.
 export const Highlighted: Story = {
 	render: (args) => ({
 		props: args,
@@ -202,7 +195,6 @@ export const Highlighted: Story = {
 	},
 };
 
-// Vitrina con las tres variantes en simultáneo.
 // Nota: se usan bindings explícitos (en lugar de argsToTemplate) porque la variante difiere por
 // instancia; argsToTemplate genera bindings `[variant]="variant"` que apuntan a un único `props.variant`.
 export const AllVariants: Story = {
@@ -278,7 +270,6 @@ export const AllVariants: Story = {
 	},
 };
 
-// Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
 // La tarjeta renderiza su propio skeleton cuando no recibe story.
 export const Estados: StoryObj<StoryCardTeaserV3Component & { loading: boolean }> = {
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },

--- a/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
+++ b/src/app/components/story-card-teaser/story-card-teaser.component.stories.ts
@@ -94,7 +94,6 @@ const meta: Meta<StoryCardTeaserComponent> = {
 export default meta;
 type Story = StoryObj<StoryCardTeaserComponent>;
 
-// Historia de documentación/Playground interactivo
 export const Docs: Story = {
 	render: (args) => ({
 		props: args,
@@ -129,7 +128,6 @@ export const Docs: Story = {
 	},
 };
 
-// Historia por defecto con configuración básica
 export const Default: Story = {
 	render: (args) => ({
 		props: args,
@@ -161,7 +159,6 @@ export const Default: Story = {
 	},
 };
 
-// Con información del autor
 export const WithAuthor: Story = {
 	render: (args) => ({
 		props: args,
@@ -193,7 +190,6 @@ export const WithAuthor: Story = {
 	},
 };
 
-// Con número de orden
 export const WithOrder: Story = {
 	render: (args) => ({
 		props: args,
@@ -226,7 +222,6 @@ export const WithOrder: Story = {
 	},
 };
 
-// Con extracto
 export const WithExcerpt: Story = {
 	render: (args) => ({
 		props: args,
@@ -258,7 +253,6 @@ export const WithExcerpt: Story = {
 	},
 };
 
-// Variante con todas las características
 export const FullFeatured: Story = {
 	render: (args) => ({
 		props: args,
@@ -296,7 +290,6 @@ export const FullFeatured: Story = {
 	},
 };
 
-// Diferentes cantidades de líneas de extracto
 export const ExcerptVariations: Story = {
 	render: (args) => ({
 		props: args,
@@ -332,7 +325,6 @@ export const ExcerptVariations: Story = {
 	},
 };
 
-// Vitrina de todas las variantes
 export const AllVariants: Story = {
 	render: (args) => ({
 		props: args,

--- a/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
+++ b/src/app/components/story-media-selectors/story-media-selectors.component.stories.ts
@@ -63,7 +63,6 @@ const meta: Meta<StoryMediaSelectorsComponent> = {
 export default meta;
 type Story = StoryObj<StoryMediaSelectorsComponent>;
 
-// Modo agrupado (decorativo) — usado por StoryCardTeaserV3.
 export const Grouped: Story = {
 	render: (args) => ({ props: args, template: `<cuentoneta-story-media-selectors ${argsToTemplate(args)} />` }),
 	args: { media, theme: 'subtle', orientation: 'horizontal', selectable: false },
@@ -76,7 +75,6 @@ export const Grouped: Story = {
 	},
 };
 
-// Modo seleccionable (interactivo) — pensado para la vista Story.
 export const Selectable: Story = {
 	render: (args) => ({ props: args, template: `<cuentoneta-story-media-selectors ${argsToTemplate(args)} />` }),
 	args: { media, theme: 'solid', orientation: 'horizontal', selectable: true },
@@ -89,7 +87,6 @@ export const Selectable: Story = {
 	},
 };
 
-// Vitrina de los tres temas en sus contextos de fondo.
 // Nota: se usan bindings explícitos (en lugar de argsToTemplate) porque theme/orientation difieren
 // por instancia; argsToTemplate genera `[theme]="theme"` que apunta a un único `props.theme`.
 export const Themes: Story = {

--- a/src/app/components/tag/tag.component.stories.ts
+++ b/src/app/components/tag/tag.component.stories.ts
@@ -81,7 +81,6 @@ export const Showcase: Story = {
 	parameters: { docs: { description: { story: 'Las tres variantes: soft, filled y gray.' } } },
 };
 
-// Estado de carga (skeleton) del tag.
 export const Skeleton: StoryObj = {
 	decorators: [moduleMetadata({ imports: [TagSkeletonComponent] })],
 	render: () => ({ template: `<cuentoneta-tag-skeleton />` }),
@@ -90,7 +89,6 @@ export const Skeleton: StoryObj = {
 	},
 };
 
-// Switch "Cargando" para alternar real↔skeleton en el mismo slot y evaluar la transición/alineación.
 export const Estados: StoryObj<TagComponent & { loading: boolean }> = {
 	decorators: [moduleMetadata({ imports: [TagSkeletonComponent] })],
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },

--- a/src/app/components/tags-list/tags-list.component.stories.ts
+++ b/src/app/components/tags-list/tags-list.component.stories.ts
@@ -60,7 +60,6 @@ const meta: Meta<Args> = {
 export default meta;
 type Story = StoryObj<Args>;
 
-// Contenedor ancho: entran todos, no se muestra contador.
 export const Default: Story = {
 	render: (args) => ({ props: { ...args, tags }, template: projected }),
 	args: { variant: 'filled' },
@@ -74,7 +73,6 @@ export const Default: Story = {
 	},
 };
 
-// Contenedor acotado: el excedente que no entra por ancho se colapsa en "+N".
 export const WidthOverflow: Story = {
 	render: (args) => ({ props: { ...args, tags }, template: projected }),
 	args: { variant: 'filled' },
@@ -88,7 +86,6 @@ export const WidthOverflow: Story = {
 	},
 };
 
-// Contenedor muy angosto: entran muy pocos y el contador refleja el resto.
 export const NarrowWidth: Story = {
 	render: (args) => ({ props: { ...args, tags }, template: projected }),
 	args: { variant: 'filled' },
@@ -102,7 +99,6 @@ export const NarrowWidth: Story = {
 	},
 };
 
-// Tope duro: el contenedor daría para más, pero maxVisible corta antes.
 export const MaxVisibleCap: Story = {
 	render: (args) => ({ props: { ...args, tags }, template: projected }),
 	args: { variant: 'filled', maxVisible: 2 },
@@ -116,7 +112,6 @@ export const MaxVisibleCap: Story = {
 	},
 };
 
-// Las tres variantes recortando por ancho en cajas idénticas.
 export const Variants: Story = {
 	render: () => ({
 		props: { tags },
@@ -143,7 +138,6 @@ export const Variants: Story = {
 	},
 };
 
-// Caja redimensionable: arrastrá el borde inferior-derecho para ver el contador reaccionar al ancho.
 export const Playground: Story = {
 	render: (args) => ({ props: { ...args, tags }, template: projected }),
 	args: { variant: 'filled' },

--- a/src/app/directives/portable-text-parser/portable-text-parser.directive.ts
+++ b/src/app/directives/portable-text-parser/portable-text-parser.directive.ts
@@ -19,15 +19,12 @@ export class PortableTextDirective {
 	}
 
 	private render(content: TextBlockContent, classes: string) {
-		// Limpia el contenido actual
 		while (this.el.nativeElement.firstChild) {
 			this.el.nativeElement.removeChild(this.el.nativeElement.firstChild);
 		}
 
-		// Elimina las clases actuales
 		this.el.nativeElement.className = '';
 
-		// Agrega las clases en base a las pasadas como input
 		const updatedClasses = this.appendClasses(content, classes);
 		if (updatedClasses) {
 			updatedClasses.split(' ').forEach((className) => {
@@ -37,7 +34,6 @@ export class PortableTextDirective {
 			});
 		}
 
-		// Process and append content
 		content.children.forEach((block) => {
 			let element: HTMLElement | Text = this.renderer.createText(block.text);
 			const marks = (block.marks ?? []).slice(0);


### PR DESCRIPTION
## Descripción

Elimina comentarios redundantes (no aportan un porqué no obvio — Sección 3 de `coding-agent-policies`). **Solo se borran comentarios: 66 líneas, 0 cambios de código.**

- **Stories (12 archivos):** las narraciones de una línea sobre cada `export const <Story>` que duplican el `name` + `docs.description.story`; el comentario de convención de autodocs (ya documentada en `testing.md`); el `// Switch "Cargando"…` copiado entre archivos; los `<!-- Desktop/Mobile View -->` que restatean el `<h3>` adyacente.
- **`portable-text-parser.directive.ts`:** parafraseos de la línea siguiente (`// Limpia el contenido actual`, etc.).
- **Specs de backend (`content`/`sitemap`):** etiquetas arrange/act/assert redundantes.

Se **conservan** los comentarios que explican un porqué: bindings explícitos vs `argsToTemplate`, self-skeleton, propósito de fixtures, límite del ACL y el detalle de `Promise.all`.

## Plan de pruebas

- [x] `pnpm typecheck` — verde
- [x] `pnpm lint` — verde
- [x] `pnpm test` (specs de backend tocados, 31/31) — verde
- [x] `pnpm storybook:build` — verde
