### PR TITLE
[#1860] - Documenta como restricción dura que los hijos de un epic se crean como sub-issues reales

### DIFF
--- a/.claude/references/coding-agent-policies.md
+++ b/.claude/references/coding-agent-policies.md
@@ -100,6 +100,20 @@ Prohibido. Si el componente tiene un **estado de carga (skeleton)**, su story de
 
 Prohibido. Nunca incluir `🤖 Generated with [Claude Code]…`, `Co-Authored-By: Claude …` ni `Claude-Session: …` en un mensaje de commit ni en el cuerpo de un PR (`gh pr create --body`/`--body-file`). El trailer **automático** de commits ya está suprimido por `attribution` en `.claude/settings.json`; el vector que queda es que el agente lo **tipee a mano** en el cuerpo del PR —ese setting no lo borra porque no es un trailer del harness—. La descripción de un PR o commit que lo contenga es bloqueante para la review.
 
+### "Listo los hijos del epic en el cuerpo y queda linkeado igual"
+
+Prohibido. Los issues hijos de un epic se crean **como child issues reales** (relación de sub-issue de GitHub), nunca como una tasklist o una lista de menciones `#<id>` en el cuerpo del epic. Una mención crea una referencia cruzada, no una jerarquía: no aparece en el panel de sub-issues, no aporta progreso agregado y se pierde al reordenar el cuerpo.
+
+El cuerpo del epic **puede** incluir una tabla de hijos como resumen legible, pero eso **no reemplaza** el vínculo: cada hijo debe quedar además enlazado como sub-issue.
+
+```bash
+# El endpoint toma el id numérico interno del issue (`.id`), no su número (`.number`).
+id=$(gh api repos/<owner>/<repo>/issues/<hijo> --jq .id)
+gh api repos/<owner>/<repo>/issues/<epic>/sub_issues -X POST -F sub_issue_id="$id"
+```
+
+Un epic cuyos hijos figuren solo como menciones es bloqueante para la review. Si la API de GitHub falla al vincular, **reportarlo explícitamente** y dejar el vínculo pendiente: no darlo por hecho ni sustituirlo por una tasklist.
+
 ---
 
 ## Sección 3 — Disciplina de comentarios
@@ -189,4 +203,4 @@ Proponé cambios vía issue en `cuentoneta/cuentoneta`. Las enmiendas requieren 
 
 ---
 
-_Última actualización: 2026-06-19. Versión inicial en #1495 (CLAUDE.md + archivos de referencia); Sección 3 (Disciplina de comentarios) agregada en #1499 y ampliada en #1542 (visibilidad de API y reemplazos canónicos); regla de story intercambiable para estados de carga agregada en #1581._
+_Última actualización: 2026-07-19. Versión inicial en #1495 (CLAUDE.md + archivos de referencia); Sección 3 (Disciplina de comentarios) agregada en #1499 y ampliada en #1542 (visibilidad de API y reemplazos canónicos); regla de story intercambiable para estados de carga agregada en #1581; regla de child issues reales en epics agregada en #1843._


### PR DESCRIPTION
## Descripción

- Agrega a [`coding-agent-policies.md`](.claude/references/coding-agent-policies.md) Sección 2 el anti-patrón **"Listo los hijos del epic en el cuerpo y queda linkeado igual"**: los hijos de un epic se crean como child issues reales, nunca como tasklist ni menciones `#<id>`.
- Documenta el detalle que hace fallar el primer intento: el endpoint toma el **id interno** del issue (`.id`), no su número.
- Aclara que una tabla de hijos en el cuerpo del epic es admisible como resumen legible, pero **no reemplaza** el vínculo estructural.
- Exige reportar explícitamente si la API falla al vincular, en vez de darlo por hecho o sustituirlo por una tasklist.
- Actualiza la fecha de "Última actualización" del pie, como el propio documento exige.

Closes #1860.

Parte de #1843.

## Plan de pruebas

- [x] La regla se aplicó a sí misma: los 8 hijos de #1843 (#1844–#1850 y #1860) están vinculados como sub-issues reales, verificado por GraphQL (`subIssues.totalCount` = 8), no por suposición.
- [x] El cuerpo de #1843 no contiene tasklist ni lista de menciones a sus hijos.
- [x] Fecha de pie del documento actualizada.

## Notas

- Cambio solo-documentación (un archivo `.md` de `.claude/`), sin efecto en runtime: exento del requisito de test según `coding-agent-policies.md` Sección 2.
- El commit conserva el prefijo `[#1843]` porque se creó antes que este issue hijo, y las reglas de commit del repo prohíben `--amend`. La trazabilidad fina la aporta este PR.
