### PR TITLE
[#1872] - Tres ejemplos de angular-components.md inyectan un StoryService que no existe

### DIFF
--- a/.claude/agents/test-generator.md
+++ b/.claude/agents/test-generator.md
@@ -56,21 +56,22 @@ Es la **única** referencia que cargás. No asumas convenciones del starter ni d
 
 ```typescript
 import { clearAllMocks, fn } from '@test-utils';
+import { of, type Observable } from 'rxjs';
 
-const getStory = fn<[string], Promise<Story>>();
+const getBySlug = fn<[string], Observable<Story>>();
 
 beforeEach(() => {
 	clearAllMocks();
 });
 
 // ...
-getStory.mockResolvedValue(storyMock);
+getBySlug.mockReturnValue(of(storyMock));
 await render(StoryComponent, {
-	providers: [{ provide: StoryService, useValue: { getStory } }],
+	providers: [{ provide: StoryApi, useValue: { getBySlug } }],
 });
 ```
 
-`fn()` es genérico: `fn<[number], Promise<User>>()`. Para castear una función auto-mockeada usá `as Mock` importado de `@test-utils` (nunca `vi.mocked()`).
+`fn()` es genérico: `fn<[string], Observable<Story>>()`. Para castear una función auto-mockeada usá `as Mock` importado de `@test-utils` (nunca `vi.mocked()`).
 
 ### Timers
 

--- a/.claude/references/angular-components.md
+++ b/.claude/references/angular-components.md
@@ -60,7 +60,8 @@ Regla central: **un campo de componente nunca es `public` por defecto.** Las pla
 | `public`    | **Solo** inputs/outputs/models de signals (`input()`, `output()`, `model()`), **API imperativa** llamada por padres (`open()`, `close()`), y miembros **requeridos por interfaces**. |
 
 ```typescript
-// Patrón de `src/app/components/share-button/share-button.component.ts`
+// Miembros de `src/app/components/share-button/share-button.component.ts`
+// (el archivo real declara la dependencia sin `readonly`: es deuda, no el patrón)
 export class ShareButtonComponent {
 	public readonly platform = input.required<SharingPlatform>();
 
@@ -168,7 +169,7 @@ Todo `effect()` / `afterRenderEffect()` / `afterNextRender()` se declara como **
 
 ```typescript
 // ✅ Correcto — effect nombrado como field, después de lo que referencia
-// (patrón de `share-button.component.ts`)
+// (tomado de `share-button.component.ts`)
 export class ShareButtonComponent {
 	private readonly tooltipDirective = inject(TooltipDirective);
 	public readonly platform = input.required<SharingPlatform>();

--- a/.claude/references/angular-components.md
+++ b/.claude/references/angular-components.md
@@ -41,9 +41,9 @@ import { TagsListComponent } from '../tags-list/tags-list.component';
 })
 export class AuthorTeaserV3Component {
 	// Inputs
-	readonly author = input.required<AuthorTeaser>();
-	readonly tags = input<Tag[]>([]);
-	readonly storyCount = input<number>();
+	public readonly author = input.required<AuthorTeaser>();
+	public readonly tags = input<Tag[]>([]);
+	public readonly storyCount = input<number>();
 }
 ```
 
@@ -60,19 +60,28 @@ Regla central: **un campo de componente nunca es `public` por defecto.** Las pla
 | `public`    | **Solo** inputs/outputs/models de signals (`input()`, `output()`, `model()`), **API imperativa** llamada por padres (`open()`, `close()`), y miembros **requeridos por interfaces**. |
 
 ```typescript
-export class AuthorTeaserV3Component {
-	// public: input de signal → parte de la API del componente
-	readonly author = input.required<AuthorTeaser>();
+// Patrón de `src/app/components/share-button/share-button.component.ts`
+export class ShareButtonComponent {
+	public readonly platform = input.required<SharingPlatform>();
 
-	// protected: solo lo consume la plantilla
-	protected readonly appRoutes = AppRoutes;
+	protected readonly NgIcon = NgIcon;
 
-	// private: interno, no aparece en la plantilla
-	private readonly store = inject(StoryService);
+	private readonly tooltipDirective = inject(TooltipDirective);
 }
 ```
 
-> Los `input()`/`output()`/`model()` no llevan modificador (son `public` implícito): son la API del componente. El resto, decidir entre `protected` y `private` según se use o no en la plantilla.
+> Los `input()` / `output()` / `model()` llevan **`public` explícito**: son la API del componente. El resto, decidir entre `protected` y `private` según la plantilla lo consuma o no.
+
+### Signals dentro del componente
+
+Un `computed()` —y cualquier otra signal que no sea `input()`/`output()`/`model()`— es **`private` por defecto**. Pasa a **`protected`** solo cuando la plantilla del propio componente interpola su valor.
+
+```typescript
+protected readonly icon = computed(() => /* … */); // la plantilla lo interpola
+private readonly isExpanded = signal(false); // estado interno, no llega a la plantilla
+```
+
+`public` queda reservado a las dos excepciones que ya fija la tabla: un miembro **requerido por una interfaz** (p. ej. `story` en `StoryComponent`, exigido por `StoryHost`) o **consumido por otro componente** (p. ej. `hiddenCount` de `TagsOverflowDirective`, que lee `TagsListComponent`). Exponer una signal en `public` "por las dudas" agranda la API del componente sin que nadie la consuma.
 
 ---
 
@@ -92,25 +101,27 @@ Nunca usar decoradores `@Input()`/`@Output()`/`@ViewChild()`/`@ContentChild()`. 
 
 ```typescript
 // Inputs
-readonly author = input.required<AuthorTeaser>();
-readonly tags = input<Tag[]>([]);
-readonly storyCount = input<number>();
+public readonly author = input.required<AuthorTeaser>();
+public readonly tags = input<Tag[]>([]);
+public readonly storyCount = input<number>();
 
 // Input con transform
-readonly isVisible = input(VisibilityState.Visible, {
+public readonly isVisible = input(VisibilityState.Visible, {
 	transform: (value) => (value ? VisibilityState.Visible : VisibilityState.Hidden),
 });
 
-// Output / model / queries
-readonly selected = output<string>();
-readonly value = model<string>('');
-readonly listItems = contentChildren(TagComponent);
+// Output / model — también API del componente
+public readonly selected = output<string>();
+public readonly value = model<string>('');
+
+// Queries — no son API: `protected` si la plantilla las usa, `private` si no
+private readonly listItems = contentChildren(TagComponent);
 ```
 
 Los valores **derivados** son `computed()`, nunca estado duplicado guardado a mano:
 
 ```typescript
-readonly icon = computed(() => {
+protected readonly icon = computed(() => {
 	if (!this.tag().slug) {
 		return null;
 	}
@@ -157,13 +168,14 @@ Todo `effect()` / `afterRenderEffect()` / `afterNextRender()` se declara como **
 
 ```typescript
 // ✅ Correcto — effect nombrado como field, después de lo que referencia
-export class StoryComponent {
-	private readonly store = inject(StoryService);
-	readonly slug = input.required<string>();
+// (patrón de `share-button.component.ts`)
+export class ShareButtonComponent {
+	private readonly tooltipDirective = inject(TooltipDirective);
+	public readonly platform = input.required<SharingPlatform>();
 
-	private readonly syncSlugEffect = effect(() => {
-		const slug = this.slug();
-		untracked(() => this.store.load(slug));
+	private readonly syncTooltipEffect = effect(() => {
+		this.tooltipDirective.text.set(`Compartir en ${this.platform().name}`);
+		this.tooltipDirective.position.set('bottom');
 	});
 }
 
@@ -191,7 +203,7 @@ Reglas:
 - Marcar las dependencias `private readonly` (o `protected readonly` si la plantilla las usa).
 
 ```typescript
-private readonly store = inject(StoryService);
+private readonly storyApi = inject(StoryApi); // token del API provider, no la clase concreta
 private readonly injector = inject(EnvironmentInjector);
 ```
 

--- a/.claude/references/angular-state.md
+++ b/.claude/references/angular-state.md
@@ -80,10 +80,10 @@ export class CarouselStateService {
 	private readonly _isTransitioning = signal(false);
 
 	// Signals públicas de solo lectura
-	readonly activeIndex: Signal<number> = this._activeIndex.asReadonly();
-	readonly isTransitioning: Signal<boolean> = this._isTransitioning.asReadonly();
+	public readonly activeIndex: Signal<number> = this._activeIndex.asReadonly();
+	public readonly isTransitioning: Signal<boolean> = this._isTransitioning.asReadonly();
 
-	selectSlide(index: number, direction: 'left' | 'right'): void {
+	public selectSlide(index: number, direction: 'left' | 'right'): void {
 		if (this._isTransitioning() || index === this._activeIndex()) return;
 		this._isTransitioning.set(true);
 		this._activeIndex.set(index);

--- a/.claude/references/angular-state.md
+++ b/.claude/references/angular-state.md
@@ -55,14 +55,14 @@ Los valores derivados son **`computed`** (o `toSignal` para fuentes observables)
 
 ```typescript
 // ✅ Correcto — todo lo derivado cuelga de un único origen (story.component.ts)
-readonly story = computed(() => this.storyResource.value());
-readonly sharingRoute = computed(() => `${AppRoutes.Story}/${this.story()?.slug}`);
-readonly shareMessage = computed(
+public readonly story = computed(() => this.storyResource.value()); // `public`: lo exige la interfaz StoryHost
+protected readonly sharingRoute = computed(() => `${AppRoutes.Story}/${this.story()?.slug}`);
+protected readonly shareMessage = computed(
 	() => `Leí "${this.story()?.title}" de ${this.story()?.author.name} en La Cuentoneta ...`,
 );
 
 // ❌ Incorrecto — segundo signal que hay que mantener en sync a mano
-readonly sharingRoute = signal('');
+protected readonly sharingRoute = signal('');
 // ...y luego un effect/set por cada cambio de story → estado duplicado
 ```
 

--- a/.claude/references/clean-architecture.md
+++ b/.claude/references/clean-architecture.md
@@ -89,13 +89,13 @@ La interfaz lleva el **nombre limpio** (la responsabilidad), y la **implementaci
 | Repository de stories    | `StoryRepository`        | `SanityStoryRepository`       | `InMemoryStoryRepository`     |
 | Repository de autores    | `AuthorRepository`       | `SanityAuthorRepository`      | `InMemoryAuthorRepository`    |
 | Repository de storylists | `StorylistRepository`    | `SanityStorylistRepository`   | `InMemoryStorylistRepository` |
-| Service (impl. única)    | `LayoutService`          | `LayoutService` (mismo nombre) | `InMemoryLayoutService`      |
+| Service (impl. única)    | `StoryService`           | `StoryService` (mismo nombre) | `InMemoryStoryService`        |
 
 - Prefijo **`Sanity*`** para implementaciones de repository respaldadas por Sanity/GROQ.
 - Prefijo **`InMemory*`** para **todos** los dobles de test (jamás `Mock*`).
 - Los services de implementación única **conservan el nombre de la interfaz** (sin prefijo, sin sufijo `Impl`).
 
-> Nota sobre el estado actual: hoy los módulos backend exponen funciones (`getStoryBySlug`, `fetchStories`) más que clases con interfaz explícita. La convención de arriba rige al introducir abstracciones de repository/service o sus dobles de test, y es la dirección a la que tienden los `*.service.spec.ts`.
+> Nota sobre el estado actual: hoy los módulos backend exponen funciones (`getStoryBySlug`, `fetchStories`) más que clases con interfaz explícita, así que **los nombres de esta tabla son ilustrativos de la convención, no símbolos existentes** — las clases llegan con #1503. La convención rige al introducir abstracciones de repository/service o sus dobles de test, y es la dirección a la que tienden los `*.service.spec.ts`.
 
 ### Frontend
 
@@ -104,8 +104,10 @@ La interfaz lleva el **nombre limpio** (la responsabilidad), y la **implementaci
 | API de stories    | `StoryApi`                          | `HttpStoryApi`     | `InMemoryStoryApi`     |
 | API de autores    | `AuthorApi`                         | `HttpAuthorApi`    | `InMemoryAuthorApi`    |
 | API de storylists | `StorylistApi`                      | `HttpStorylistApi` | `InMemoryStorylistApi` |
+| Service (impl. única) | `LayoutService` (sin token)     | `LayoutService`    | `InMemoryLayoutService` |
 
 - Prefijo **`Http*`** para implementaciones de servicios de API basadas en HTTP.
+- Un service de **implementación única** (`LayoutService`, `NavigationFrameService`, `SchemaOrgService`) no necesita interfaz ni token: se inyecta la clase y su doble es `InMemory*` (`layout.mock.ts`). El par interfaz + `InjectionToken` se reserva a los **API providers**, que sí tienen dos implementaciones intercambiables.
 - Los tokens son `InjectionToken` planos (sin `providedIn`/`factory`), cableados vía `provide<X>Api()` (real) y `provide<X>ApiMock()` (doble) con `makeEnvironmentProviders`.
 - **Archivos (3 por API provider):**
   - **`<dominio>-api.interface.ts`** — la interfaz `<X>Api` + el `InjectionToken`. El sufijo **`-api`** distingue el archivo de una interfaz del **modelo de dominio**: `author-api.interface.ts` exporta `AuthorApi`, no una interfaz del agregado `Author`.

--- a/.claude/references/clean-architecture.md
+++ b/.claude/references/clean-architecture.md
@@ -89,7 +89,7 @@ La interfaz lleva el **nombre limpio** (la responsabilidad), y la **implementaci
 | Repository de stories    | `StoryRepository`        | `SanityStoryRepository`       | `InMemoryStoryRepository`     |
 | Repository de autores    | `AuthorRepository`       | `SanityAuthorRepository`      | `InMemoryAuthorRepository`    |
 | Repository de storylists | `StorylistRepository`    | `SanityStorylistRepository`   | `InMemoryStorylistRepository` |
-| Service (impl. única)    | `StoryService`           | `StoryService` (mismo nombre) | `InMemoryStoryService`        |
+| Service (impl. única)    | `LayoutService`          | `LayoutService` (mismo nombre) | `InMemoryLayoutService`      |
 
 - Prefijo **`Sanity*`** para implementaciones de repository respaldadas por Sanity/GROQ.
 - Prefijo **`InMemory*`** para **todos** los dobles de test (jamás `Mock*`).

--- a/.claude/references/solid.md
+++ b/.claude/references/solid.md
@@ -141,7 +141,7 @@ interface StoryListProvider {
 export class StoryComponent {
 	private readonly storyApi = inject(StoryApi);
 	public readonly slug = input.required<string>();
-	protected readonly story = toSignal(/* derivado del slug vía el API provider */);
+	public readonly story = computed(/* derivado del slug vía el API provider */); // `public`: lo exige StoryHost
 }
 
 // ❌ El componente conoce GROQ y el cliente de Sanity directamente: alto nivel

--- a/.claude/references/solid.md
+++ b/.claude/references/solid.md
@@ -139,9 +139,9 @@ interface StoryListProvider {
 ```typescript
 // ✅ El componente (alto nivel) depende de una abstracción inyectada, no de Sanity directo.
 export class StoryComponent {
-	private readonly stories = inject(StoryApi);
-	readonly slug = input.required<string>();
-	protected readonly story = toSignal(/* derivado del slug vía el service */);
+	private readonly storyApi = inject(StoryApi);
+	public readonly slug = input.required<string>();
+	protected readonly story = toSignal(/* derivado del slug vía el API provider */);
 }
 
 // ❌ El componente conoce GROQ y el cliente de Sanity directamente: alto nivel


### PR DESCRIPTION
Los tres ejemplos marcados como **✅ Correcto** en `angular-components.md` inyectaban `StoryService`, que no existe en el repo. No admitían un rename directo: modelaban un state service con `load(slug)`, y acá el acceso a datos va por tokens `*Api` que devuelven `Observable`. Se los reancla a **`ShareButtonComponent`**, que ilustra los tres puntos —visibilidad, `effect()` como field initializer nombrado, `inject()`— con código real.

## La contradicción que apareció al hacerlo

`angular-components.md` se contradecía a sí mismo sobre los inputs:

- la **tabla de visibilidad** asigna `public` a `input()` / `output()` / `model()`;
- la **nota diez líneas abajo** decía que "no llevan modificador".

El código no deja lugar a dudas: **cero** inputs/outputs/models sin modificador explícito en `src/`, todos con `public readonly`. Gana la tabla. Se corrige la nota y también `solid.md`, que en #1848 había quedado alineado a la nota equivocada.

## Regla nueva: visibilidad de signals dentro del componente

Un `computed()` —y cualquier signal que no sea `input()`/`output()`/`model()`— es **`private` por defecto**, y **`protected`** solo si la plantilla del propio componente interpola su valor. Es la especialización a signals de lo que la tabla ya decía para cualquier campo.

`public` queda para las dos excepciones que la tabla ya preveía, ambas con ejemplo real verificado:

| Caso | Ejemplo |
| ---- | ------- |
| Requerido por una interfaz | `story` en `StoryComponent`, exigido por `StoryHost` |
| Consumido por otro componente | `hiddenCount` de `TagsOverflowDirective`, que lee `TagsListComponent` |

El código ya cumple: **64** `computed` en `protected`, **2** en `private`, **0** sin modificador. Las queries (`contentChildren`, `viewChild`) siguen la misma regla y no son API.

## Hallazgos del mismo defecto, fuera de la tabla del issue

- **`test-generator.md`** repetía los **dos** errores que #1848 corrigió en `testing.md`: mock de servicio frontend como `Promise` y `provide: StoryService`. Ahora `Observable` + `of()` + `StoryApi.getBySlug`.
- **`clean-architecture.md`** ilustraba "service de implementación única" con `StoryService`.
- **`angular-state.md`** mostraba los `computed` de `story.component.ts` sin modificador; el archivo real usa `public` para `story` (interfaz `StoryHost`) y `protected` para los derivados de plantilla.

## Lo que corrigió la review local

- **`solid.md` dejaba `protected readonly story`** en `StoryComponent`, mientras los otros dos archivos del mismo commit citaban ese mismo miembro como el ejemplo canónico de `public` por interfaz. Era justo el tipo de contradicción que este PR venía a erradicar.
- **`LayoutService` quedó mal ubicado**: lo puse como ejemplo de service de implementación única en la tabla de **backend**, siendo un service de frontend. La fila de backend vuelve a nombres ilustrativos —el backend hoy expone funciones, no clases, y la nota ahora lo dice explícitamente— y el ejemplo real se suma a la tabla de frontend, donde `LayoutService` y su `InMemoryLayoutService` sí existen.
- El snippet de `CarouselStateService` en `angular-state.md` declaraba sus miembros sin modificador.

## Deuda de código detectada (fuera de alcance)

Este PR es solo documentación; lo siguiente es código y no se tocó:

- **3 `computed` en `public` que no lo justifican**: `slideCount` y `showControls` de `CarouselComponent` (solo los usa su propia plantilla → `protected`) y `visibleCount` de `TagsOverflowDirective` (sin consumidores → `private`).
- **39 dependencias inyectadas sin `readonly`** contra 26 con él, pese a que `angular-components.md` manda `private readonly`. Por eso el ejemplo aclara que esa parte de `share-button.component.ts` es deuda y no el patrón.

Cambio **solo de documentación** (5 Markdown bajo `.claude/`): exento del requisito de test según `coding-agent-policies.md` Sección 2.

Closes #1872