### PR TITLE
[#1842] - La plantilla del PR del skill issue-workflow inyectaba la leyenda de atribución prohibida

### DIFF
--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -123,10 +123,9 @@ No avanzar a la Fase 3 sin aprobación explícita.
 
      ## Plan de pruebas
      [checklist de lo verificado]
-
-     🤖 Generated with [Claude Code](https://claude.com/claude-code)
      ```
 
+   - **El cuerpo termina en el plan de pruebas (restricción dura):** sin leyenda de atribución de agente (`🤖 Generated with …`, `Co-Authored-By: Claude …`, `Claude-Session: …`). Ver [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 2.
    - **El PR DEBE enlazar su issue de origen (restricción dura):** el cuerpo debe contener un keyword de cierre — `Closes #<issue>` (o `Fixes`/`Resolves`). El prefijo `[#<issue>]` del título **no** crea el enlace; el keyword en el cuerpo es obligatorio.
    - Si el issue es **hijo de un epic**, agregar además una línea `Parte de #<epic>.` (sin keyword de cierre) para cross-linkear el epic sin auto-cerrarlo.
 


### PR DESCRIPTION
## Descripción

- La plantilla de `gh pr create` de la Fase 6 del skill `issue-workflow` tenía hardcodeada la leyenda `🤖 Generated with [Claude Code]`, que [`coding-agent-policies.md`](.claude/references/coding-agent-policies.md) Sección 2 prohíbe. El agente la escribía a mano obedeciendo una instrucción del repo, mientras violaba otra.
- Explica por qué aparecía en PRs pero no en commits: el setting `attribution` de `.claude/settings.json` suprime el trailer automático de los commits, pero no toca lo que un skill ordena escribir en el cuerpo de un PR.
- Se reemplaza la línea por una restricción dura explícita que apunta a la Sección 2, para que el hueco no se vuelva a llenar.

Closes #1842.

## Plan de pruebas

- [x] `grep -rn "Generated with|Co-Authored-By|Claude-Session" .claude/ CLAUDE.md` — la única coincidencia restante es el texto de la política que la prohíbe, más la nueva restricción del skill. No queda ninguna plantilla que **ordene** escribir la leyenda.
- [x] El cuerpo de este mismo PR se redactó con la plantilla corregida.

## Notas

- Cambio solo-documentación (un archivo `.md` de `.claude/`), sin efecto en runtime: exento del requisito de test según `coding-agent-policies.md` Sección 2.
- Los 5 worktrees bajo `.claude/worktrees/` conservan su copia con la línea vieja. Son ramas de feature en curso y la reciben al mergear `develop`; no se editan a mano.
