### PR TITLE
[#1844] - Los 5 sitios que transcriben los gates de CI omiten e2e y/o studio-build

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -53,7 +53,7 @@ Cargá todas estas juntas:
 3. **Verificar cobertura de tests** — Confirmá que hay tests para el código nuevo (Vitest + Angular Testing Library + `@test-utils`).
 4. **Correr los gates de CI** — Ejecutá los gates vía `pnpm` para asegurar que nada se rompió. Debés correr esta verificación vos mismo en **cada** invocación; nunca confíes en ni reportes un estado de CI que no observaste directamente.
 
-Los gates que deben quedar verdes en cada PR son: `pnpm lint`, `pnpm test`, `pnpm stylelint`, `pnpm typecheck`, `pnpm build` y `pnpm storybook:build`. Corré cada uno y reportá el resultado real que observaste.
+Los gates que deben quedar verdes en cada PR son los definidos en la sección [Comandos comunes](../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**). Corré cada uno y reportá el resultado real que observaste.
 
 ## Falsos positivos conocidos — NO marcar
 
@@ -211,16 +211,11 @@ La columna **#** da un número secuencial a través de las tres tablas dentro de
 
 ### Resultados de verificación
 
-Corré los gates vía `pnpm` vos mismo en cada invocación y reportá el resultado que observaste:
+Corré vos mismo, en cada invocación, los gates de CI definidos en la sección [Comandos comunes](../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**) y reportá el resultado real que observaste. Generá una fila por gate:
 
-| Comando                | Resultado |
-| ---------------------- | --------- |
-| `pnpm lint`            | PASS/FAIL |
-| `pnpm stylelint`       | PASS/FAIL |
-| `pnpm typecheck`       | PASS/FAIL |
-| `pnpm test`            | PASS/FAIL |
-| `pnpm build`           | PASS/FAIL |
-| `pnpm storybook:build` | PASS/FAIL |
+| Comando          | Resultado |
+| ---------------- | --------- |
+| `pnpm <comando>` | PASS/FAIL |
 
 Si alguno falla, reportá cuál y el detalle del fallo.
 

--- a/.claude/agents/migration-planner.md
+++ b/.claude/agents/migration-planner.md
@@ -107,7 +107,7 @@ pnpm outdated
 
 ### Verificación final (gates de CI)
 
-Todos deben quedar verdes antes de mergear: `pnpm test`, `pnpm lint`, `pnpm stylelint`, `pnpm typecheck`, `pnpm build`, `pnpm storybook:build`.
+Todos los gates de CI definidos en la sección [Comandos comunes](../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**) deben quedar verdes antes de mergear — un upgrade de dependencias es el caso típico donde `studio-build` (bundler del Studio en `cms/`) rompe sin que lo capture `typecheck` ni `build` (motivo original del gate, #1799).
 
 ### Plan de rollback
 

--- a/.claude/agents/plan-writer.md
+++ b/.claude/agents/plan-writer.md
@@ -126,7 +126,7 @@ Escribí el plan en `workspace/PLAN.md` con esta estructura:
 
 ## Gates de CI
 
-Listar los gates que deben quedar verdes para este cambio (vía `pnpm`): `test`, `lint`, `stylelint`, `typecheck`, `e2e`, `build`, `storybook`. Indicar cuáles son relevantes al diff.
+Listar los gates de CI definidos en la sección [Comandos comunes](../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**) que aplican a este cambio. Indicar cuáles son relevantes al diff.
 
 ## Convenciones del repo a respetar
 

--- a/.claude/references/coding-agent-policies.md
+++ b/.claude/references/coding-agent-policies.md
@@ -195,7 +195,7 @@ El principio: **el documento es canónico; la memoria es refuerzo**. Si los dos 
 
 ### Gates de CI
 
-Independientemente de lo anterior, todo PR debe dejar verdes los gates de CI definidos en `CLAUDE.md`: `test`, `lint`, `stylelint`, `typecheck`, `e2e`, `build`, `storybook`, `studio-build`. Que un gate sea "molesto" o "lento" no es justificación para saltearlo o deshabilitarlo.
+Independientemente de lo anterior, todo PR debe dejar verdes los gates de CI definidos en la sección [Comandos comunes](../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**). Que un gate sea "molesto" o "lento" no es justificación para saltearlo o deshabilitarlo.
 
 ### Enmiendas
 
@@ -203,4 +203,4 @@ Proponé cambios vía issue en `cuentoneta/cuentoneta`. Las enmiendas requieren 
 
 ---
 
-_Última actualización: 2026-07-19. Versión inicial en #1495 (CLAUDE.md + archivos de referencia); Sección 3 (Disciplina de comentarios) agregada en #1499 y ampliada en #1542 (visibilidad de API y reemplazos canónicos); regla de story intercambiable para estados de carga agregada en #1581; regla de child issues reales en epics agregada en #1843._
+_Última actualización: 2026-07-20. Versión inicial en #1495 (CLAUDE.md + archivos de referencia); Sección 3 (Disciplina de comentarios) agregada en #1499 y ampliada en #1542 (visibilidad de API y reemplazos canónicos); regla de story intercambiable para estados de carga agregada en #1581; regla de child issues reales en epics agregada en #1843; "Gates de CI" convertida a remisión a CLAUDE.md en #1844._

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -78,8 +78,7 @@ No avanzar a la Fase 3 sin aprobación explícita.
 
 **Propósito:** verificar que pasen los gates de CI y correr el agente `code-reviewer`.
 
-1. Correr los **gates de CI** localmente (con `pnpm`, nunca `nx` directo):
-   - `pnpm lint` · `pnpm test` · `pnpm stylelint` · `pnpm typecheck` · `pnpm build` · `pnpm storybook:build` · (`pnpm test:e2e` si el cambio toca flujos E2E).
+1. Correr localmente (con `pnpm`, nunca `nx` directo) los **gates de CI** definidos en la sección [Comandos comunes](../../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**). `test:e2e` y `studio-build` son costosos de correr en cada iteración: corré `test:e2e` si el cambio toca flujos E2E y `studio-build` si toca `cms/`; el resto, siempre.
    - Si alguno falla: reportar cuál, diagnosticar, arreglar, commitear el fix (reglas de Fase 3) y re-correr hasta que pasen.
 2. Delegar al agente **`code-reviewer`** para revisar todos los cambios de la rama vs. `develop`.
 3. El code-reviewer escribe los hallazgos en `workspace/CODE_REVIEW.md`.

--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -59,7 +59,7 @@ Formato de commit: `[#<issue>] - <qué cambió>` (español). Cada commit deja el
 
 **Propósito:** confirmar que el release no rompe el pipeline automático.
 
-1. **Gates de CI** (con `pnpm`): `pnpm lint · pnpm stylelint · pnpm typecheck · pnpm test · pnpm build · pnpm storybook:build`. Un bump + CHANGELOG no toca runtime, pero se corren igual por política. El `build` confirma de paso la versión (`@cuentoneta/app@<x>` en el `postbuild`).
+1. Correr los **gates de CI** (con `pnpm`) definidos en la sección [Comandos comunes](../../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**), incluido `studio-build` — el bump lockstep de la Fase 2 toca `cms/package.json`. Un bump + CHANGELOG no toca runtime, pero se corren igual por política. `test:e2e` es opcional acá (sin cambios de flujo de usuario). El `build` confirma de paso la versión (`@cuentoneta/app@<x>` en el `postbuild`).
 2. **Dry-run de la extracción de notas de `release.yml`:** el workflow extrae con `awk` el cuerpo entre `## Versión <x>` y el próximo `## Versión`. Simularlo y confirmar que devuelve una sección **no vacía** (si falta, el job del release falla):
 
    ```bash


### PR DESCRIPTION
## Descripción

- Reemplaza en 6 sitios de `.claude/` la lista de gates de CI transcripta a mano —que estaba desincronizada de su fuente, omitiendo `e2e` y/o `studio-build`— por una remisión a la sección [Comandos comunes](CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**), única fuente de la lista.
- Los 5 sitios que nombra el issue (`issue-workflow`, `release-workflow`, `code-reviewer` —con su segunda copia en la tabla "Resultados de verificación"—, `migration-planner`, `plan-writer`) dejan de enumerar gates; a partir de ahora un cambio en la lista requiere editar un solo archivo.
- Suma un 6º sitio (`coding-agent-policies.md`): su lista estaba en sync hoy pero es la misma transcripción de mano, así que sin convertirla el criterio "editar un solo archivo" no se cumplía. Se actualizó también el pie "Última actualización" por la regla de enmiendas del propio archivo.
- Se preservó la condicionalidad operativa de `test:e2e`/`studio-build` (gates caros de correr localmente) en los skills que los ejecutan, sin volver a transcribir el catálogo completo.

Cambio solo-documentación (`.claude/*.md`): no toca `src/`, `api/` ni `cms/`. `CLAUDE.md` no se modifica — sigue siendo la fuente canónica.

Closes #1844.

Parte de #1843.

## Plan de pruebas

- [x] `grep -rn "pnpm storybook:build" .claude/` devuelve solo `.claude/settings.json` (regla de permisos Bash), sin listas de gates.
- [x] No queda ninguna lista de gates transcripta en los 6 archivos tocados.
- [x] Cada remisión usa una ruta relativa que resuelve a la raíz `CLAUDE.md` (`../../CLAUDE.md` desde `agents/`/`references/`, `../../../CLAUDE.md` desde `skills/<x>/`) y el anchor `#comandos-comunes` corresponde al heading real `## Comandos comunes`.
- [x] `CLAUDE.md` no fue modificado por la rama.
- [x] `code-reviewer` sobre el diff: APROBADO, sin hallazgos.
- Gates de código exentos por ser cambio solo-documentación (`coding-agent-policies.md` Sección 2); corren igual en CI sobre el PR.
