### PR TITLE
[#1722] - Apunta los e2e de SEO de CI al dataset staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,12 +256,14 @@ jobs:
             nx-cache-e2e-
 
       # El webServer de Playwright levanta el build SSR de producción (fidelidad con el crawler), así
-      # que hay que compilarlo acá. Mismas env vars que el job `build`.
+      # que hay que compilarlo acá. Los e2e corren contra `staging` (espejo de producción, aislado del
+      # `development` compartido que los devs mutan) para reducir la fragilidad por curación de contenido
+      # (#1722); en local se usa `development` (default del .env). staging es público → no requiere token.
       - name: Build de producción para e2e (SSR real)
         run: bash .github/scripts/nx-run.sh nx run @cuentoneta/app:build:production
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          SANITY_STUDIO_DATASET: ${{ secrets.SANITY_STUDIO_DATASET || 'development' }}
+          SANITY_STUDIO_DATASET: staging
           SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID || 's4dbqkc5' }}
           SANITY_STUDIO_TOKEN: ${{ secrets.SANITY_STUDIO_TOKEN }}
           CLARITY_TOKEN: ${{ secrets.CLARITY_TOKEN }}
@@ -275,10 +277,15 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 
+      # El webServer SSR resuelve el dataset en runtime (environment.ts lee process.env), no en build:
+      # se fija acá `staging` para que sea el dataset que ve el crawler. Gana sobre el `development` del
+      # .env porque process.loadEnvFile() no pisa variables ya presentes en el entorno.
       - name: Run Tests
         run: bash .github/scripts/nx-run.sh nx run @cuentoneta/app:e2e
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          SANITY_STUDIO_DATASET: staging
+          SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID || 's4dbqkc5' }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Descripción

- Los tests e2e de SEO en GitHub Actions pasan a correr contra el dataset **`staging`** (espejo de producción, aislado del `development` compartido que los devs mutan), reduciendo la fragilidad por curación de contenido. En el **entorno local** se mantiene `development` (default del `.env`).
- Al ser CI un único workflow (PRs, push a `develop` y `workflow_dispatch`), el cambio cubre también la corrida que gatea el merge `develop → master`.

## Implementación

Único archivo tocado: `.github/workflows/ci.yml` (job `e2e`). Se fija `SANITY_STUDIO_DATASET: staging` en el step de build y en el de "Run Tests". El webServer SSR resuelve el dataset en runtime (`environment.ts` lee `process.env`), y el env del step gana sobre el `.env` porque `process.loadEnvFile()` no pisa variables ya presentes. `staging` es público → no requiere token de lectura.

## Alcance (acotado por decisión del proyecto)

Se descartó el scope original (dataset e2e dedicado + seed idempotente + reactivar celdas `test.fixme`): el riesgo residual de correr contra un espejo es aceptable y no justifica el costo/tradeoff de un 4.º dataset (bloqueado por cuota del plan Sanity) ni de mockear la capa (choca con el roadmap de `sanity-acl.md`, #1503). Este PR se limita al cambio de dataset en CI; los ítems restantes quedan fuera de alcance.

Closes #1722.

Parte de #1720.

## Plan de pruebas

- [x] Verificado que `staging` contiene los documentos que consumen los specs (`el-aleph`, `jorge-luis-borges`, `verano-2022`, la landing page de la semana ISO actual y el singleton `rotatingContent`).
- [x] Verificado empíricamente que `process.loadEnvFile()` no pisa un env var ya presente → el `SANITY_STUDIO_DATASET: staging` del step gana sobre el `development` del `.env`.
- [x] Verificado que el frontend (`environment.ts`) se genera desde `VERCEL_TARGET_ENV`, no desde el dataset → sin efecto colateral en el bundle.
- [x] YAML de `ci.yml` válido; gates de CI locales en verde (`lint`, `stylelint`, `typecheck`, `test`, `build`, `storybook:build`).
- [ ] Confirmación end-to-end del gate `e2e` contra `staging`: se validará en la corrida de CI de este PR.
