### PR TITLE
[#1810] - Correcciones del hero: asume al menos un tag y documenta el fondo en Storybook

### DIFF
--- a/src/app/components/story-hero-header/story-hero-header.component.spec.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.spec.ts
@@ -46,11 +46,6 @@ describe('StoryHeroHeaderComponent', () => {
 		}
 	});
 
-	it('should not render the tags list when the story has no tags', async () => {
-		await render(StoryHeroHeaderComponent, { inputs: { story: { ...story, tags: [] } } });
-		expect(screen.queryByTestId('tags')).not.toBeInTheDocument();
-	});
-
 	it('should render the foreground cover image when the story has a cover', async () => {
 		await render(StoryHeroHeaderComponent, { inputs: { story } });
 		expect(screen.getByTestId('cover-image')).toBeInTheDocument();

--- a/src/app/components/story-hero-header/story-hero-header.component.stories.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.stories.ts
@@ -19,7 +19,7 @@ const meta: Meta<StoryHeroHeaderComponent> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>Banda superior (hero) de la página de una historia. Usa la misma portada del cuento como fondo difuminado con una capa de opacidad y, en primer plano, presenta la portada nítida, los tags, el autor, el título y la colección/año de publicación originales.</p><p>Recibe el <code>Story</code> completo como único input; cuando no se provee, renderiza su propio estado de carga (skeleton).</p><p>Se compone de <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> (portada en primer plano), <a href="./?path=/docs/componentes-v3-tagslist--docs" target="_top"><strong>TagsList</strong></a> (tags de la obra, variante <code>gray</code>) e <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar del autor).</p></div>`,
+				component: `<div><p>Banda superior (hero) de la página de una historia. Usa la misma portada del cuento como fondo difuminado con una capa de opacidad y, en primer plano, presenta la portada nítida, los tags, el autor, el título y la colección/año de publicación originales.</p><p>El fondo no es otra imagen: es la misma <code>coverImage</code> pedida al CDN en una talla mayor (1920px de ancho) para cubrir el ancho completo del hero.</p><p>Recibe el <code>Story</code> completo como único input; cuando no se provee, renderiza su propio estado de carga (skeleton).</p><p>Se compone de <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> (portada en primer plano), <a href="./?path=/docs/componentes-v3-tagslist--docs" target="_top"><strong>TagsList</strong></a> (tags de la obra, variante <code>gray</code>) e <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar del autor).</p></div>`,
 			},
 		},
 		layout: 'fullscreen',
@@ -69,21 +69,6 @@ export const Default: Story = {
 		docs: {
 			description: {
 				story: 'Estado principal del hero con portada, tags, autor, título y publicación.',
-			},
-		},
-	},
-};
-
-export const SinGenero: Story = {
-	render: (args) => ({
-		props: args,
-		template: `<cuentoneta-story-hero-header ${argsToTemplate(args)} />`,
-	}),
-	args: { story: { ...palacioNueveFronterasStoryMock, tags: [] } },
-	parameters: {
-		docs: {
-			description: {
-				story: 'Cuando la historia no tiene tags, la lista de tags se omite y el resto del bloque se mantiene.',
 			},
 		},
 	},

--- a/src/app/components/story-hero-header/story-hero-header.component.ts
+++ b/src/app/components/story-hero-header/story-hero-header.component.ts
@@ -49,13 +49,11 @@ import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.c
 				<div class="mx-auto flex w-full max-w-180 items-center gap-8">
 					<cuentoneta-cover-image [src]="story.coverImage" [priority]="true" />
 					<div class="flex min-w-0 flex-col items-start gap-2.5">
-						@if (tags().length) {
-							<cuentoneta-tags-list data-testid="tags">
-								@for (tag of tags(); track tag.slug) {
-									<cuentoneta-tag [label]="tag.title" variant="gray" />
-								}
-							</cuentoneta-tags-list>
-						}
+						<cuentoneta-tags-list data-testid="tags">
+							@for (tag of story.tags; track tag.slug) {
+								<cuentoneta-tag [label]="tag.title" variant="gray" />
+							}
+						</cuentoneta-tags-list>
 						<a
 							[routerLink]="['/', appRoutes.Author, story.author.slug]"
 							class="group flex items-center gap-2"
@@ -83,9 +81,6 @@ export class StoryHeroHeaderComponent {
 
 	public readonly story = input<Story>();
 
-	protected readonly tags = computed(() => this.story()?.tags ?? []);
-
-	// La misma coverImage pedida al CDN en una talla mayor para el fondo full-bleed (no es otra imagen).
 	protected readonly backgroundImageUrl = computed(() =>
 		withSanityImageParams(this.story()?.coverImage ?? '', { w: 1920 }),
 	);


### PR DESCRIPTION
## Descripción

Correcciones sobre el hero de la página Story (#1810) que quedaron fuera del merge de #1814 (el PR se mergeó en `5cdf3210`, sin este commit):

- El hero asume el invariante "una historia siempre expone al menos un tag": se quita el guard `@if (tags().length)` y la computed `tags`, iterando `story.tags` directo.
- Se elimina la story `SinGenero` de Storybook (ya no representa un estado posible) y el test unitario del caso vacío. El test `should render all the story tags` cubre que se muestran.
- Se mueve el detalle de por qué el fondo no es otra imagen (misma `coverImage` al CDN a 1920px) del comentario inline a la descripción de autodocs en Storybook.

Relacionado con #1810.

Parte de #1471.

## Plan de pruebas

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm stylelint` — verde
- [x] `pnpm test` (spec del hero) — 10/10
- [x] `pnpm build` y `pnpm storybook:build` — verde
