### PR TITLE
[Spike #1472] - Blueprint de CollectionPage V3 (datos de Sanity + Leer más/Drawer)

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -39,6 +39,10 @@ export const serverRoutes: Array<ServerRoute> = [
 		renderMode: RenderMode.Server,
 	},
 	{
+		path: `${AppRoutes.Collection}/:slug`,
+		renderMode: RenderMode.Server,
+	},
+	{
 		path: '**',
 		renderMode: RenderMode.Prerender,
 	},

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -43,6 +43,10 @@ export const serverRoutes: Array<ServerRoute> = [
 		renderMode: RenderMode.Server,
 	},
 	{
+		path: `${AppRoutes.Collection}/:slug`,
+		renderMode: RenderMode.Server,
+	},
+	{
 		path: '**',
 		renderMode: RenderMode.Prerender,
 	},

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -42,6 +42,10 @@ export const appRoutes: Routes = [
 		loadComponent: () => import('./pages/storylist/storylist.component'),
 	},
 	{
+		path: `${AppRoutes.Collection}/:slug`,
+		loadComponent: () => import('./pages/collection/collection.component'),
+	},
+	{
 		path: AppRoutes.About,
 		loadComponent: () => import('./pages/about/about.component'),
 	},

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -47,6 +47,10 @@ export const appRoutes: Routes = [
 		loadComponent: () => import('./pages/read/read.page'),
 	},
 	{
+		path: `${AppRoutes.Collection}/:slug`,
+		loadComponent: () => import('./pages/collection/collection.component'),
+	},
+	{
 		path: AppRoutes.About,
 		loadComponent: () => import('./pages/about/about.component'),
 	},

--- a/src/app/components/drawer/drawer.component.stories.ts
+++ b/src/app/components/drawer/drawer.component.stories.ts
@@ -5,9 +5,8 @@ import { DrawerHeaderDirective } from './drawer-header.directive';
 import { DrawerFooterDirective } from './drawer-footer.directive';
 import { CoverImageComponent } from '@components/cover-image/cover-image.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { PortableTextParserComponent } from '@components/portable-text-parser/portable-text-parser.component';
 import { NavigableCollectionTeaserComponent } from '@components/navigable-collection-teaser/navigable-collection-teaser.component';
-import { storylistMock, storylistTeaserRepresentativeMock, storylistTeaserSampleMock } from '@mocks/storylist.mock';
+import { geometriasDelDesveloCollectionMock, onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
 
 type DrawerArgs = DrawerComponent & { direction: DrawerDirection };
 
@@ -120,35 +119,28 @@ export const ComposicionCollectionPage: Story = {
 	name: 'Composición CollectionPage',
 	decorators: [
 		moduleMetadata({
-			imports: [CoverImageComponent, TagComponent, PortableTextParserComponent, NavigableCollectionTeaserComponent],
+			imports: [CoverImageComponent, TagComponent, NavigableCollectionTeaserComponent],
 		}),
 	],
 	render: (args) => ({
 		props: {
 			...args,
-			collection: storylistMock,
-			suggested: [storylistTeaserRepresentativeMock, storylistTeaserSampleMock],
+			collection: geometriasDelDesveloCollectionMock,
+			suggested: onoffCollectionTeasersMock,
 		},
 		template: `
 			${openButton}
-			<cuentoneta-drawer #drawer>
+			<cuentoneta-drawer [title]="collection.title" #drawer>
 				<div class="flex flex-col gap-4">
 					@if (collection.imagery.kind === 'representative') {
 						<cuentoneta-cover-image [src]="collection.imagery.image" />
 					}
-					<div class="flex flex-col items-start gap-2">
-						<p class="font-inter text-xl font-bold text-neutral-900">{{ collection.title }}</p>
-						@if (collection.tags[0]; as tag) {
-							<cuentoneta-tag [label]="tag.title" variant="filled" />
-						}
-					</div>
+					@if (collection.tags[0]; as tag) {
+						<cuentoneta-tag [label]="tag.title" variant="filled" class="self-start" />
+					}
 				</div>
-				<cuentoneta-portable-text-parser
-					[paragraphs]="collection.description"
-					classes="font-inter text-sm font-medium text-neutral-700"
-					class="flex flex-col gap-2"
-				/>
-				<div class="h-px w-full bg-neutral-200" role="separator"></div>
+				<div [innerHTML]="collection.description" class="flex flex-col gap-2 font-inter text-sm font-medium text-neutral-700"></div>
+				<div class="h-px w-full bg-neutral-200" aria-hidden="true"></div>
 				<div class="flex flex-col gap-4">
 					<h2 class="font-inter text-base font-bold text-neutral-900">Otras colecciones sugeridas</h2>
 					@for (item of suggested; track item.slug) {

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.spec.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.spec.ts
@@ -2,10 +2,16 @@ import { render, screen } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
 
 import { NavigableCollectionTeaserComponent } from './navigable-collection-teaser.component';
-import { storylistTeaserRepresentativeMock } from '@mocks/storylist.mock';
+import { geometriasDelDesveloCollectionTeaserMock } from '@mocks/onoff-collections.mock';
+import { createCollectionTeaser } from '@models/collection.model';
 
 describe('NavigableCollectionTeaserComponent', () => {
-	const collection = storylistTeaserRepresentativeMock;
+	const collection = geometriasDelDesveloCollectionTeaserMock;
+	// Las variantes pasan por la factory y no por spread: el teaser tiene invariantes propias (título no
+	// vacío, al menos una obra) y un doble armado a mano se las saltearía.
+	const variantOf = (overrides: Partial<Parameters<typeof createCollectionTeaser>[0]>) =>
+		createCollectionTeaser({ ...collection, slug: collection.slug, ...overrides });
+
 	const setup = (teaser = collection) =>
 		render(NavigableCollectionTeaserComponent, { inputs: { collection: teaser }, providers: [provideRouter([])] });
 
@@ -20,17 +26,17 @@ describe('NavigableCollectionTeaserComponent', () => {
 	});
 
 	it('should not render a category tag when the collection has no tags', async () => {
-		await setup({ ...collection, tags: [] });
+		await setup(variantOf({ tags: [] }));
 		expect(screen.queryByText(collection.tags[0].title)).not.toBeInTheDocument();
 	});
 
 	it('should render the pluralized story count', async () => {
-		await setup({ ...collection, count: 5 });
+		await setup(variantOf({ count: 5 }));
 		expect(screen.getByText('5 historias')).toBeInTheDocument();
 	});
 
 	it('should render the singular story count', async () => {
-		await setup({ ...collection, count: 1 });
+		await setup(variantOf({ count: 1 }));
 		expect(screen.getByText('1 historia')).toBeInTheDocument();
 	});
 

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
@@ -2,7 +2,13 @@ import { argsToTemplate, componentWrapperDecorator, Meta, moduleMetadata, StoryO
 
 import { NavigableCollectionTeaserComponent } from './navigable-collection-teaser.component';
 import { NavigableCollectionTeaserSkeletonComponent } from './navigable-collection-teaser-skeleton.component';
-import { storylistTeaserRepresentativeMock } from '@mocks/storylist.mock';
+import { geometriasDelDesveloCollectionTeaserMock } from '@mocks/onoff-collections.mock';
+import { createCollectionTeaser } from '@models/collection.model';
+
+const collectionTeaser = geometriasDelDesveloCollectionTeaserMock;
+// Las variantes pasan por la factory: es la que hace cumplir las invariantes del teaser.
+const variantOf = (overrides: Partial<Parameters<typeof createCollectionTeaser>[0]>) =>
+	createCollectionTeaser({ ...collectionTeaser, slug: collectionTeaser.slug, ...overrides });
 
 const meta: Meta<NavigableCollectionTeaserComponent> = {
 	component: NavigableCollectionTeaserComponent,
@@ -20,7 +26,7 @@ const meta: Meta<NavigableCollectionTeaserComponent> = {
 		collection: {
 			control: { type: 'object' },
 			description: 'Teaser de la colección (title, slug, count, tags)',
-			table: { type: { summary: 'StorylistTeaser' }, defaultValue: { summary: 'required' } },
+			table: { type: { summary: 'CollectionTeaser' }, defaultValue: { summary: 'required' } },
 		},
 	},
 };
@@ -31,7 +37,7 @@ type Story = StoryObj<NavigableCollectionTeaserComponent>;
 export const Default: Story = {
 	name: 'Por defecto',
 	render: (args) => ({ props: args, template: `<cuentoneta-navigable-collection-teaser ${argsToTemplate(args)} />` }),
-	args: { collection: storylistTeaserRepresentativeMock },
+	args: { collection: collectionTeaser },
 	parameters: {
 		docs: {
 			description: {
@@ -44,7 +50,7 @@ export const Default: Story = {
 export const SinCategoria: Story = {
 	name: 'Sin categoría',
 	render: (args) => ({ props: args, template: `<cuentoneta-navigable-collection-teaser ${argsToTemplate(args)} />` }),
-	args: { collection: { ...storylistTeaserRepresentativeMock, tags: [] } },
+	args: { collection: variantOf({ tags: [] }) },
 	parameters: {
 		docs: {
 			description: {
@@ -58,10 +64,7 @@ export const TituloLargo: Story = {
 	name: 'Título largo',
 	render: (args) => ({ props: args, template: `<cuentoneta-navigable-collection-teaser ${argsToTemplate(args)} />` }),
 	args: {
-		collection: {
-			...storylistTeaserRepresentativeMock,
-			title: 'Book & Morfi: Especial Michis y Perritos en adopción en el refugio',
-		},
+		collection: variantOf({ title: 'Book & Morfi: Especial Michis y Perritos en adopción en el refugio' }),
 	},
 	decorators: [componentWrapperDecorator((story) => `<div style="width:320px">${story}</div>`)],
 	parameters: {
@@ -88,7 +91,7 @@ export const Estados: StoryObj<NavigableCollectionTeaserComponent & { loading: b
 			</div>
 		`,
 	}),
-	args: { loading: true, collection: storylistTeaserRepresentativeMock },
+	args: { loading: true, collection: collectionTeaser },
 	parameters: {
 		docs: { description: { story: 'Activá/desactivá "Cargando" para alternar entre el estado real y el skeleton.' } },
 	},

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
@@ -2,7 +2,6 @@ import { Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import type { CollectionTeaser } from '@models/collection.model';
-import type { StorylistTeaser } from '@models/storylist.model';
 import { AppRoutes } from '../../app.routes';
 import { ImageProfileComponent } from '../image-profile/image-profile.component';
 import { TagComponent } from '../tag/tag.component';
@@ -49,7 +48,5 @@ import { TagComponent } from '../tag/tag.component';
 export class NavigableCollectionTeaserComponent {
 	protected readonly appRoutes = AppRoutes;
 
-	// Acepta las dos vistas de teaser mientras conviven Storylist y Collection: el item solo lee nombre,
-	// slug, categoría y cantidad, que ambas transportan igual.
-	public readonly collection = input.required<CollectionTeaser | StorylistTeaser>();
+	public readonly collection = input.required<CollectionTeaser>();
 }

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
@@ -1,6 +1,7 @@
 import { Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
+import type { CollectionTeaser } from '@models/collection.model';
 import type { StorylistTeaser } from '@models/storylist.model';
 import { AppRoutes } from '../../app.routes';
 import { ImageProfileComponent } from '../image-profile/image-profile.component';
@@ -48,5 +49,7 @@ import { TagComponent } from '../tag/tag.component';
 export class NavigableCollectionTeaserComponent {
 	protected readonly appRoutes = AppRoutes;
 
-	public readonly collection = input.required<StorylistTeaser>();
+	// Acepta las dos vistas de teaser mientras conviven Storylist y Collection: el item solo lee nombre,
+	// slug, categoría y cantidad, que ambas transportan igual.
+	public readonly collection = input.required<CollectionTeaser | StorylistTeaser>();
 }

--- a/src/app/directives/clamp-overflow.directive.spec.ts
+++ b/src/app/directives/clamp-overflow.directive.spec.ts
@@ -1,0 +1,58 @@
+import { Component } from '@angular/core';
+import { render, screen } from '@testing-library/angular';
+
+import { setMeasuredSize, triggerResize } from '@testing/resize-observer.stub';
+import { ClampOverflowDirective } from './clamp-overflow.directive';
+
+@Component({
+	imports: [ClampOverflowDirective],
+	template: `
+		<div cuentonetaClampOverflow #clamp="cuentonetaClampOverflow" class="line-clamp-2" data-testid="text">
+			Prosa recortada
+		</div>
+		@if (clamp.isOverflowing()) {
+			<button type="button">Leer más</button>
+		}
+	`,
+})
+class HostComponent {}
+
+describe('ClampOverflowDirective', () => {
+	const setup = async (size?: { scrollHeight: number; clientHeight: number }) => {
+		const view = await render(HostComponent);
+		if (size) {
+			setMeasuredSize(screen.getByTestId('text'), size);
+			triggerResize();
+			await view.fixture.whenStable();
+		}
+		return view;
+	};
+
+	it('should report no overflow while the host has not been measured', async () => {
+		await setup();
+		expect(screen.queryByRole('button', { name: 'Leer más' })).not.toBeInTheDocument();
+	});
+
+	it('should report overflow when the content is taller than the visible area', async () => {
+		await setup({ scrollHeight: 400, clientHeight: 100 });
+		expect(screen.getByRole('button', { name: 'Leer más' })).toBeInTheDocument();
+	});
+
+	it('should not report overflow when the content fits', async () => {
+		await setup({ scrollHeight: 100, clientHeight: 100 });
+		expect(screen.queryByRole('button', { name: 'Leer más' })).not.toBeInTheDocument();
+	});
+
+	it('should tolerate a sub-pixel difference between content and visible height', async () => {
+		await setup({ scrollHeight: 101, clientHeight: 100 });
+		expect(screen.queryByRole('button', { name: 'Leer más' })).not.toBeInTheDocument();
+	});
+
+	it('should stop reporting overflow when the host grows enough to fit the content', async () => {
+		const view = await setup({ scrollHeight: 400, clientHeight: 100 });
+		setMeasuredSize(screen.getByTestId('text'), { scrollHeight: 400, clientHeight: 400 });
+		triggerResize();
+		await view.fixture.whenStable();
+		expect(screen.queryByRole('button', { name: 'Leer más' })).not.toBeInTheDocument();
+	});
+});

--- a/src/app/directives/clamp-overflow.directive.ts
+++ b/src/app/directives/clamp-overflow.directive.ts
@@ -1,0 +1,41 @@
+import { afterNextRender, Directive, effect, ElementRef, inject, signal } from '@angular/core';
+
+// El redondeo sub-pixel del alto de línea hace que un texto que entra justo mida un píxel de más.
+const OVERFLOW_TOLERANCE_PX = 1;
+
+/**
+ * Informa si el contenido de su host desborda el recorte por líneas (`line-clamp-*`) que tenga aplicado,
+ * comparando el alto del contenido contra el visible. Existe para decidir si ofrecer un "Leer más": sin la
+ * medición habría que mostrarlo siempre, también cuando el texto entra completo.
+ *
+ * Observa el host con `ResizeObserver` porque el recorte depende del ancho disponible, y en zoneless un
+ * resize de ventana no dispara detección de cambios por sí solo. Sin layout (SSR, entorno de tests) el
+ * observer no se crea y el host se reporta como no desbordado, que es el estado seguro: se omite el
+ * "Leer más" en vez de ofrecerlo sobre un texto entero.
+ */
+@Directive({
+	selector: '[cuentonetaClampOverflow]',
+	exportAs: 'cuentonetaClampOverflow',
+})
+export class ClampOverflowDirective {
+	private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+
+	private readonly overflowing = signal(false);
+	public readonly isOverflowing = this.overflowing.asReadonly();
+
+	// El observer recién se crea tras el primer render (browser-only).
+	private readonly ready = signal(false);
+	private readonly markReady = afterNextRender(() => this.ready.set(true));
+
+	private readonly observerEffect = effect((onCleanup) => {
+		if (!this.ready()) {
+			return;
+		}
+		const element = this.host.nativeElement;
+		const observer = new ResizeObserver(() =>
+			this.overflowing.set(element.scrollHeight > element.clientHeight + OVERFLOW_TOLERANCE_PX),
+		);
+		observer.observe(element);
+		onCleanup(() => observer.disconnect());
+	});
+}

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -63,18 +63,14 @@
 			</div>
 
 			<div class="flex flex-col gap-4">
-				<div
-					class="flex h-8 items-center rounded-md border border-dashed border-neutral-300 bg-neutral-50 px-3 text-sm text-neutral-500"
-				>
-					«Otras colecciones sugeridas» (h2)
-				</div>
+				<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Otras colecciones sugeridas</h2>
 
 				@for (index of [1, 2, 3]; track index) {
 					<div
 						class="flex items-center gap-3 rounded-lg border border-dashed border-brand-300 bg-neutral-50 p-3 text-sm text-neutral-500"
 					>
 						<div class="size-10 shrink-0 rounded-full border border-dashed border-brand-300 bg-brand-100"></div>
-						<span>CollectionCard <strong>(componente nuevo)</strong> · nombre · tag · «N historias»</span>
+						<span>NavigableCollectionTeaser <strong>(componente nuevo)</strong> · nombre · tag · «N historias»</span>
 					</div>
 				}
 			</div>

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -1,0 +1,83 @@
+<main class="mx-auto w-full max-w-[1240px] px-6 pt-8 pb-16 font-inter">
+	<p class="bg-amber-50 text-amber-700 mb-8 rounded-md px-3 py-2 text-xs">
+		Blueprint temporal de la CollectionPage V3 · ruta <code>/collection/{{ slug() ?? ':slug' }}</code> · cada bloque es
+		un placeholder del componente indicado.
+	</p>
+
+	<div class="flex items-start gap-16">
+		<!-- Columna izquierda: título + listado de historias -->
+		<section class="flex flex-1 flex-col gap-12 pt-8">
+			<div
+				class="flex h-10 w-64 items-center rounded-md border border-dashed border-neutral-300 bg-neutral-50 px-3 text-sm text-neutral-500"
+			>
+				Título · «N Historías» (h1)
+			</div>
+
+			<div class="flex flex-col gap-9">
+				<!-- Primera historia: card destacada/enmarcada -->
+				<div
+					class="flex min-h-[212px] items-center justify-center rounded-2xl border border-dashed border-brand-300 bg-neutral-50 p-6 text-center text-sm text-neutral-500"
+				>
+					StoryCardTeaserV3 · variant <strong>highlighted</strong> · order 1 <br />(autor · título numerado · extracto ·
+					tag de género · tiempo de lectura · media)
+				</div>
+
+				<!-- Resto de historias: cards planas -->
+				<div
+					class="flex min-h-[164px] items-center justify-center rounded-lg border border-dashed border-neutral-300 bg-neutral-50 p-6 text-center text-sm text-neutral-500"
+				>
+					StoryCardTeaserV3 · variant <strong>on-white</strong> · order 2 (cover izquierda + contenido)
+				</div>
+
+				<div class="h-px w-full bg-neutral-200" role="separator"></div>
+
+				<div
+					class="flex min-h-[164px] items-center justify-center rounded-lg border border-dashed border-neutral-300 bg-neutral-50 p-6 text-center text-sm text-neutral-500"
+				>
+					StoryCardTeaserV3 · variant <strong>on-white</strong> · order 3
+				</div>
+			</div>
+		</section>
+
+		<!-- Divisor vertical -->
+		<div class="w-px self-stretch bg-neutral-200" role="separator"></div>
+
+		<!-- Columna derecha: info de la colección + colecciones sugeridas -->
+		<aside class="flex w-[364px] shrink-0 flex-col gap-6 pt-8">
+			<div class="flex flex-col gap-4">
+				<div
+					class="flex h-[164px] w-[118px] items-center justify-center rounded-lg border border-dashed border-neutral-300 bg-neutral-50 text-center text-xs text-neutral-500"
+				>
+					CoverImage
+				</div>
+				<div
+					class="flex h-9 items-center rounded-md border border-dashed border-neutral-300 bg-neutral-50 px-3 text-sm text-neutral-500"
+				>
+					Título de la colección + TagComponent (filled)
+				</div>
+				<div
+					class="flex min-h-[140px] items-center justify-center rounded-lg border border-dashed border-neutral-300 bg-neutral-50 p-4 text-center text-sm text-neutral-500"
+				>
+					Descripción · PortableTextParser
+				</div>
+			</div>
+
+			<div class="flex flex-col gap-4">
+				<div
+					class="flex h-8 items-center rounded-md border border-dashed border-neutral-300 bg-neutral-50 px-3 text-sm text-neutral-500"
+				>
+					«Otras colecciones sugeridas» (h2)
+				</div>
+
+				@for (index of [1, 2, 3]; track index) {
+					<div
+						class="flex items-center gap-3 rounded-lg border border-dashed border-brand-300 bg-neutral-50 p-3 text-sm text-neutral-500"
+					>
+						<div class="size-10 shrink-0 rounded-full border border-dashed border-brand-300 bg-brand-100"></div>
+						<span>CollectionCard <strong>(componente nuevo)</strong> · nombre · tag · «N historias»</span>
+					</div>
+				}
+			</div>
+		</aside>
+	</div>
+</main>

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -125,6 +125,13 @@
 				class="flex flex-col gap-2"
 				data-testid="drawer-description"
 			/>
+			<div class="h-px w-full bg-neutral-200" role="separator"></div>
+			<div class="flex w-full flex-col gap-4">
+				<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Otras colecciones sugeridas</h2>
+				@for (suggested of suggestedCollections; track suggested.slug) {
+					<cuentoneta-navigable-collection-teaser [collection]="suggested" data-testid="drawer-suggested-collection" />
+				}
+			</div>
 		</cuentoneta-drawer>
 	} @else {
 		<!-- Estado sin resultados: el slug no matcheó ninguna colección (o el fetch falló) -->

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -7,35 +7,24 @@
 	<div class="flex items-start gap-16">
 		<!-- Columna izquierda: título + listado de historias -->
 		<section class="flex flex-1 flex-col gap-12 pt-8">
-			<div
-				class="flex h-10 w-64 items-center rounded-md border border-dashed border-neutral-300 bg-neutral-50 px-3 text-sm text-neutral-500"
-			>
-				Título · «N Historías» (h1)
-			</div>
+			<h1 class="font-inter text-4xl leading-10 font-bold text-neutral-900">{{ collection.title }}</h1>
 
 			<div class="flex flex-col gap-9">
-				<!-- Primera historia: card destacada/enmarcada -->
-				<div
-					class="flex min-h-[212px] items-center justify-center rounded-2xl border border-dashed border-brand-300 bg-neutral-50 p-6 text-center text-sm text-neutral-500"
-				>
-					StoryCardTeaserV3 · variant <strong>highlighted</strong> · order 1 <br />(autor · título numerado · extracto ·
-					tag de género · tiempo de lectura · media)
-				</div>
-
-				<!-- Resto de historias: cards planas -->
-				<div
-					class="flex min-h-[164px] items-center justify-center rounded-lg border border-dashed border-neutral-300 bg-neutral-50 p-6 text-center text-sm text-neutral-500"
-				>
-					StoryCardTeaserV3 · variant <strong>on-white</strong> · order 2 (cover izquierda + contenido)
-				</div>
-
-				<div class="h-px w-full bg-neutral-200" role="separator"></div>
-
-				<div
-					class="flex min-h-[164px] items-center justify-center rounded-lg border border-dashed border-neutral-300 bg-neutral-50 p-6 text-center text-sm text-neutral-500"
-				>
-					StoryCardTeaserV3 · variant <strong>on-white</strong> · order 3
-				</div>
+				@for (story of collection.stories; track story._id; let i = $index) {
+					@if (i >= 2) {
+						<div class="h-px w-full bg-neutral-200" role="separator"></div>
+					}
+					<cuentoneta-story-card-teaser-v3
+						[story]="story"
+						[variant]="i === 0 ? 'highlighted' : 'on-white'"
+						[order]="i + 1"
+						[showAuthor]="collection.config.showAuthors"
+						[showExcerpt]="true"
+						[showMultimedia]="true"
+						[tagLabel]="story.tags[0]?.title"
+						data-testid="story-card"
+					/>
+				}
 			</div>
 		</section>
 

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -39,16 +39,17 @@
 				>
 					CoverImage
 				</div>
-				<div
-					class="flex h-9 items-center rounded-md border border-dashed border-neutral-300 bg-neutral-50 px-3 text-sm text-neutral-500"
-				>
-					Título de la colección + TagComponent (filled)
+				<div class="flex flex-col items-start gap-2">
+					<p class="font-inter text-xl leading-7 font-bold text-neutral-900">{{ collection.title }}</p>
+					@if (collection.tags[0]; as tag) {
+						<cuentoneta-tag [label]="tag.title" variant="filled" />
+					}
 				</div>
-				<div
-					class="flex min-h-[140px] items-center justify-center rounded-lg border border-dashed border-neutral-300 bg-neutral-50 p-4 text-center text-sm text-neutral-500"
-				>
-					Descripción · PortableTextParser
-				</div>
+				<cuentoneta-portable-text-parser
+					[paragraphs]="collection.description"
+					classes="font-inter text-sm font-medium text-neutral-700"
+					class="flex flex-col gap-2"
+				/>
 			</div>
 
 			<div class="flex flex-col gap-4">

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -61,7 +61,7 @@
 							[showAuthor]="collection.config.showAuthors"
 							[showExcerpt]="true"
 							[showMultimedia]="true"
-							[excerptLines]="3"
+							[excerptLines]="collection.config.showAuthors ? 3 : 4"
 							[tagLabel]="story.tags[0]?.title"
 							data-testid="story-card"
 						/>

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -34,11 +34,9 @@
 		<!-- Columna derecha: info de la colección + colecciones sugeridas -->
 		<aside class="flex w-[364px] shrink-0 flex-col gap-6 pt-8">
 			<div class="flex flex-col gap-4">
-				<div
-					class="flex h-[164px] w-[118px] items-center justify-center rounded-lg border border-dashed border-neutral-300 bg-neutral-50 text-center text-xs text-neutral-500"
-				>
-					CoverImage
-				</div>
+				@if (collection.imagery.kind === 'representative') {
+					<cuentoneta-cover-image [src]="collection.imagery.image" [priority]="true" />
+				}
 				<div class="flex flex-col items-start gap-2">
 					<p class="font-inter text-xl leading-7 font-bold text-neutral-900">{{ collection.title }}</p>
 					@if (collection.tags[0]; as tag) {

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -1,42 +1,116 @@
 <main class="mx-auto w-full max-w-[1240px] px-6 pt-8 pb-16 font-inter">
 	<p class="bg-amber-50 text-amber-700 mb-8 rounded-md px-3 py-2 text-xs">
-		Blueprint temporal de la CollectionPage V3 · ruta <code>/collection/{{ slug() ?? ':slug' }}</code> · cada bloque es
-		un placeholder del componente indicado.
+		Blueprint de la CollectionPage V3 · ruta <code>/collection/{{ slug() ?? ':slug' }}</code> · alimentada con la
+		storylist real de Sanity por slug.
 	</p>
 
-	<div class="flex items-start gap-16">
-		<!-- Columna izquierda: título + listado de historias -->
-		<section class="flex flex-1 flex-col gap-12 pt-8">
-			<h1 class="font-inter text-4xl leading-10 font-bold text-neutral-900">{{ collection.title }}</h1>
-
-			<div class="flex flex-col gap-9">
-				@for (story of collection.stories; track story._id; let i = $index) {
-					@if (i >= 2) {
-						<div class="h-px w-full bg-neutral-200" role="separator"></div>
+	@if (isLoading()) {
+		<!-- Estado de carga: skeletons que reflejan el layout de dos columnas -->
+		<div class="flex items-start gap-16" aria-busy="true" data-testid="loading">
+			<section class="flex flex-1 flex-col gap-12 pt-8">
+				<cuentoneta-skeleton appearance="line" class="h-10 w-64 bg-neutral-300" />
+				<div class="flex flex-col gap-9">
+					@for (i of [1, 2, 3]; track i) {
+						<cuentoneta-story-card-teaser-v3
+							[showAuthor]="true"
+							[showExcerpt]="true"
+							[showMultimedia]="true"
+							[excerptLines]="3"
+						/>
 					}
-					<cuentoneta-story-card-teaser-v3
-						[story]="story"
-						[variant]="i === 0 ? 'highlighted' : 'on-white'"
-						[order]="i + 1"
-						[showAuthor]="collection.config.showAuthors"
-						[showExcerpt]="true"
-						[showMultimedia]="true"
-						[excerptLines]="3"
-						[tagLabel]="story.tags[0]?.title"
-						data-testid="story-card"
-					/>
-				}
-			</div>
-		</section>
+				</div>
+			</section>
 
-		<!-- Divisor vertical -->
-		<div class="w-px self-stretch bg-neutral-200" role="separator"></div>
+			<div class="w-px self-stretch bg-neutral-200"></div>
 
-		<!-- Columna derecha: info de la colección + colecciones sugeridas -->
-		<aside class="flex w-[364px] shrink-0 flex-col gap-6 pt-8">
+			<aside class="flex w-[364px] shrink-0 flex-col gap-6 pt-8">
+				<div class="flex flex-col gap-4">
+					<cuentoneta-skeleton appearance="line" class="h-[164px] w-[118px] bg-neutral-300" />
+					<cuentoneta-skeleton appearance="line" class="h-7 w-40 bg-neutral-300" />
+					<cuentoneta-skeleton appearance="line" class="h-6 w-24 bg-neutral-300" />
+					<div class="flex flex-col gap-2">
+						@for (i of [1, 2, 3, 4]; track i) {
+							<cuentoneta-skeleton appearance="line" class="h-4 w-full bg-neutral-300" />
+						}
+					</div>
+				</div>
+
+				<div class="flex flex-col gap-4">
+					<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Otras colecciones sugeridas</h2>
+					@for (i of [1, 2, 3]; track i) {
+						<cuentoneta-navigable-collection-teaser-skeleton />
+					}
+				</div>
+			</aside>
+		</div>
+	} @else if (collection(); as collection) {
+		<div class="flex items-start gap-16">
+			<!-- Columna izquierda: título + listado de historias -->
+			<section class="flex flex-1 flex-col gap-12 pt-8">
+				<h1 class="font-inter text-4xl leading-10 font-bold text-neutral-900">{{ collection.title }}</h1>
+
+				<div class="flex flex-col gap-9">
+					@for (story of collection.stories; track story._id; let i = $index) {
+						@if (i >= 2) {
+							<div class="h-px w-full bg-neutral-200" role="separator"></div>
+						}
+						<cuentoneta-story-card-teaser-v3
+							[story]="story"
+							[variant]="i === 0 ? 'highlighted' : 'on-white'"
+							[order]="i + 1"
+							[showAuthor]="collection.config.showAuthors"
+							[showExcerpt]="true"
+							[showMultimedia]="true"
+							[excerptLines]="3"
+							[tagLabel]="story.tags[0]?.title"
+							data-testid="story-card"
+						/>
+					}
+				</div>
+			</section>
+
+			<!-- Divisor vertical -->
+			<div class="w-px self-stretch bg-neutral-200" role="separator"></div>
+
+			<!-- Columna derecha: info de la colección + colecciones sugeridas -->
+			<aside class="flex w-[364px] shrink-0 flex-col gap-6 pt-8">
+				<div class="flex flex-col gap-4">
+					@if (collection.imagery.kind === 'representative') {
+						<cuentoneta-cover-image [src]="collection.imagery.image" [priority]="true" />
+					}
+					<div class="flex flex-col items-start gap-2">
+						<p class="font-inter text-xl leading-7 font-bold text-neutral-900">{{ collection.title }}</p>
+						@if (collection.tags[0]; as tag) {
+							<cuentoneta-tag [label]="tag.title" variant="filled" data-testid="collection-tag" />
+						}
+					</div>
+					<div class="flex flex-col items-start gap-3">
+						<div #description class="line-clamp-[8] font-inter text-sm font-medium text-neutral-700">
+							<cuentoneta-portable-text-parser [paragraphs]="collection.description" />
+						</div>
+						@if (isDescriptionOverflowing()) {
+							<button (click)="descriptionDrawer.open()" cuentoneta-button type="outline" data-testid="read-more">
+								Leer más
+							</button>
+						}
+					</div>
+				</div>
+
+				<div class="flex flex-col gap-4">
+					<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Otras colecciones sugeridas</h2>
+
+					@for (suggested of suggestedCollections; track suggested.slug) {
+						<cuentoneta-navigable-collection-teaser [collection]="suggested" data-testid="suggested-collection" />
+					}
+				</div>
+			</aside>
+		</div>
+
+		<!-- Drawer con la descripción completa (se abre desde "Leer más") -->
+		<cuentoneta-drawer #descriptionDrawer>
 			<div class="flex flex-col gap-4">
 				@if (collection.imagery.kind === 'representative') {
-					<cuentoneta-cover-image [src]="collection.imagery.image" [priority]="true" />
+					<cuentoneta-cover-image [src]="collection.imagery.image" />
 				}
 				<div class="flex flex-col items-start gap-2">
 					<p class="font-inter text-xl leading-7 font-bold text-neutral-900">{{ collection.title }}</p>
@@ -44,20 +118,19 @@
 						<cuentoneta-tag [label]="tag.title" variant="filled" />
 					}
 				</div>
-				<cuentoneta-portable-text-parser
-					[paragraphs]="collection.description"
-					classes="font-inter text-sm font-medium text-neutral-700"
-					class="flex flex-col gap-2"
-				/>
 			</div>
-
-			<div class="flex flex-col gap-4">
-				<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Otras colecciones sugeridas</h2>
-
-				@for (suggested of suggestedCollections; track suggested.slug) {
-					<cuentoneta-navigable-collection-teaser [collection]="suggested" data-testid="suggested-collection" />
-				}
-			</div>
-		</aside>
-	</div>
+			<cuentoneta-portable-text-parser
+				[paragraphs]="collection.description"
+				classes="font-inter text-sm font-medium text-neutral-700"
+				class="flex flex-col gap-2"
+				data-testid="drawer-description"
+			/>
+		</cuentoneta-drawer>
+	} @else {
+		<!-- Estado sin resultados: el slug no matcheó ninguna colección (o el fetch falló) -->
+		<div class="py-16 text-center" data-testid="not-found">
+			<p class="font-inter text-lg font-bold text-neutral-900">No encontramos esta colección</p>
+			<p class="mt-2 font-inter text-sm text-neutral-600">Revisá el enlace o volvé al inicio.</p>
+		</div>
+	}
 </main>

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -21,6 +21,7 @@
 						[showAuthor]="collection.config.showAuthors"
 						[showExcerpt]="true"
 						[showMultimedia]="true"
+						[excerptLines]="3"
 						[tagLabel]="story.tags[0]?.title"
 						data-testid="story-card"
 					/>

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -54,13 +54,8 @@
 			<div class="flex flex-col gap-4">
 				<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Otras colecciones sugeridas</h2>
 
-				@for (index of [1, 2, 3]; track index) {
-					<div
-						class="flex items-center gap-3 rounded-lg border border-dashed border-brand-300 bg-neutral-50 p-3 text-sm text-neutral-500"
-					>
-						<div class="size-10 shrink-0 rounded-full border border-dashed border-brand-300 bg-brand-100"></div>
-						<span>NavigableCollectionTeaser <strong>(componente nuevo)</strong> · nombre · tag · «N historias»</span>
-					</div>
+				@for (suggested of suggestedCollections; track suggested.slug) {
+					<cuentoneta-navigable-collection-teaser [collection]="suggested" data-testid="suggested-collection" />
 				}
 			</div>
 		</aside>

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -1,7 +1,7 @@
 <main class="mx-auto w-full max-w-[1240px] px-6 pt-8 pb-16 font-inter">
 	<p class="bg-amber-50 text-amber-700 mb-8 rounded-md px-3 py-2 text-xs">
-		Blueprint de la CollectionPage V3 · ruta <code>/collection/{{ slug() ?? ':slug' }}</code> · alimentada con la
-		storylist real de Sanity por slug.
+		Blueprint de la CollectionPage V3 · ruta <code>/collection/{{ slug() }}</code> · alimentada con la colección real de
+		Sanity por slug.
 	</p>
 
 	@if (isLoading()) {
@@ -11,7 +11,7 @@
 				<cuentoneta-skeleton appearance="line" class="h-10 w-64 bg-neutral-300" />
 				<div class="flex flex-col gap-9">
 					@for (i of [1, 2, 3]; track i) {
-						<cuentoneta-story-card-teaser-v3
+						<cuentoneta-literary-work-card-teaser
 							[showAuthor]="true"
 							[showExcerpt]="true"
 							[showMultimedia]="true"
@@ -45,25 +45,26 @@
 		</div>
 	} @else if (collection(); as collection) {
 		<div class="flex items-start gap-16">
-			<!-- Columna izquierda: título + listado de historias -->
+			<!-- Columna izquierda: título + listado de obras -->
 			<section class="flex flex-1 flex-col gap-12 pt-8">
 				<h1 class="font-inter text-4xl leading-10 font-bold text-neutral-900">{{ collection.title }}</h1>
 
 				<div class="flex flex-col gap-9">
-					@for (story of collection.stories; track story._id; let i = $index) {
+					@for (literaryWork of collection.literaryWorks; track literaryWork._id; let i = $index) {
 						@if (i >= 2) {
 							<div class="h-px w-full bg-neutral-200" role="separator"></div>
 						}
-						<cuentoneta-story-card-teaser-v3
-							[story]="story"
+						<cuentoneta-literary-work-card-teaser
+							[literaryWork]="literaryWork"
 							[variant]="i === 0 ? 'highlighted' : 'on-white'"
 							[order]="i + 1"
+							[priority]="i === 0"
 							[showAuthor]="collection.config.showAuthors"
 							[showExcerpt]="true"
 							[showMultimedia]="true"
 							[excerptLines]="collection.config.showAuthors ? 3 : 4"
-							[tagLabel]="story.tags[0]?.title"
-							data-testid="story-card"
+							[tagLabel]="collection.tags[0]?.title"
+							data-testid="work-card"
 						/>
 					}
 				</div>
@@ -85,9 +86,13 @@
 						}
 					</div>
 					<div class="flex flex-col items-start gap-3">
-						<div #description class="line-clamp-[8] font-inter text-sm font-medium text-neutral-700">
-							<cuentoneta-portable-text-parser [paragraphs]="collection.description" />
-						</div>
+						<!-- La descripción llega como HTML ya saneado por el ACL del backend. -->
+						<div
+							[innerHTML]="collection.description"
+							#description
+							class="line-clamp-[8] font-inter text-sm font-medium text-neutral-700"
+							data-testid="collection-description"
+						></div>
 						@if (isDescriptionOverflowing()) {
 							<button (click)="descriptionDrawer.open()" cuentoneta-button type="outline" data-testid="read-more">
 								Leer más
@@ -99,7 +104,7 @@
 				<div class="flex flex-col gap-4">
 					<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Otras colecciones sugeridas</h2>
 
-					@for (suggested of suggestedCollections; track suggested.slug) {
+					@for (suggested of suggestedCollections(); track suggested.slug) {
 						<cuentoneta-navigable-collection-teaser [collection]="suggested" data-testid="suggested-collection" />
 					}
 				</div>
@@ -119,16 +124,15 @@
 					}
 				</div>
 			</div>
-			<cuentoneta-portable-text-parser
-				[paragraphs]="collection.description"
-				classes="font-inter text-sm font-medium text-neutral-700"
-				class="flex flex-col gap-2"
+			<div
+				[innerHTML]="collection.description"
+				class="flex flex-col gap-2 font-inter text-sm font-medium text-neutral-700"
 				data-testid="drawer-description"
-			/>
+			></div>
 			<div class="h-px w-full bg-neutral-200" role="separator"></div>
 			<div class="flex w-full flex-col gap-4">
 				<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Otras colecciones sugeridas</h2>
-				@for (suggested of suggestedCollections; track suggested.slug) {
+				@for (suggested of suggestedCollections(); track suggested.slug) {
 					<cuentoneta-navigable-collection-teaser [collection]="suggested" data-testid="drawer-suggested-collection" />
 				}
 			</div>

--- a/src/app/pages/collection/collection.component.html
+++ b/src/app/pages/collection/collection.component.html
@@ -5,7 +5,6 @@
 	</p>
 
 	@if (isLoading()) {
-		<!-- Estado de carga: skeletons que reflejan el layout de dos columnas -->
 		<div class="flex items-start gap-16" aria-busy="true" data-testid="loading">
 			<section class="flex flex-1 flex-col gap-12 pt-8">
 				<cuentoneta-skeleton appearance="line" class="h-10 w-64 bg-neutral-300" />
@@ -21,7 +20,7 @@
 				</div>
 			</section>
 
-			<div class="w-px self-stretch bg-neutral-200"></div>
+			<div class="w-px self-stretch bg-neutral-200" aria-hidden="true"></div>
 
 			<aside class="flex w-[364px] shrink-0 flex-col gap-6 pt-8">
 				<div class="flex flex-col gap-4">
@@ -45,14 +44,13 @@
 		</div>
 	} @else if (collection(); as collection) {
 		<div class="flex items-start gap-16">
-			<!-- Columna izquierda: título + listado de obras -->
 			<section class="flex flex-1 flex-col gap-12 pt-8">
 				<h1 class="font-inter text-4xl leading-10 font-bold text-neutral-900">{{ collection.title }}</h1>
 
 				<div class="flex flex-col gap-9">
 					@for (literaryWork of collection.literaryWorks; track literaryWork._id; let i = $index) {
 						@if (i >= 2) {
-							<div class="h-px w-full bg-neutral-200" role="separator"></div>
+							<div class="h-px w-full bg-neutral-200" aria-hidden="true"></div>
 						}
 						<cuentoneta-literary-work-card-teaser
 							[literaryWork]="literaryWork"
@@ -70,15 +68,14 @@
 				</div>
 			</section>
 
-			<!-- Divisor vertical -->
-			<div class="w-px self-stretch bg-neutral-200" role="separator"></div>
+			<div class="w-px self-stretch bg-neutral-200" aria-hidden="true"></div>
 
-			<!-- Columna derecha: info de la colección + colecciones sugeridas -->
 			<aside class="flex w-[364px] shrink-0 flex-col gap-6 pt-8">
 				<div class="flex flex-col gap-4">
-					@if (collection.imagery.kind === 'representative') {
-						<cuentoneta-cover-image [src]="collection.imagery.image" [priority]="true" />
-					}
+					<ng-container
+						[ngTemplateOutlet]="cover"
+						[ngTemplateOutletContext]="{ $implicit: collection, priority: true }"
+					/>
 					<div class="flex flex-col items-start gap-2">
 						<p class="font-inter text-xl leading-7 font-bold text-neutral-900">{{ collection.title }}</p>
 						@if (collection.tags[0]; as tag) {
@@ -86,14 +83,14 @@
 						}
 					</div>
 					<div class="flex flex-col items-start gap-3">
-						<!-- La descripción llega como HTML ya saneado por el ACL del backend. -->
 						<div
-							[innerHTML]="collection.description"
-							#description
+							[innerHTML]="safeDescription()"
+							#descriptionClamp="cuentonetaClampOverflow"
+							cuentonetaClampOverflow
 							class="line-clamp-[8] font-inter text-sm font-medium text-neutral-700"
 							data-testid="collection-description"
 						></div>
-						@if (isDescriptionOverflowing()) {
+						@if (descriptionClamp.isOverflowing()) {
 							<button (click)="descriptionDrawer.open()" cuentoneta-button type="outline" data-testid="read-more">
 								Leer más
 							</button>
@@ -101,47 +98,61 @@
 					</div>
 				</div>
 
-				<div class="flex flex-col gap-4">
-					<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Otras colecciones sugeridas</h2>
-
-					@for (suggested of suggestedCollections(); track suggested.slug) {
-						<cuentoneta-navigable-collection-teaser [collection]="suggested" data-testid="suggested-collection" />
-					}
-				</div>
+				<ng-container [ngTemplateOutlet]="suggestions" [ngTemplateOutletContext]="{ testid: 'suggested-collection' }" />
 			</aside>
 		</div>
 
-		<!-- Drawer con la descripción completa (se abre desde "Leer más") -->
-		<cuentoneta-drawer #descriptionDrawer>
+		<cuentoneta-drawer [title]="collection.title" #descriptionDrawer>
 			<div class="flex flex-col gap-4">
-				@if (collection.imagery.kind === 'representative') {
-					<cuentoneta-cover-image [src]="collection.imagery.image" />
+				<ng-container
+					[ngTemplateOutlet]="cover"
+					[ngTemplateOutletContext]="{ $implicit: collection, priority: false }"
+				/>
+				@if (collection.tags[0]; as tag) {
+					<cuentoneta-tag [label]="tag.title" variant="filled" class="self-start" />
 				}
-				<div class="flex flex-col items-start gap-2">
-					<p class="font-inter text-xl leading-7 font-bold text-neutral-900">{{ collection.title }}</p>
-					@if (collection.tags[0]; as tag) {
-						<cuentoneta-tag [label]="tag.title" variant="filled" />
-					}
-				</div>
 			</div>
 			<div
-				[innerHTML]="collection.description"
+				[innerHTML]="safeDescription()"
 				class="flex flex-col gap-2 font-inter text-sm font-medium text-neutral-700"
 				data-testid="drawer-description"
 			></div>
-			<div class="h-px w-full bg-neutral-200" role="separator"></div>
-			<div class="flex w-full flex-col gap-4">
-				<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Otras colecciones sugeridas</h2>
-				@for (suggested of suggestedCollections(); track suggested.slug) {
-					<cuentoneta-navigable-collection-teaser [collection]="suggested" data-testid="drawer-suggested-collection" />
-				}
-			</div>
+			<div class="h-px w-full bg-neutral-200" aria-hidden="true"></div>
+			<ng-container
+				[ngTemplateOutlet]="suggestions"
+				[ngTemplateOutletContext]="{ testid: 'drawer-suggested-collection' }"
+			/>
 		</cuentoneta-drawer>
 	} @else {
-		<!-- Estado sin resultados: el slug no matcheó ninguna colección (o el fetch falló) -->
+		<!-- El slug no matcheó ninguna colección, o el fetch falló -->
 		<div class="py-16 text-center" data-testid="not-found">
 			<p class="font-inter text-lg font-bold text-neutral-900">No encontramos esta colección</p>
 			<p class="mt-2 font-inter text-sm text-neutral-600">Revisá el enlace o volvé al inicio.</p>
 		</div>
 	}
 </main>
+
+<!-- Portada de la colección: la editorial propia, o el abanico con las de sus obras cuando no tiene una. -->
+<ng-template #cover let-collection let-priority="priority">
+	@if (collection.imagery.kind === 'representative') {
+		<cuentoneta-cover-image [src]="collection.imagery.image" [priority]="priority" />
+	} @else {
+		<div
+			class="relative flex h-48 items-end justify-center overflow-hidden rounded-xl bg-neutral-100 px-3"
+			data-testid="cover-fan"
+		>
+			@for (image of collection.imagery.images; track $index) {
+				<cuentoneta-cover-image [src]="image" [class]="sampleImageClasses[$index]" />
+			}
+		</div>
+	}
+</ng-template>
+
+<ng-template #suggestions let-testid="testid">
+	<div class="flex w-full flex-col gap-4">
+		<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Otras colecciones sugeridas</h2>
+		@for (suggested of suggestedCollections(); track suggested.slug) {
+			<cuentoneta-navigable-collection-teaser [collection]="suggested" [attr.data-testid]="testid" />
+		}
+	</div>
+</ng-template>

--- a/src/app/pages/collection/collection.component.spec.ts
+++ b/src/app/pages/collection/collection.component.spec.ts
@@ -8,8 +8,8 @@ describe('CollectionComponent (blueprint)', () => {
 		expect(screen.getByText('/collection/miscelaneas-tertulianas')).toBeInTheDocument();
 	});
 
-	it('should render the suggested-collections section', async () => {
+	it('should render the static suggested-collections heading', async () => {
 		await render(CollectionComponent, { inputs: { slug: 'x' } });
-		expect(screen.getByText(/Otras colecciones sugeridas/)).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Otras colecciones sugeridas' })).toBeInTheDocument();
 	});
 });

--- a/src/app/pages/collection/collection.component.spec.ts
+++ b/src/app/pages/collection/collection.component.spec.ts
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/angular';
+
+import CollectionComponent from './collection.component';
+
+describe('CollectionComponent (blueprint)', () => {
+	it('should render the route note with the current slug', async () => {
+		await render(CollectionComponent, { inputs: { slug: 'miscelaneas-tertulianas' } });
+		expect(screen.getByText('/collection/miscelaneas-tertulianas')).toBeInTheDocument();
+	});
+
+	it('should render the suggested-collections section', async () => {
+		await render(CollectionComponent, { inputs: { slug: 'x' } });
+		expect(screen.getByText(/Otras colecciones sugeridas/)).toBeInTheDocument();
+	});
+});

--- a/src/app/pages/collection/collection.component.spec.ts
+++ b/src/app/pages/collection/collection.component.spec.ts
@@ -28,4 +28,10 @@ describe('CollectionComponent (blueprint)', () => {
 		await setup();
 		expect(screen.getByText(storylistMock.tags[0].title)).toBeInTheDocument();
 	});
+
+	it('should render the suggested collections list', async () => {
+		await setup();
+		expect(screen.getAllByTestId('suggested-collection')).toHaveLength(3);
+		expect(screen.getByText('El inventario de las pasiones')).toBeInTheDocument();
+	});
 });

--- a/src/app/pages/collection/collection.component.spec.ts
+++ b/src/app/pages/collection/collection.component.spec.ts
@@ -1,37 +1,61 @@
 import { render, screen } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
+import { NEVER, throwError } from 'rxjs';
 
 import CollectionComponent from './collection.component';
 import { storylistMock } from '@mocks/storylist.mock';
+import { provideStorylistApiMock } from '../../providers/storylist.mock';
+import { StorylistApi } from '../../providers/storylist-api.interface';
+
+// Doble mínimo para forzar los estados de carga/sin-resultados (el CollectionPage solo llama a `get`).
+const apiWith = (get: StorylistApi['get']): StorylistApi => ({
+	get,
+	getStorylistNavigationTeasers: () => NEVER,
+});
 
 describe('CollectionComponent (blueprint)', () => {
-	const setup = (slug = 'geometrias-del-desvelo') =>
-		render(CollectionComponent, { inputs: { slug }, providers: [provideRouter([])] });
+	const setup = (options?: { slug?: string; api?: StorylistApi }) =>
+		render(CollectionComponent, {
+			inputs: { slug: options?.slug ?? 'geometrias-del-desvelo' },
+			providers: [provideRouter([]), provideStorylistApiMock(options?.api)],
+		});
 
 	it('should render the route note with the current slug', async () => {
-		await setup('miscelaneas-tertulianas');
+		await setup({ slug: 'miscelaneas-tertulianas' });
 		expect(screen.getByText('/collection/miscelaneas-tertulianas')).toBeInTheDocument();
-	});
-
-	it('should render the static suggested-collections heading', async () => {
-		await setup();
-		expect(screen.getByRole('heading', { name: 'Otras colecciones sugeridas' })).toBeInTheDocument();
 	});
 
 	it('should render one story card per collection story', async () => {
 		await setup();
-		expect(screen.getAllByTestId('story-card')).toHaveLength(storylistMock.stories.length);
+		expect(await screen.findAllByTestId('story-card')).toHaveLength(storylistMock.stories.length);
 		expect(screen.getByText(storylistMock.stories[0].title)).toBeInTheDocument();
 	});
 
 	it('should render the collection tag in the sidebar', async () => {
 		await setup();
-		expect(screen.getByText(storylistMock.tags[0].title)).toBeInTheDocument();
+		expect(await screen.findByTestId('collection-tag')).toHaveTextContent(storylistMock.tags[0].title);
+	});
+
+	it('should render the full description inside the drawer', async () => {
+		await setup();
+		expect(await screen.findByTestId('drawer-description')).toBeInTheDocument();
 	});
 
 	it('should render the suggested collections list', async () => {
 		await setup();
-		expect(screen.getAllByTestId('suggested-collection')).toHaveLength(3);
+		expect(await screen.findAllByTestId('suggested-collection')).toHaveLength(3);
 		expect(screen.getByText('El inventario de las pasiones')).toBeInTheDocument();
+	});
+
+	it('should render the loading skeletons while the collection resolves', async () => {
+		await setup({ api: apiWith(() => NEVER) });
+		expect(screen.getByTestId('loading')).toBeInTheDocument();
+		expect(screen.queryByTestId('story-card')).not.toBeInTheDocument();
+	});
+
+	it('should render the not-found state when the collection fetch fails', async () => {
+		await setup({ api: apiWith(() => throwError(() => new Error('not found'))) });
+		expect(screen.getByTestId('not-found')).toBeInTheDocument();
+		expect(screen.queryByTestId('story-card')).not.toBeInTheDocument();
 	});
 });

--- a/src/app/pages/collection/collection.component.spec.ts
+++ b/src/app/pages/collection/collection.component.spec.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
-import { NEVER, throwError } from 'rxjs';
+import { NEVER, of, throwError } from 'rxjs';
 
 import CollectionComponent from './collection.component';
 import { storylistMock } from '@mocks/storylist.mock';
@@ -29,6 +29,18 @@ describe('CollectionComponent (blueprint)', () => {
 		await setup();
 		expect(await screen.findAllByTestId('story-card')).toHaveLength(storylistMock.stories.length);
 		expect(screen.getByText(storylistMock.stories[0].title)).toBeInTheDocument();
+	});
+
+	it('should clamp story excerpts to 3 lines when authors are shown', async () => {
+		await setup({ api: apiWith(() => of({ ...storylistMock, config: { showAuthors: true } })) });
+		const descriptions = await screen.findAllByTestId('description');
+		expect(descriptions[0]).toHaveClass('line-clamp-3');
+	});
+
+	it('should clamp story excerpts to 4 lines when authors are hidden', async () => {
+		await setup({ api: apiWith(() => of({ ...storylistMock, config: { showAuthors: false } })) });
+		const descriptions = await screen.findAllByTestId('description');
+		expect(descriptions[0]).toHaveClass('line-clamp-4');
 	});
 
 	it('should render the collection tag in the sidebar', async () => {

--- a/src/app/pages/collection/collection.component.spec.ts
+++ b/src/app/pages/collection/collection.component.spec.ts
@@ -23,4 +23,9 @@ describe('CollectionComponent (blueprint)', () => {
 		expect(screen.getAllByTestId('story-card')).toHaveLength(storylistMock.stories.length);
 		expect(screen.getByText(storylistMock.stories[0].title)).toBeInTheDocument();
 	});
+
+	it('should render the collection tag in the sidebar', async () => {
+		await setup();
+		expect(screen.getByText(storylistMock.tags[0].title)).toBeInTheDocument();
+	});
 });

--- a/src/app/pages/collection/collection.component.spec.ts
+++ b/src/app/pages/collection/collection.component.spec.ts
@@ -1,15 +1,26 @@
 import { render, screen } from '@testing-library/angular';
+import { provideRouter } from '@angular/router';
 
 import CollectionComponent from './collection.component';
+import { storylistMock } from '@mocks/storylist.mock';
 
 describe('CollectionComponent (blueprint)', () => {
+	const setup = (slug = 'geometrias-del-desvelo') =>
+		render(CollectionComponent, { inputs: { slug }, providers: [provideRouter([])] });
+
 	it('should render the route note with the current slug', async () => {
-		await render(CollectionComponent, { inputs: { slug: 'miscelaneas-tertulianas' } });
+		await setup('miscelaneas-tertulianas');
 		expect(screen.getByText('/collection/miscelaneas-tertulianas')).toBeInTheDocument();
 	});
 
 	it('should render the static suggested-collections heading', async () => {
-		await render(CollectionComponent, { inputs: { slug: 'x' } });
+		await setup();
 		expect(screen.getByRole('heading', { name: 'Otras colecciones sugeridas' })).toBeInTheDocument();
+	});
+
+	it('should render one story card per collection story', async () => {
+		await setup();
+		expect(screen.getAllByTestId('story-card')).toHaveLength(storylistMock.stories.length);
+		expect(screen.getByText(storylistMock.stories[0].title)).toBeInTheDocument();
 	});
 });

--- a/src/app/pages/collection/collection.component.spec.ts
+++ b/src/app/pages/collection/collection.component.spec.ts
@@ -41,10 +41,16 @@ describe('CollectionComponent (blueprint)', () => {
 		expect(await screen.findByTestId('drawer-description')).toBeInTheDocument();
 	});
 
-	it('should render the suggested collections list', async () => {
+	it('should render the suggested collections list in the sidebar', async () => {
 		await setup();
 		expect(await screen.findAllByTestId('suggested-collection')).toHaveLength(3);
-		expect(screen.getByText('El inventario de las pasiones')).toBeInTheDocument();
+		// El título del sample aparece en el sidebar y también dentro del drawer.
+		expect(screen.getAllByText('El inventario de las pasiones').length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('should also list the suggested collections inside the drawer', async () => {
+		await setup();
+		expect(await screen.findAllByTestId('drawer-suggested-collection')).toHaveLength(3);
 	});
 
 	it('should render the loading skeletons while the collection resolves', async () => {

--- a/src/app/pages/collection/collection.component.spec.ts
+++ b/src/app/pages/collection/collection.component.spec.ts
@@ -3,21 +3,32 @@ import { provideRouter } from '@angular/router';
 import { NEVER, of, throwError } from 'rxjs';
 
 import CollectionComponent from './collection.component';
-import { storylistMock } from '@mocks/storylist.mock';
-import { provideStorylistApiMock } from '../../providers/storylist.mock';
-import { StorylistApi } from '../../providers/storylist-api.interface';
+import {
+	geometriasDelDesveloCollectionMock,
+	onoffCollectionTeasersMock,
+	onoffCollectionsMock,
+} from '@mocks/onoff-collections.mock';
+import { provideCollectionApiMock, StubCollectionApi } from '../../providers/collection.mock';
+import type { CollectionApi } from '../../providers/collection-api.interface';
 
-// Doble mínimo para forzar los estados de carga/sin-resultados (el CollectionPage solo llama a `get`).
-const apiWith = (get: StorylistApi['get']): StorylistApi => ({
-	get,
-	getStorylistNavigationTeasers: () => NEVER,
+const collection = geometriasDelDesveloCollectionMock;
+const otherCollectionTeasers = onoffCollectionTeasersMock.filter((teaser) => teaser.slug !== collection.slug);
+
+// Doble mínimo para forzar los estados de carga y de error de la colección; el catálogo se mantiene sano
+// para que el sidebar siga siendo observable en esos estados.
+const apiWith = (getBySlug: CollectionApi['getBySlug']): CollectionApi => ({
+	getBySlug,
+	getAll: () => of(onoffCollectionTeasersMock),
 });
 
 describe('CollectionComponent (blueprint)', () => {
-	const setup = (options?: { slug?: string; api?: StorylistApi }) =>
+	const setup = (options?: { slug?: string; api?: CollectionApi }) =>
 		render(CollectionComponent, {
-			inputs: { slug: options?.slug ?? 'geometrias-del-desvelo' },
-			providers: [provideRouter([]), provideStorylistApiMock(options?.api)],
+			inputs: { slug: options?.slug ?? collection.slug },
+			providers: [
+				provideRouter([]),
+				provideCollectionApiMock(options?.api ?? new StubCollectionApi(onoffCollectionsMock)),
+			],
 		});
 
 	it('should render the route note with the current slug', async () => {
@@ -25,55 +36,63 @@ describe('CollectionComponent (blueprint)', () => {
 		expect(screen.getByText('/collection/miscelaneas-tertulianas')).toBeInTheDocument();
 	});
 
-	it('should render one story card per collection story', async () => {
+	it('should render one card per literary work of the collection', async () => {
 		await setup();
-		expect(await screen.findAllByTestId('story-card')).toHaveLength(storylistMock.stories.length);
-		expect(screen.getByText(storylistMock.stories[0].title)).toBeInTheDocument();
+		expect(await screen.findAllByTestId('work-card')).toHaveLength(collection.literaryWorks.length);
+		expect(screen.getByText(collection.literaryWorks[0].title)).toBeInTheDocument();
 	});
 
-	it('should clamp story excerpts to 3 lines when authors are shown', async () => {
-		await setup({ api: apiWith(() => of({ ...storylistMock, config: { showAuthors: true } })) });
+	it('should clamp work excerpts to 3 lines when authors are shown', async () => {
+		await setup({ api: apiWith(() => of({ ...collection, config: { showAuthors: true } })) });
 		const descriptions = await screen.findAllByTestId('description');
 		expect(descriptions[0]).toHaveClass('line-clamp-3');
 	});
 
-	it('should clamp story excerpts to 4 lines when authors are hidden', async () => {
-		await setup({ api: apiWith(() => of({ ...storylistMock, config: { showAuthors: false } })) });
+	it('should clamp work excerpts to 4 lines when authors are hidden', async () => {
+		await setup({ api: apiWith(() => of({ ...collection, config: { showAuthors: false } })) });
 		const descriptions = await screen.findAllByTestId('description');
 		expect(descriptions[0]).toHaveClass('line-clamp-4');
 	});
 
 	it('should render the collection tag in the sidebar', async () => {
 		await setup();
-		expect(await screen.findByTestId('collection-tag')).toHaveTextContent(storylistMock.tags[0].title);
+		expect(await screen.findByTestId('collection-tag')).toHaveTextContent(collection.tags[0].title);
 	});
 
-	it('should render the full description inside the drawer', async () => {
+	it('should render the sanitized description in the sidebar and in the drawer', async () => {
 		await setup();
-		expect(await screen.findByTestId('drawer-description')).toBeInTheDocument();
+		expect(await screen.findByTestId('collection-description')).not.toBeEmptyDOMElement();
+		expect(screen.getByTestId('drawer-description')).not.toBeEmptyDOMElement();
 	});
 
-	it('should render the suggested collections list in the sidebar', async () => {
+	it('should list the other collections of the catalog as suggestions', async () => {
 		await setup();
-		expect(await screen.findAllByTestId('suggested-collection')).toHaveLength(3);
-		// El título del sample aparece en el sidebar y también dentro del drawer.
-		expect(screen.getAllByText('El inventario de las pasiones').length).toBeGreaterThanOrEqual(1);
+		const suggested = await screen.findAllByTestId('suggested-collection');
+		expect(suggested).toHaveLength(otherCollectionTeasers.length);
+		expect(suggested[0]).toHaveTextContent(otherCollectionTeasers[0].title);
+	});
+
+	it('should not suggest the collection being viewed', async () => {
+		await setup();
+		await screen.findAllByTestId('suggested-collection');
+		const suggestedTitles = screen.getAllByTestId('suggested-collection').map((item) => item.textContent);
+		expect(suggestedTitles.some((title) => title?.includes(collection.title))).toBe(false);
 	});
 
 	it('should also list the suggested collections inside the drawer', async () => {
 		await setup();
-		expect(await screen.findAllByTestId('drawer-suggested-collection')).toHaveLength(3);
+		expect(await screen.findAllByTestId('drawer-suggested-collection')).toHaveLength(otherCollectionTeasers.length);
 	});
 
 	it('should render the loading skeletons while the collection resolves', async () => {
 		await setup({ api: apiWith(() => NEVER) });
 		expect(screen.getByTestId('loading')).toBeInTheDocument();
-		expect(screen.queryByTestId('story-card')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('work-card')).not.toBeInTheDocument();
 	});
 
 	it('should render the not-found state when the collection fetch fails', async () => {
 		await setup({ api: apiWith(() => throwError(() => new Error('not found'))) });
 		expect(screen.getByTestId('not-found')).toBeInTheDocument();
-		expect(screen.queryByTestId('story-card')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('work-card')).not.toBeInTheDocument();
 	});
 });

--- a/src/app/pages/collection/collection.component.spec.ts
+++ b/src/app/pages/collection/collection.component.spec.ts
@@ -1,30 +1,50 @@
-import { render, screen } from '@testing-library/angular';
+import { render, screen, within } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 import { provideRouter } from '@angular/router';
-import { NEVER, of, throwError } from 'rxjs';
+import { NEVER, Observable, of, throwError } from 'rxjs';
 
 import CollectionComponent from './collection.component';
 import {
-	geometriasDelDesveloCollectionMock,
 	onoffCollectionTeasersMock,
 	onoffCollectionsMock,
+	onoffCollectionsWithRepresentativeImageryMock,
+	onoffCollectionsWithSampleImageryMock,
 } from '@mocks/onoff-collections.mock';
+import { createCollectionTeaser, type Collection, type CollectionTeaser } from '@models/collection.model';
 import { provideCollectionApiMock, StubCollectionApi } from '../../providers/collection.mock';
 import type { CollectionApi } from '../../providers/collection-api.interface';
+import { setMeasuredSize, triggerResize } from '@testing/resize-observer.stub';
+import { clearAllMocks } from '@test-utils';
 
-const collection = geometriasDelDesveloCollectionMock;
-const otherCollectionTeasers = onoffCollectionTeasersMock.filter((teaser) => teaser.slug !== collection.slug);
+const [collectionWithRepresentativeImagery] = onoffCollectionsWithRepresentativeImageryMock;
+const [collectionWithSampleImagery] = onoffCollectionsWithSampleImageryMock;
+const otherCollectionTeasers = onoffCollectionTeasersMock.filter(
+	(teaser) => teaser.slug !== collectionWithRepresentativeImagery.slug,
+);
 
-// Doble mínimo para forzar los estados de carga y de error de la colección; el catálogo se mantiene sano
-// para que el sidebar siga siendo observable en esos estados.
-const apiWith = (getBySlug: CollectionApi['getBySlug']): CollectionApi => ({
-	getBySlug,
-	getAll: () => of(onoffCollectionTeasersMock),
-});
+// El test decide qué responde cada operación: la carga y el error de la colección no son estados que el
+// stub del catálogo sepa producir, y el tope de sugeridas necesita un catálogo más largo que el corpus.
+class ControllableCollectionApi implements CollectionApi {
+	constructor(
+		private readonly bySlug: () => Observable<Collection>,
+		private readonly all: () => Observable<CollectionTeaser[]> = () => of(onoffCollectionTeasersMock),
+	) {}
+
+	public getBySlug(): Observable<Collection> {
+		return this.bySlug();
+	}
+
+	public getAll(): Observable<CollectionTeaser[]> {
+		return this.all();
+	}
+}
 
 describe('CollectionComponent (blueprint)', () => {
+	beforeEach(() => clearAllMocks());
+
 	const setup = (options?: { slug?: string; api?: CollectionApi }) =>
 		render(CollectionComponent, {
-			inputs: { slug: options?.slug ?? collection.slug },
+			inputs: { slug: options?.slug ?? collectionWithRepresentativeImagery.slug },
 			providers: [
 				provideRouter([]),
 				provideCollectionApiMock(options?.api ?? new StubCollectionApi(onoffCollectionsMock)),
@@ -36,27 +56,42 @@ describe('CollectionComponent (blueprint)', () => {
 		expect(screen.getByText('/collection/miscelaneas-tertulianas')).toBeInTheDocument();
 	});
 
-	it('should render one card per literary work of the collection', async () => {
+	it('should render the collection title as the page heading', async () => {
 		await setup();
-		expect(await screen.findAllByTestId('work-card')).toHaveLength(collection.literaryWorks.length);
-		expect(screen.getByText(collection.literaryWorks[0].title)).toBeInTheDocument();
+		expect(
+			await screen.findByRole('heading', { level: 1, name: collectionWithRepresentativeImagery.title }),
+		).toBeInTheDocument();
 	});
 
-	it('should clamp work excerpts to 3 lines when authors are shown', async () => {
-		await setup({ api: apiWith(() => of({ ...collection, config: { showAuthors: true } })) });
+	it('should render one card per literary work of the collection', async () => {
+		await setup();
+		const works = collectionWithRepresentativeImagery.literaryWorks;
+		expect(await screen.findAllByTestId('work-card')).toHaveLength(works.length);
+		expect(screen.getByText(works[0].title)).toBeInTheDocument();
+	});
+
+	it('should clamp work excerpts to 3 lines when the collection shows authors', async () => {
+		await setup({ api: new ControllableCollectionApi(() => of(collectionWithRepresentativeImagery)) });
+		expect(collectionWithRepresentativeImagery.config.showAuthors).toBe(true);
 		const descriptions = await screen.findAllByTestId('description');
 		expect(descriptions[0]).toHaveClass('line-clamp-3');
 	});
 
-	it('should clamp work excerpts to 4 lines when authors are hidden', async () => {
-		await setup({ api: apiWith(() => of({ ...collection, config: { showAuthors: false } })) });
+	it('should clamp work excerpts to 4 lines when the collection hides authors', async () => {
+		const hidingAuthors = onoffCollectionsMock.find((candidate) => !candidate.config.showAuthors);
+		if (!hidingAuthors) {
+			throw new Error('El corpus no tiene ninguna colección que oculte los autores');
+		}
+		await setup({ api: new ControllableCollectionApi(() => of(hidingAuthors)) });
 		const descriptions = await screen.findAllByTestId('description');
 		expect(descriptions[0]).toHaveClass('line-clamp-4');
 	});
 
 	it('should render the collection tag in the sidebar', async () => {
 		await setup();
-		expect(await screen.findByTestId('collection-tag')).toHaveTextContent(collection.tags[0].title);
+		expect(await screen.findByTestId('collection-tag')).toHaveTextContent(
+			collectionWithRepresentativeImagery.tags[0].title,
+		);
 	});
 
 	it('should render the sanitized description in the sidebar and in the drawer', async () => {
@@ -65,18 +100,42 @@ describe('CollectionComponent (blueprint)', () => {
 		expect(screen.getByTestId('drawer-description')).not.toBeEmptyDOMElement();
 	});
 
-	it('should list the other collections of the catalog as suggestions', async () => {
-		await setup();
-		const suggested = await screen.findAllByTestId('suggested-collection');
-		expect(suggested).toHaveLength(otherCollectionTeasers.length);
-		expect(suggested[0]).toHaveTextContent(otherCollectionTeasers[0].title);
+	it('should render a single editorial cover when the collection has one', async () => {
+		await setup({ api: new ControllableCollectionApi(() => of(collectionWithRepresentativeImagery)) });
+		await screen.findByTestId('collection-tag');
+		expect(screen.queryByTestId('cover-fan')).not.toBeInTheDocument();
+	});
+
+	it('should fan out the works covers when the collection has no editorial cover', async () => {
+		await setup({ api: new ControllableCollectionApi(() => of(collectionWithSampleImagery)) });
+		// El abanico se repite en el sidebar y en el drawer; alcanza con verificar el del sidebar.
+		const [fan] = await screen.findAllByTestId('cover-fan');
+		expect(within(fan).getAllByTestId('cover-image')).toHaveLength(3);
 	});
 
 	it('should not suggest the collection being viewed', async () => {
 		await setup();
-		await screen.findAllByTestId('suggested-collection');
-		const suggestedTitles = screen.getAllByTestId('suggested-collection').map((item) => item.textContent);
-		expect(suggestedTitles.some((title) => title?.includes(collection.title))).toBe(false);
+		const suggested = await screen.findAllByTestId('suggested-collection');
+		expect(suggested).toHaveLength(otherCollectionTeasers.length);
+		expect(suggested.some((item) => item.textContent?.includes(collectionWithRepresentativeImagery.title))).toBe(false);
+	});
+
+	it('should cap the suggestions at three even when the catalog is longer', async () => {
+		const catalog = Array.from({ length: 6 }, (_, index) =>
+			createCollectionTeaser({
+				...onoffCollectionTeasersMock[0],
+				_id: `catalog-${index}`,
+				slug: `coleccion-${index}`,
+				title: `Colección ${index}`,
+			}),
+		);
+		await setup({
+			api: new ControllableCollectionApi(
+				() => of(collectionWithRepresentativeImagery),
+				() => of(catalog),
+			),
+		});
+		expect(await screen.findAllByTestId('suggested-collection')).toHaveLength(3);
 	});
 
 	it('should also list the suggested collections inside the drawer', async () => {
@@ -84,15 +143,49 @@ describe('CollectionComponent (blueprint)', () => {
 		expect(await screen.findAllByTestId('drawer-suggested-collection')).toHaveLength(otherCollectionTeasers.length);
 	});
 
+	it('should offer "Leer más" only when the description overflows its clamp', async () => {
+		const view = await setup();
+		const description = await screen.findByTestId('collection-description');
+		expect(screen.queryByTestId('read-more')).not.toBeInTheDocument();
+
+		setMeasuredSize(description, { scrollHeight: 400, clientHeight: 160 });
+		triggerResize();
+		await view.fixture.whenStable();
+
+		expect(screen.getByTestId('read-more')).toBeInTheDocument();
+	});
+
+	it('should open the drawer with the full description from "Leer más"', async () => {
+		const view = await setup();
+		setMeasuredSize(await screen.findByTestId('collection-description'), { scrollHeight: 400, clientHeight: 160 });
+		triggerResize();
+		await view.fixture.whenStable();
+
+		await userEvent.click(screen.getByTestId('read-more'));
+
+		expect(screen.getByRole('dialog', { name: collectionWithRepresentativeImagery.title })).toBeInTheDocument();
+	});
+
 	it('should render the loading skeletons while the collection resolves', async () => {
-		await setup({ api: apiWith(() => NEVER) });
+		await setup({ api: new ControllableCollectionApi(() => NEVER) });
 		expect(screen.getByTestId('loading')).toBeInTheDocument();
 		expect(screen.queryByTestId('work-card')).not.toBeInTheDocument();
 	});
 
 	it('should render the not-found state when the collection fetch fails', async () => {
-		await setup({ api: apiWith(() => throwError(() => new Error('not found'))) });
+		await setup({ api: new ControllableCollectionApi(() => throwError(() => new Error('not found'))) });
 		expect(screen.getByTestId('not-found')).toBeInTheDocument();
 		expect(screen.queryByTestId('work-card')).not.toBeInTheDocument();
+	});
+
+	it('should still render the collection when the catalog of suggestions fails', async () => {
+		await setup({
+			api: new ControllableCollectionApi(
+				() => of(collectionWithRepresentativeImagery),
+				() => throwError(() => new Error('catalog down')),
+			),
+		});
+		expect(await screen.findAllByTestId('work-card')).not.toHaveLength(0);
+		expect(screen.queryByTestId('suggested-collection')).not.toBeInTheDocument();
 	});
 });

--- a/src/app/pages/collection/collection.component.ts
+++ b/src/app/pages/collection/collection.component.ts
@@ -1,0 +1,25 @@
+import { Component, inject, input } from '@angular/core';
+
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
+
+// Blueprint de la CollectionPage V3 (spike). Página temporal en /collection/:slug con placeholders para cada
+// región del diseño de Figma; se irá reemplazando por los componentes reales. Marcada `noindex` mientras es
+// un placeholder (no debe indexarse ni competir con /storylist/:slug).
+@Component({
+	selector: 'cuentoneta-collection',
+	hostDirectives: [HeadMetadataDirective],
+	templateUrl: './collection.component.html',
+})
+export default class CollectionComponent {
+	public readonly slug = input<string>();
+
+	private readonly metaTagsDirective = inject(HeadMetadataDirective);
+
+	constructor() {
+		this.metaTagsDirective.setTitle('Colección (blueprint)');
+		this.metaTagsDirective.setDefaultDescription();
+		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl('collection'));
+		this.metaTagsDirective.setRobots('noindex, nofollow');
+	}
+}

--- a/src/app/pages/collection/collection.component.ts
+++ b/src/app/pages/collection/collection.component.ts
@@ -2,17 +2,23 @@ import { Component, inject, input } from '@angular/core';
 
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
+import { StoryCardTeaserV3Component } from '@components/story-card-teaser-v3/story-card-teaser-v3.component';
+import { storylistMock } from '@mocks/storylist.mock';
 
 // Blueprint de la CollectionPage V3 (spike). Página temporal en /collection/:slug con placeholders para cada
 // región del diseño de Figma; se irá reemplazando por los componentes reales. Marcada `noindex` mientras es
 // un placeholder (no debe indexarse ni competir con /storylist/:slug).
 @Component({
 	selector: 'cuentoneta-collection',
+	imports: [StoryCardTeaserV3Component],
 	hostDirectives: [HeadMetadataDirective],
 	templateUrl: './collection.component.html',
 })
 export default class CollectionComponent {
 	public readonly slug = input<string>();
+
+	// Datos de ejemplo del corpus Onoff mientras el blueprint no consume un servicio real.
+	protected readonly collection = storylistMock;
 
 	private readonly metaTagsDirective = inject(HeadMetadataDirective);
 

--- a/src/app/pages/collection/collection.component.ts
+++ b/src/app/pages/collection/collection.component.ts
@@ -3,6 +3,8 @@ import { Component, inject, input } from '@angular/core';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 import { StoryCardTeaserV3Component } from '@components/story-card-teaser-v3/story-card-teaser-v3.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { PortableTextParserComponent } from '@components/portable-text-parser/portable-text-parser.component';
 import { storylistMock } from '@mocks/storylist.mock';
 
 // Blueprint de la CollectionPage V3 (spike). Página temporal en /collection/:slug con placeholders para cada
@@ -10,7 +12,7 @@ import { storylistMock } from '@mocks/storylist.mock';
 // un placeholder (no debe indexarse ni competir con /storylist/:slug).
 @Component({
 	selector: 'cuentoneta-collection',
-	imports: [StoryCardTeaserV3Component],
+	imports: [StoryCardTeaserV3Component, TagComponent, PortableTextParserComponent],
 	hostDirectives: [HeadMetadataDirective],
 	templateUrl: './collection.component.html',
 })

--- a/src/app/pages/collection/collection.component.ts
+++ b/src/app/pages/collection/collection.component.ts
@@ -1,19 +1,27 @@
 import { Component, inject, input } from '@angular/core';
 
+import type { StorylistTeaser } from '@models/storylist.model';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 import { StoryCardTeaserV3Component } from '@components/story-card-teaser-v3/story-card-teaser-v3.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { PortableTextParserComponent } from '@components/portable-text-parser/portable-text-parser.component';
 import { CoverImageComponent } from '@components/cover-image/cover-image.component';
-import { storylistMock } from '@mocks/storylist.mock';
+import { NavigableCollectionTeaserComponent } from '@components/navigable-collection-teaser/navigable-collection-teaser.component';
+import { storylistMock, storylistTeaserSampleMock } from '@mocks/storylist.mock';
 
 // Blueprint de la CollectionPage V3 (spike). Página temporal en /collection/:slug con placeholders para cada
 // región del diseño de Figma; se irá reemplazando por los componentes reales. Marcada `noindex` mientras es
 // un placeholder (no debe indexarse ni competir con /storylist/:slug).
 @Component({
 	selector: 'cuentoneta-collection',
-	imports: [StoryCardTeaserV3Component, TagComponent, PortableTextParserComponent, CoverImageComponent],
+	imports: [
+		StoryCardTeaserV3Component,
+		TagComponent,
+		PortableTextParserComponent,
+		CoverImageComponent,
+		NavigableCollectionTeaserComponent,
+	],
 	hostDirectives: [HeadMetadataDirective],
 	templateUrl: './collection.component.html',
 })
@@ -22,6 +30,31 @@ export default class CollectionComponent {
 
 	// Datos de ejemplo del corpus Onoff mientras el blueprint no consume un servicio real.
 	protected readonly collection = storylistMock;
+
+	// Colecciones sugeridas de ejemplo (distintas de la actual y con categorías variadas para el blueprint).
+	protected readonly suggestedCollections: StorylistTeaser[] = [
+		{
+			...storylistTeaserSampleMock,
+			count: 12,
+			tags: [{ title: 'Curaduría', slug: 'curaduria', shortDescription: '', description: [] }],
+		},
+		{
+			...storylistTeaserSampleMock,
+			_id: 'onoff-creaciones',
+			slug: 'creaciones-de-navidad',
+			title: 'Creaciones de Navidad',
+			count: 8,
+			tags: [{ title: 'Antología', slug: 'antologia', shortDescription: '', description: [] }],
+		},
+		{
+			...storylistTeaserSampleMock,
+			_id: 'onoff-textos-invierno',
+			slug: 'textos-de-invierno',
+			title: 'Textos de invierno',
+			count: 6,
+			tags: [{ title: 'Selección', slug: 'seleccion', shortDescription: '', description: [] }],
+		},
+	];
 
 	private readonly metaTagsDirective = inject(HeadMetadataDirective);
 

--- a/src/app/pages/collection/collection.component.ts
+++ b/src/app/pages/collection/collection.component.ts
@@ -5,6 +5,7 @@ import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
 import { StoryCardTeaserV3Component } from '@components/story-card-teaser-v3/story-card-teaser-v3.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { PortableTextParserComponent } from '@components/portable-text-parser/portable-text-parser.component';
+import { CoverImageComponent } from '@components/cover-image/cover-image.component';
 import { storylistMock } from '@mocks/storylist.mock';
 
 // Blueprint de la CollectionPage V3 (spike). Página temporal en /collection/:slug con placeholders para cada
@@ -12,7 +13,7 @@ import { storylistMock } from '@mocks/storylist.mock';
 // un placeholder (no debe indexarse ni competir con /storylist/:slug).
 @Component({
 	selector: 'cuentoneta-collection',
-	imports: [StoryCardTeaserV3Component, TagComponent, PortableTextParserComponent],
+	imports: [StoryCardTeaserV3Component, TagComponent, PortableTextParserComponent, CoverImageComponent],
 	hostDirectives: [HeadMetadataDirective],
 	templateUrl: './collection.component.html',
 })

--- a/src/app/pages/collection/collection.component.ts
+++ b/src/app/pages/collection/collection.component.ts
@@ -1,18 +1,25 @@
-import { Component, inject, input } from '@angular/core';
+import { afterRenderEffect, Component, computed, ElementRef, inject, input, signal, viewChild } from '@angular/core';
 
 import type { StorylistTeaser } from '@models/storylist.model';
+import { StorylistApi } from '../../providers/storylist-api.interface';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
+import { progressiveRxResource } from '@utils/ssr-resource';
 import { StoryCardTeaserV3Component } from '@components/story-card-teaser-v3/story-card-teaser-v3.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { PortableTextParserComponent } from '@components/portable-text-parser/portable-text-parser.component';
 import { CoverImageComponent } from '@components/cover-image/cover-image.component';
 import { NavigableCollectionTeaserComponent } from '@components/navigable-collection-teaser/navigable-collection-teaser.component';
-import { storylistMock, storylistTeaserSampleMock } from '@mocks/storylist.mock';
+import { NavigableCollectionTeaserSkeletonComponent } from '@components/navigable-collection-teaser/navigable-collection-teaser-skeleton.component';
+import { SkeletonComponent } from '@components/skeleton/skeleton.component';
+import { DrawerComponent } from '@components/drawer/drawer.component';
+import { ButtonComponent } from '@components/button/button.component';
+import { storylistTeaserSampleMock } from '@mocks/storylist.mock';
 
-// Blueprint de la CollectionPage V3 (spike). Página temporal en /collection/:slug con placeholders para cada
-// región del diseño de Figma; se irá reemplazando por los componentes reales. Marcada `noindex` mientras es
-// un placeholder (no debe indexarse ni competir con /storylist/:slug).
+// Blueprint de la CollectionPage V3 (spike). Página en /collection/:slug: trae la colección real desde Sanity por
+// slug (misma vía que /storylist/:slug) y la renderiza con los componentes V3. Marcada `noindex` mientras el
+// diseño se estabiliza; por eso el fetch es no bloqueante (progressiveRxResource). La lista de «colecciones
+// sugeridas» todavía usa datos de ejemplo (no hay endpoint de sugeridas).
 @Component({
 	selector: 'cuentoneta-collection',
 	imports: [
@@ -21,15 +28,33 @@ import { storylistMock, storylistTeaserSampleMock } from '@mocks/storylist.mock'
 		PortableTextParserComponent,
 		CoverImageComponent,
 		NavigableCollectionTeaserComponent,
+		NavigableCollectionTeaserSkeletonComponent,
+		SkeletonComponent,
+		DrawerComponent,
+		ButtonComponent,
 	],
 	hostDirectives: [HeadMetadataDirective],
 	templateUrl: './collection.component.html',
 })
 export default class CollectionComponent {
-	public readonly slug = input<string>();
+	public readonly slug = input.required<string>();
 
-	// Datos de ejemplo del corpus Onoff mientras el blueprint no consume un servicio real.
-	protected readonly collection = storylistMock;
+	private readonly storylistService = inject(StorylistApi);
+
+	private readonly collectionResource = progressiveRxResource({
+		params: this.slug,
+		stream: ({ params }) => this.storylistService.get(params, 60, 'asc'),
+		defaultValue: undefined,
+	});
+	// `value()` lanza si el resource está en error; `hasValue()` no. Así el estado de error cae a "sin resultados".
+	protected readonly collection = computed(() =>
+		this.collectionResource.hasValue() ? this.collectionResource.value() : undefined,
+	);
+	protected readonly isLoading = this.collectionResource.isLoading;
+
+	// Descripción del sidebar recortada a 8 líneas: se muestra "Leer más" solo si el texto real desborda el clamp.
+	private readonly descriptionEl = viewChild<ElementRef<HTMLElement>>('description');
+	protected readonly isDescriptionOverflowing = signal(false);
 
 	// Colecciones sugeridas de ejemplo (distintas de la actual y con categorías variadas para el blueprint).
 	protected readonly suggestedCollections: StorylistTeaser[] = [
@@ -63,5 +88,15 @@ export default class CollectionComponent {
 		this.metaTagsDirective.setDefaultDescription();
 		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl('collection'));
 		this.metaTagsDirective.setRobots('noindex, nofollow');
+
+		// Mide el desborde del clamp después de renderizar (scrollHeight real vs. alto visible) y expone el
+		// resultado a la plantilla. `earlyRead` lee el DOM; `write` fija el signal con ese valor.
+		afterRenderEffect({
+			earlyRead: () => {
+				const el = this.descriptionEl()?.nativeElement;
+				return !!el && el.scrollHeight > el.clientHeight + 1;
+			},
+			write: (overflowing) => this.isDescriptionOverflowing.set(overflowing()),
+		});
 	}
 }

--- a/src/app/pages/collection/collection.component.ts
+++ b/src/app/pages/collection/collection.component.ts
@@ -1,24 +1,11 @@
 // Core
-import {
-	afterRenderEffect,
-	Component,
-	computed,
-	effect,
-	ElementRef,
-	inject,
-	input,
-	signal,
-	untracked,
-	viewChild,
-} from '@angular/core';
-import { map } from 'rxjs';
+import { Component, computed, effect, inject, input, untracked } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { DomSanitizer } from '@angular/platform-browser';
 
 // Utils
 import { progressiveRxResource } from '@app-utils/ssr-resource';
 import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
-
-// Models
-import type { CollectionTeaser } from '@models/collection.model';
 
 // Services
 import { CollectionApi } from '../../providers/collection-api.interface';
@@ -26,6 +13,9 @@ import { CollectionApi } from '../../providers/collection-api.interface';
 // SEO
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { AppRoutes } from '../../app.routes';
+
+// Directives
+import { ClampOverflowDirective } from '../../directives/clamp-overflow.directive';
 
 // Components
 import { LiteraryWorkCardTeaserComponent } from '@components/literary-work-card-teaser/literary-work-card-teaser.component';
@@ -37,13 +27,15 @@ import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 import { DrawerComponent } from '@components/drawer/drawer.component';
 import { ButtonComponent } from '@components/button/button.component';
 
-// Blueprint de la CollectionPage V3 (spike). Página en /collection/:slug alimentada por el dominio Collection
-// real —el que la épica fue construyendo desde este mismo spike— y renderizada con los componentes del Design
-// System v3. Marcada `noindex` mientras el diseño se estabiliza; por eso el fetch es no bloqueante
-// (progressiveRxResource) y no declara directivas de meta tags ni de datos estructurados.
+// Blueprint de la CollectionPage V3 (spike). Página en /collection/:slug alimentada por el dominio Collection y
+// renderizada con los componentes del Design System v3. Marcada `noindex` mientras el diseño se estabiliza; por
+// eso el fetch es no bloqueante (progressiveRxResource) y no declara directivas de meta tags ni de datos
+// estructurados.
 @Component({
 	selector: 'cuentoneta-collection',
 	imports: [
+		NgTemplateOutlet,
+		ClampOverflowDirective,
 		LiteraryWorkCardTeaserComponent,
 		TagComponent,
 		CoverImageComponent,
@@ -61,7 +53,16 @@ export default class CollectionComponent {
 
 	private readonly suggestedCollectionsCount = 3;
 
+	// Posiciones del abanico de portadas cuando la colección no tiene una editorial propia: [0] central al
+	// frente con bottom-bleed, [1] y [2] laterales desplazadas. Mismas que en CollectionTeaserCard.
+	protected readonly sampleImageClasses = [
+		'absolute bottom-[-8px] left-1/2 z-20 -translate-x-1/2 border-[3px] border-neutral-100',
+		'absolute top-[calc(50%_+_39.35px)] left-[calc(50%_-_82.75px)] z-10 -translate-x-1/2 -translate-y-1/2 border-[3px] border-neutral-100',
+		'absolute top-[calc(50%_+_39.35px)] left-[calc(50%_+_83.03px)] z-10 -translate-x-1/2 -translate-y-1/2 border-[3px] border-neutral-100',
+	] as const;
+
 	private readonly collectionApi = inject(CollectionApi);
+	private readonly sanitizer = inject(DomSanitizer);
 
 	private readonly collectionResource = progressiveRxResource({
 		params: this.slug,
@@ -74,26 +75,27 @@ export default class CollectionComponent {
 	);
 	protected readonly isLoading = this.collectionResource.isLoading;
 
-	// Las «otras colecciones sugeridas» salen del catálogo real, descartando la que se está viendo. No hay
-	// todavía un criterio de recomendación: el recorte a las primeras tres es del blueprint, no del producto.
-	private readonly suggestedCollectionsResource = progressiveRxResource({
-		params: this.slug,
-		stream: ({ params }) =>
-			this.collectionApi
-				.getAll()
-				.pipe(
-					map((teasers) => teasers.filter((teaser) => teaser.slug !== params).slice(0, this.suggestedCollectionsCount)),
-				),
+	// El backend entrega la descripción ya saneada por el pipeline compartido, y el brand del tipo es la prueba
+	// de que pasó por ahí. Sin el bypass, el sanitizer de Angular vuelve a recortar una marcación que ya está
+	// acotada a la allow-list, y el énfasis de la prosa se pierde.
+	protected readonly safeDescription = computed(() => {
+		const collection = this.collection();
+		return collection ? this.sanitizer.bypassSecurityTrustHtml(collection.description) : undefined;
+	});
+
+	// El catálogo entero se pide una vez: no depende del slug, así que navegar entre colecciones lo filtra de
+	// nuevo en vez de volver a pedirlo.
+	private readonly catalogResource = progressiveRxResource({
+		stream: () => this.collectionApi.getAll(),
 		defaultValue: [],
 	});
 	// Bloque accesorio: si el catálogo falla, el sidebar se queda sin sugeridas en vez de romper la página.
-	protected readonly suggestedCollections = computed<readonly CollectionTeaser[]>(() =>
-		this.suggestedCollectionsResource.hasValue() ? this.suggestedCollectionsResource.value() : [],
+	// Todavía no hay criterio de recomendación: el recorte es del blueprint, no del producto.
+	protected readonly suggestedCollections = computed(() =>
+		(this.catalogResource.hasValue() ? this.catalogResource.value() : [])
+			.filter((teaser) => teaser.slug !== this.slug())
+			.slice(0, this.suggestedCollectionsCount),
 	);
-
-	// Descripción del sidebar recortada a 8 líneas: se muestra "Leer más" solo si el texto real desborda el clamp.
-	private readonly descriptionEl = viewChild<ElementRef<HTMLElement>>('description');
-	protected readonly isDescriptionOverflowing = signal(false);
 
 	private readonly head = inject(HeadMetadataDirective);
 
@@ -106,16 +108,4 @@ export default class CollectionComponent {
 			this.head.setCanonicalUrl(buildCanonicalUrl(`${AppRoutes.Collection}/${slug}`));
 		});
 	});
-
-	constructor() {
-		// Mide el desborde del clamp después de renderizar (scrollHeight real vs. alto visible) y expone el
-		// resultado a la plantilla. `earlyRead` lee el DOM; `write` fija el signal con ese valor.
-		afterRenderEffect({
-			earlyRead: () => {
-				const el = this.descriptionEl()?.nativeElement;
-				return !!el && el.scrollHeight > el.clientHeight + 1;
-			},
-			write: (overflowing) => this.isDescriptionOverflowing.set(overflowing()),
-		});
-	}
 }

--- a/src/app/pages/collection/collection.component.ts
+++ b/src/app/pages/collection/collection.component.ts
@@ -1,31 +1,51 @@
-import { afterRenderEffect, Component, computed, ElementRef, inject, input, signal, viewChild } from '@angular/core';
+// Core
+import {
+	afterRenderEffect,
+	Component,
+	computed,
+	effect,
+	ElementRef,
+	inject,
+	input,
+	signal,
+	untracked,
+	viewChild,
+} from '@angular/core';
+import { map } from 'rxjs';
 
-import type { StorylistTeaser } from '@models/storylist.model';
-import { StorylistApi } from '../../providers/storylist-api.interface';
+// Utils
+import { progressiveRxResource } from '@app-utils/ssr-resource';
+import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+
+// Models
+import type { CollectionTeaser } from '@models/collection.model';
+
+// Services
+import { CollectionApi } from '../../providers/collection-api.interface';
+
+// SEO
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
-import { buildCanonicalUrl } from '@utils/build-canonical-url.util';
-import { progressiveRxResource } from '@utils/ssr-resource';
-import { StoryCardTeaserV3Component } from '@components/story-card-teaser-v3/story-card-teaser-v3.component';
+import { AppRoutes } from '../../app.routes';
+
+// Components
+import { LiteraryWorkCardTeaserComponent } from '@components/literary-work-card-teaser/literary-work-card-teaser.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { PortableTextParserComponent } from '@components/portable-text-parser/portable-text-parser.component';
 import { CoverImageComponent } from '@components/cover-image/cover-image.component';
 import { NavigableCollectionTeaserComponent } from '@components/navigable-collection-teaser/navigable-collection-teaser.component';
 import { NavigableCollectionTeaserSkeletonComponent } from '@components/navigable-collection-teaser/navigable-collection-teaser-skeleton.component';
 import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 import { DrawerComponent } from '@components/drawer/drawer.component';
 import { ButtonComponent } from '@components/button/button.component';
-import { storylistTeaserSampleMock } from '@mocks/storylist.mock';
 
-// Blueprint de la CollectionPage V3 (spike). Página en /collection/:slug: trae la colección real desde Sanity por
-// slug (misma vía que /storylist/:slug) y la renderiza con los componentes V3. Marcada `noindex` mientras el
-// diseño se estabiliza; por eso el fetch es no bloqueante (progressiveRxResource). La lista de «colecciones
-// sugeridas» todavía usa datos de ejemplo (no hay endpoint de sugeridas).
+// Blueprint de la CollectionPage V3 (spike). Página en /collection/:slug alimentada por el dominio Collection
+// real —el que la épica fue construyendo desde este mismo spike— y renderizada con los componentes del Design
+// System v3. Marcada `noindex` mientras el diseño se estabiliza; por eso el fetch es no bloqueante
+// (progressiveRxResource) y no declara directivas de meta tags ni de datos estructurados.
 @Component({
 	selector: 'cuentoneta-collection',
 	imports: [
-		StoryCardTeaserV3Component,
+		LiteraryWorkCardTeaserComponent,
 		TagComponent,
-		PortableTextParserComponent,
 		CoverImageComponent,
 		NavigableCollectionTeaserComponent,
 		NavigableCollectionTeaserSkeletonComponent,
@@ -39,11 +59,13 @@ import { storylistTeaserSampleMock } from '@mocks/storylist.mock';
 export default class CollectionComponent {
 	public readonly slug = input.required<string>();
 
-	private readonly storylistService = inject(StorylistApi);
+	private readonly suggestedCollectionsCount = 3;
+
+	private readonly collectionApi = inject(CollectionApi);
 
 	private readonly collectionResource = progressiveRxResource({
 		params: this.slug,
-		stream: ({ params }) => this.storylistService.get(params, 60, 'asc'),
+		stream: ({ params }) => this.collectionApi.getBySlug(params),
 		defaultValue: undefined,
 	});
 	// `value()` lanza si el resource está en error; `hasValue()` no. Así el estado de error cae a "sin resultados".
@@ -52,43 +74,40 @@ export default class CollectionComponent {
 	);
 	protected readonly isLoading = this.collectionResource.isLoading;
 
+	// Las «otras colecciones sugeridas» salen del catálogo real, descartando la que se está viendo. No hay
+	// todavía un criterio de recomendación: el recorte a las primeras tres es del blueprint, no del producto.
+	private readonly suggestedCollectionsResource = progressiveRxResource({
+		params: this.slug,
+		stream: ({ params }) =>
+			this.collectionApi
+				.getAll()
+				.pipe(
+					map((teasers) => teasers.filter((teaser) => teaser.slug !== params).slice(0, this.suggestedCollectionsCount)),
+				),
+		defaultValue: [],
+	});
+	// Bloque accesorio: si el catálogo falla, el sidebar se queda sin sugeridas en vez de romper la página.
+	protected readonly suggestedCollections = computed<readonly CollectionTeaser[]>(() =>
+		this.suggestedCollectionsResource.hasValue() ? this.suggestedCollectionsResource.value() : [],
+	);
+
 	// Descripción del sidebar recortada a 8 líneas: se muestra "Leer más" solo si el texto real desborda el clamp.
 	private readonly descriptionEl = viewChild<ElementRef<HTMLElement>>('description');
 	protected readonly isDescriptionOverflowing = signal(false);
 
-	// Colecciones sugeridas de ejemplo (distintas de la actual y con categorías variadas para el blueprint).
-	protected readonly suggestedCollections: StorylistTeaser[] = [
-		{
-			...storylistTeaserSampleMock,
-			count: 12,
-			tags: [{ title: 'Curaduría', slug: 'curaduria', shortDescription: '', description: [] }],
-		},
-		{
-			...storylistTeaserSampleMock,
-			_id: 'onoff-creaciones',
-			slug: 'creaciones-de-navidad',
-			title: 'Creaciones de Navidad',
-			count: 8,
-			tags: [{ title: 'Antología', slug: 'antologia', shortDescription: '', description: [] }],
-		},
-		{
-			...storylistTeaserSampleMock,
-			_id: 'onoff-textos-invierno',
-			slug: 'textos-de-invierno',
-			title: 'Textos de invierno',
-			count: 6,
-			tags: [{ title: 'Selección', slug: 'seleccion', shortDescription: '', description: [] }],
-		},
-	];
+	private readonly head = inject(HeadMetadataDirective);
 
-	private readonly metaTagsDirective = inject(HeadMetadataDirective);
+	private readonly applyHeadMetadataEffect = effect(() => {
+		const slug = this.slug();
+		untracked(() => {
+			this.head.setRobots('noindex, nofollow');
+			this.head.setTitle('Colección (blueprint)');
+			this.head.setDefaultDescription();
+			this.head.setCanonicalUrl(buildCanonicalUrl(`${AppRoutes.Collection}/${slug}`));
+		});
+	});
 
 	constructor() {
-		this.metaTagsDirective.setTitle('Colección (blueprint)');
-		this.metaTagsDirective.setDefaultDescription();
-		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl('collection'));
-		this.metaTagsDirective.setRobots('noindex, nofollow');
-
 		// Mide el desborde del clamp después de renderizar (scrollHeight real vs. alto visible) y expone el
 		// resultado a la plantilla. `earlyRead` lee el DOM; `write` fija el signal con ese valor.
 		afterRenderEffect({

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -6,6 +6,7 @@ import { getTestBed } from '@angular/core/testing';
 import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 
 import { installIntersectionObserverStub } from '@testing/intersection-observer.stub';
+import { installResizeObserverStub } from '@testing/resize-observer.stub';
 
 // Angular 22 corre el TestBed en modo zoneless por defecto cuando zone.js no está presente,
 // por eso no se provee `provideZonelessChangeDetection()` explícitamente. El ErrorHandler relanza
@@ -32,3 +33,6 @@ getTestBed().initTestEnvironment([BrowserTestingModule, ZonelessTestModule], pla
 // jsdom/happy-dom no implementan IntersectionObserver: se instala un stub global para todos los tests.
 // Los specs que necesitan controlar el observer (simular overflow) reutilizan los helpers del mismo stub.
 installIntersectionObserverStub();
+
+// Ídem ResizeObserver: lo usan las directivas que reaccionan al alto o al ancho real de su host.
+installResizeObserverStub();

--- a/src/testing/resize-observer.stub.ts
+++ b/src/testing/resize-observer.stub.ts
@@ -1,0 +1,48 @@
+// Stub global de ResizeObserver para tests (el entorno de tests no lo implementa). Se instala en
+// test-setup para que las directivas que miden su host se puedan renderizar, y expone el control que un
+// observer real no da: qué elementos están observados y cuándo se entrega el callback.
+//
+// El entorno de tests no computa layout, así que un ResizeObserver real nunca dispararía y las medidas
+// darían todas cero. Estos helpers sustituyen ese entorno: `setMeasuredSize` fija el alto real y el
+// visible de un elemento, y `triggerResize` entrega el callback de forma síncrona.
+let callbacks: ResizeObserverCallback[] = [];
+let observed: Element[] = [];
+
+class ResizeObserverStub {
+	constructor(callback: ResizeObserverCallback) {
+		callbacks.push(callback);
+	}
+	public observe(target: Element): void {
+		observed.push(target);
+	}
+	public unobserve(): void {
+		return;
+	}
+	public disconnect(): void {
+		return;
+	}
+}
+
+/** Instala el stub como `ResizeObserver` global y resetea el estado capturado. */
+export function installResizeObserverStub(): void {
+	(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub;
+	callbacks = [];
+	observed = [];
+}
+
+/**
+ * Fija el alto del contenido y el alto visible de un elemento, que el entorno de tests deja en cero.
+ * Un `scrollHeight` mayor que el `clientHeight` es lo que una directiva de recorte lee como desborde.
+ */
+export function setMeasuredSize(element: Element, size: { scrollHeight: number; clientHeight: number }): void {
+	Object.defineProperty(element, 'scrollHeight', { value: size.scrollHeight, configurable: true });
+	Object.defineProperty(element, 'clientHeight', { value: size.clientHeight, configurable: true });
+}
+
+/** Entrega el callback de todos los observers creados, como haría un resize real. */
+export function triggerResize(): void {
+	const entries = observed.map((target) => ({ target }) as ResizeObserverEntry);
+	for (const callback of callbacks) {
+		callback(entries, {} as ResizeObserver);
+	}
+}


### PR DESCRIPTION
> **Spike / blueprint** de la página Story**list → Collection** V3 (#1472). No está pensado para mergearse tal cual: valida los building blocks, la estructura de la página y las interacciones sobre datos reales, con decisiones marcadas para extraer a issues/PRs propios.

> **Actualización (rebase sobre `develop`, 2.10.0):** la rama se rebaseó sobre `develop` —casi mil commits después del corte original— y el blueprint se **realimentó con lo que la épica ya mergeó**. Cuando se escribió, la colección solo existía como `Storylist` y las obras se renderizaban con `StoryCardTeaserV3`; hoy el repo tiene el dominio `Collection` completo y la tríada de tarjetas renombrada a `LiteraryWork`, así que el prototipo pasó a consumirlos en vez de seguir describiendo una arquitectura que ya no es la del repo.

## Qué incluye

**Ruta y página** — `/collection/:slug` (temporal, `noindex`). La página se alimenta del **agregado `Collection` real** vía `CollectionApi.getBySlug()` + `progressiveRxResource` (no bloqueante por ser `noindex`; migrar a `ssrBlockingRxResource` cuando pase a indexable). Tres estados: **skeletons de carga**, contenido, y **not-found**.

**Layout de dos columnas** reproducido con componentes V3 reales:

- Izquierda: título + lista de `LiteraryWorkCardTeaser` (destacada + planas con divisor, clamp de excerpt condicional).
- Sidebar: portada + título + `Tag` (filled) + descripción + lista de «Otras colecciones sugeridas» con `NavigableCollectionTeaser`. La portada es la editorial propia (`imagery.representative`) o el abanico con las de sus obras (`imagery.sample`).

**Descripción con "Leer más" + Drawer** (nodos Figma 4798-5532 / 4801-15255):

- La descripción del sidebar se recorta a **8 líneas** (`line-clamp-[8]`); la nueva directiva `ClampOverflowDirective` mide el desborde real con `ResizeObserver` para mostrar **"Leer más"** solo cuando está truncada, y reaccionar al ancho.
- "Leer más" abre el **`DrawerComponent`** del DS v3 con la descripción completa: portada, tag, texto y colecciones sugeridas, proyectadas por `<ng-content>`.

## Qué cambió respecto de la versión anterior del spike

- **Datos**: `StorylistApi.get()` → **`CollectionApi.getBySlug()`**. La página recibe un `Collection` con sus obras como `LiteraryWorkTeaser` y su `count` derivado por la factory.
- **Tarjetas**: `StoryCardTeaserV3` → **`LiteraryWorkCardTeaser`**, alimentada con la obra del agregado (el extracto sale de su `teaserSection`, sin puente de Portable Text).
- **Descripción**: era Portable Text parseado por `PortableTextParser`; ahora llega como **HTML ya saneado por el ACL** y se inyecta con `innerHTML` + `bypassSecurityTrustHtml`, igual que en `CollectionTeaserCard`.
- **Sugeridas**: dejan de ser datos de ejemplo. Salen de **`CollectionApi.getAll()`** (pedido una vez) descartando la colección que se está viendo. Sigue sin haber criterio de recomendación: el recorte a tres es del blueprint.
- **`NavigableCollectionTeaser`** pasa a tipar su input contra **`CollectionTeaser`**, y sus stories y spec al corpus de `Collection`. Se actualiza también la story de composición del `Drawer`, que decía replicar esta página y seguía en Portable Text.
- **Nueva `ClampOverflowDirective`** (`src/app/directives/`) + stub global de `ResizeObserver` en `@testing/`, que hacen testeable la medición y con ella el flujo de "Leer más".
- **Canónica** por ruta + slug, emitida en un `effect`. La página sigue `noindex` y sin datos estructurados, conforme al guardrail de directivas de SEO.
- Imports migrados a `@app-utils/*` y specs reescritos sobre el **canon de Onoff** (`onoffCollectionsMock` + `StubCollectionApi`).

## Deuda declarada (para la implementación real, no para el spike)

- **Estado de error**: la página resuelve el fallo con el cartel de "no encontramos esta colección" y responde **200**. `read.page.ts` ya distingue 404 de 503 vía `RESPONSE_INIT`, y el porqué está documentado ahí: un fallo transitorio servido como 200 lo cachea el borde como contenido y el crawler lo lee como soft-404. Al indexar la ruta, hay que replicarlo.
- **Duplicación sidebar/drawer**: la portada y la lista de sugeridas se comparten hoy con plantillas proyectadas dentro de la misma página. La versión real pide extraerlas a componentes propios (con su story).
- **`StubCollectionApi.getBySlug()`** cae a la primera colección cuando el slug no matchea, así que un "no encontrado" genuino no es simulable con el doble; los tests lo fuerzan con un error. Vale revisarlo cuando el doble tenga más consumidores.
- **Clamp del excerpt**: los tests de 3 vs 4 líneas afirman sobre una clase de Tailwind y sobre el `data-testid` interno de la tarjeta. Es la única forma hoy de observar esa decisión de la página.

## Notas

- Las «colecciones sugeridas» son las primeras del catálogo, no una recomendación.
- Fidelidad diferida del drawer: el diseño repite las sugeridas y un abanico de 3 covers; acá el drawer se enfocó en la descripción completa.
- No integra ni reemplaza la página `/storylist/:slug` existente.
- Los teasers de obra enlazan a `/story/:slug` y no a `/read/:slug`: lo decide `LiteraryWorkCardTeaser`, que mantiene el destino viejo mientras `/read` siga con el opt-out de indexación.

Verificado en local: `typecheck`, `lint`, `test` (1807 verdes), `build` y `storybook:build`.

Spike de #1472.
