### PR TITLE
[#1827] - [DS V3] DrawerComponent — panel modal direccional con transiciones

### DIFF
--- a/src/app/components/drawer/drawer-footer.directive.ts
+++ b/src/app/components/drawer/drawer-footer.directive.ts
@@ -1,0 +1,7 @@
+import { Directive, inject, TemplateRef } from '@angular/core';
+
+/** Marca el `<ng-template>` a proyectar como pie del drawer: `<ng-template cuentonetaDrawerFooter>…</ng-template>`. */
+@Directive({ selector: '[cuentonetaDrawerFooter]' })
+export class DrawerFooterDirective {
+	public readonly templateRef = inject(TemplateRef);
+}

--- a/src/app/components/drawer/drawer-header.directive.ts
+++ b/src/app/components/drawer/drawer-header.directive.ts
@@ -1,0 +1,7 @@
+import { Directive, inject, TemplateRef } from '@angular/core';
+
+/** Marca el `<ng-template>` a proyectar como encabezado del drawer: `<ng-template cuentonetaDrawerHeader>…</ng-template>`. */
+@Directive({ selector: '[cuentonetaDrawerHeader]' })
+export class DrawerHeaderDirective {
+	public readonly templateRef = inject(TemplateRef);
+}

--- a/src/app/components/drawer/drawer-panel.directive.ts
+++ b/src/app/components/drawer/drawer-panel.directive.ts
@@ -6,18 +6,23 @@ import type { DrawerDirection } from './drawer.component';
  * Calcula las clases de posición, tamaño y transform del panel del drawer según su dirección. Se aplica como
  * `hostDirective` de `DrawerComponent` con el input `direction` forwardeado. El par de transforms (offset base
  * + `data-[open]:...`) resuelve el slide en combinación con la transición declarada en el propio componente.
+ *
+ * El panel flota con un gap de `spacing/4` (16px) respecto de los bordes del viewport —igual que el contenedor
+ * del Drawer en Figma—: el borde anclado más los dos perpendiculares. El offset de salida es `120%` (relativo al
+ * propio tamaño), que oculta el panel por completo pese al margen. Los `*-auto` resetean el `inset: 0` que el
+ * user-agent aplica a `dialog:modal` en el borde opuesto al anclado (si no, ese borde quedaría pegado en `0`).
  */
 @Directive({})
 export class DrawerPanelDirective {
 	public readonly direction = input<DrawerDirection>('right');
 
 	private readonly panelConfig: Record<DrawerDirection, string> = {
-		left: 'inset-y-0 left-0 h-full w-screen sm:w-[704px] -translate-x-full data-[open]:translate-x-0 drawer-left',
+		left: 'left-4 right-auto top-4 h-[calc(100vh_-_2rem)] max-h-none w-[calc(100vw_-_2rem)] sm:w-[704px] -translate-x-[120%] data-[open]:translate-x-0 drawer-left',
 		right:
-			'inset-y-0 right-0 ml-auto h-full w-screen sm:w-[704px] translate-x-full data-[open]:translate-x-0 drawer-right',
-		top: 'inset-x-0 top-0 h-full w-screen sm:max-h-3/4 -translate-y-full data-[open]:translate-y-0 drawer-top',
+			'right-4 left-auto top-4 h-[calc(100vh_-_2rem)] max-h-none w-[calc(100vw_-_2rem)] sm:w-[704px] translate-x-[120%] data-[open]:translate-x-0 drawer-right',
+		top: 'left-4 top-4 bottom-auto w-[calc(100vw_-_2rem)] max-h-[calc(100vh_-_2rem)] -translate-y-[120%] data-[open]:translate-y-0 drawer-top',
 		bottom:
-			'inset-x-0 bottom-0 mt-auto h-full w-screen sm:max-h-3/4 translate-y-full data-[open]:translate-y-0 drawer-bottom',
+			'bottom-4 top-auto left-4 w-[calc(100vw_-_2rem)] max-h-[calc(100vh_-_2rem)] translate-y-[120%] data-[open]:translate-y-0 drawer-bottom',
 	};
 
 	public readonly panelClasses = computed(() => this.panelConfig[this.direction()]);

--- a/src/app/components/drawer/drawer-panel.directive.ts
+++ b/src/app/components/drawer/drawer-panel.directive.ts
@@ -1,0 +1,24 @@
+import { computed, Directive, input } from '@angular/core';
+
+import type { DrawerDirection } from './drawer.component';
+
+/**
+ * Calcula las clases de posición, tamaño y transform del panel del drawer según su dirección. Se aplica como
+ * `hostDirective` de `DrawerComponent` con el input `direction` forwardeado. El par de transforms (offset base
+ * + `data-[open]:...`) resuelve el slide en combinación con la transición declarada en el propio componente.
+ */
+@Directive({})
+export class DrawerPanelDirective {
+	public readonly direction = input<DrawerDirection>('right');
+
+	private readonly panelConfig: Record<DrawerDirection, string> = {
+		left: 'inset-y-0 left-0 h-full w-screen sm:w-[704px] -translate-x-full data-[open]:translate-x-0 drawer-left',
+		right:
+			'inset-y-0 right-0 ml-auto h-full w-screen sm:w-[704px] translate-x-full data-[open]:translate-x-0 drawer-right',
+		top: 'inset-x-0 top-0 h-full w-screen sm:max-h-3/4 -translate-y-full data-[open]:translate-y-0 drawer-top',
+		bottom:
+			'inset-x-0 bottom-0 mt-auto h-full w-screen sm:max-h-3/4 translate-y-full data-[open]:translate-y-0 drawer-bottom',
+	};
+
+	public readonly panelClasses = computed(() => this.panelConfig[this.direction()]);
+}

--- a/src/app/components/drawer/drawer-tracker.service.spec.ts
+++ b/src/app/components/drawer/drawer-tracker.service.spec.ts
@@ -1,0 +1,31 @@
+import { DrawerTrackerService } from './drawer-tracker.service';
+import type { DrawerComponent } from './drawer.component';
+
+const drawerStub = (): DrawerComponent => ({}) as unknown as DrawerComponent;
+
+describe('DrawerTrackerService', () => {
+	it('should generate incrementing ids', () => {
+		const tracker = new DrawerTrackerService();
+		expect(tracker.nextId()).toBe(1);
+		expect(tracker.nextId()).toBe(2);
+	});
+
+	it('should allow registering a single drawer', () => {
+		const tracker = new DrawerTrackerService();
+		expect(() => tracker.register(drawerStub())).not.toThrow();
+	});
+
+	it('should throw when a second drawer registers while one is active', () => {
+		const tracker = new DrawerTrackerService();
+		tracker.register(drawerStub());
+		expect(() => tracker.register(drawerStub())).toThrow('Only one drawer can be active at a time.');
+	});
+
+	it('should allow registering again after the active drawer unregisters', () => {
+		const tracker = new DrawerTrackerService();
+		const first = drawerStub();
+		tracker.register(first);
+		tracker.unregister(first);
+		expect(() => tracker.register(drawerStub())).not.toThrow();
+	});
+});

--- a/src/app/components/drawer/drawer-tracker.service.ts
+++ b/src/app/components/drawer/drawer-tracker.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+
+import type { DrawerComponent } from './drawer.component';
+
+/**
+ * Registro global de drawers: garantiza que haya un solo drawer activo a la vez y genera ids únicos para los
+ * atributos aria de cada instancia. Es la única pieza con estado compartido entre instancias de `DrawerComponent`,
+ * por eso vive en un servicio singleton (`providedIn: 'root'`).
+ */
+@Injectable({ providedIn: 'root' })
+export class DrawerTrackerService {
+	private activeInstance: DrawerComponent | null = null;
+	private instanceCount = 0;
+
+	public nextId(): number {
+		return ++this.instanceCount;
+	}
+
+	public register(drawer: DrawerComponent): void {
+		if (this.activeInstance) {
+			throw new Error('Only one drawer can be active at a time.');
+		}
+		this.activeInstance = drawer;
+	}
+
+	public unregister(drawer: DrawerComponent): void {
+		if (this.activeInstance === drawer) {
+			this.activeInstance = null;
+		}
+	}
+}

--- a/src/app/components/drawer/drawer-transition.directive.spec.ts
+++ b/src/app/components/drawer/drawer-transition.directive.spec.ts
@@ -1,0 +1,40 @@
+import { DrawerTransitionDirective } from './drawer-transition.directive';
+
+const nextFrame = (): Promise<void> => new Promise((resolve) => requestAnimationFrame(() => resolve()));
+
+describe('DrawerTransitionDirective', () => {
+	let directive: DrawerTransitionDirective;
+	let dialog: HTMLDialogElement;
+
+	beforeEach(() => {
+		directive = new DrawerTransitionDirective();
+		dialog = document.createElement('dialog');
+		document.body.appendChild(dialog);
+	});
+
+	afterEach(() => dialog.remove());
+
+	it('should open the dialog and flag the transition on the next frame', async () => {
+		directive.open(dialog);
+		expect(dialog.open).toBe(true);
+		expect(directive.isTransitionedIn()).toBe(false);
+
+		await nextFrame();
+		expect(directive.isTransitionedIn()).toBe(true);
+	});
+
+	it('should close the dialog only after transitionend fires', async () => {
+		directive.open(dialog);
+		await nextFrame();
+
+		let completed = false;
+		directive.close(dialog, () => (completed = true));
+		expect(directive.isTransitionedIn()).toBe(false);
+		expect(dialog.open).toBe(true);
+
+		// happy-dom no ejecuta transiciones CSS reales: se despacha `transitionend` a mano.
+		dialog.dispatchEvent(new Event('transitionend'));
+		expect(dialog.open).toBe(false);
+		expect(completed).toBe(true);
+	});
+});

--- a/src/app/components/drawer/drawer-transition.directive.ts
+++ b/src/app/components/drawer/drawer-transition.directive.ts
@@ -1,0 +1,33 @@
+import { Directive, signal } from '@angular/core';
+
+/**
+ * Orquesta la transición de entrada/salida del drawer. Expone `isTransitionedIn` como signal para que
+ * `DrawerComponent` maneje el atributo `data-open` de forma declarativa en la plantilla; solo el timing de
+ * pintado (`requestAnimationFrame`) y el fin de la transición CSS (`transitionend`) se manejan de forma
+ * imperativa, porque son Web APIs sin equivalente reactivo. Se aplica como `hostDirective` de `DrawerComponent`.
+ */
+@Directive({})
+export class DrawerTransitionDirective {
+	private readonly _isTransitionedIn = signal(false);
+	public readonly isTransitionedIn = this._isTransitionedIn.asReadonly();
+
+	/** Abre el diálogo y dispara el slide-in después de un frame (para que el navegador aplique primero el estado cerrado). */
+	public open(element: HTMLDialogElement): void {
+		element.showModal();
+		requestAnimationFrame(() => this._isTransitionedIn.set(true));
+	}
+
+	/** Dispara la transición de salida y llama a `onComplete` recién después de `transitionend`. */
+	public close(element: HTMLDialogElement, onComplete: () => void): void {
+		this._isTransitionedIn.set(false);
+		const handler = (event: Event): void => {
+			if (event.target !== element) {
+				return;
+			}
+			element.removeEventListener('transitionend', handler);
+			element.close();
+			onComplete();
+		};
+		element.addEventListener('transitionend', handler);
+	}
+}

--- a/src/app/components/drawer/drawer.component.spec.ts
+++ b/src/app/components/drawer/drawer.component.spec.ts
@@ -1,9 +1,12 @@
 import { Component } from '@angular/core';
-import { fireEvent, render, screen } from '@testing-library/angular';
+import { TestBed } from '@angular/core/testing';
+import { render, screen } from '@testing-library/angular';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
 
 import { DrawerComponent, DrawerDirection } from './drawer.component';
 import { DrawerHeaderDirective } from './drawer-header.directive';
 import { DrawerFooterDirective } from './drawer-footer.directive';
+import { DrawerTrackerService } from './drawer-tracker.service';
 
 @Component({
 	imports: [DrawerComponent, DrawerHeaderDirective, DrawerFooterDirective],
@@ -44,9 +47,11 @@ class HostComponent {
 }
 
 const getDialog = (): HTMLDialogElement => screen.getByRole('dialog', { hidden: true }) as HTMLDialogElement;
-const openDrawer = (): void => {
-	fireEvent.click(screen.getByRole('button', { name: 'Abrir' }));
+const openDrawer = async (user: UserEvent): Promise<void> => {
+	await user.click(screen.getByRole('button', { name: 'Abrir' }));
 };
+// El tracker solo guarda la referencia; para probar registro/desregistro alcanza un doble vacío.
+const drawerStub = (): DrawerComponent => ({}) as unknown as DrawerComponent;
 
 describe('DrawerComponent', () => {
 	it('should project its content', async () => {
@@ -55,64 +60,85 @@ describe('DrawerComponent', () => {
 	});
 
 	it('should open the native dialog and emit opened', async () => {
+		const user = userEvent.setup();
 		const { fixture } = await render(HostComponent);
-		openDrawer();
+		await openDrawer(user);
 		expect(getDialog().open).toBe(true);
 		expect(fixture.componentInstance.openedCount).toBe(1);
 	});
 
 	it('should not open twice while already open', async () => {
+		const user = userEvent.setup();
 		const { fixture } = await render(HostComponent);
-		openDrawer();
-		openDrawer();
+		await openDrawer(user);
+		await openDrawer(user);
 		expect(fixture.componentInstance.openedCount).toBe(1);
 	});
 
 	it('should close via the X button: emit closed immediately and afterClosed on transitionend', async () => {
+		const user = userEvent.setup();
 		const { fixture } = await render(HostComponent);
-		openDrawer();
+		await openDrawer(user);
 		const dialog = getDialog();
 
-		fireEvent.click(screen.getByRole('button', { name: 'Cerrar' }));
+		await user.click(screen.getByRole('button', { name: 'Cerrar' }));
 		expect(fixture.componentInstance.closedCount).toBe(1);
 		expect(dialog.open).toBe(true); // aún abierto hasta que termina la transición
 
-		fireEvent(dialog, new Event('transitionend'));
+		dialog.dispatchEvent(new Event('transitionend'));
 		expect(dialog.open).toBe(false);
 		expect(fixture.componentInstance.afterClosedCount).toBe(1);
 	});
 
-	it('should close on backdrop click but not on content click', async () => {
+	it('should emit closed and afterClosed only once when close is triggered repeatedly mid-transition', async () => {
+		const user = userEvent.setup();
 		const { fixture } = await render(HostComponent);
-		openDrawer();
+		await openDrawer(user);
 		const dialog = getDialog();
 
-		fireEvent.click(screen.getByText('Contenido del drawer'));
+		await user.click(screen.getByRole('button', { name: 'Cerrar' }));
+		await user.click(screen.getByRole('button', { name: 'Cerrar' }));
+		dialog.dispatchEvent(new Event('transitionend'));
+
+		expect(fixture.componentInstance.closedCount).toBe(1);
+		expect(fixture.componentInstance.afterClosedCount).toBe(1);
+	});
+
+	it('should close on backdrop click but not on content click', async () => {
+		const user = userEvent.setup();
+		const { fixture } = await render(HostComponent);
+		await openDrawer(user);
+		const dialog = getDialog();
+
+		await user.click(screen.getByText('Contenido del drawer'));
 		expect(fixture.componentInstance.closedCount).toBe(0);
 
-		fireEvent.click(dialog);
+		await user.click(dialog);
 		expect(fixture.componentInstance.closedCount).toBe(1);
 	});
 
 	it('should not close on backdrop click when closeOnBackdrop is false', async () => {
+		const user = userEvent.setup();
 		const { fixture } = await render(HostComponent, { componentProperties: { closeOnBackdrop: false } });
-		openDrawer();
-		fireEvent.click(getDialog());
+		await openDrawer(user);
+		await user.click(getDialog());
 		expect(fixture.componentInstance.closedCount).toBe(0);
 	});
 
 	it('should close on Escape (cancel) when closeOnEscape is true', async () => {
+		const user = userEvent.setup();
 		const { fixture } = await render(HostComponent);
-		openDrawer();
-		fireEvent(getDialog(), new Event('cancel', { cancelable: true }));
+		await openDrawer(user);
+		getDialog().dispatchEvent(new Event('cancel', { cancelable: true }));
 		expect(fixture.componentInstance.closedCount).toBe(1);
 	});
 
 	it('should prevent the native Escape close without closing when closeOnEscape is false', async () => {
+		const user = userEvent.setup();
 		const { fixture } = await render(HostComponent, { componentProperties: { closeOnEscape: false } });
-		openDrawer();
+		await openDrawer(user);
 		const event = new Event('cancel', { cancelable: true });
-		fireEvent(getDialog(), event);
+		getDialog().dispatchEvent(event);
 		expect(event.defaultPrevented).toBe(true);
 		expect(fixture.componentInstance.closedCount).toBe(0);
 	});
@@ -124,6 +150,12 @@ describe('DrawerComponent', () => {
 			screen.getByRole('heading', { name: 'Título', hidden: true }).id,
 		);
 		expect(dialog.getAttribute('aria-describedby')).toBe(screen.getByText('Descripción').id);
+		expect(dialog.getAttribute('aria-label')).toBeNull();
+	});
+
+	it('should fall back to a generic aria-label when there is no title', async () => {
+		await render(HostComponent);
+		expect(getDialog().getAttribute('aria-label')).toBe('Panel lateral');
 	});
 
 	it('should render header and footer slots when provided', async () => {
@@ -135,5 +167,26 @@ describe('DrawerComponent', () => {
 	it('should apply the direction class to the dialog', async () => {
 		await render(HostComponent, { componentProperties: { direction: 'left' } });
 		expect(getDialog()).toHaveClass('drawer-left');
+	});
+
+	it('should unregister from the tracker when destroyed while open', async () => {
+		const user = userEvent.setup();
+		const { fixture } = await render(HostComponent);
+		await openDrawer(user);
+		const tracker = TestBed.inject(DrawerTrackerService);
+
+		fixture.destroy();
+
+		// Tras destruir el drawer abierto, el tracker queda libre para un nuevo registro.
+		expect(() => tracker.register(drawerStub())).not.toThrow();
+	});
+
+	it('should reject a second registration while a drawer is already active', async () => {
+		const user = userEvent.setup();
+		await render(HostComponent);
+		await openDrawer(user);
+		const tracker = TestBed.inject(DrawerTrackerService);
+
+		expect(() => tracker.register(drawerStub())).toThrowError('Only one drawer can be active at a time.');
 	});
 });

--- a/src/app/components/drawer/drawer.component.spec.ts
+++ b/src/app/components/drawer/drawer.component.spec.ts
@@ -1,0 +1,139 @@
+import { Component } from '@angular/core';
+import { fireEvent, render, screen } from '@testing-library/angular';
+
+import { DrawerComponent, DrawerDirection } from './drawer.component';
+import { DrawerHeaderDirective } from './drawer-header.directive';
+import { DrawerFooterDirective } from './drawer-footer.directive';
+
+@Component({
+	imports: [DrawerComponent, DrawerHeaderDirective, DrawerFooterDirective],
+	template: `
+		<button (click)="drawer.open()" type="button">Abrir</button>
+		<cuentoneta-drawer
+			(opened)="openedCount = openedCount + 1"
+			(closed)="closedCount = closedCount + 1"
+			(afterClosed)="afterClosedCount = afterClosedCount + 1"
+			[direction]="direction"
+			[title]="title"
+			[description]="description"
+			[closeOnBackdrop]="closeOnBackdrop"
+			[closeOnEscape]="closeOnEscape"
+			#drawer
+		>
+			@if (withHeaderSlot) {
+				<ng-template cuentonetaDrawerHeader><span>Encabezado propio</span></ng-template>
+			}
+			@if (withFooterSlot) {
+				<ng-template cuentonetaDrawerFooter><span>Pie propio</span></ng-template>
+			}
+			<p>Contenido del drawer</p>
+		</cuentoneta-drawer>
+	`,
+})
+class HostComponent {
+	public direction: DrawerDirection = 'right';
+	public title = '';
+	public description = '';
+	public closeOnBackdrop = true;
+	public closeOnEscape = true;
+	public withHeaderSlot = false;
+	public withFooterSlot = false;
+	public openedCount = 0;
+	public closedCount = 0;
+	public afterClosedCount = 0;
+}
+
+const getDialog = (): HTMLDialogElement => screen.getByRole('dialog', { hidden: true }) as HTMLDialogElement;
+const openDrawer = (): void => {
+	fireEvent.click(screen.getByRole('button', { name: 'Abrir' }));
+};
+
+describe('DrawerComponent', () => {
+	it('should project its content', async () => {
+		await render(HostComponent);
+		expect(screen.getByText('Contenido del drawer')).toBeInTheDocument();
+	});
+
+	it('should open the native dialog and emit opened', async () => {
+		const { fixture } = await render(HostComponent);
+		openDrawer();
+		expect(getDialog().open).toBe(true);
+		expect(fixture.componentInstance.openedCount).toBe(1);
+	});
+
+	it('should not open twice while already open', async () => {
+		const { fixture } = await render(HostComponent);
+		openDrawer();
+		openDrawer();
+		expect(fixture.componentInstance.openedCount).toBe(1);
+	});
+
+	it('should close via the X button: emit closed immediately and afterClosed on transitionend', async () => {
+		const { fixture } = await render(HostComponent);
+		openDrawer();
+		const dialog = getDialog();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Cerrar' }));
+		expect(fixture.componentInstance.closedCount).toBe(1);
+		expect(dialog.open).toBe(true); // aún abierto hasta que termina la transición
+
+		fireEvent(dialog, new Event('transitionend'));
+		expect(dialog.open).toBe(false);
+		expect(fixture.componentInstance.afterClosedCount).toBe(1);
+	});
+
+	it('should close on backdrop click but not on content click', async () => {
+		const { fixture } = await render(HostComponent);
+		openDrawer();
+		const dialog = getDialog();
+
+		fireEvent.click(screen.getByText('Contenido del drawer'));
+		expect(fixture.componentInstance.closedCount).toBe(0);
+
+		fireEvent.click(dialog);
+		expect(fixture.componentInstance.closedCount).toBe(1);
+	});
+
+	it('should not close on backdrop click when closeOnBackdrop is false', async () => {
+		const { fixture } = await render(HostComponent, { componentProperties: { closeOnBackdrop: false } });
+		openDrawer();
+		fireEvent.click(getDialog());
+		expect(fixture.componentInstance.closedCount).toBe(0);
+	});
+
+	it('should close on Escape (cancel) when closeOnEscape is true', async () => {
+		const { fixture } = await render(HostComponent);
+		openDrawer();
+		fireEvent(getDialog(), new Event('cancel', { cancelable: true }));
+		expect(fixture.componentInstance.closedCount).toBe(1);
+	});
+
+	it('should prevent the native Escape close without closing when closeOnEscape is false', async () => {
+		const { fixture } = await render(HostComponent, { componentProperties: { closeOnEscape: false } });
+		openDrawer();
+		const event = new Event('cancel', { cancelable: true });
+		fireEvent(getDialog(), event);
+		expect(event.defaultPrevented).toBe(true);
+		expect(fixture.componentInstance.closedCount).toBe(0);
+	});
+
+	it('should wire aria-labelledby/aria-describedby from title and description', async () => {
+		await render(HostComponent, { componentProperties: { title: 'Título', description: 'Descripción' } });
+		const dialog = getDialog();
+		expect(dialog.getAttribute('aria-labelledby')).toBe(
+			screen.getByRole('heading', { name: 'Título', hidden: true }).id,
+		);
+		expect(dialog.getAttribute('aria-describedby')).toBe(screen.getByText('Descripción').id);
+	});
+
+	it('should render header and footer slots when provided', async () => {
+		await render(HostComponent, { componentProperties: { withHeaderSlot: true, withFooterSlot: true } });
+		expect(screen.getByText('Encabezado propio')).toBeInTheDocument();
+		expect(screen.getByText('Pie propio')).toBeInTheDocument();
+	});
+
+	it('should apply the direction class to the dialog', async () => {
+		await render(HostComponent, { componentProperties: { direction: 'left' } });
+		expect(getDialog()).toHaveClass('drawer-left');
+	});
+});

--- a/src/app/components/drawer/drawer.component.spec.ts
+++ b/src/app/components/drawer/drawer.component.spec.ts
@@ -169,6 +169,21 @@ describe('DrawerComponent', () => {
 		expect(getDialog()).toHaveClass('drawer-left');
 	});
 
+	it('should anchor the close button to the inner edge according to direction', async () => {
+		const { rerender } = await render(HostComponent, { componentProperties: { direction: 'left' } });
+		const closeButton = (): HTMLElement => screen.getByRole('button', { name: 'Cerrar', hidden: true });
+		expect(closeButton()).toHaveClass('self-end');
+
+		await rerender({ componentProperties: { direction: 'right' } });
+		expect(closeButton()).toHaveClass('self-start');
+
+		await rerender({ componentProperties: { direction: 'top' } });
+		expect(closeButton()).toHaveClass('order-last', 'self-center');
+
+		await rerender({ componentProperties: { direction: 'bottom' } });
+		expect(closeButton()).toHaveClass('self-center');
+	});
+
 	it('should unregister from the tracker when destroyed while open', async () => {
 		const user = userEvent.setup();
 		const { fixture } = await render(HostComponent);

--- a/src/app/components/drawer/drawer.component.stories.ts
+++ b/src/app/components/drawer/drawer.component.stories.ts
@@ -34,6 +34,31 @@ const meta: Meta<DrawerArgs> = {
 			description: 'Lado desde el que aparece el panel',
 			table: { type: { summary: 'DrawerDirection' }, defaultValue: { summary: 'right' } },
 		},
+		title: {
+			control: 'text',
+			description: 'Título del encabezado por defecto (omitir si se usa el slot `cuentonetaDrawerHeader`)',
+			table: { type: { summary: 'string' }, defaultValue: { summary: '' } },
+		},
+		description: {
+			control: 'text',
+			description: 'Bajada opcional del encabezado por defecto',
+			table: { type: { summary: 'string' }, defaultValue: { summary: '' } },
+		},
+		ariaLabel: {
+			control: 'text',
+			description: 'Nombre accesible del panel cuando no hay `title` ni slot de encabezado',
+			table: { type: { summary: 'string' }, defaultValue: { summary: '' } },
+		},
+		closeOnBackdrop: {
+			control: 'boolean',
+			description: 'Cerrar al hacer click fuera del panel',
+			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'true' } },
+		},
+		closeOnEscape: {
+			control: 'boolean',
+			description: 'Cerrar al presionar Escape',
+			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'true' } },
+		},
 	},
 };
 

--- a/src/app/components/drawer/drawer.component.stories.ts
+++ b/src/app/components/drawer/drawer.component.stories.ts
@@ -1,0 +1,177 @@
+import { applicationConfig, moduleMetadata, Meta, StoryObj } from '@storybook/angular';
+import { provideRouter } from '@angular/router';
+
+import { DrawerComponent, DrawerDirection } from './drawer.component';
+import { DrawerHeaderDirective } from './drawer-header.directive';
+import { DrawerFooterDirective } from './drawer-footer.directive';
+import { CoverImageComponent } from '@components/cover-image/cover-image.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { PortableTextParserComponent } from '@components/portable-text-parser/portable-text-parser.component';
+import { NavigableCollectionTeaserComponent } from '@components/navigable-collection-teaser/navigable-collection-teaser.component';
+import { storylistMock, storylistTeaserRepresentativeMock, storylistTeaserSampleMock } from '@mocks/storylist.mock';
+
+type DrawerArgs = DrawerComponent & { direction: DrawerDirection };
+
+const openButton = `<button type="button" (click)="drawer.open()" class="m-8 rounded-full border border-neutral-300 bg-white px-6 py-3 font-inter text-sm font-semibold">Abrir drawer</button>`;
+
+const meta: Meta<DrawerArgs> = {
+	component: DrawerComponent,
+	title: 'Componentes V3/Drawer',
+	decorators: [moduleMetadata({ imports: [DrawerComponent, DrawerHeaderDirective, DrawerFooterDirective] })],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>El componente <strong>DrawerComponent</strong> es un panel modal lateral del Design System v3 que aparece desde <code>left</code>/<code>right</code>/<code>top</code>/<code>bottom</code> con una transición de entrada/salida. Se apoya en el elemento nativo <code>&lt;dialog&gt;</code> + <code>showModal()</code> (foco atrapado, Escape y backdrop accesibles, sin dependencias).</p><p>El contenido va por <code>&lt;ng-content&gt;</code>; admite encabezado/pie por <code>cuentonetaDrawerHeader</code>/<code>cuentonetaDrawerFooter</code> o un encabezado por defecto vía <code>title</code>/<code>description</code>. Se abre/cierra por referencia de plantilla (<code>open()</code>/<code>close()</code>) y emite <code>opened</code>/<code>closed</code>/<code>afterClosed</code>. Solo un drawer puede estar activo a la vez.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		direction: {
+			control: 'inline-radio',
+			options: ['left', 'right', 'top', 'bottom'],
+			description: 'Lado desde el que aparece el panel',
+			table: { type: { summary: 'DrawerDirection' }, defaultValue: { summary: 'right' } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<DrawerArgs>;
+
+const directionStory = (direction: DrawerDirection, name: string, usos: string): Story => ({
+	name,
+	render: (args) => ({
+		props: args,
+		template: `${openButton}<cuentoneta-drawer #drawer [direction]="direction"><p class="font-inter text-sm text-neutral-700">Contenido de ejemplo. Cerrá con la X, con Escape o con click fuera del panel.</p></cuentoneta-drawer>`,
+	}),
+	args: { direction },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Panel que entra desde <strong>${name.toLowerCase()}</strong> con su transición.</p><p><strong>Usos:</strong> ${usos}</p>`,
+			},
+		},
+	},
+});
+
+export const Derecha = directionStory(
+	'right',
+	'Derecha',
+	'descripción extendida de una colección ("Leer más" en la CollectionPage).',
+);
+export const Izquierda = directionStory('left', 'Izquierda', 'navegación o filtros laterales.');
+export const Arriba = directionStory('top', 'Arriba', 'notificaciones o banners contextuales.');
+export const Abajo = directionStory('bottom', 'Abajo', 'acciones tipo sheet en viewports angostos.');
+
+export const ConEncabezadoYPie: Story = {
+	name: 'Con encabezado y pie',
+	render: (args) => ({
+		props: args,
+		template: `
+			${openButton}
+			<cuentoneta-drawer #drawer [direction]="direction">
+				<ng-template cuentonetaDrawerHeader>
+					<h2 class="font-inter text-xl font-bold text-neutral-900">Encabezado propio</h2>
+				</ng-template>
+				<p class="font-inter text-sm text-neutral-700">Cuerpo proyectado por ng-content.</p>
+				<ng-template cuentonetaDrawerFooter>
+					<p class="font-inter text-xs text-neutral-600">Pie propio del drawer.</p>
+				</ng-template>
+			</cuentoneta-drawer>
+		`,
+	}),
+	args: { direction: 'right' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Encabezado y pie proyectados con <code>cuentonetaDrawerHeader</code>/<code>cuentonetaDrawerFooter</code>.</p><p><strong>Usos:</strong> paneles con acciones fijas en el pie o un encabezado estructurado propio.</p>`,
+			},
+		},
+	},
+};
+
+export const ComposicionCollectionPage: Story = {
+	name: 'Composición CollectionPage',
+	decorators: [
+		moduleMetadata({
+			imports: [CoverImageComponent, TagComponent, PortableTextParserComponent, NavigableCollectionTeaserComponent],
+		}),
+		applicationConfig({ providers: [provideRouter([])] }),
+	],
+	render: (args) => ({
+		props: {
+			...args,
+			collection: storylistMock,
+			suggested: [storylistTeaserRepresentativeMock, storylistTeaserSampleMock],
+		},
+		template: `
+			${openButton}
+			<cuentoneta-drawer #drawer>
+				<div class="flex flex-col gap-4">
+					@if (collection.imagery.kind === 'representative') {
+						<cuentoneta-cover-image [src]="collection.imagery.image" />
+					}
+					<div class="flex flex-col items-start gap-2">
+						<p class="font-inter text-xl font-bold text-neutral-900">{{ collection.title }}</p>
+						@if (collection.tags[0]; as tag) {
+							<cuentoneta-tag [label]="tag.title" variant="filled" />
+						}
+					</div>
+				</div>
+				<cuentoneta-portable-text-parser
+					[paragraphs]="collection.description"
+					classes="font-inter text-sm font-medium text-neutral-700"
+					class="flex flex-col gap-2"
+				/>
+				<div class="h-px w-full bg-neutral-200" role="separator"></div>
+				<div class="flex flex-col gap-4">
+					<h2 class="font-inter text-base font-bold text-neutral-900">Otras colecciones sugeridas</h2>
+					@for (item of suggested; track item.slug) {
+						<cuentoneta-navigable-collection-teaser [collection]="item" />
+					}
+				</div>
+			</cuentoneta-drawer>
+		`,
+	}),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Réplica del contenido real del drawer de la CollectionPage: portada, título, tag, descripción completa, divisor y colecciones sugeridas — todo por <code>ng-content</code> plano.</p><p><strong>Usos:</strong> el "Leer más" de la descripción de una colección.</p>`,
+			},
+		},
+	},
+};
+
+export const SinCierrePorOverlay: Story = {
+	name: 'Sin cierre por overlay',
+	render: (args) => ({
+		props: args,
+		template: `${openButton}<cuentoneta-drawer #drawer [direction]="direction" [closeOnBackdrop]="false"><p class="font-inter text-sm text-neutral-700">El click en el overlay no cierra; usá la X o Escape.</p></cuentoneta-drawer>`,
+	}),
+	args: { direction: 'right' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Con <code>closeOnBackdrop</code> en <code>false</code>, el click fuera del panel no cierra.</p><p><strong>Usos:</strong> flujos donde el cierre accidental sería costoso (formularios sin guardar).</p>`,
+			},
+		},
+	},
+};
+
+export const SinCierrePorEscape: Story = {
+	name: 'Sin cierre por Escape',
+	render: (args) => ({
+		props: args,
+		template: `${openButton}<cuentoneta-drawer #drawer [direction]="direction" [closeOnEscape]="false"><p class="font-inter text-sm text-neutral-700">Escape no cierra; usá la X o el overlay.</p></cuentoneta-drawer>`,
+	}),
+	args: { direction: 'right' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Con <code>closeOnEscape</code> en <code>false</code>, la tecla Escape no cierra el drawer.</p><p><strong>Usos:</strong> paneles que requieren una acción explícita para cerrarse.</p>`,
+			},
+		},
+	},
+};

--- a/src/app/components/drawer/drawer.component.ts
+++ b/src/app/components/drawer/drawer.component.ts
@@ -47,7 +47,7 @@ export type DrawerDirection = 'left' | 'right' | 'top' | 'bottom';
 			[attr.aria-describedby]="description() ? descriptionId : null"
 			#dialog
 			tabindex="-1"
-			class="m-0 flex max-h-full max-w-full flex-col gap-5 overflow-y-auto rounded-xl bg-white p-10 transition-transform duration-300 ease-out backdrop:bg-black/60 motion-reduce:duration-[0.01ms]"
+			class="m-0 flex max-w-full flex-col gap-5 overflow-y-auto rounded-xl bg-white p-10 transition-transform duration-300 ease-out backdrop:bg-black/60 motion-reduce:duration-[0.01ms]"
 		>
 			<button
 				(click)="close()"

--- a/src/app/components/drawer/drawer.component.ts
+++ b/src/app/components/drawer/drawer.component.ts
@@ -1,0 +1,135 @@
+import { Component, computed, contentChild, effect, ElementRef, inject, input, output, viewChild } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+
+import { DrawerTrackerService } from './drawer-tracker.service';
+import { DrawerTransitionDirective } from './drawer-transition.directive';
+import { DrawerPanelDirective } from './drawer-panel.directive';
+import { DrawerHeaderDirective } from './drawer-header.directive';
+import { DrawerFooterDirective } from './drawer-footer.directive';
+
+export type DrawerDirection = 'left' | 'right' | 'top' | 'bottom';
+
+/**
+ * Panel modal lateral del Design System v3. Se apoya en el elemento nativo `<dialog>` + `showModal()` (foco
+ * atrapado, Escape y backdrop accesibles, sin dependencias) y compone tres piezas vía `hostDirectives`: la
+ * transición (`DrawerTransitionDirective`), las clases por dirección (`DrawerPanelDirective`) y el registro
+ * global de un único drawer activo (`DrawerTrackerService`).
+ *
+ * El contenido va por `<ng-content>`; opcionalmente admite encabezado/pie por `cuentonetaDrawerHeader`/
+ * `cuentonetaDrawerFooter`, o un encabezado por defecto vía los inputs `title`/`description`. El estado de carga
+ * NO es responsabilidad del drawer: el consumidor proyecta skeletons mientras carga (patrón del resto del repo).
+ */
+@Component({
+	selector: 'cuentoneta-drawer',
+	imports: [NgTemplateOutlet],
+	hostDirectives: [DrawerTransitionDirective, { directive: DrawerPanelDirective, inputs: ['direction'] }],
+	host: { class: 'contents' },
+	template: `
+		<dialog
+			[class]="panel.panelClasses()"
+			[attr.data-open]="transition.isTransitionedIn() ? '' : null"
+			[attr.aria-labelledby]="title() ? titleId : null"
+			[attr.aria-describedby]="description() ? descriptionId : null"
+			#dialog
+			tabindex="-1"
+			class="m-0 flex max-h-full flex-col gap-5 overflow-y-auto rounded-xl bg-white p-10 transition-transform duration-300 ease-out backdrop:bg-black/60 motion-reduce:duration-[0.01ms]"
+		>
+			<div class="flex items-start justify-between gap-4">
+				@if (headerTemplate(); as header) {
+					<ng-container [ngTemplateOutlet]="header.templateRef" />
+				} @else if (title()) {
+					<div>
+						<h2 [id]="titleId" class="font-inter text-xl font-bold text-neutral-900">{{ title() }}</h2>
+						@if (description()) {
+							<p [id]="descriptionId" class="mt-1 font-inter text-sm text-neutral-600">{{ description() }}</p>
+						}
+					</div>
+				}
+				<button
+					(click)="close()"
+					type="button"
+					aria-label="Cerrar"
+					class="flex size-10 shrink-0 items-center justify-center rounded-full bg-neutral-100 p-2 text-neutral-900 hover:bg-neutral-200"
+				>
+					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+						<path d="M18 6 6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+					</svg>
+				</button>
+			</div>
+
+			<div class="flex-1"><ng-content /></div>
+
+			@if (footerTemplate(); as footer) {
+				<ng-container [ngTemplateOutlet]="footer.templateRef" />
+			}
+		</dialog>
+	`,
+})
+export class DrawerComponent {
+	public readonly title = input('');
+	public readonly description = input('');
+	public readonly closeOnBackdrop = input(true);
+	public readonly closeOnEscape = input(true);
+
+	public readonly opened = output<void>();
+	public readonly closed = output<void>();
+	public readonly afterClosed = output<void>();
+
+	private readonly dialogRef = viewChild.required<ElementRef<HTMLDialogElement>>('dialog');
+	private readonly dialogElement = computed(() => this.dialogRef().nativeElement);
+
+	protected readonly headerTemplate = contentChild(DrawerHeaderDirective);
+	protected readonly footerTemplate = contentChild(DrawerFooterDirective);
+
+	private readonly tracker = inject(DrawerTrackerService);
+	private readonly instanceId = this.tracker.nextId();
+	protected readonly titleId = `drawer-title-${this.instanceId}`;
+	protected readonly descriptionId = `drawer-desc-${this.instanceId}`;
+
+	protected readonly transition = inject(DrawerTransitionDirective);
+	protected readonly panel = inject(DrawerPanelDirective);
+
+	// Backdrop-click y Escape se cablean con addEventListener (no en la plantilla): la regla de ESLint
+	// click-events-have-key-events solo analiza bindings de plantilla, y la paridad de teclado ya la dan el
+	// Escape (evento `cancel`) y el botón de cierre real.
+	private readonly wireDismissEffect = effect((onCleanup) => {
+		const dialog = this.dialogElement();
+		const onClick = (event: MouseEvent): void => {
+			if (this.closeOnBackdrop() && event.target === dialog) {
+				this.close();
+			}
+		};
+		const onCancel = (event: Event): void => {
+			event.preventDefault();
+			if (this.closeOnEscape()) {
+				this.close();
+			}
+		};
+		dialog.addEventListener('click', onClick);
+		dialog.addEventListener('cancel', onCancel);
+		onCleanup(() => {
+			dialog.removeEventListener('click', onClick);
+			dialog.removeEventListener('cancel', onCancel);
+		});
+	});
+
+	public open(): void {
+		const dialog = this.dialogElement();
+		if (dialog.open) {
+			return;
+		}
+		this.tracker.register(this);
+		this.transition.open(dialog);
+		this.opened.emit();
+	}
+
+	public close(): void {
+		const dialog = this.dialogElement();
+		if (!dialog.open) {
+			return;
+		}
+		this.tracker.unregister(this);
+		this.transition.close(dialog, () => this.afterClosed.emit());
+		this.closed.emit();
+	}
+}

--- a/src/app/components/drawer/drawer.component.ts
+++ b/src/app/components/drawer/drawer.component.ts
@@ -1,5 +1,18 @@
-import { Component, computed, contentChild, effect, ElementRef, inject, input, output, viewChild } from '@angular/core';
+import {
+	Component,
+	computed,
+	contentChild,
+	effect,
+	ElementRef,
+	inject,
+	input,
+	output,
+	signal,
+	viewChild,
+} from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { faSolidXmark } from '@ng-icons/font-awesome/solid';
 
 import { DrawerTrackerService } from './drawer-tracker.service';
 import { DrawerTransitionDirective } from './drawer-transition.directive';
@@ -21,7 +34,8 @@ export type DrawerDirection = 'left' | 'right' | 'top' | 'bottom';
  */
 @Component({
 	selector: 'cuentoneta-drawer',
-	imports: [NgTemplateOutlet],
+	imports: [NgTemplateOutlet, NgIcon],
+	providers: [provideIcons({ faSolidXmark })],
 	hostDirectives: [DrawerTransitionDirective, { directive: DrawerPanelDirective, inputs: ['direction'] }],
 	host: { class: 'contents' },
 	template: `
@@ -29,6 +43,7 @@ export type DrawerDirection = 'left' | 'right' | 'top' | 'bottom';
 			[class]="panel.panelClasses()"
 			[attr.data-open]="transition.isTransitionedIn() ? '' : null"
 			[attr.aria-labelledby]="title() ? titleId : null"
+			[attr.aria-label]="dialogAriaLabel()"
 			[attr.aria-describedby]="description() ? descriptionId : null"
 			#dialog
 			tabindex="-1"
@@ -51,9 +66,7 @@ export type DrawerDirection = 'left' | 'right' | 'top' | 'bottom';
 					aria-label="Cerrar"
 					class="flex size-10 shrink-0 items-center justify-center rounded-full bg-neutral-100 p-2 text-neutral-900 hover:bg-neutral-200"
 				>
-					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-						<path d="M18 6 6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-					</svg>
+					<ng-icon name="faSolidXmark" class="text-2xl" aria-hidden="true" />
 				</button>
 			</div>
 
@@ -68,6 +81,7 @@ export type DrawerDirection = 'left' | 'right' | 'top' | 'bottom';
 export class DrawerComponent {
 	public readonly title = input('');
 	public readonly description = input('');
+	public readonly ariaLabel = input('');
 	public readonly closeOnBackdrop = input(true);
 	public readonly closeOnEscape = input(true);
 
@@ -86,8 +100,22 @@ export class DrawerComponent {
 	protected readonly titleId = `drawer-title-${this.instanceId}`;
 	protected readonly descriptionId = `drawer-desc-${this.instanceId}`;
 
+	// Todo `<dialog>` modal necesita un nombre accesible: si hay `title` lo cubre `aria-labelledby`; en su ausencia
+	// (slot de encabezado o contenido plano) se cae a `ariaLabel`, con un rótulo genérico por defecto.
+	protected readonly dialogAriaLabel = computed(() => this.ariaLabel() || (this.title() ? null : 'Panel lateral'));
+
 	protected readonly transition = inject(DrawerTransitionDirective);
 	protected readonly panel = inject(DrawerPanelDirective);
+
+	// Marca la ventana entre `close()` y `transitionend`, durante la cual el `<dialog>` sigue `open === true`: sin
+	// esta guarda, un segundo `close()` en pleno cierre volvería a emitir eventos y a apilar listeners de transición.
+	private readonly isClosing = signal(false);
+
+	// Desregistra del tracker si el componente se destruye sin cerrar antes (p. ej. navegación con el drawer abierto):
+	// de otro modo `activeInstance` quedaría apuntando a una instancia muerta y bloquearía todo `register()` futuro.
+	private readonly unregisterOnDestroy = effect((onCleanup) => {
+		onCleanup(() => this.tracker.unregister(this));
+	});
 
 	// Backdrop-click y Escape se cablean con addEventListener (no en la plantilla): la regla de ESLint
 	// click-events-have-key-events solo analiza bindings de plantilla, y la paridad de teclado ya la dan el
@@ -118,6 +146,7 @@ export class DrawerComponent {
 		if (dialog.open) {
 			return;
 		}
+		this.isClosing.set(false);
 		this.tracker.register(this);
 		this.transition.open(dialog);
 		this.opened.emit();
@@ -125,11 +154,15 @@ export class DrawerComponent {
 
 	public close(): void {
 		const dialog = this.dialogElement();
-		if (!dialog.open) {
+		if (!dialog.open || this.isClosing()) {
 			return;
 		}
+		this.isClosing.set(true);
 		this.tracker.unregister(this);
-		this.transition.close(dialog, () => this.afterClosed.emit());
+		this.transition.close(dialog, () => {
+			this.isClosing.set(false);
+			this.afterClosed.emit();
+		});
 		this.closed.emit();
 	}
 }

--- a/src/app/components/drawer/drawer.component.ts
+++ b/src/app/components/drawer/drawer.component.ts
@@ -47,28 +47,28 @@ export type DrawerDirection = 'left' | 'right' | 'top' | 'bottom';
 			[attr.aria-describedby]="description() ? descriptionId : null"
 			#dialog
 			tabindex="-1"
-			class="m-0 flex max-h-full flex-col gap-5 overflow-y-auto rounded-xl bg-white p-10 transition-transform duration-300 ease-out backdrop:bg-black/60 motion-reduce:duration-[0.01ms]"
+			class="m-0 flex max-h-full max-w-full flex-col gap-5 overflow-y-auto rounded-xl bg-white p-10 transition-transform duration-300 ease-out backdrop:bg-black/60 motion-reduce:duration-[0.01ms]"
 		>
-			<div class="flex items-start justify-between gap-4">
-				@if (headerTemplate(); as header) {
-					<ng-container [ngTemplateOutlet]="header.templateRef" />
-				} @else if (title()) {
-					<div>
-						<h2 [id]="titleId" class="font-inter text-xl font-bold text-neutral-900">{{ title() }}</h2>
-						@if (description()) {
-							<p [id]="descriptionId" class="mt-1 font-inter text-sm text-neutral-600">{{ description() }}</p>
-						}
-					</div>
-				}
-				<button
-					(click)="close()"
-					type="button"
-					aria-label="Cerrar"
-					class="flex size-10 shrink-0 items-center justify-center rounded-full bg-neutral-100 p-2 text-neutral-900 hover:bg-neutral-200"
-				>
-					<ng-icon name="faSolidXmark" class="text-2xl" aria-hidden="true" />
-				</button>
-			</div>
+			<button
+				(click)="close()"
+				[class]="closeButtonClasses()"
+				type="button"
+				aria-label="Cerrar"
+				class="flex size-10 shrink-0 items-center justify-center rounded-full bg-neutral-100 p-2 text-neutral-900 hover:bg-neutral-200"
+			>
+				<ng-icon name="faSolidXmark" class="text-2xl" aria-hidden="true" />
+			</button>
+
+			@if (headerTemplate(); as header) {
+				<ng-container [ngTemplateOutlet]="header.templateRef" />
+			} @else if (title()) {
+				<div>
+					<h2 [id]="titleId" class="font-inter text-xl font-bold text-neutral-900">{{ title() }}</h2>
+					@if (description()) {
+						<p [id]="descriptionId" class="mt-1 font-inter text-sm text-neutral-600">{{ description() }}</p>
+					}
+				</div>
+			}
 
 			<div class="flex-1"><ng-content /></div>
 
@@ -106,6 +106,16 @@ export class DrawerComponent {
 
 	protected readonly transition = inject(DrawerTransitionDirective);
 	protected readonly panel = inject(DrawerPanelDirective);
+
+	// El botón de cierre se ancla al borde interior del panel (el que da hacia el contenido, no hacia el borde del
+	// viewport): a la derecha en `left`, a la izquierda en `right`, y centrado al fondo/al top en `top`/`bottom`.
+	private readonly closeButtonConfig: Record<DrawerDirection, string> = {
+		left: 'self-end',
+		right: 'self-start',
+		top: 'order-last self-center',
+		bottom: 'self-center',
+	};
+	protected readonly closeButtonClasses = computed(() => this.closeButtonConfig[this.panel.direction()]);
 
 	// Marca la ventana entre `close()` y `transitionend`, durante la cual el `<dialog>` sigue `open === true`: sin
 	// esta guarda, un segundo `close()` en pleno cierre volvería a emitir eventos y a apilar listeners de transición.


### PR DESCRIPTION
## Descripción

- Nuevo `DrawerComponent` V3: panel modal direccional (`left`/`right`/`top`/`bottom`) sobre `<dialog>` nativo + `showModal()` (foco atrapado, Escape y backdrop accesibles, sin dependencias), con transición de entrada/salida vía `[data-open]` + `requestAnimationFrame` + `transitionend`. Compone tres piezas por `hostDirectives`: transición, clases por dirección y registro de un único drawer activo (`DrawerTrackerService`).
- Contenido por `<ng-content>`; encabezado/pie opcionales por `cuentonetaDrawerHeader`/`cuentonetaDrawerFooter` o encabezado por defecto vía `title`/`description`. El estado de carga lo proyecta el consumidor (skeletons), no el drawer.
- Stories de Storybook: direcciones, slots, flags de cierre configurables y una composición realista de la CollectionPage.

Inspirado en el Drawer del starter ResetShop, adaptado a Angular 22 zoneless / signals-first (sin lifecycle hooks) y al diseño de Figma.

Closes #1827.
Parte de #1472.

## Plan de pruebas

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm stylelint` — verde
- [x] `pnpm test` — suite del drawer verde (tracker single-active, desregistro en destroy, doble cierre en transición, aria, direcciones y posición del botón de cierre)
- [x] `pnpm build` · `pnpm storybook:build` — verde
- [x] Verificación visual en Storybook de las 4 direcciones (ancho completo y anclaje del botón de cierre)
- [x] Code review (`code-reviewer`): 1 crítico + 4 advertencias + 3 sugerencias → 7 abordados, 1 diferido (ver abajo)

## Hallazgos de la review abordados

- **Crítico:** desregistro del tracker al destruir el componente (`effect`/`onCleanup`), evitando bloqueo permanente de `register()`.
- **Advertencias:** guarda `isClosing` contra doble cierre en transición; tests de integración de tracker; `ng-icon` en el botón de cierre; `argTypes` completos en Storybook.
- **Sugerencias:** `ariaLabel` de fallback para el nombre accesible; migración del spec a `userEvent`.
- **Diferido:** posible mismatch SSR/hidratación de los ids `aria-labelledby`/`describedby` (contador singleton) — no reproducible en el componente aislado; se validará con E2E al integrar el drawer en la CollectionPage.

## Ajustes de layout direccional (revisión visual)

- **Ancho completo en `top`/`bottom`:** se agregó `max-w-full` al `<dialog>` para neutralizar el `max-width: calc(100% - 38px)` que el user-agent impone a todo `<dialog>` y que dejaba los paneles horizontales ~38px cortos de ancho.
- **Botón de cierre anclado al borde interior según la dirección** (vía `align-self`/`order`, fuera del row del encabezado): a la derecha en `left`, a la izquierda en `right`, centrado al fondo en `top` y centrado al top en `bottom`. Cubierto por test.
- **Drawer flotante con gap de 16px respecto del viewport** (paridad con el `Drawer Container` de Figma, que usa `p-[spacing/4]`): el panel se separa del borde anclado y de los dos perpendiculares. `left`/`right` ganan espacio arriba/abajo; `top`/`bottom` ganan el análogo izquierda/derecha (y quedan a altura de contenido con tope `max-h`). Se usa tamaño explícito en el eje fijo para vencer el `fit-content` del `<dialog>`, `*-auto` para resetear el `inset:0` del UA en `dialog:modal`, y un offset de salida de `120%` para ocultarlo por completo pese al margen.
