### PR TITLE
[#1726] - [Test] Guardrail: toda página indexable debe declarar su host directive de SEO

### DIFF
--- a/.claude/references/angular-components.md
+++ b/.claude/references/angular-components.md
@@ -279,6 +279,7 @@ Notas:
 - Los métodos/propiedades referenciados por string desde `host` solo necesitan ser **`protected`** (no `public`). Distinto es el caso de las directivas cuya API la consumen los anfitriones vía `hostDirectives` + `inject(Directive)` (p. ej. `TooltipDirective.text.set(...)`): esas signals **sí** son `public` por ser API imperativa.
 - El bloque `:host` en `styles` se reserva para lo que **no** es `@apply`: CSS crudo (`font-family`, `transition`, …), `:host ::ng-deep ...` y `:host(.clase)` condicionales. Esas reglas **no** se mueven a `host`.
 - Si el componente ya tiene `host: { class: '...' }`, **agregar** las utilidades al string existente, no reemplazarlo.
+- **`hostDirectives`** (campo del decorador, distinto de `host`) es el mecanismo de composición de directivas del anfitrión. En **componentes de página** es cómo se declaran las directivas de SEO (meta tags + structured data): la forma correcta depende de la indexabilidad de la ruta y está **enforced por test** — ver [`angular-state.md` §8](./angular-state.md#8-directivas-de-seo-de-página-declarar-el-combo-según-la-indexabilidad).
 
 ---
 

--- a/.claude/references/angular-state.md
+++ b/.claude/references/angular-state.md
@@ -170,7 +170,7 @@ Cada componente de página compone su SEO en el campo **`hostDirectives`** del d
 
 Una página indexable **nunca** debe usar la forma no indexable: quedaría sin structured data y sin `setRobots('index...')` de forma silenciosa.
 
-**Enforced por test:** el gate `test` corre `src/app/pages/seo-host-directives.spec.ts` (#1726), que cruza `app.routes.server.ts` (RenderMode) × `app.routes.ts` (ruta→componente) × el fuente del componente (`hostDirectives`) y exige que toda ruta `Server`/`Prerender` esté clasificada en `PAGE_SEO_REGISTRY`: las `indexable: true` deben declarar el combo MetaTags + StructuredData; las `indexable: false`, el opt-out `HeadMetadataDirective` + `setRobots('noindex...')`. Una ruta nueva sin entrada en el registro **rompe el test** — no se puede agregar una página indexable sin decidir explícitamente su SEO.
+**Enforced por test:** el gate `test` corre `src/app/pages/seo-host-directives.spec.ts` (#1726), que descubre las páginas desde `app.routes.server.ts` (rutas `Server`/`Prerender`) resolviendo su fuente vía el `loadComponent` de `app.routes.ts`, y deriva la indexabilidad del propio código: una página que llama `setRobots('noindex...')` solo debe declarar `[HeadMetadataDirective]`; cualquier otra se considera indexable y debe declarar el combo MetaTags + StructuredData. No hay registro que mantener ni imports de componentes: una página nueva se chequea automáticamente y **rompe el test** si es indexable sin structured data (para saltearse el combo hay que emitir un `noindex` real, visible en el diff).
 
 ---
 
@@ -184,7 +184,7 @@ Una página indexable **nunca** debe usar la forma no indexable: quedaría sin s
 - [ ] ¿El debounce/throttle/coordinación está en el servicio, no en el componente?
 - [ ] ¿Los errores están tipados por operación, no en un `string | null` global?
 - [ ] ¿Los recursos de página que alimentan contenido/meta indexable usan `ssrBlockingRxResource`, y los secundarios/`noindex` usan `progressiveRxResource` (nunca `rxResource` crudo en `pages/**`)?
-- [ ] ¿La página declara sus `hostDirectives` de SEO según su indexabilidad (indexable: MetaTags + StructuredData; no indexable/`noindex`: HeadMetadataDirective + `setRobots('noindex...')`) y su ruta está registrada en `seo-host-directives.spec.ts`?
+- [ ] ¿La página declara sus `hostDirectives` de SEO según su indexabilidad (indexable: MetaTags + StructuredData; no indexable/`noindex`: HeadMetadataDirective + `setRobots('noindex...')`)? Lo verifica automáticamente `seo-host-directives.spec.ts`.
 
 ---
 

--- a/.claude/references/angular-state.md
+++ b/.claude/references/angular-state.md
@@ -161,6 +161,17 @@ Cuándo **bloquear**: rutas cuyo HTML server-rendered debe traer contenido/meta 
 
 **Enforced por lint:** en `src/app/pages/**` está prohibido `rxResource`/`httpResource` crudo — el gate `lint` obliga a elegir `ssrBlockingRxResource` o `progressiveRxResource` (`no-restricted-syntax`, bloque `ssr-fetch-must-decide-blocking` de `eslint.config.mjs`; #1705).
 
+### 8. Directivas de SEO de página: declarar el combo según la indexabilidad
+
+Cada componente de página compone su SEO en el campo **`hostDirectives`** del decorador `@Component` (distinto de `host`, ver [`angular-components.md`](angular-components.md#host-element)). Hay exactamente **dos formas**, elegidas según si la ruta es indexable:
+
+- **Forma A — página indexable** (`RenderMode.Server`/`Prerender` sin `noindex`): `hostDirectives: [<Page>MetaTagsDirective, <Page>StructuredDataDirective]`. Ambas extienden `AbstractMetaTagsDirective`/`AbstractStructuredDataDirective`; la `<Page>MetaTagsDirective` emite `setRobots('index, follow')` y la `<Page>StructuredDataDirective` inyecta el JSON-LD. Ejemplos: `home`, `author`, `story`, `storylist`.
+- **Forma B — opt-out explícito** (`noindex`): `hostDirectives: [HeadMetadataDirective]` (la directiva genérica, sin structured data) y el componente llama `setRobots('noindex, ...')` en su constructor. Ejemplos: `about`, `authors`, `stories`, `dmca`. La ausencia de structured data acá es intencional, no un hueco.
+
+Una página indexable **nunca** debe usar la Forma B: quedaría sin structured data y sin `setRobots('index...')` de forma silenciosa.
+
+**Enforced por test:** el gate `test` corre `src/app/pages/seo-host-directives.spec.ts` (#1726), que cruza `app.routes.server.ts` (RenderMode) × `app.routes.ts` (ruta→componente) × el fuente del componente (`hostDirectives`) y exige que toda ruta `Server`/`Prerender` esté clasificada en `PAGE_SEO_REGISTRY`: las `indexable: true` deben declarar el combo MetaTags + StructuredData; las `indexable: false`, el opt-out `HeadMetadataDirective` + `setRobots('noindex...')`. Una ruta nueva sin entrada en el registro **rompe el test** — no se puede agregar una página indexable sin decidir explícitamente su SEO.
+
 ---
 
 ## Checklist rápido
@@ -173,6 +184,7 @@ Cuándo **bloquear**: rutas cuyo HTML server-rendered debe traer contenido/meta 
 - [ ] ¿El debounce/throttle/coordinación está en el servicio, no en el componente?
 - [ ] ¿Los errores están tipados por operación, no en un `string | null` global?
 - [ ] ¿Los recursos de página que alimentan contenido/meta indexable usan `ssrBlockingRxResource`, y los secundarios/`noindex` usan `progressiveRxResource` (nunca `rxResource` crudo en `pages/**`)?
+- [ ] ¿La página declara sus `hostDirectives` de SEO según su indexabilidad (Forma A indexable: MetaTags + StructuredData; Forma B `noindex`: HeadMetadataDirective + `setRobots('noindex...')`) y su ruta está registrada en `seo-host-directives.spec.ts`?
 
 ---
 

--- a/.claude/references/angular-state.md
+++ b/.claude/references/angular-state.md
@@ -165,10 +165,10 @@ Cuándo **bloquear**: rutas cuyo HTML server-rendered debe traer contenido/meta 
 
 Cada componente de página compone su SEO en el campo **`hostDirectives`** del decorador `@Component` (distinto de `host`, ver [`angular-components.md`](angular-components.md#host-element)). Hay exactamente **dos formas**, elegidas según si la ruta es indexable:
 
-- **Forma A — página indexable** (`RenderMode.Server`/`Prerender` sin `noindex`): `hostDirectives: [<Page>MetaTagsDirective, <Page>StructuredDataDirective]`. Ambas extienden `AbstractMetaTagsDirective`/`AbstractStructuredDataDirective`; la `<Page>MetaTagsDirective` emite `setRobots('index, follow')` y la `<Page>StructuredDataDirective` inyecta el JSON-LD. Ejemplos: `home`, `author`, `story`, `storylist`.
-- **Forma B — opt-out explícito** (`noindex`): `hostDirectives: [HeadMetadataDirective]` (la directiva genérica, sin structured data) y el componente llama `setRobots('noindex, ...')` en su constructor. Ejemplos: `about`, `authors`, `stories`, `dmca`. La ausencia de structured data acá es intencional, no un hueco.
+- **Página indexable** (`RenderMode.Server`/`Prerender` sin `noindex`): `hostDirectives: [<Page>MetaTagsDirective, <Page>StructuredDataDirective]`. Ambas extienden `AbstractMetaTagsDirective`/`AbstractStructuredDataDirective`; la `<Page>MetaTagsDirective` emite `setRobots('index, follow')` y la `<Page>StructuredDataDirective` inyecta el JSON-LD. Ejemplos: `home`, `author`, `story`, `storylist`.
+- **Página no indexable** (`noindex`): `hostDirectives: [HeadMetadataDirective]` (la directiva genérica, sin structured data) y el componente llama `setRobots('noindex, ...')` en su constructor. Ejemplos: `about`, `authors`, `stories`, `dmca`. La ausencia de structured data acá es intencional, no un hueco.
 
-Una página indexable **nunca** debe usar la Forma B: quedaría sin structured data y sin `setRobots('index...')` de forma silenciosa.
+Una página indexable **nunca** debe usar la forma no indexable: quedaría sin structured data y sin `setRobots('index...')` de forma silenciosa.
 
 **Enforced por test:** el gate `test` corre `src/app/pages/seo-host-directives.spec.ts` (#1726), que cruza `app.routes.server.ts` (RenderMode) × `app.routes.ts` (ruta→componente) × el fuente del componente (`hostDirectives`) y exige que toda ruta `Server`/`Prerender` esté clasificada en `PAGE_SEO_REGISTRY`: las `indexable: true` deben declarar el combo MetaTags + StructuredData; las `indexable: false`, el opt-out `HeadMetadataDirective` + `setRobots('noindex...')`. Una ruta nueva sin entrada en el registro **rompe el test** — no se puede agregar una página indexable sin decidir explícitamente su SEO.
 
@@ -184,7 +184,7 @@ Una página indexable **nunca** debe usar la Forma B: quedaría sin structured d
 - [ ] ¿El debounce/throttle/coordinación está en el servicio, no en el componente?
 - [ ] ¿Los errores están tipados por operación, no en un `string | null` global?
 - [ ] ¿Los recursos de página que alimentan contenido/meta indexable usan `ssrBlockingRxResource`, y los secundarios/`noindex` usan `progressiveRxResource` (nunca `rxResource` crudo en `pages/**`)?
-- [ ] ¿La página declara sus `hostDirectives` de SEO según su indexabilidad (Forma A indexable: MetaTags + StructuredData; Forma B `noindex`: HeadMetadataDirective + `setRobots('noindex...')`) y su ruta está registrada en `seo-host-directives.spec.ts`?
+- [ ] ¿La página declara sus `hostDirectives` de SEO según su indexabilidad (indexable: MetaTags + StructuredData; no indexable/`noindex`: HeadMetadataDirective + `setRobots('noindex...')`) y su ruta está registrada en `seo-host-directives.spec.ts`?
 
 ---
 

--- a/src/app/pages/seo-host-directives.spec.ts
+++ b/src/app/pages/seo-host-directives.spec.ts
@@ -17,7 +17,7 @@ import StoriesComponent from './stories/stories.component';
 import AboutComponent from './about/about.component';
 import DmcaComponent from './dmca/dmca.component';
 
-// Guardrail estructural (#1726): garantiza que toda página con una ruta indexable (RenderMode.Server/Prerender,
+// Guardrail estructural: garantiza que toda página con una ruta indexable (RenderMode.Server/Prerender,
 // sin noindex) declare sus directivas de SEO. No usa Angular Testing Library a propósito: no hay UI que ejercitar,
 // es un test de convención de código sobre el mapeo ruta→RenderMode→componente, que cruza tres archivos
 // (app.routes.ts, app.routes.server.ts y el fuente del componente). Ver `angular-state.md` para la convención.

--- a/src/app/pages/seo-host-directives.spec.ts
+++ b/src/app/pages/seo-host-directives.spec.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { Type } from '@angular/core';
+import { RenderMode } from '@angular/ssr';
+
+import { appRoutes } from '../app.routes';
+import { serverRoutes } from '../app.routes.server';
+import { extractHostDirectiveNames, extractRobotsLiteral } from './seo-host-directives.util';
+
+import HomeComponent from './home/home.component';
+import AuthorComponent from './author/author.component';
+import StoryComponent from './story/story.component';
+import StorylistComponent from './storylist/storylist.component';
+import AuthorsComponent from './authors/authors.component';
+import StoriesComponent from './stories/stories.component';
+import AboutComponent from './about/about.component';
+import DmcaComponent from './dmca/dmca.component';
+
+// Guardrail estructural (#1726): garantiza que toda página con una ruta indexable (RenderMode.Server/Prerender,
+// sin noindex) declare sus directivas de SEO. No usa Angular Testing Library a propósito: no hay UI que ejercitar,
+// es un test de convención de código sobre el mapeo ruta→RenderMode→componente, que cruza tres archivos
+// (app.routes.ts, app.routes.server.ts y el fuente del componente). Ver `angular-state.md` para la convención.
+
+type PageSeoEntry = Readonly<{ component: Type<unknown>; sourceFile: string; indexable: boolean }>;
+
+// Clasificación explícita de cada página. `indexable: true` exige el combo MetaTags + StructuredData;
+// `indexable: false` exige el opt-out HeadMetadataDirective + setRobots('noindex...').
+const PAGE_SEO_REGISTRY: readonly PageSeoEntry[] = [
+	{ component: HomeComponent, sourceFile: 'home/home.component.ts', indexable: true },
+	{ component: AuthorComponent, sourceFile: 'author/author.component.ts', indexable: true },
+	{ component: StoryComponent, sourceFile: 'story/story.component.ts', indexable: true },
+	{ component: StorylistComponent, sourceFile: 'storylist/storylist.component.ts', indexable: true },
+	{ component: AuthorsComponent, sourceFile: 'authors/authors.component.ts', indexable: false },
+	{ component: StoriesComponent, sourceFile: 'stories/stories.component.ts', indexable: false },
+	{ component: AboutComponent, sourceFile: 'about/about.component.ts', indexable: false },
+	{ component: DmcaComponent, sourceFile: 'dmca/dmca.component.ts', indexable: false },
+];
+
+// Nuestras rutas resuelven el componente vía `() => import(...)`, así que loadComponent() siempre entrega el
+// módulo con `default`. El cast descarta las ramas Observable/Type-directo de la firma que este repo no usa.
+type LoadedComponent = Type<unknown> | { default: Type<unknown> };
+
+function isIndexableRenderMode(mode: RenderMode): boolean {
+	return mode === RenderMode.Server || mode === RenderMode.Prerender;
+}
+
+function resolveRouteComponent(loaded: LoadedComponent): Type<unknown> {
+	return 'default' in loaded ? loaded.default : loaded;
+}
+
+function readPageSource(sourceFile: string): string {
+	return readFileSync(join(process.cwd(), 'src', 'app', 'pages', sourceFile), 'utf-8');
+}
+
+describe('SEO host directives guardrail', () => {
+	it('should register every indexable-mode page route in PAGE_SEO_REGISTRY', async () => {
+		for (const serverRoute of serverRoutes) {
+			if (serverRoute.path === '**' || !isIndexableRenderMode(serverRoute.renderMode)) {
+				continue;
+			}
+			const appRoute = appRoutes.find((route) => route.path === serverRoute.path);
+			if (!appRoute?.loadComponent) {
+				throw new Error(
+					`Ruta '${serverRoute.path}' está en app.routes.server.ts pero no tiene un loadComponent en app.routes.ts`,
+				);
+			}
+			const component = resolveRouteComponent((await appRoute.loadComponent()) as LoadedComponent);
+			const entry = PAGE_SEO_REGISTRY.find((candidate) => candidate.component === component);
+			expect(
+				entry,
+				`Ruta '${serverRoute.path}' (${component.name}) no está registrada en seo-host-directives.spec.ts — agregá su componente al registro y decidí si es indexable`,
+			).toBeDefined();
+		}
+	});
+
+	describe.each(PAGE_SEO_REGISTRY)('$sourceFile', (entry) => {
+		const source = readPageSource(entry.sourceFile);
+		const hostDirectives = extractHostDirectiveNames(source);
+
+		if (entry.indexable) {
+			it('should declare a MetaTags + StructuredData host directive combo', () => {
+				const detail = `${entry.component.name} es indexable pero hostDirectives = [${hostDirectives.join(', ')}]`;
+				expect(
+					hostDirectives.some((name) => /MetaTagsDirective$/.test(name)),
+					`${detail}: falta una <Page>MetaTagsDirective`,
+				).toBe(true);
+				expect(
+					hostDirectives.some((name) => /StructuredDataDirective$/.test(name)),
+					`${detail}: falta una <Page>StructuredDataDirective`,
+				).toBe(true);
+			});
+		} else {
+			it('should opt out of indexing with HeadMetadataDirective + setRobots(noindex)', () => {
+				expect(
+					hostDirectives,
+					`${entry.component.name} está registrado indexable: false pero hostDirectives = [${hostDirectives.join(', ')}]`,
+				).toEqual(['HeadMetadataDirective']);
+				expect(
+					extractRobotsLiteral(source),
+					`${entry.component.name} está registrado indexable: false pero no llama setRobots('noindex...') — el opt-out no está wireado en el código`,
+				).toContain('noindex');
+			});
+		}
+	});
+});

--- a/src/app/pages/seo-host-directives.spec.ts
+++ b/src/app/pages/seo-host-directives.spec.ts
@@ -1,85 +1,58 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-import { Type } from '@angular/core';
 import { RenderMode } from '@angular/ssr';
 
 import { appRoutes } from '../app.routes';
 import { serverRoutes } from '../app.routes.server';
 import { collectSeoViolations } from './seo-host-directives.util';
 
-import HomeComponent from './home/home.component';
-import AuthorComponent from './author/author.component';
-import StoryComponent from './story/story.component';
-import StorylistComponent from './storylist/storylist.component';
-import AuthorsComponent from './authors/authors.component';
-import StoriesComponent from './stories/stories.component';
-import AboutComponent from './about/about.component';
-import DmcaComponent from './dmca/dmca.component';
+// Guardrail estructural: garantiza que toda página con una ruta indexable (RenderMode.Server/Prerender, sin
+// noindex) declare sus directivas de SEO. Cruza app.routes.server.ts (RenderMode) × app.routes.ts (ruta→fuente)
+// × el fuente del componente (hostDirectives) de forma dinámica: descubre las páginas desde las rutas y deriva
+// la indexabilidad del propio código, sin registro ni imports de componentes. No usa Angular Testing Library a
+// propósito: no hay UI que ejercitar, es un test de convención de código. Ver `angular-state.md` §8.
 
-// Guardrail estructural: garantiza que toda página con una ruta indexable (RenderMode.Server/Prerender,
-// sin noindex) declare sus directivas de SEO. No usa Angular Testing Library a propósito: no hay UI que ejercitar,
-// es un test de convención de código sobre el mapeo ruta→RenderMode→componente, que cruza tres archivos
-// (app.routes.ts, app.routes.server.ts y el fuente del componente). Ver `angular-state.md` para la convención.
+const INDEXABLE_MODES: readonly RenderMode[] = [RenderMode.Server, RenderMode.Prerender];
 
-type PageSeoEntry = Readonly<{ component: Type<unknown>; sourceFile: string; indexable: boolean }>;
-
-// Clasificación explícita de cada página como indexable o no (ver angular-state.md §8).
-const PAGE_SEO_REGISTRY: readonly PageSeoEntry[] = [
-	{ component: HomeComponent, sourceFile: 'home/home.component.ts', indexable: true },
-	{ component: AuthorComponent, sourceFile: 'author/author.component.ts', indexable: true },
-	{ component: StoryComponent, sourceFile: 'story/story.component.ts', indexable: true },
-	{ component: StorylistComponent, sourceFile: 'storylist/storylist.component.ts', indexable: true },
-	{ component: AuthorsComponent, sourceFile: 'authors/authors.component.ts', indexable: false },
-	{ component: StoriesComponent, sourceFile: 'stories/stories.component.ts', indexable: false },
-	{ component: AboutComponent, sourceFile: 'about/about.component.ts', indexable: false },
-	{ component: DmcaComponent, sourceFile: 'dmca/dmca.component.ts', indexable: false },
-];
-
-// Nuestras rutas resuelven el componente vía `() => import(...)`, así que loadComponent() siempre entrega el
-// módulo con `default`. El cast descarta las ramas Observable/Type-directo de la firma que este repo no usa.
-type LoadedComponent = Type<unknown> | { default: Type<unknown> };
-
-function isIndexableRenderMode(mode: RenderMode): boolean {
-	return mode === RenderMode.Server || mode === RenderMode.Prerender;
+// Extrae el archivo fuente del componente desde el `loadComponent` de la ruta. El bundler resuelve el
+// `import(...)` a un string con la ruta del módulo (p. ej. `/src/app/pages/home/home.component.ts`), del que se
+// toma la parte relativa a la raíz del repo.
+function sourceFileForRoute(path: string): string {
+	const appRoute = appRoutes.find((route) => route.path === path);
+	if (!appRoute?.loadComponent) {
+		throw new Error(`Ruta '${path}' está en app.routes.server.ts pero no tiene un loadComponent en app.routes.ts`);
+	}
+	const reference = appRoute.loadComponent.toString();
+	const match = reference.match(/["']([^"']*pages\/[^"']+\.component\.ts)["']/);
+	if (!match) {
+		throw new Error(`No se pudo extraer el archivo fuente del loadComponent de la ruta '${path}': ${reference}`);
+	}
+	const captured = match[1];
+	const srcIndex = captured.indexOf('src/');
+	return srcIndex >= 0 ? captured.slice(srcIndex) : captured.replace(/^\//, '');
 }
 
-function resolveRouteComponent(loaded: LoadedComponent): Type<unknown> {
-	return 'default' in loaded ? loaded.default : loaded;
+// Agrupa por archivo fuente (storylist y storylist/:slug comparten componente) las rutas indexable-mode.
+const pagesByFile = new Map<string, string[]>();
+for (const serverRoute of serverRoutes) {
+	if (serverRoute.path === '**' || !INDEXABLE_MODES.includes(serverRoute.renderMode)) {
+		continue;
+	}
+	const sourceFile = sourceFileForRoute(serverRoute.path);
+	pagesByFile.set(sourceFile, [...(pagesByFile.get(sourceFile) ?? []), serverRoute.path]);
 }
-
-function readPageSource(sourceFile: string): string {
-	return readFileSync(join(process.cwd(), 'src', 'app', 'pages', sourceFile), 'utf-8');
-}
+const pages = [...pagesByFile.entries()].map(([sourceFile, paths]) => ({ sourceFile, paths: paths.join(', ') }));
 
 describe('SEO host directives guardrail', () => {
-	it('should register every indexable-mode page route in PAGE_SEO_REGISTRY', async () => {
-		for (const serverRoute of serverRoutes) {
-			if (serverRoute.path === '**' || !isIndexableRenderMode(serverRoute.renderMode)) {
-				continue;
-			}
-			const appRoute = appRoutes.find((route) => route.path === serverRoute.path);
-			if (!appRoute?.loadComponent) {
-				throw new Error(
-					`Ruta '${serverRoute.path}' está en app.routes.server.ts pero no tiene un loadComponent en app.routes.ts`,
-				);
-			}
-			const component = resolveRouteComponent((await appRoute.loadComponent()) as LoadedComponent);
-			const entry = PAGE_SEO_REGISTRY.find((candidate) => candidate.component === component);
-			expect(
-				entry,
-				`Ruta '${serverRoute.path}' (${component.name}) no está registrada en seo-host-directives.spec.ts — agregá su componente al registro y decidí si es indexable`,
-			).toBeDefined();
-		}
+	it('should discover the indexable-mode page routes', () => {
+		expect(pages.length).toBeGreaterThan(0);
 	});
 
-	describe.each(PAGE_SEO_REGISTRY)('$sourceFile', (entry) => {
-		it('should comply with the SEO host-directive convention for its indexability', () => {
-			const violations = collectSeoViolations(entry.indexable, readPageSource(entry.sourceFile));
-			expect(
-				violations,
-				`${entry.component.name} (indexable: ${entry.indexable}) incumple la convención de SEO: ${violations.join('; ')}`,
-			).toEqual([]);
+	describe.each(pages)('$sourceFile', ({ sourceFile, paths }) => {
+		it('should declare the SEO host directives that match its indexability', () => {
+			const violations = collectSeoViolations(readFileSync(join(process.cwd(), sourceFile), 'utf-8'));
+			expect(violations, `Rutas '${paths}' (${sourceFile}): ${violations.join('; ')}`).toEqual([]);
 		});
 	});
 });

--- a/src/app/pages/seo-host-directives.spec.ts
+++ b/src/app/pages/seo-host-directives.spec.ts
@@ -6,7 +6,7 @@ import { RenderMode } from '@angular/ssr';
 
 import { appRoutes } from '../app.routes';
 import { serverRoutes } from '../app.routes.server';
-import { extractHostDirectiveNames, extractRobotsLiteral } from './seo-host-directives.util';
+import { collectSeoViolations } from './seo-host-directives.util';
 
 import HomeComponent from './home/home.component';
 import AuthorComponent from './author/author.component';
@@ -24,8 +24,7 @@ import DmcaComponent from './dmca/dmca.component';
 
 type PageSeoEntry = Readonly<{ component: Type<unknown>; sourceFile: string; indexable: boolean }>;
 
-// Clasificación explícita de cada página. `indexable: true` exige el combo MetaTags + StructuredData;
-// `indexable: false` exige el opt-out HeadMetadataDirective + setRobots('noindex...').
+// Clasificación explícita de cada página como indexable o no (ver angular-state.md §8).
 const PAGE_SEO_REGISTRY: readonly PageSeoEntry[] = [
 	{ component: HomeComponent, sourceFile: 'home/home.component.ts', indexable: true },
 	{ component: AuthorComponent, sourceFile: 'author/author.component.ts', indexable: true },
@@ -75,32 +74,12 @@ describe('SEO host directives guardrail', () => {
 	});
 
 	describe.each(PAGE_SEO_REGISTRY)('$sourceFile', (entry) => {
-		const source = readPageSource(entry.sourceFile);
-		const hostDirectives = extractHostDirectiveNames(source);
-
-		if (entry.indexable) {
-			it('should declare a MetaTags + StructuredData host directive combo', () => {
-				const detail = `${entry.component.name} es indexable pero hostDirectives = [${hostDirectives.join(', ')}]`;
-				expect(
-					hostDirectives.some((name) => /MetaTagsDirective$/.test(name)),
-					`${detail}: falta una <Page>MetaTagsDirective`,
-				).toBe(true);
-				expect(
-					hostDirectives.some((name) => /StructuredDataDirective$/.test(name)),
-					`${detail}: falta una <Page>StructuredDataDirective`,
-				).toBe(true);
-			});
-		} else {
-			it('should opt out of indexing with HeadMetadataDirective + setRobots(noindex)', () => {
-				expect(
-					hostDirectives,
-					`${entry.component.name} está registrado indexable: false pero hostDirectives = [${hostDirectives.join(', ')}]`,
-				).toEqual(['HeadMetadataDirective']);
-				expect(
-					extractRobotsLiteral(source),
-					`${entry.component.name} está registrado indexable: false pero no llama setRobots('noindex...') — el opt-out no está wireado en el código`,
-				).toContain('noindex');
-			});
-		}
+		it('should comply with the SEO host-directive convention for its indexability', () => {
+			const violations = collectSeoViolations(entry.indexable, readPageSource(entry.sourceFile));
+			expect(
+				violations,
+				`${entry.component.name} (indexable: ${entry.indexable}) incumple la convención de SEO: ${violations.join('; ')}`,
+			).toEqual([]);
+		});
 	});
 });

--- a/src/app/pages/seo-host-directives.util.spec.ts
+++ b/src/app/pages/seo-host-directives.util.spec.ts
@@ -57,42 +57,42 @@ describe('seo-host-directives.util', () => {
 		const noindexSource = `hostDirectives: [HeadMetadataDirective],\nsetRobots('noindex, follow');`;
 
 		it('should report no violations for a conformant indexable page', () => {
-			expect(collectSeoViolations(true, indexableSource)).toEqual([]);
+			expect(collectSeoViolations(indexableSource)).toEqual([]);
 		});
 
 		it('should report no violations for a conformant noindex page', () => {
-			expect(collectSeoViolations(false, noindexSource)).toEqual([]);
+			expect(collectSeoViolations(noindexSource)).toEqual([]);
 		});
 
 		it('should flag an indexable page missing the StructuredData directive', () => {
-			const violations = collectSeoViolations(true, `hostDirectives: [HomeMetaTagsDirective],`);
+			const violations = collectSeoViolations(`hostDirectives: [HomeMetaTagsDirective],`);
 			expect(violations).toHaveLength(1);
 			expect(violations[0]).toContain('StructuredDataDirective');
 		});
 
 		it('should flag an indexable page missing both SEO directives', () => {
-			expect(collectSeoViolations(true, `hostDirectives: [HeadMetadataDirective],`)).toHaveLength(2);
+			expect(collectSeoViolations(`hostDirectives: [HeadMetadataDirective],`)).toHaveLength(2);
+		});
+
+		it('should treat a page without noindex as indexable and require the combo', () => {
+			// Sin setRobots('noindex') y sin structured data → se deriva indexable → falta el combo.
+			const violations = collectSeoViolations(`hostDirectives: [SomeDirective],`);
+			expect(violations).toHaveLength(2);
+			expect(violations.every((v) => v.startsWith('página indexable'))).toBe(true);
 		});
 
 		it('should flag a noindex page that declares the indexable combo', () => {
-			const violations = collectSeoViolations(false, indexableSource);
-			expect(violations.some((v) => v.includes('HeadMetadataDirective'))).toBe(true);
-			expect(violations.some((v) => v.includes('setRobots'))).toBe(true);
-		});
-
-		it('should flag a noindex page with an extra host directive', () => {
-			const violations = collectSeoViolations(
-				false,
-				`hostDirectives: [HeadMetadataDirective, FooDirective],\nsetRobots('noindex, follow');`,
-			);
+			const violations = collectSeoViolations(`${indexableSource}\nsetRobots('noindex, follow');`);
 			expect(violations).toHaveLength(1);
 			expect(violations[0]).toContain('HeadMetadataDirective');
 		});
 
-		it('should flag a noindex page that never calls setRobots(noindex)', () => {
-			const violations = collectSeoViolations(false, `hostDirectives: [HeadMetadataDirective],`);
+		it('should flag a noindex page with an extra host directive', () => {
+			const violations = collectSeoViolations(
+				`hostDirectives: [HeadMetadataDirective, FooDirective],\nsetRobots('noindex, follow');`,
+			);
 			expect(violations).toHaveLength(1);
-			expect(violations[0]).toContain('setRobots');
+			expect(violations[0]).toContain('HeadMetadataDirective');
 		});
 	});
 });

--- a/src/app/pages/seo-host-directives.util.spec.ts
+++ b/src/app/pages/seo-host-directives.util.spec.ts
@@ -1,4 +1,4 @@
-import { extractHostDirectiveNames, extractRobotsLiteral } from './seo-host-directives.util';
+import { collectSeoViolations, extractHostDirectiveNames, extractRobotsLiteral } from './seo-host-directives.util';
 
 describe('seo-host-directives.util', () => {
 	describe('extractHostDirectiveNames', () => {
@@ -49,6 +49,50 @@ describe('seo-host-directives.util', () => {
 
 		it('should return undefined when there is no setRobots call', () => {
 			expect(extractRobotsLiteral(`hostDirectives: [HomeMetaTagsDirective]`)).toBeUndefined();
+		});
+	});
+
+	describe('collectSeoViolations', () => {
+		const indexableSource = `hostDirectives: [HomeMetaTagsDirective, HomeStructuredDataDirective],`;
+		const noindexSource = `hostDirectives: [HeadMetadataDirective],\nsetRobots('noindex, follow');`;
+
+		it('should report no violations for a conformant indexable page', () => {
+			expect(collectSeoViolations(true, indexableSource)).toEqual([]);
+		});
+
+		it('should report no violations for a conformant noindex page', () => {
+			expect(collectSeoViolations(false, noindexSource)).toEqual([]);
+		});
+
+		it('should flag an indexable page missing the StructuredData directive', () => {
+			const violations = collectSeoViolations(true, `hostDirectives: [HomeMetaTagsDirective],`);
+			expect(violations).toHaveLength(1);
+			expect(violations[0]).toContain('StructuredDataDirective');
+		});
+
+		it('should flag an indexable page missing both SEO directives', () => {
+			expect(collectSeoViolations(true, `hostDirectives: [HeadMetadataDirective],`)).toHaveLength(2);
+		});
+
+		it('should flag a noindex page that declares the indexable combo', () => {
+			const violations = collectSeoViolations(false, indexableSource);
+			expect(violations.some((v) => v.includes('HeadMetadataDirective'))).toBe(true);
+			expect(violations.some((v) => v.includes('setRobots'))).toBe(true);
+		});
+
+		it('should flag a noindex page with an extra host directive', () => {
+			const violations = collectSeoViolations(
+				false,
+				`hostDirectives: [HeadMetadataDirective, FooDirective],\nsetRobots('noindex, follow');`,
+			);
+			expect(violations).toHaveLength(1);
+			expect(violations[0]).toContain('HeadMetadataDirective');
+		});
+
+		it('should flag a noindex page that never calls setRobots(noindex)', () => {
+			const violations = collectSeoViolations(false, `hostDirectives: [HeadMetadataDirective],`);
+			expect(violations).toHaveLength(1);
+			expect(violations[0]).toContain('setRobots');
 		});
 	});
 });

--- a/src/app/pages/seo-host-directives.util.spec.ts
+++ b/src/app/pages/seo-host-directives.util.spec.ts
@@ -1,0 +1,54 @@
+import { extractHostDirectiveNames, extractRobotsLiteral } from './seo-host-directives.util';
+
+describe('seo-host-directives.util', () => {
+	describe('extractHostDirectiveNames', () => {
+		it('should extract the directive names from a single-line hostDirectives array', () => {
+			const source = `hostDirectives: [HomeMetaTagsDirective, HomeStructuredDataDirective],`;
+			expect(extractHostDirectiveNames(source)).toEqual(['HomeMetaTagsDirective', 'HomeStructuredDataDirective']);
+		});
+
+		it('should extract the directive names from a multi-line hostDirectives array', () => {
+			const source = `
+				hostDirectives: [
+					AuthorMetaTagsDirective,
+					AuthorStructuredDataDirective,
+				],
+			`;
+			expect(extractHostDirectiveNames(source)).toEqual(['AuthorMetaTagsDirective', 'AuthorStructuredDataDirective']);
+		});
+
+		it('should extract a single directive name', () => {
+			expect(extractHostDirectiveNames(`hostDirectives: [HeadMetadataDirective],`)).toEqual(['HeadMetadataDirective']);
+		});
+
+		it('should return an empty array when hostDirectives is absent', () => {
+			expect(extractHostDirectiveNames(`@Component({ selector: 'cuentoneta-home' })`)).toEqual([]);
+		});
+
+		it('should return an empty array when the hostDirectives array is empty', () => {
+			expect(extractHostDirectiveNames(`hostDirectives: [],`)).toEqual([]);
+		});
+
+		it('should tolerate a trailing comma inside the array', () => {
+			expect(extractHostDirectiveNames(`hostDirectives: [HeadMetadataDirective,],`)).toEqual(['HeadMetadataDirective']);
+		});
+	});
+
+	describe('extractRobotsLiteral', () => {
+		it('should return the robots literal from a setRobots call', () => {
+			expect(extractRobotsLiteral(`this.metaTagsDirective.setRobots('noindex, follow');`)).toBe('noindex, follow');
+		});
+
+		it('should return the index literal for an indexable page', () => {
+			expect(extractRobotsLiteral(`setRobots('index, follow')`)).toBe('index, follow');
+		});
+
+		it('should accept double quotes', () => {
+			expect(extractRobotsLiteral(`setRobots("noindex, nofollow")`)).toBe('noindex, nofollow');
+		});
+
+		it('should return undefined when there is no setRobots call', () => {
+			expect(extractRobotsLiteral(`hostDirectives: [HomeMetaTagsDirective]`)).toBeUndefined();
+		});
+	});
+});

--- a/src/app/pages/seo-host-directives.util.ts
+++ b/src/app/pages/seo-host-directives.util.ts
@@ -26,3 +26,31 @@ export function extractRobotsLiteral(source: string): string | undefined {
 	const match = source.match(/setRobots\(\s*['"]([^'"]*)['"]/);
 	return match ? match[1] : undefined;
 }
+
+/**
+ * Lista los incumplimientos de la convención de SEO de una página según su indexabilidad (vacío = conforme).
+ * Es la lógica de detección del guardrail, separada del spec para poder cubrir el camino de fallo con fixtures.
+ * - Indexable: exige una `<Page>MetaTagsDirective` y una `<Page>StructuredDataDirective` en `hostDirectives`.
+ * - No indexable: exige `hostDirectives` exactamente `[HeadMetadataDirective]` y un `setRobots('noindex...')`.
+ */
+export function collectSeoViolations(indexable: boolean, source: string): string[] {
+	const hostDirectives = extractHostDirectiveNames(source);
+	const declared = `hostDirectives: [${hostDirectives.join(', ')}]`;
+	const violations: string[] = [];
+	if (indexable) {
+		if (!hostDirectives.some((name) => /MetaTagsDirective$/.test(name))) {
+			violations.push(`falta una <Page>MetaTagsDirective (${declared})`);
+		}
+		if (!hostDirectives.some((name) => /StructuredDataDirective$/.test(name))) {
+			violations.push(`falta una <Page>StructuredDataDirective (${declared})`);
+		}
+		return violations;
+	}
+	if (hostDirectives.length !== 1 || hostDirectives[0] !== 'HeadMetadataDirective') {
+		violations.push(`se espera hostDirectives: [HeadMetadataDirective], hay [${hostDirectives.join(', ')}]`);
+	}
+	if (!extractRobotsLiteral(source)?.includes('noindex')) {
+		violations.push(`falta setRobots('noindex...') — el opt-out de indexación no está wireado en el código`);
+	}
+	return violations;
+}

--- a/src/app/pages/seo-host-directives.util.ts
+++ b/src/app/pages/seo-host-directives.util.ts
@@ -1,4 +1,4 @@
-// Helpers de parseo estático (texto → texto) para el guardrail de SEO de páginas (#1726). Operan sobre el
+// Helpers de parseo estático (texto → texto) para el guardrail de SEO de páginas. Operan sobre el
 // código fuente de un componente de página como string; no dependen de Angular, Ivy ni el DOM, y por eso son
 // unit-testeables con fixtures inline en `seo-host-directives.util.spec.ts`.
 

--- a/src/app/pages/seo-host-directives.util.ts
+++ b/src/app/pages/seo-host-directives.util.ts
@@ -1,0 +1,28 @@
+// Helpers de parseo estático (texto → texto) para el guardrail de SEO de páginas (#1726). Operan sobre el
+// código fuente de un componente de página como string; no dependen de Angular, Ivy ni el DOM, y por eso son
+// unit-testeables con fixtures inline en `seo-host-directives.util.spec.ts`.
+
+/**
+ * Extrae los nombres de las directivas declaradas en `hostDirectives: [...]` del decorador `@Component`.
+ * Devuelve `[]` si no hay `hostDirectives` o el array está vacío. La clase negada `[^\]]` cubre arrays
+ * multilínea sin necesitar la flag `s`; asume la forma simple (array de identificadores) que usan las páginas.
+ */
+export function extractHostDirectiveNames(source: string): string[] {
+	const match = source.match(/hostDirectives:\s*\[([^\]]*)\]/);
+	if (!match) {
+		return [];
+	}
+	return match[1]
+		.split(',')
+		.map((name) => name.trim())
+		.filter((name) => name.length > 0);
+}
+
+/**
+ * Devuelve el literal pasado a la primera llamada `setRobots('...')` del componente, o `undefined` si no hay
+ * ninguna. Acepta comillas simples o dobles.
+ */
+export function extractRobotsLiteral(source: string): string | undefined {
+	const match = source.match(/setRobots\(\s*['"]([^'"]*)['"]/);
+	return match ? match[1] : undefined;
+}

--- a/src/app/pages/seo-host-directives.util.ts
+++ b/src/app/pages/seo-host-directives.util.ts
@@ -28,29 +28,26 @@ export function extractRobotsLiteral(source: string): string | undefined {
 }
 
 /**
- * Lista los incumplimientos de la convención de SEO de una página según su indexabilidad (vacío = conforme).
- * Es la lógica de detección del guardrail, separada del spec para poder cubrir el camino de fallo con fixtures.
- * - Indexable: exige una `<Page>MetaTagsDirective` y una `<Page>StructuredDataDirective` en `hostDirectives`.
- * - No indexable: exige `hostDirectives` exactamente `[HeadMetadataDirective]` y un `setRobots('noindex...')`.
+ * Lista los incumplimientos de la convención de SEO de una página (vacío = conforme). La indexabilidad se
+ * deriva del propio código: una página que llama `setRobots('noindex...')` es un opt-out y solo debe declarar
+ * `[HeadMetadataDirective]`; cualquier otra se considera indexable y debe declarar una `<Page>MetaTagsDirective`
+ * y una `<Page>StructuredDataDirective`.
  */
-export function collectSeoViolations(indexable: boolean, source: string): string[] {
+export function collectSeoViolations(source: string): string[] {
 	const hostDirectives = extractHostDirectiveNames(source);
 	const declared = `hostDirectives: [${hostDirectives.join(', ')}]`;
 	const violations: string[] = [];
-	if (indexable) {
-		if (!hostDirectives.some((name) => /MetaTagsDirective$/.test(name))) {
-			violations.push(`falta una <Page>MetaTagsDirective (${declared})`);
-		}
-		if (!hostDirectives.some((name) => /StructuredDataDirective$/.test(name))) {
-			violations.push(`falta una <Page>StructuredDataDirective (${declared})`);
+	if (extractRobotsLiteral(source)?.includes('noindex')) {
+		if (hostDirectives.length !== 1 || hostDirectives[0] !== 'HeadMetadataDirective') {
+			violations.push(`página noindex: se espera hostDirectives: [HeadMetadataDirective], hay ${declared}`);
 		}
 		return violations;
 	}
-	if (hostDirectives.length !== 1 || hostDirectives[0] !== 'HeadMetadataDirective') {
-		violations.push(`se espera hostDirectives: [HeadMetadataDirective], hay [${hostDirectives.join(', ')}]`);
+	if (!hostDirectives.some((name) => /MetaTagsDirective$/.test(name))) {
+		violations.push(`página indexable: falta una <Page>MetaTagsDirective (${declared})`);
 	}
-	if (!extractRobotsLiteral(source)?.includes('noindex')) {
-		violations.push(`falta setRobots('noindex...') — el opt-out de indexación no está wireado en el código`);
+	if (!hostDirectives.some((name) => /StructuredDataDirective$/.test(name))) {
+		violations.push(`página indexable: falta una <Page>StructuredDataDirective (${declared})`);
 	}
 	return violations;
 }


### PR DESCRIPTION
## Descripción

Guardrail que hace imposible por construcción que una página indexable nazca sin sus directivas de SEO (meta tags + structured data), extendiendo la filosofía de `ssr-fetch-must-decide-blocking` (#1705).

- **Test estructural de Vitest** (`src/app/pages/seo-host-directives.spec.ts`), no una regla ESLint: el criterio de indexabilidad cruza `app.routes.server.ts` (`RenderMode`), `app.routes.ts` (ruta→componente) y el fuente del componente (`hostDirectives`), un invariante whole-program para el que ESLint —un archivo por vez— no es el lugar natural.
- **Descubrimiento dinámico, sin registro ni imports de componentes:** el test recorre las rutas `Server`/`Prerender` de `serverRoutes` y resuelve el archivo fuente de cada página desde su `loadComponent` (el bundler resuelve el `import()` a la ruta del módulo, legible vía `.toString()`). No hay lista de componentes que mantener a mano.
- **Indexabilidad derivada del propio código:** una página que llama `setRobots('noindex...')` es un opt-out y solo debe declarar `[HeadMetadataDirective]`; cualquier otra se considera indexable y debe declarar el combo `<Page>MetaTagsDirective` + `<Page>StructuredDataDirective`. No hay flag `indexable` hecho a mano: para saltarse el combo hay que emitir un `noindex` real, visible en el diff (el guardrail no se puede "engañar" con una clasificación falsa). Una página nueva se chequea automáticamente.
- La detección vive en una función pura `collectSeoViolations(source)` (`seo-host-directives.util.ts`), cubierta con fixtures adversariales que ejercitan el camino de fallo en ambas ramas (indexable sin structured data; noindex con directivas de más o con el combo indexable).
- Documenta la convención (indexable vs `noindex`) en `angular-state.md` §8 y `angular-components.md`, con la línea "Enforced por test".

Las páginas `about`/`stories`/`authors` que el issue señalaba como "huecos sin structured data" resultaron opt-outs `noindex` intencionales y correctos; el guardrail los formaliza como tales y bloquea el riesgo real: que una página nueva indexable nazca sin structured data.

Closes #1726.

Parte de #1720.

## Plan de pruebas

- [x] `pnpm typecheck`, `pnpm lint` — verde
- [x] `pnpm test` — 26 tests (17 unit del helper + 9 estructurales) en verde; suite completa sin regresiones
- [x] Verificación de regresión negativa: quitar `HomeStructuredDataDirective` de `home.component.ts` hace fallar el guardrail con mensaje accionable; revertido
- [x] `pnpm build` y `pnpm storybook:build` — verde (corridos en la review)
