### PR TITLE
[#1845] - El catálogo de referencias se declara completo con 13 de los 15 archivos en 3 sitios

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -28,23 +28,10 @@ Claude debería delegar proactivamente en este agente cuando:
 
 ## Step 0: cargar las referencias
 
-Antes de revisar, leé **LAS 13** referencias para tener el contexto completo del proyecto. Cargalas en **una sola tanda paralela** — emití todas las llamadas `Read` en un único turno (todas en el mismo mensaje), no una tras otra. **No omitas ninguna**: el revisor es la última línea de defensa y siempre carga el set completo (la carga condicional/según-diff está explícitamente fuera del alcance de `code-reviewer`).
+Antes de revisar, leé **todas** las referencias del catálogo para tener el contexto completo del proyecto — sin importar cuántas sean, sin omitir ninguna: el revisor es la última línea de defensa y siempre carga el set completo (la carga condicional/según-diff está explícitamente fuera del alcance de `code-reviewer`). Cargalas en **una sola tanda paralela** — emití todas las llamadas `Read` en un único turno (todas en el mismo mensaje), no una tras otra.
 
-Cargá todas estas juntas:
-
-- `.claude/references/coding-agent-policies.md` — pinneada en duro, bloqueante de la review; **siempre** se carga primero
-- `.claude/references/solid.md`
-- `.claude/references/cupid.md`
-- `.claude/references/guiding-principles.md` — YAGNI / KISS + disciplina de operadores RxJS
-- `.claude/references/cross-reference.md`
-- `.claude/references/clean-architecture.md`
-- `.claude/references/domain-model.md`
-- `.claude/references/angular-components.md`
-- `.claude/references/angular-state.md`
-- `.claude/references/testing.md`
-- `.claude/references/sanity-acl.md`
-- `.claude/references/typescript.md`
-- `.claude/references/maintainability.md` — lente de simplificación estructural / "code judo"
+1. `.claude/references/coding-agent-policies.md` — pinneada en duro, bloqueante de la review; **siempre** se carga primero.
+2. El resto de los archivos listados en la tabla "Catálogo completo" de [Carga estratificada de referencias](../../CLAUDE.md#carga-estratificada-de-referencias) en `CLAUDE.md` — cargalos **todos**.
 
 ## Proceso de revisión
 

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -79,23 +79,7 @@ Antes de escribir, leé las referencias relevantes para tener el contexto del pr
 
 ## Catálogo de referencias (`.claude/references/`)
 
-Este es el set **válido y completo**; no inventes archivos que no existan.
-
-| Referencia                 | Contenido                                                               |
-| -------------------------- | ----------------------------------------------------------------------- |
-| `coding-agent-policies.md` | Políticas de colaboración de agentes (carga obligatoria al inicio)      |
-| `solid.md`                 | Principios SOLID                                                        |
-| `cupid.md`                 | Propiedades CUPID                                                       |
-| `guiding-principles.md`    | YAGNI / KISS + disciplina de operadores RxJS                            |
-| `cross-reference.md`       | Cómo se relacionan SOLID / CUPID / Clean Architecture / DDD             |
-| `clean-architecture.md`    | Capas, regla de dependencia, "Qualified Implementation"                 |
-| `domain-model.md`          | DDD estratégico — Story/Author/Storylist                                |
-| `angular-components.md`    | Componentes, effects, DI/providers, control flow                        |
-| `angular-state.md`         | Estado signals-first sin NgRx                                           |
-| `testing.md`               | Vitest + Angular Testing Library + `@test-utils` + Storybook            |
-| `sanity-acl.md`            | GROQ → repository → mapper → modelo de dominio                          |
-| `typescript.md`            | Micro-convenciones TS/JS (`Object.freeze`, type-only, duration strings) |
-| `maintainability.md`       | Mantenibilidad y simplificación estructural                             |
+El catálogo completo y actualizado — con la descripción de cada archivo — vive en la tabla "Catálogo completo" de [Carga estratificada de referencias](../../CLAUDE.md#carga-estratificada-de-referencias) en `CLAUDE.md`. No lo transcribas acá: consultalo ahí antes de escribir, y no inventes archivos que no figuren en esa tabla.
 
 ## Formato de salida
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ Si un cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología
 | Componentes / plantillas Angular     | `angular-components`, `angular-state`                                                              |
 | Estado / servicios / RxJS            | `angular-state`, `guiding-principles`                                                              |
 | Backend / Sanity / GROQ / mappers    | `sanity-acl`, `clean-architecture`, `domain-model`                                                 |
-| Scripts / migraciones de datos (Sanity) | `scripts`, `sanity-migrations`                                                                  |
+| Scripts / migraciones de datos       | `scripts`, `sanity-migrations`                                                                     |
 | Modelo de dominio / DDD              | `domain-model`, `clean-architecture`                                                               |
 | Tests (Vitest / Storybook)           | `testing`                                                                                          |
 | Tipos / constantes / imports (TS/JS) | `typescript`                                                                                       |
@@ -174,7 +174,7 @@ Si un cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología
 | `angular-state.md`         | Estado signals-first sin NgRx (servicios + signals/RxJS)                            |
 | `testing.md`               | Vitest + Angular Testing Library + `@test-utils` + Storybook                        |
 | `sanity-acl.md`            | GROQ → repository → mapper → modelo de dominio (el ACL central)                     |
-| `scripts.md`               | Convención de `scripts/`: qué vive en la raíz vs. `scripts/audit/` (auditoría one-off) |
-| `sanity-migrations.md`     | Migraciones de datos de Sanity (`cms/migrations/`) — separadas de `scripts/`           |
+| `scripts.md`               | Convención de `scripts/` vs. `scripts/audit/` (auditoría one-off)                   |
+| `sanity-migrations.md`     | Migraciones de datos de Sanity (`cms/migrations/`), no en `scripts/`                |
 | `typescript.md`            | Micro-convenciones TS/JS (`Object.freeze`, type-only, duration strings)             |
 | `maintainability.md`       | Mantenibilidad y simplificación estructural                                         |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,7 @@ Si un cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología
 | Componentes / plantillas Angular     | `angular-components`, `angular-state`                                                              |
 | Estado / servicios / RxJS            | `angular-state`, `guiding-principles`                                                              |
 | Backend / Sanity / GROQ / mappers    | `sanity-acl`, `clean-architecture`, `domain-model`                                                 |
+| Scripts / migraciones de datos (Sanity) | `scripts`, `sanity-migrations`                                                                  |
 | Modelo de dominio / DDD              | `domain-model`, `clean-architecture`                                                               |
 | Tests (Vitest / Storybook)           | `testing`                                                                                          |
 | Tipos / constantes / imports (TS/JS) | `typescript`                                                                                       |
@@ -173,5 +174,7 @@ Si un cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología
 | `angular-state.md`         | Estado signals-first sin NgRx (servicios + signals/RxJS)                            |
 | `testing.md`               | Vitest + Angular Testing Library + `@test-utils` + Storybook                        |
 | `sanity-acl.md`            | GROQ → repository → mapper → modelo de dominio (el ACL central)                     |
+| `scripts.md`               | Convención de `scripts/`: qué vive en la raíz vs. `scripts/audit/` (auditoría one-off) |
+| `sanity-migrations.md`     | Migraciones de datos de Sanity (`cms/migrations/`) — separadas de `scripts/`           |
 | `typescript.md`            | Micro-convenciones TS/JS (`Object.freeze`, type-only, duration strings)             |
 | `maintainability.md`       | Mantenibilidad y simplificación estructural                                         |


### PR DESCRIPTION
## Descripción

- Completa la tabla "Catálogo completo" de `CLAUDE.md` con las 2 referencias que faltaban (`scripts.md` y `sanity-migrations.md`): antes listaba 13 de los 15 archivos reales de `.claude/references/`, afirmando ser completa. Se suma también una fila "Scripts / migraciones de datos" a la tabla "Qué cargar según la tarea".
- `documentation-writer.md` y `code-reviewer.md` dejan de transcribir el catálogo (uno lo declaraba "set válido y completo", el otro pedía "leé LAS 13 referencias") y pasan a remitir a la sección [Carga estratificada de referencias](CLAUDE.md#carga-estratificada-de-referencias) de `CLAUDE.md`, sin citar un conteo fijo. Mismo patrón "remitir a la fuente" que #1844.
- Resuelve la autocontradicción de `CLAUDE.md:62`, que enlazaba `sanity-migrations.md` sin listarlo en su propio catálogo "completo".

Resultado: `CLAUDE.md` es la única fuente del catálogo; agregar una referencia nueva requiere editar un solo archivo. Cambio solo-documentación (`.claude/**` + `CLAUDE.md`): no toca `src/`, `api/` ni `cms/`.

Closes #1845.

Parte de #1843.

## Plan de pruebas

- [x] La tabla "Catálogo completo" de `CLAUDE.md` lista los 15 archivos reales de `.claude/references/` (cruzado 1 a 1 contra `ls`).
- [x] Ningún agente transcribe el catálogo ni cita un conteo fijo: grep de `LAS 13` / `válido y completo` en `.claude/agents/` sin resultados.
- [x] Las 2 remisiones usan `../../CLAUDE.md#carga-estratificada-de-referencias`, anchor que corresponde al heading real `## Carga estratificada de referencias` (no se inventó anchor — evita recrear #1846).
- [x] Se preservó el comportamiento propio de `code-reviewer` (carga `coding-agent-policies.md` primero, set completo siempre, en una sola tanda paralela).
- [x] Columnas de las tablas de `CLAUDE.md` alineadas; render GFM correcto.
- [x] `code-reviewer` sobre el diff: APROBADO (única sugerencia cosmética de alineación, ya abordada).
- Gates de código exentos por ser cambio solo-documentación (`coding-agent-policies.md` Sección 2); corren igual en CI sobre el PR.
