### PR TITLE
[#1863] - Generar release para versión 2.8.6 de La Cuentoneta

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -148,7 +148,6 @@ jobs:
         env:
           VERSION: ${{ steps.resolve.outputs.version }}
           REPO: ${{ github.repository }}
-          RELEASE_ISSUE: ${{ steps.resolve.outputs.release_issue }}
         run: |
           set -euo pipefail
           body_file="${RUNNER_TEMP}/release-pr-body.md"
@@ -159,19 +158,13 @@ jobs:
             echo "- [ ] Mergear este PR a \`master\` → dispara \`release.yml\` (tag + GitHub Release + deploy de Studio)."
             echo "- [ ] Verificar que el workflow Release quede verde y la app/Studio en producción sin regresiones."
             echo ""
-            if [ -n "${RELEASE_ISSUE:-}" ]; then
-              echo "Relacionado: #${RELEASE_ISSUE}"
-              echo ""
-            fi
-            echo "CI: este PR no dispara checks por sí mismo (anti-recursión del \`GITHUB_TOKEN\`); el workflow corre \`ci.yml\` sobre \`develop\` al preparar el PR."
-            echo ""
-            echo "CHANGELOG: https://github.com/${REPO}/blob/develop/CHANGELOG.md"
-            echo ""
-            echo "El deploy de la app lo cubre Vercel por integración Git nativa."
+            # El release y su changelog los publica release.yml al mergear a master, así
+            # que el link resuelve recién después del merge (404 hasta entonces).
+            echo "Changelog de la versión: https://github.com/${REPO}/releases/tag/${VERSION}"
           } > "$body_file"
 
           echo "body_file=$body_file" >> "$GITHUB_OUTPUT"
-          echo "title=Release ${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "title=[RELEASE] - Lanzamiento de la versión ${VERSION} de La Cuentoneta" >> "$GITHUB_OUTPUT"
 
       - name: Crear o actualizar PR develop → master
         if: steps.resolve.outputs.skip != 'true' && steps.milestone.outputs.ready == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,40 @@ La lista de características futuras a implementar puede hallarse en la sección
 
 Los hitos futuros de desarrollo, en los cuales se detallan las funcionalidades a desarrollar y los cambios a implementar, pueden encontrarse en las secciones [milestones](https://github.com/cuentoneta/cuentoneta/milestones) y [projects](https://github.com/cuentoneta/cuentoneta/projects) del repositorio de Github del proyecto.
 
+## Versión 2.8.6 (2026-07-20)
+
+La versión 2.8.6 avanza el **Design System v3** con una tanda de componentes nuevos para las páginas de dominio. Se incorpora el **StoryHeroHeader**, el hero de la página de cuento con portada de fondo difuminada y metadatos, listando todos los tags del cuento con `TagsList` (#1810, con una corrección posterior del listado de tags #1819); el **EditorialTextBlock**, un bloque de nota/destacado editorial que reemplaza al `EpigraphComponent` (#1812); el **NavigableCollectionTeaser**, un ítem compacto y navegable de colección enlazado a `/collection/:slug` (#1823); y el **DrawerComponent**, un panel modal direccional con transiciones sobre `<dialog>` nativo (#1827). Se corrige además el nombre accesible duplicado en el enlace de autor cuando el avatar queda dentro del `<a>`, dejándolo decorativo en las tarjetas afectadas (#1815).
+
+En el frente de **SEO/AEO y verificación**, se agrega la validación estructural de **JSON-LD**: los builders se tipan con `schema-dts` y se valida en runtime con `assertValidJsonLd` (#1721). Los e2e de SEO pasan a correr contra el **dataset `staging`** aislado en CI —en lugar del `development` compartido— para estabilizar la suite (#1722), y un **guardrail estructural** exige que toda página indexable declare su host directive de SEO acorde a su indexabilidad, derivándola del código y cubriendo el camino de fallo con fixtures adversariales (#1726).
+
+En **tooling y pipeline de release**, se elimina de la plantilla de PR del skill `issue-workflow` la leyenda de atribución prohibida, reemplazándola por una restricción dura (#1842), y se adapta el PR de release `develop → master` que genera `prepare-release-pr.yml`: nuevo título `[RELEASE] - Lanzamiento de la versión X.Y.Z de La Cuentoneta` y cuerpo reducido a los pasos manuales más el link al changelog de GitHub de la versión (#1863).
+
+### Cambios completos
+
+Ver el changelog completo en [2.8.6](https://github.com/cuentoneta/cuentoneta/releases/tag/2.8.6)
+
+### Cambios
+
+#### Design System v3 (componentes)
+
+- [#1810] - Agrega el componente V3 `StoryHeroHeader` (portada de fondo difuminada + meta del cuento) con su skeleton y stories, listando todos los tags del cuento con `TagsList`.
+- [#1812] - Agrega el componente V3 `EditorialTextBlock` (variantes nota y destacado) y migra la epígrafe de la página Story, eliminando `EpigraphComponent`.
+- [#1823] - Agrega `NavigableCollectionTeaser` (DS v3): ítem compacto navegable de colección enlazado a `/collection/:slug`, con su skeleton y stories, e introduce la ruta de dominio Collection.
+- [#1827] - Agrega `DrawerComponent` (DS v3): panel modal direccional con transiciones sobre `<dialog>` nativo, con slots header/footer y flags de cierre.
+- [#1815] - Corrige el nombre accesible duplicado en el enlace de autor dejando avatar y bandera decorativos en `HomeStoryCard`, `StoryCardTeaser`, `StoryCardTeaserV3` y `AuthorTeaser`.
+
+#### SEO / AEO y testing
+
+- [#1721] - Validación estructural de JSON-LD: tipado de los builders con `schema-dts` y verificación en runtime con `assertValidJsonLd`.
+- [#1722] - Apunta los e2e de SEO en CI al dataset `staging` aislado (local sigue en `development`).
+- [#1726] - Guardrail estructural que exige a cada página indexable declarar su host directive de SEO según su indexabilidad, derivada del código.
+
+#### Tooling / mantenimiento
+
+- [#1842] - Quita la leyenda de atribución prohibida de la plantilla de PR del skill `issue-workflow` y la reemplaza por una restricción dura.
+- [#1863] - Adapta el título y el cuerpo del PR de release `develop → master` generado por `prepare-release-pr.yml`.
+- (Hotfix) Reemplaza `ts-node` por `tsx` en los scripts.
+
 ## Versión 2.8.5 (2026-07-15)
 
 La versión 2.8.5 consolida la **indexación por SSR** de las fichas de autor, que era el mayor punto ciego de SEO pendiente. La ficha de autor ahora completa su render en el servidor —hidratación incremental y biografía servida aunque esté detrás de tabs— en lugar de emitir un body vacío por los `@defer`/tabs que solo montaban en cliente (#1771), con un hotfix previo que reemplazó los `@defer` por `@if` plano para restaurar el H1, la biografía y los enlaces `/story/` en el HTML crudo (#1773). Sobre esa corrección se incorpora una **suite de verificación del HTML SSR** (invariantes de indexado con cobertura Vitest, e2e contra el build de producción y un smoke post-deploy sobre el sitemap) para blindar que el indexado no vuelva a romperse silenciosamente (#1772).

--- a/cms/package.json
+++ b/cms/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/cms",
 	"private": true,
-	"version": "2.8.5",
+	"version": "2.8.6",
 	"description": "",
 	"main": "package.json",
 	"author": "Ramiro Olivencia <ramiro@olivencia.com.ar>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/app",
 	"type": "module",
-	"version": "2.8.5",
+	"version": "2.8.6",
 	"imports": {
 		"#tailwind-theme": "./src/tailwind.css"
 	},


### PR DESCRIPTION
Prepara el release de la versión **2.8.6** de La Cuentoneta.

Closes #1863

## Qué incluye

- **Bump de versión en lockstep** a `2.8.6` (`package.json` raíz + `cms/package.json`).
- **Entrada de CHANGELOG** de la versión 2.8.6, agrupada por tema (Design System v3, SEO/AEO y testing, Tooling/mantenimiento).
- **Adaptación de `prepare-release-pr.yml`** (bundleada en esta rama por pedido): el PR de release `develop → master` que genera el Action ahora usa el título `[RELEASE] - Lanzamiento de la versión X.Y.Z de La Cuentoneta` y un cuerpo reducido a los pasos manuales + link al changelog de GitHub de la versión (`releases/tag/X.Y.Z`).

## Verificación

- Milestone 2.8.6 completo: 0 issues abiertos aparte del de release.
- Sin migración de Sanity pendiente (la única migración, `set-default-story-coverimage`, es de #1648 y ya se aplicó en releases previos; no fue tocada en `2.8.5..HEAD`).
- Dry-run de la extracción `awk` de `release.yml`: la sección `## Versión 2.8.6` no queda vacía.
- Lockstep confirmado (`package.json` == `cms/package.json` == `2.8.6`).
- YAML del workflow válido (parseado y formateado por el hook de prettier).

## Pasos manuales para completar la release

1. Mergear este PR a `develop` (el issue de release #1863 ya tiene el label `release`).
2. Tras el merge, el workflow `prepare-release-pr` crea/actualiza el PR `develop → master` (ya con el título y cuerpo nuevos) y dispara `ci.yml` sobre `develop`.
3. Revisar y mergear ese PR a `master` → dispara `release.yml` (tag `2.8.6` + GitHub Release con las notas del CHANGELOG + deploy de Sanity Studio). El deploy de la app lo cubre Vercel.
4. Verificar post-release: workflow Release verde (jobs `release` y `deploy-studio`), Release `2.8.6` publicado y el link del changelog resolviendo, Studio con el schema al día, app en producción sin regresiones.

_No hay migraciones de Sanity que correr en este release (paso 1 del handoff estándar omitido)._
