### PR TITLE
[#1848] - Cuatro ejemplos del corpus violan las reglas que el propio corpus enuncia

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -96,7 +96,7 @@ Estos patrones son intencionales y correctos. NO los reportes como problemas:
 
 ### Patrones del modelo de dominio (si aplica)
 
-- [ ] Diseño interface-first (patrón Entity sin prefijo `I`, sin excepciones — nada de notación húngara)
+- [ ] Diseño interface-first (patrón Entity sin prefijo `I`, sin excepciones)
 - [ ] Objetos inmutables (propiedades `readonly`)
 - [ ] Factory functions con patrón de objeto de opciones
 - [ ] Validación Zod para datos externos (en los bordes del sistema)

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -96,7 +96,7 @@ Estos patrones son intencionales y correctos. NO los reportes como problemas:
 
 ### Patrones del modelo de dominio (si aplica)
 
-- [ ] Diseño interface-first (patrón Entity sin prefijo `I`, salvo coexistencia con clase homónima)
+- [ ] Diseño interface-first (patrón Entity sin prefijo `I`, sin excepciones — nada de notación húngara)
 - [ ] Objetos inmutables (propiedades `readonly`)
 - [ ] Factory functions con patrón de objeto de opciones
 - [ ] Validación Zod para datos externos (en los bordes del sistema)

--- a/.claude/agents/domain-model-advisor.md
+++ b/.claude/agents/domain-model-advisor.md
@@ -53,7 +53,7 @@ Como toda sesión de agente sobre este repo: cargá también `.claude/references
 ### Diseño interface-first
 
 - [ ] Los componentes y services dependen de **interfaces de dominio** (`Story`, `Author`, `Storylist`, `Resource`), no del shape crudo de Sanity ni de DTOs de contrato.
-- [ ] **Sin notación húngara:** la interfaz de dominio lleva el nombre limpio (`Story`, `Author`) y **nunca** el prefijo `I`, sin excepciones. No se declara una clase homónima que duplique el contrato: las invariantes las hace cumplir la factory del mapper.
+- [ ] **Sin prefijo `I`:** la interfaz de dominio lleva el nombre limpio (`Story`, `Author`) y **nunca** el prefijo `I`, sin excepciones. No se declara una clase homónima que duplique el contrato: las invariantes las hace cumplir la factory del mapper.
 - [ ] La interfaz contiene todas las propiedades y métodos públicos del contrato.
 
 ### Vistas polimórficas (projection pattern) — vigente

--- a/.claude/agents/domain-model-advisor.md
+++ b/.claude/agents/domain-model-advisor.md
@@ -53,7 +53,7 @@ Como toda sesión de agente sobre este repo: cargá también `.claude/references
 ### Diseño interface-first
 
 - [ ] Los componentes y services dependen de **interfaces de dominio** (`Story`, `Author`, `Storylist`, `Resource`), no del shape crudo de Sanity ni de DTOs de contrato.
-- [ ] **Convención de prefijo `I`:** usar `I` **solo** cuando coexiste una clase concreta con el mismo nombre (`IStory`/`Story`) para distinguir contrato de implementación. Donde hoy hay solo una `interface Story` (sin clase), **no** se usa prefijo. (No imponer `I` por defecto — diverge de otros starters.)
+- [ ] **Sin notación húngara:** la interfaz de dominio lleva el nombre limpio (`Story`, `Author`) y **nunca** el prefijo `I`, sin excepciones. No se declara una clase homónima que duplique el contrato: las invariantes las hace cumplir la factory del mapper.
 - [ ] La interfaz contiene todas las propiedades y métodos públicos del contrato.
 
 ### Vistas polimórficas (projection pattern) — vigente
@@ -119,10 +119,9 @@ Objetivo (roadmap #1503, **no inventar estos archivos hoy**): agrupar por bounde
 
 ```
 <contexto>/                  # p. ej. content-catalog/, curation/
-├── <entidad>.interface.ts    # contrato de dominio (IStory, IAuthor, …)
-├── <entidad>.model.ts        # implementación con invariantes
-├── <entidad>.mapper.ts       # factory + traducción desde Sanity
-└── <entidad>.model.spec.ts
+├── <entidad>.interface.ts    # contrato de dominio (Story, Author, …)
+├── <entidad>.mapper.ts       # factory (hace cumplir las invariantes) + traducción desde Sanity
+└── <entidad>.mapper.spec.ts
 ```
 
 > No inventes archivos inexistentes ni recomiendes migrar la estructura física salvo que el issue lo pida; seguí la organización vigente hasta que #1503 la cambie.

--- a/.claude/references/angular-state.md
+++ b/.claude/references/angular-state.md
@@ -14,7 +14,7 @@ Cuentoneta **no usa NgRx**. El estado vive en **servicios**, se expone como **si
 
 Dónde viven los servicios de estado:
 
-- **`@Injectable({ providedIn: 'root' })`** para estado/acceso a datos de aplicación (singleton). Ej.: `LayoutService`, `NavigationFrameService`, `SchemaOrgService` en [`src/app/providers/`](../../src/app/providers/). El **acceso a datos** no usa services `providedIn: 'root'`: va por los tokens `*Api` del mismo directorio (`StoryApi`, `AuthorApi`, …) — ver [`clean-architecture.md`](clean-architecture.md).
+- **`@Injectable({ providedIn: 'root' })`** para estado/acceso a datos de aplicación (singleton). Es el default de todo servicio del frontend, salvo indicación explícita en contrario. Ej.: `LayoutService`, `NavigationFrameService`, `SchemaOrgService` y las implementaciones de API (`HttpStoryApi`, `HttpAuthorApi`, …) en [`src/app/providers/`](../../src/app/providers/). Los consumidores inyectan el **token** `*Api` (`StoryApi`, `AuthorApi`, …), no la clase concreta — ver [`clean-architecture.md`](clean-architecture.md).
 - **`@Injectable()` provisto en un componente** cuando el estado es local a un subárbol y debe morir con él. Ej.: `CarouselStateService`, provisto en el `providers` del componente de carousel.
 
 > Los servicios de acceso a datos del frontend viven en `src/app/providers/` _(en migración al patrón `provideX()` / `*.provider.ts` — ver #1499)_.

--- a/.claude/references/angular-state.md
+++ b/.claude/references/angular-state.md
@@ -14,7 +14,7 @@ Cuentoneta **no usa NgRx**. El estado vive en **servicios**, se expone como **si
 
 Dónde viven los servicios de estado:
 
-- **`@Injectable({ providedIn: 'root' })`** para estado/acceso a datos de aplicación (singleton). Ej.: `LayoutService`, `StoryService`, `StorylistService`, `ContentService` en [`src/app/providers/`](../../src/app/providers/).
+- **`@Injectable({ providedIn: 'root' })`** para estado/acceso a datos de aplicación (singleton). Ej.: `LayoutService`, `NavigationFrameService`, `SchemaOrgService` en [`src/app/providers/`](../../src/app/providers/). El **acceso a datos** no usa services `providedIn: 'root'`: va por los tokens `*Api` del mismo directorio (`StoryApi`, `AuthorApi`, …) — ver [`clean-architecture.md`](clean-architecture.md).
 - **`@Injectable()` provisto en un componente** cuando el estado es local a un subárbol y debe morir con él. Ej.: `CarouselStateService`, provisto en el `providers` del componente de carousel.
 
 > Los servicios de acceso a datos del frontend viven en `src/app/providers/` _(en migración al patrón `provideX()` / `*.provider.ts` — ver #1499)_.

--- a/.claude/references/clean-architecture.md
+++ b/.claude/references/clean-architecture.md
@@ -80,7 +80,7 @@ Angular **signals-first** (sin NgRx). Los componentes y servicios consumen **mod
 
 La interfaz lleva el **nombre limpio** (la responsabilidad), y la **implementación** lleva un **prefijo de tecnología/propósito**. El doble de test es siempre `InMemory*` — **nunca `Mock*`**.
 
-**Regla del prefijo `I`:** la interfaz **no** lleva prefijo `I` (no `IStoryRepository`). La única excepción es una **colisión** con una clase del mismo nombre que deba coexistir; recién ahí se admite `I` para desambiguar.
+**Regla del prefijo `I`:** la interfaz **nunca** lleva prefijo `I` (no `IStoryRepository`), sin excepciones. Si una clase necesitara el mismo nombre que la interfaz, el problema es el **nombre de la clase**, no el de la interfaz: la implementación se califica (`Sanity*`, `Http*`, `InMemory*`), o directamente no se declara la clase — ver el caso de los modelos de dominio en [`domain-model.md`](domain-model.md).
 
 ### Backend
 
@@ -114,7 +114,7 @@ La interfaz lleva el **nombre limpio** (la responsabilidad), y la **implementaci
 
 **Resumen de reglas:**
 
-- Interfaz sin prefijo `I` (salvo colisión con clase homónima).
+- Interfaz sin prefijo `I`, sin excepciones.
 - `Sanity*` para repositories sobre Sanity/GROQ; `Http*` para API services del front.
 - `InMemory*` para todo doble de test — nunca `Mock*`.
 - Servicio de implementación única → conserva el nombre de la interfaz.

--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -72,6 +72,8 @@ export interface IStory {
 
 **Convención `I`:** usar el prefijo `I` **solo** cuando coexista una clase concreta con el mismo nombre (`IStory`/`Story`), para distinguir contrato de implementación. Donde hoy hay solo una `interface Story` (sin clase), no hace falta el prefijo.
 
+> Por eso los bloques de **roadmap** de esta referencia sí usan `IStory`/`IAuthor` —ahí coexisten con las clases `Story`/`Author` de `<entidad>.model.ts`—, mientras que el texto que describe el código **de hoy** usa `Story`/`Author` a secas: hoy no hay clases homónimas. Ninguno de los dos usos contradice la regla de [`CLAUDE.md` → Naming](../../CLAUDE.md#naming).
+
 ### Factory functions
 
 Usá factories para abstraer la instanciación y **devolver la interfaz**, no la clase concreta. Esto encaja con el rol actual de los mappers del ACL (`mapAuthor`, `mapStoryContent`):
@@ -234,7 +236,7 @@ El ACL es la frontera explícita entre la infraestructura (Sanity) y el dominio:
 
 ## Binding en componentes: solo dominio
 
-Los componentes deben hacer binding **exclusivamente** a interfaces de dominio (`IStory`, `IAuthor`, `IStorylist`, `IResource`) o sus modelos. El **shape crudo de Sanity** y cualquier DTO de contrato pertenecen a la capa de API/provider — **nunca** se importan ni se referencian en componentes ni plantillas.
+Los componentes deben hacer binding **exclusivamente** a interfaces de dominio (hoy `Story`, `Author`, `Storylist`, `Resource`) o sus modelos. El **shape crudo de Sanity** y cualquier DTO de contrato pertenecen a la capa de API/provider — **nunca** se importan ni se referencian en componentes ni plantillas.
 
 La frontera es clara: los repositories/services de Sanity manejan el shape crudo; desde la superficie pública del provider/store hacia arriba (componentes, plantillas), **solo** interfaces de dominio. Los modelos de dominio exponen propiedades computadas y métodos que encierran las reglas de negocio en un único lugar.
 
@@ -252,7 +254,7 @@ Un **agregado** es un cluster de objetos de dominio tratado como una unidad para
 
 **Cómo identificar la raíz:** buscá la entidad que **posee más invariantes de negocio**; esa entidad es la raíz, porque las invariantes solo se garantizan si toda mutación pasa por ella.
 
-En cuentoneta, **`Story` es la raíz** del agregado de contenido. Posee `author: IAuthor`, `paragraphs`, `epigraphs`, `resources: IResource[]`, `tags: Tag[]` y `media: Media[]`. Sus invariantes (de `docs/DOMAIN_MODEL.md`):
+En cuentoneta, **`Story` es la raíz** del agregado de contenido. Posee `author: Author`, `paragraphs`, `epigraphs`, `resources: Resource[]`, `tags: Tag[]` y `media: Media[]`. Sus invariantes (de `docs/DOMAIN_MODEL.md`):
 
 - El `slug` es único e inmutable una vez creado.
 - Toda historia **debe tener un autor**.
@@ -302,17 +304,17 @@ En cuentoneta, candidatas naturales a policy:
 
 ```typescript
 // policy pura: ¿esta Storylist debe mostrar info de autores en sus tarjetas?
-function shouldShowAuthors(storylist: IStorylist): boolean {
+function shouldShowAuthors(storylist: Storylist): boolean {
 	return storylist.config.showAuthors;
 }
 
 // policy pura: ¿este Story lleva advertencia de lenguaje explícito?
-function requiresLanguageWarning(story: IStory): boolean {
+function requiresLanguageWarning(story: Story): boolean {
 	return story.badLanguage === true;
 }
 
 // composición de predicados pequeños con && / ||
-function isReadyForLanding(story: IStory): boolean {
+function isReadyForLanding(story: Story): boolean {
 	return story.approximateReadingTime >= 1 && Boolean(story.author);
 }
 ```

--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -76,10 +76,10 @@ export interface IStory {
 
 ### Factory functions
 
-Usá factories para abstraer la instanciación y **devolver la interfaz**, no la clase concreta. Esto encaja con el rol actual de los mappers del ACL (`mapAuthor`, `mapStoryContent`):
+Usá factories para abstraer la instanciación y **devolver la interfaz**, no la clase concreta. Es la evolución natural del rol que hoy cumplen los mappers del ACL (`mapAuthor`, `mapStoryContent`), que devuelven objetos planos tipados y no instancian clases:
 
 ```typescript
-// story.mapper.ts
+// story.mapper.ts (objetivo: la factory devuelve la interfaz, no la clase)
 interface CreateStoryOptions {
 	slug: string;
 	title: string;

--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -45,10 +45,9 @@ Hoy los tipos de dominio viven en `src/app/models/` (frontend) y la ACL/dominio 
 
 ```
 <contexto>/                 # p. ej. content-catalog/, curation/
-├── <entidad>.interface.ts   # contrato de dominio (IStory, IAuthor, …)
-├── <entidad>.model.ts       # implementación con invariantes
-├── <entidad>.mapper.ts      # factory + traducción desde Sanity
-└── <entidad>.model.spec.ts
+├── <entidad>.interface.ts   # contrato de dominio (Story, Author, …)
+├── <entidad>.mapper.ts      # factory (hace cumplir las invariantes) + traducción desde Sanity
+└── <entidad>.mapper.spec.ts
 ```
 
 > **Roadmap:** la separación física por carpeta de contexto es objetivo. No inventar estos archivos al implementar features actuales; seguir la organización vigente (`src/app/models/`, `src/api/_utils/`) hasta que #1503 la migre.
@@ -57,39 +56,43 @@ Hoy los tipos de dominio viven en `src/app/models/` (frontend) y la ACL/dominio 
 
 ## Diseño orientado a interfaces
 
-Definí **interfaces** para las entidades de dominio. Los componentes dependen de interfaces, no de clases concretas. Esto ya rige hoy: el frontend consume `Story`, `Author`, `Storylist`, `Resource` como contratos, nunca el shape crudo de Sanity.
+Definí **interfaces** para las entidades de dominio. Los componentes dependen de esas interfaces, nunca de un tipo de infraestructura. Esto ya rige hoy: el frontend consume `Story`, `Author`, `Storylist`, `Resource` como contratos, nunca el shape crudo de Sanity.
 
 ```typescript
-// story.interface.ts (objetivo: contrato explícito separado de la implementación)
-export interface IStory {
+// story.interface.ts (objetivo: el contrato de dominio, sin clase que lo duplique)
+export interface Story {
 	readonly slug: string; // business key, invariante única
 	readonly title: string;
-	readonly author: IAuthor; // un Story siempre tiene autor
+	readonly author: Author; // un Story siempre tiene autor
 	readonly approximateReadingTime: number; // minutos, >= 1
 	hasMedia(): boolean;
 }
 ```
 
-**Convención `I`:** usar el prefijo `I` **solo** cuando coexista una clase concreta con el mismo nombre (`IStory`/`Story`), para distinguir contrato de implementación. Donde hoy hay solo una `interface Story` (sin clase), no hace falta el prefijo.
-
-> Por eso los bloques de **roadmap** de esta referencia sí usan `IStory`/`IAuthor` —ahí coexisten con las clases `Story`/`Author` de `<entidad>.model.ts`—, mientras que el texto que describe el código **de hoy** usa `Story`/`Author` a secas: hoy no hay clases homónimas. Ninguno de los dos usos contradice la regla de [`CLAUDE.md` → Naming](../../CLAUDE.md#naming).
+**Nada de notación húngara.** La interfaz de dominio lleva el **nombre limpio** (`Story`, `Author`, `Storylist`, `Resource`) y **nunca** el prefijo `I` — ver [`CLAUDE.md` → Naming](../../CLAUDE.md#naming). No se declara una clase homónima que duplique el contrato: quien hace cumplir las invariantes es la **factory** del mapper, que devuelve un objeto congelado tipado como la interfaz.
 
 ### Factory functions
 
-Usá factories para abstraer la instanciación y **devolver la interfaz**, no la clase concreta. Es la evolución natural del rol que hoy cumplen los mappers del ACL (`mapAuthor`, `mapStoryContent`), que devuelven objetos planos tipados y no instancian clases:
+La factory es el **único** punto de construcción de un objeto de dominio: ahí se validan las invariantes y se devuelve el contrato ya congelado. Es la evolución natural del rol que hoy cumplen los mappers del ACL (`mapAuthor`, `mapStoryContent`), que devuelven objetos planos tipados:
 
 ```typescript
-// story.mapper.ts (objetivo: la factory devuelve la interfaz, no la clase)
+// story.mapper.ts (objetivo: la factory valida las invariantes y devuelve el contrato)
 interface CreateStoryOptions {
 	slug: string;
 	title: string;
-	author: IAuthor;
+	author: Author;
 	paragraphs: TextBlockContent[];
 	approximateReadingTime: number;
 }
 
-export function createStory(options: CreateStoryOptions): IStory {
-	return new Story(options);
+export function createStory(options: CreateStoryOptions): Story {
+	if (!options.author) {
+		throw new Error(`La historia "${options.slug}" no tiene autor`);
+	}
+	return Object.freeze({
+		...options,
+		hasMedia: () => options.paragraphs.some(isMediaBlock),
+	});
 }
 ```
 
@@ -97,7 +100,8 @@ export function createStory(options: CreateStoryOptions): IStory {
 
 - **Options object** para funciones con 3+ parámetros.
 - Mantené las interfaces de options **privadas** (no exportadas) — TS infiere el tipo en el call site.
-- Devolvé el **tipo interfaz**, no la clase concreta.
+- Devolvé el **tipo de la interfaz** de dominio.
+- La construcción pasa **siempre** por la factory: es el único lugar donde una invariante puede quedar sin verificar.
 
 ---
 
@@ -127,18 +131,19 @@ Cada vista es una proyección coherente del mismo agregado; el mapper correspond
 Los objetos de dominio deben ser **inmutables** tras su construcción:
 
 ```typescript
-export class Story implements IStory {
+export interface Story {
 	readonly slug: string;
 	readonly title: string;
-	readonly author: IAuthor;
-	readonly resources: readonly IResource[];
+	readonly author: Author;
+	readonly resources: readonly Resource[];
 	// …
 }
 ```
 
 - Marcá todas las propiedades `readonly`.
 - Usá `readonly T[]` para arrays.
-- Calculá los valores derivados en el constructor y guardalos en campos privados.
+- Calculá los valores derivados en la factory, antes de congelar el objeto.
+- `readonly` es una garantía **de tipos** (desaparece en runtime); el `Object.freeze` de la factory es la que sobrevive a la compilación.
 
 El contenido enriquecido (`TextBlockContent` / Portable Text) **se trata como inmutable**: una vez producido por Sanity, no se modifica en la aplicación.
 
@@ -261,16 +266,18 @@ En cuentoneta, **`Story` es la raíz** del agregado de contenido. Posee `author:
 - Debe tener **al menos un párrafo** de contenido.
 - El tiempo de lectura es un número positivo (`>= 1`).
 
-El objetivo (roadmap #1503) es hacer cumplir esas invariantes **en construcción**, de modo que ningún caller pueda crear un `Story` inconsistente:
+El objetivo (roadmap #1503) es hacer cumplir esas invariantes **en construcción**, dentro de la factory, de modo que ningún caller pueda crear un `Story` inconsistente:
 
 ```typescript
-// story.model.ts — objetivo: invariantes en tiempo de construcción
-constructor(options: CreateStoryOptions) {
+// story.mapper.ts — objetivo: invariantes en tiempo de construcción
+export function createStory(options: CreateStoryOptions): Story {
 	if (!options.author) throw new Error('Story requiere autor');
 	if (options.paragraphs.length === 0) throw new Error('Story requiere al menos un párrafo');
-	this.slug = slug(options.slug);
-	this.approximateReadingTime = readingTime(options.approximateReadingTime);
-	// …
+	return Object.freeze({
+		...options,
+		slug: slug(options.slug),
+		approximateReadingTime: readingTime(options.approximateReadingTime),
+	});
 }
 ```
 

--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -69,7 +69,7 @@ export interface Story {
 }
 ```
 
-**Nada de notación húngara.** La interfaz de dominio lleva el **nombre limpio** (`Story`, `Author`, `Storylist`, `Resource`) y **nunca** el prefijo `I` — ver [`CLAUDE.md` → Naming](../../CLAUDE.md#naming). No se declara una clase homónima que duplique el contrato: quien hace cumplir las invariantes es la **factory** del mapper, que devuelve un objeto congelado tipado como la interfaz.
+**Sin prefijo `I`.** La interfaz de dominio lleva el **nombre limpio** (`Story`, `Author`, `Storylist`, `Resource`) y **nunca** el prefijo `I` — ver [`CLAUDE.md` → Naming](../../CLAUDE.md#naming). No se declara una clase homónima que duplique el contrato: quien hace cumplir las invariantes es la **factory** del mapper, que devuelve un objeto congelado tipado como la interfaz.
 
 ### Factory functions
 

--- a/.claude/references/guiding-principles.md
+++ b/.claude/references/guiding-principles.md
@@ -119,13 +119,13 @@ El frontend de cuentoneta modela el estado con **servicios + signals + RxJS** (v
 @Injectable({ providedIn: 'root' })
 export class StorylistService {
 	private readonly api = inject(StorylistApi);
-	private readonly stories = signal<Story[]>([]);
+	private readonly stories = signal<StoryTeaserWithAuthor[]>([]);
 
 	readonly storyCount = computed(() => this.stories().length); // derivado, no guardado
 
-	load(slug: string): Observable<Story[]> {
-		return this.api.getStorylistBySlug(slug).pipe(
-			map((raw) => raw.stories.map(mapStory)),
+	load(slug: string): Observable<StoryTeaserWithAuthor[]> {
+		return this.api.get(slug).pipe(
+			map((storylist) => storylist.stories), // ya viene mapeado por el ACL del backend
 			tap((stories) => this.stories.set(stories)), // efecto colateral en tap
 			catchError((err) => {
 				this.logError('load', err);

--- a/.claude/references/guiding-principles.md
+++ b/.claude/references/guiding-principles.md
@@ -118,7 +118,7 @@ El frontend de cuentoneta modela el estado con **servicios + signals + RxJS** (v
 //              efectos colaterales en tap y sin promesas
 @Injectable({ providedIn: 'root' })
 export class StorylistService {
-	private readonly api = inject(StorylistApiService);
+	private readonly api = inject(StorylistApi);
 	private readonly stories = signal<Story[]>([]);
 
 	readonly storyCount = computed(() => this.stories().length); // derivado, no guardado

--- a/.claude/references/solid.md
+++ b/.claude/references/solid.md
@@ -139,8 +139,8 @@ interface StoryListProvider {
 ```typescript
 // ✅ El componente (alto nivel) depende de una abstracción inyectada, no de Sanity directo.
 export class StoryComponent {
-	private readonly stories = inject(StoryService);
-	private readonly slug = input.required<string>();
+	private readonly stories = inject(StoryApi);
+	readonly slug = input.required<string>();
 	protected readonly story = toSignal(/* derivado del slug vía el service */);
 }
 

--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -114,8 +114,7 @@ expect(heading).toBeInTheDocument();
 
 ```typescript
 import { fn } from '@test-utils';
-import { of } from 'rxjs';
-import type { Observable } from 'rxjs';
+import { of, type Observable } from 'rxjs';
 
 const getBySlug = fn<[string], Observable<Story>>();
 getBySlug.mockReturnValue(of(storyMock));

--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -114,12 +114,14 @@ expect(heading).toBeInTheDocument();
 
 ```typescript
 import { fn } from '@test-utils';
+import { of } from 'rxjs';
+import type { Observable } from 'rxjs';
 
-const getStory = fn<[string], Promise<Story>>();
-getStory.mockResolvedValue(storyMock);
+const getBySlug = fn<[string], Observable<Story>>();
+getBySlug.mockReturnValue(of(storyMock));
 
 await render(StoryComponent, {
-	providers: [{ provide: StoryService, useValue: { getStory } }],
+	providers: [{ provide: StoryApi, useValue: { getBySlug } }],
 });
 
 expect(await screen.findByText(storyMock.title)).toBeInTheDocument();

--- a/.claude/references/typescript.md
+++ b/.claude/references/typescript.md
@@ -51,7 +51,7 @@ Usar la palabra clave `type` cuando un import se use **solo** como anotación de
 // ✅ Correcto
 import type { Story } from '@models/story.model';
 import { type Mock } from '@test-utils';
-import { StoryService } from '../../providers/story.service'; // se usa en runtime → sin `type`
+import { StoryApi } from '../../providers/story-api.interface'; // token, se usa en runtime → sin `type`
 
 // ❌ Incorrecto — falta `type` en imports solo-de-tipo
 import { Story } from '@models/story.model';

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Reglas no negociables. Una violación requiere justificación explícita.
 ### Naming
 
 - Archivos `kebab-case`; clases `PascalCase`; funciones/métodos `camelCase`; constantes globales `SCREAMING_SNAKE_CASE`, locales `camelCase`.
-- Interfaces **sin** prefijo `I`, sin excepciones (nada de notación húngara). Convención **Qualified Implementation**: la interfaz tiene el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test son `InMemory*` (**nunca** `Mock*`).
+- Interfaces **sin** prefijo `I`, sin excepciones. Convención **Qualified Implementation**: la interfaz tiene el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test son `InMemory*` (**nunca** `Mock*`).
 - **API providers del frontend:** el archivo de la interfaz lleva el sufijo `-api` — `<dominio>-api.interface.ts` (export `<X>Api`) — para distinguirlo de una interfaz del modelo de dominio. La impl y el doble viven en `<dominio>.provider.ts` (`Http<X>Api` + `provide<X>Api()`) y `<dominio>.mock.ts` (`InMemory<X>Api` + `provide<X>ApiMock()`). Ver [`clean-architecture.md`](.claude/references/clean-architecture.md).
 
 ### Comentarios

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Reglas no negociables. Una violación requiere justificación explícita.
 ### Naming
 
 - Archivos `kebab-case`; clases `PascalCase`; funciones/métodos `camelCase`; constantes globales `SCREAMING_SNAKE_CASE`, locales `camelCase`.
-- Interfaces **sin** prefijo `I` (salvo que coexista con una clase homónima). Convención **Qualified Implementation**: la interfaz tiene el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test son `InMemory*` (**nunca** `Mock*`).
+- Interfaces **sin** prefijo `I`, sin excepciones (nada de notación húngara). Convención **Qualified Implementation**: la interfaz tiene el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test son `InMemory*` (**nunca** `Mock*`).
 - **API providers del frontend:** el archivo de la interfaz lleva el sufijo `-api` — `<dominio>-api.interface.ts` (export `<X>Api`) — para distinguirlo de una interfaz del modelo de dominio. La impl y el doble viven en `<dominio>.provider.ts` (`Http<X>Api` + `provide<X>Api()`) y `<dominio>.mock.ts` (`InMemory<X>Api` + `provide<X>ApiMock()`). Ver [`clean-architecture.md`](.claude/references/clean-architecture.md).
 
 ### Comentarios


### PR DESCRIPTION
> **PR stackeado.** Base: `feat/1847-rutas-y-deuda-inexistentes` (PR #1870), que a su vez va sobre #1869. Al mergearse los de abajo, GitHub reapunta esta base sola.

Corrige los ejemplos del corpus que muestran patrones que el propio corpus prohíbe: un agente que los copiara violaba la regla enunciada unas líneas más arriba.

## Los casos del issue

| Sitio | Violaba | Arreglo |
| ----- | ------- | ------- |
| `solid.md:143` | `angular-components.md:75` — los `input()`/`output()`/`model()` no llevan modificador | quita el `private` |
| `testing.md:117` | `angular-state.md:43` — el servicio de datos devuelve siempre `Observable<T>` | `Observable` + `of()`, y calca la interfaz real (`StoryApi`, `getBySlug`) |
| `guiding-principles.md:121` | convención Qualified Implementation (`clean-architecture.md:106`) | `inject(StorylistApi)`, el token real |
| `domain-model.md` (14 usos de `I*`) | `CLAUDE.md` → Naming | se elimina el prefijo por completo — ver abajo |

## El prefijo `I`: eliminado, y la excepción cerrada

El proyecto **no usa el prefijo `I` en interfaces**. Se lo quita de los modelos de dominio y, además, se cierra la escapatoria _"salvo que coexista con una clase homónima"_ en **todo** el corpus (`CLAUDE.md`, `clean-architecture.md`, `domain-model-advisor.md`, `code-reviewer.md`), para que el prefijo no pueda volver por ninguna vía.

Al quitar el prefijo, interfaz y clase ya no pueden llamarse ambas `Story`. Se resuelve **eliminando la clase del roadmap**: la interfaz es el único contrato, y las invariantes las hace cumplir la **factory** del mapper, que devuelve un objeto congelado.

```typescript
// story.interface.ts — único contrato de dominio
export interface Story {
	readonly slug: string;
	readonly author: Author;
	hasMedia(): boolean;
}

// story.mapper.ts — la factory valida las invariantes
export function createStory(options: CreateStoryOptions): Story {
	if (!options.author) throw new Error(`La historia "${options.slug}" no tiene autor`);
	return Object.freeze({ ...options, hasMedia: () => … });
}
```

Es lo que el repo ya hace hoy —los mappers del ACL devuelven objetos planos tipados, no instancian clases— y evita la colisión de raíz en vez de codificarla en el nombre. Arrastres del modelo con clase que quedaban inconsistentes (el bloque de invariantes usaba un `constructor`; el de inmutabilidad pedía calcular derivados "en el constructor") pasan también a la factory, y se explicita que `readonly` desaparece en runtime: la garantía real es el `Object.freeze`.

## `providedIn: 'root'` es el default

Una versión previa de este PR afirmaba en `angular-state.md` que el acceso a datos **no** usa services `providedIn: 'root'`. Es falso: `HttpStoryApi`, `HttpAuthorApi` y el resto de las implementaciones sí lo son —el token `*Api` es la indirección de DI, no un reemplazo del singleton—. Corregido: `providedIn: 'root'` es el default de todo servicio del frontend salvo indicación explícita en contrario.

## Hallazgos fuera de la tabla del issue

- `solid.md` y `testing.md` inyectaban **`StoryService`**, que no existe; el token real es `StoryApi`.
- `angular-state.md:17` afirmaba que `StoryService`/`StorylistService`/`ContentService` viven en `src/app/providers/`: ninguno existe.
- `typescript.md:54` importaba de `'../../providers/story.service'`, inexistente.

## Lo que destapó la review local

Cambiar el token de `guiding-principles.md` por uno **real y verificable** dejó a la vista que el resto de ese snippet nunca compiló, algo que la clase ficticia anterior tapaba:

- llamaba `getStorylistBySlug`, cuando el método real es `get(slug, amount?, ordering?)`;
- remapeaba con `mapStory`, que no existe en el frontend — y ese remapeo **contradecía el ACL** que el propio corpus declara no negociable: el mapeo Sanity→dominio ocurre en el backend, así que `StorylistApi.get()` ya devuelve un `Storylist` mapeado;
- los tipos no cerraban: `Storylist.stories` es `StoryTeaserWithAuthor[]`, no `Story[]`.

Buen argumento a favor de anclar los ejemplos a símbolos reales: mientras el nombre era ficticio, el error no se podía detectar.

## Follow-ups abiertos

- **#1872** — `angular-components.md:71,161,194` usa `inject(StoryService)`. Mismo defecto, pero **no admite rename directo**: esos snippets modelan un state service con `load(slug)` que no existe en el repo. Arreglarlo bien exige decidir a qué anclar los ejemplos.
- **#1873** ([Slice 6] del epic #1481) — cuando `LiteraryWork` pase a ser el agregado principal, todo este corpus deberá realinearse: hoy está escrito alrededor de `Story` como raíz.

Cambio **solo de documentación**: exento del requisito de test según `coding-agent-policies.md` Sección 2.

Closes #1848
