### PR TITLE
[#1823] - Implementar NavigableCollectionTeaser (DS v3) — item compacto de colección sugerida

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,6 +8,7 @@ export const AppRoutes = Object.freeze({
 	Authors: 'authors',
 	About: 'about',
 	Dmca: 'dmca',
+	Collection: 'collection',
 } as const);
 export type AppRoutes = (typeof AppRoutes)[keyof typeof AppRoutes];
 

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser-skeleton.component.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser-skeleton.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+
+import { SkeletonComponent } from '@components/skeleton/skeleton.component';
+
+/** Estado de carga de NavigableCollectionTeaser: círculo del ícono + línea del nombre + línea corta de metadatos. */
+@Component({
+	selector: 'cuentoneta-navigable-collection-teaser-skeleton',
+	imports: [SkeletonComponent],
+	host: { class: 'block' },
+	template: `
+		<div class="flex items-center gap-3" data-testid="skeleton">
+			<cuentoneta-skeleton appearance="circle" class="size-10 shrink-0 bg-neutral-300" />
+			<div class="flex min-w-0 flex-1 flex-col gap-2">
+				<cuentoneta-skeleton appearance="line" class="h-5 w-40 bg-neutral-300" />
+				<cuentoneta-skeleton appearance="line" class="h-4 w-24 bg-neutral-300" />
+			</div>
+		</div>
+	`,
+})
+export class NavigableCollectionTeaserSkeletonComponent {}

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.spec.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.spec.ts
@@ -39,6 +39,6 @@ describe('NavigableCollectionTeaserComponent', () => {
 		// El ícono es decorativo (alt vacío) y el enlace envuelve solo el título, así que el nombre accesible
 		// del link es el título de la colección.
 		const link = screen.getByRole('link', { name: collection.title });
-		expect(link).toHaveAttribute('href', expect.stringContaining(`/storylist/${collection.slug}`));
+		expect(link).toHaveAttribute('href', expect.stringContaining(`/collection/${collection.slug}`));
 	});
 });

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.spec.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.spec.ts
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/angular';
+import { provideRouter } from '@angular/router';
+
+import { NavigableCollectionTeaserComponent } from './navigable-collection-teaser.component';
+import { storylistTeaserRepresentativeMock } from '@mocks/storylist.mock';
+
+describe('NavigableCollectionTeaserComponent', () => {
+	const collection = storylistTeaserRepresentativeMock;
+	const setup = (teaser = collection) =>
+		render(NavigableCollectionTeaserComponent, { inputs: { collection: teaser }, providers: [provideRouter([])] });
+
+	it('should render the collection title', async () => {
+		await setup();
+		expect(screen.getByText(collection.title)).toBeInTheDocument();
+	});
+
+	it('should render the category tag when the collection has tags', async () => {
+		await setup();
+		expect(screen.getByText(collection.tags[0].title)).toBeInTheDocument();
+	});
+
+	it('should not render a category tag when the collection has no tags', async () => {
+		await setup({ ...collection, tags: [] });
+		expect(screen.queryByText(collection.tags[0].title)).not.toBeInTheDocument();
+	});
+
+	it('should render the pluralized story count', async () => {
+		await setup({ ...collection, count: 5 });
+		expect(screen.getByText('5 historias')).toBeInTheDocument();
+	});
+
+	it('should render the singular story count', async () => {
+		await setup({ ...collection, count: 1 });
+		expect(screen.getByText('1 historia')).toBeInTheDocument();
+	});
+
+	it('should link to the collection exposing just the title as the accessible name', async () => {
+		await setup();
+		// El ícono es decorativo (alt vacío) y el enlace envuelve solo el título, así que el nombre accesible
+		// del link es el título de la colección.
+		const link = screen.getByRole('link', { name: collection.title });
+		expect(link).toHaveAttribute('href', expect.stringContaining(`/storylist/${collection.slug}`));
+	});
+});

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
@@ -61,7 +61,7 @@ export const SinCategoria: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Colección sin categoría asignada: se omiten el tag y el separador, y queda solo la cantidad de historias.</p>`,
+				story: `<p>Colección sin categoría asignada: se omiten el tag y el separador, y queda solo la cantidad de historias.</p><p><strong>Usos:</strong> «Otras colecciones sugeridas», para colecciones que todavía no tienen una categoría cargada en el CMS.</p>`,
 			},
 		},
 	},
@@ -80,7 +80,7 @@ export const TituloLargo: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Colección con título extenso en un contenedor acotado de 320px: el nombre se recorta a una línea con puntos suspensivos.</p>`,
+				story: `<p>Colección con título extenso en un contenedor acotado de 320px: el nombre se recorta a una línea con puntos suspensivos.</p><p><strong>Usos:</strong> el sidebar de la CollectionPage en columnas o viewports angostos, donde el nombre no entra completo.</p>`,
 			},
 		},
 	},

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
@@ -1,0 +1,108 @@
+import {
+	applicationConfig,
+	argsToTemplate,
+	componentWrapperDecorator,
+	Meta,
+	moduleMetadata,
+	StoryObj,
+} from '@storybook/angular';
+import { provideRouter } from '@angular/router';
+
+import { NavigableCollectionTeaserComponent } from './navigable-collection-teaser.component';
+import { NavigableCollectionTeaserSkeletonComponent } from './navigable-collection-teaser-skeleton.component';
+import { storylistTeaserRepresentativeMock } from '@mocks/storylist.mock';
+
+const meta: Meta<NavigableCollectionTeaserComponent> = {
+	component: NavigableCollectionTeaserComponent,
+	title: 'Componentes V3/NavigableCollectionTeaser',
+	decorators: [
+		applicationConfig({
+			providers: [provideRouter([])],
+		}),
+	],
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>El componente <strong>NavigableCollectionTeaserComponent</strong> es el item compacto y navegable de una colección (Design System v3): ícono de biblioteca, nombre, categoría y cantidad de historias. Pensado para listas como «Otras colecciones sugeridas» del sidebar de la página de una colección.</p><p>Se modela como un <code>&lt;article&gt;</code> con un único enlace real sobre el nombre, estirado con un pseudo-elemento para que toda la tarjeta sea clickeable sin inflar el nombre accesible del link.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (ícono de colección, variante <code>collection</code>) y <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> (categoría, variante <code>soft</code>).</p></div>`,
+			},
+		},
+		layout: 'padded',
+	},
+	argTypes: {
+		collection: {
+			control: { type: 'object' },
+			description: 'Teaser de la colección (title, slug, count, tags)',
+			table: { type: { summary: 'StorylistTeaser' }, defaultValue: { summary: 'required' } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<NavigableCollectionTeaserComponent>;
+
+export const Default: Story = {
+	name: 'Por defecto',
+	render: (args) => ({ props: args, template: `<cuentoneta-navigable-collection-teaser ${argsToTemplate(args)} />` }),
+	args: { collection: storylistTeaserRepresentativeMock },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Item completo: ícono de colección, nombre, categoría y cantidad de historias. Toda la tarjeta es clickeable y navega a la colección.</p><p><strong>Usos:</strong> «Otras colecciones sugeridas» en el sidebar de la CollectionPage.</p>`,
+			},
+		},
+	},
+};
+
+export const SinCategoria: Story = {
+	name: 'Sin categoría',
+	render: (args) => ({ props: args, template: `<cuentoneta-navigable-collection-teaser ${argsToTemplate(args)} />` }),
+	args: { collection: { ...storylistTeaserRepresentativeMock, tags: [] } },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Colección sin categoría asignada: se omiten el tag y el separador, y queda solo la cantidad de historias.</p>`,
+			},
+		},
+	},
+};
+
+export const TituloLargo: Story = {
+	name: 'Título largo',
+	render: (args) => ({ props: args, template: `<cuentoneta-navigable-collection-teaser ${argsToTemplate(args)} />` }),
+	args: {
+		collection: {
+			...storylistTeaserRepresentativeMock,
+			title: 'Book & Morfi: Especial Michis y Perritos en adopción en el refugio',
+		},
+	},
+	decorators: [componentWrapperDecorator((story) => `<div style="width:320px">${story}</div>`)],
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Colección con título extenso en un contenedor acotado de 320px: el nombre se recorta a una línea con puntos suspensivos.</p>`,
+			},
+		},
+	},
+};
+
+export const Estados: StoryObj<NavigableCollectionTeaserComponent & { loading: boolean }> = {
+	decorators: [moduleMetadata({ imports: [NavigableCollectionTeaserSkeletonComponent] })],
+	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="w-[320px]">
+				@if (loading) {
+					<cuentoneta-navigable-collection-teaser-skeleton />
+				} @else {
+					<cuentoneta-navigable-collection-teaser [collection]="collection" />
+				}
+			</div>
+		`,
+	}),
+	args: { loading: true, collection: storylistTeaserRepresentativeMock },
+	parameters: {
+		docs: { description: { story: 'Activá/desactivá "Cargando" para alternar entre el estado real y el skeleton.' } },
+	},
+};

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
@@ -23,7 +23,7 @@ import { TagComponent } from '../tag/tag.component';
 			<div class="flex min-w-0 flex-1 flex-col gap-1">
 				<!-- Enlace real (nombre de la colección) estirado con ::after para cubrir toda la tarjeta. -->
 				<a
-					[routerLink]="['/', appRoutes.StoryList, collection().slug]"
+					[routerLink]="['/', appRoutes.Collection, collection().slug]"
 					class="min-w-0 after:absolute after:inset-0 after:content-['']"
 					data-testid="collection-link"
 				>

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
@@ -1,0 +1,52 @@
+import { Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import type { StorylistTeaser } from '@models/storylist.model';
+import { AppRoutes } from '../../app.routes';
+import { ImageProfileComponent } from '../image-profile/image-profile.component';
+import { TagComponent } from '../tag/tag.component';
+
+/**
+ * Item compacto y navegable de una colección (Design System v3): ícono de biblioteca, nombre, categoría y
+ * cantidad de historias. Pensado para listas como «Otras colecciones sugeridas» del sidebar de la CollectionPage.
+ *
+ * Se modela como un `<article>` con un único enlace real sobre el nombre, estirado con un pseudo-elemento
+ * (`after:absolute after:inset-0`) para que toda la tarjeta sea clickeable sin inflar el nombre accesible del
+ * link. El ícono lo resuelve `ImageProfile` (variante `collection`, decorativa) y la categoría `Tag`.
+ */
+@Component({
+	selector: 'cuentoneta-navigable-collection-teaser',
+	imports: [RouterLink, ImageProfileComponent, TagComponent],
+	template: `
+		<article class="relative flex items-center gap-3" data-testid="collection">
+			<cuentoneta-image-profile variant="collection" size="medium" class="shrink-0" />
+			<div class="flex min-w-0 flex-1 flex-col gap-1">
+				<!-- Enlace real (nombre de la colección) estirado con ::after para cubrir toda la tarjeta. -->
+				<a
+					[routerLink]="['/', appRoutes.StoryList, collection().slug]"
+					class="min-w-0 after:absolute after:inset-0 after:content-['']"
+					data-testid="collection-link"
+				>
+					<span class="block truncate font-inter text-sm font-semibold text-neutral-900">{{ collection().title }}</span>
+				</a>
+				<div class="flex items-center gap-2" data-testid="meta">
+					@if (collection().tags[0]; as tag) {
+						<cuentoneta-tag [label]="tag.title" variant="soft" />
+						<span class="font-inter text-xxs font-medium text-neutral-600" aria-hidden="true">•</span>
+					}
+					<span class="font-inter text-xs font-medium text-neutral-600">
+						{{ collection().count }} {{ collection().count === 1 ? 'historia' : 'historias' }}
+					</span>
+				</div>
+			</div>
+		</article>
+	`,
+	host: {
+		class: 'block',
+	},
+})
+export class NavigableCollectionTeaserComponent {
+	protected readonly appRoutes = AppRoutes;
+
+	public readonly collection = input.required<StorylistTeaser>();
+}


### PR DESCRIPTION
## Descripción

Nuevo componente V3 `NavigableCollectionTeaserComponent`: el item compacto y navegable de una colección para la lista «Otras colecciones sugeridas» del sidebar de la CollectionPage V3.

- Ícono de biblioteca (`ImageProfile` variante `collection`) + nombre + categoría (`Tag` variante `soft`) + «N historias», dentro de un único enlace a la colección.
- **Enlace estirado** (`after:absolute after:inset-0`) sobre el título, como `AuthorTeaserV3`/`StoryCardTeaserV3`: toda la tarjeta es clickeable pero el nombre accesible del link es exactamente el título (el ícono queda decorativo). Verificado por test con `getByRole('link', { name: título })`.
- Input `StorylistTeaser` completo, consistente con `CollectionTeaser`.
- Enlaza a `/collection/:slug`, introduciendo `Collection` como ruta de dominio en `AppRoutes` (paso hacia el rename storylist→collection de #1469). La página `/collection/:slug` aún no existe en `develop` (llega con la CollectionPage V3); este PR aporta solo el átomo navegable y su constante de ruta.
- Incluye skeleton hermano y stories de Storybook (`Default`, `SinCategoria`, `TituloLargo`, `Estados` con switch real↔skeleton).

No confundir con `CollectionTeaser` (#1465), que es el teaser con portadas del home/decks; este es el item compacto con ícono.

Closes #1823.

Parte de #1472.

## Plan de pruebas

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm stylelint` — verde
- [x] `pnpm test` — spec del componente 6/6 (título, tag presente/ausente, singular/plural, navegación + a11y del link); suite completa sin regresiones (el guardrail de SEO sigue en verde con la nueva constante `Collection`)
- [x] `pnpm build` y `pnpm storybook:build` — verde
