### PR TITLE
[#1850] - Evaluar cómo acelerar la ejecución de los flujos de Claude Code sin perder calidad

### DIFF
--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -1,11 +1,9 @@
 ---
 name: documentation-writer
-description: Escribe o actualiza documentación del proyecto: guías de `docs/`, `CLAUDE.md` y referencias de `.claude/references/`. Usalo en fase de mantenimiento o cuando se detecten huecos de documentación.
+description: Escribe o actualiza documentación del proyecto — guías de `docs/`, `CLAUDE.md` y referencias de `.claude/references/`. Usalo en fase de mantenimiento, o cuando un cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología de dominio y hay que correr el scan de impacto en documentación.
 tools: Read, Grep, Glob, Write, WebSearch
 model: sonnet
 ---
-
-> **⚠️ Este agente no está operativo.** No aparece en el registro de agentes de la sesión (cargan 8 de los 9 archivos de `.claude/agents/`), por una causa todavía no diagnosticada — ver **#1874**. Hasta que se resuelva, ningún flujo lo invoca: delegar en él haría fallar el paso. La decisión de integrarlo o retirarlo se toma en ese issue.
 
 Sos un especialista en documentación técnica para **La Cuentoneta** (Angular 22 zoneless + Nx 23.1, pnpm, Hono + Sanity). **Toda la documentación se escribe en español**; el código y los identificadores van en inglés.
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: security-auditor
-description: Audita el código en busca de vulnerabilidades OWASP aplicables a un sitio público de lectura (inyección en GROQ, XSS vía PortableText/HTML, secrets de Sanity hardcodeados, validación con zod en controllers Hono, SSRF en fetch externo, dependencias vulnerables). Lo invoca la Fase 4 del skill `issue-workflow`, antes del `code-reviewer`, cuando el diff toca superficie de seguridad: `src/api/**`, renderizado de contenido del CMS, fetch externo o dependencias.
+description: Audita el código en busca de vulnerabilidades OWASP aplicables a un sitio público de lectura (inyección en GROQ, XSS vía PortableText/HTML, secrets de Sanity hardcodeados, validación con zod en controllers Hono, SSRF en fetch externo, dependencias vulnerables). Lo invoca la Fase 4 del skill `issue-workflow`, antes del `code-reviewer`, cuando el diff toca superficie de seguridad — `src/api/**`, renderizado de contenido del CMS, fetch externo o dependencias.
 tools: Read, Grep, Glob, Bash
 model: sonnet
 ---

--- a/.claude/references/scripts.md
+++ b/.claude/references/scripts.md
@@ -19,3 +19,4 @@
 - `remove-all-unpublished-drafts.ts` — limpia drafts no publicados (operacional, no en package.json).
 - `fix-index-file-name.mjs` — postbuild: renombra el index SSR.
 - `vercel-environments.model.ts` — tipos compartidos con `cms/set-environment.ts`.
+- `check-agent-frontmatter.ts` — valida el frontmatter de `.claude/agents/`; lo corre `pnpm lint`.

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -80,7 +80,8 @@ No avanzar a la Fase 3 sin aprobación explícita.
 **Propósito:** verificar que pasen los gates de CI y correr los agentes de review.
 
 1. Correr localmente (con `pnpm`, nunca `nx` directo) los **gates de CI** definidos en la sección [Comandos comunes](../../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**). `test:e2e` y `studio-build` son costosos de correr en cada iteración: corré `test:e2e` si el cambio toca flujos E2E y `studio-build` si toca `cms/`; el resto, siempre.
-   - Si alguno falla: reportar cuál, diagnosticar, arreglar, commitear el fix (reglas de Fase 3) y re-correr hasta que pasen.
+   - **Lanzalos concurrentemente**, no uno tras otro: son independientes entre sí y así los corre CI (todos los jobs cuelgan de `setup` y van en runners separados). En serie tardan la **suma**; en paralelo, lo que tarde el más lento. Medido en #1850: 105s → 29s.
+   - Si alguno falla: reportar cuál, diagnosticar, arreglar, commitear el fix (reglas de Fase 3) y re-correr **solo el que falló** mientras el resto sigue verde; re-correr todo solo si el fix toca superficie compartida.
 2. Si el diff toca **superficie de seguridad**, delegar primero al agente **`security-auditor`**. La lista de disparadores es la sección **"Cuándo correr"** del propio agente: `src/api/**` (endpoints, GROQ, mappers), manejo de contenido externo (PortableText/HTML del CMS, `bypassSecurityTrust*`, fetch a servicios externos, `localStorage`), variables de entorno / secrets / config de Sanity o Clarity, y dependencias (`package.json` / `pnpm-lock.yaml`). Un diff que no toca nada de eso —solo documentación, estilos o UI sin datos externos— **no** lo requiere; también puede invocarse a demanda si surge una preocupación puntual.
 3. Delegar al agente **`code-reviewer`** para revisar todos los cambios de la rama vs. `develop`.
 4. Ambos agentes escriben sus hallazgos en `workspace/CODE_REVIEW.md`; los del `security-auditor` van en una sección propia.

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -55,7 +55,8 @@ No avanzar a la Fase 3 sin aprobación explícita.
 
 1. Ejecutar los pasos de `workspace/PLAN.md` en orden.
 2. Un commit atómico por unidad lógica de trabajo.
-3. **CHANGELOG:** cuentoneta mantiene `CHANGELOG.md` **por release/versión** (no por PR), al cerrar un milestone. **No** se exige una entrada por issue en este flujo; el tracking del cambio vive en el issue + su milestone. (Esto reemplaza el gate de CHANGELOG del starter.)
+3. **Scan de impacto en documentación.** Si el cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología de dominio, delegar en el agente **`documentation-writer`** la actualización de `docs/`, `CLAUDE.md` y `.claude/references/`, en el **mismo** commit/PR — lo exige la sección [Scan de impacto en documentación](../../../CLAUDE.md#scan-de-impacto-en-documentación) de `CLAUDE.md`. Si el cambio no toca nada de eso, saltear el paso.
+4. **CHANGELOG:** cuentoneta mantiene `CHANGELOG.md` **por release/versión** (no por PR), al cerrar un milestone. **No** se exige una entrada por issue en este flujo; el tracking del cambio vive en el issue + su milestone. (Esto reemplaza el gate de CHANGELOG del starter.)
 
 ### Reglas de commit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Usar **siempre `pnpm`** para instalar y ejecutar scripts. Los scripts envuelven 
 | `pnpm install`                            | Instala dependencias                                                                                                                 |
 | `pnpm dev`                                | Dev server (SSR) en desarrollo                                                                                                       |
 | `pnpm build`                              | Build de producción                                                                                                                  |
-| `pnpm lint`                               | ESLint sobre `src` y `e2e`                                                                                                           |
+| `pnpm lint`                               | Valida el frontmatter de `.claude/agents/` y corre ESLint sobre `src` y `e2e`                                                       |
 | `pnpm stylelint`                          | Stylelint sobre CSS                                                                                                                  |
 | `pnpm typecheck`                          | Type-check estricto (`tsc --noEmit`)                                                                                                 |
 | `pnpm test`                               | Tests unitarios (Vitest)                                                                                                             |
@@ -137,6 +137,7 @@ Si un cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología
 
 - **`.mcp.json`** (raíz, versionado): servidores MCP del equipo — **Sanity** (remoto `https://mcp.sanity.io`, OAuth; no requiere token en el archivo), **Figma** (remoto `https://mcp.figma.com/mcp`, OAuth; para desarrollo de componentes a partir del diseño) y **nx** (análisis del workspace). Sin secrets.
 - **`.claude/settings.json`** (versionado): permisos de equipo — `deny` de lectura/escritura/edición de `.env*` en la raíz y en cualquier subdirectorio (`**/.env*`, cubre `./.env` y `./cms/.env`), más bloqueo de su creación por shell (redirecciones `>`/`>>`, `tee`, `touch`, `cp`, `mv`); y una `allow` mínima (gates de CI con `pnpm` + inspección read-only de git/gh).
+- **`.claude/agents/*.md`** (versionado): un `description:` **no puede contener `: `** (dos puntos + espacio) sin comillas — YAML lo lee como un mapping anidado, el frontmatter queda inválido y el agente **no carga, sin emitir ningún error**. Usar un guion (`—`) en su lugar. Lo verifica `pnpm lint` (gate de CI) vía `scripts/check-agent-frontmatter.ts`; el fallo silencioso costó dos agentes caídos (#1874).
 - **`.claude/settings.local.json`** y **`.claude/worktrees/`**: **personales/locales**, gitignoreados. Las allowlists o MCP propios de cada quien van ahí — p. ej. el **Figma Dev Mode** local (`http://127.0.0.1:3845/sse`), que requiere la app de escritorio corriendo y es distinto del servidor remoto de Figma versionado en `.mcp.json`.
 
 ---

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"delete-unused-assets": "node --import tsx --env-file=.env ./scripts/delete-unused-assets.ts",
 		"storybook": "nx run @cuentoneta/app:storybook",
 		"storybook:build": "nx run @cuentoneta/app:build-storybook",
-		"lint": "nx eslint:lint --skip-nx-cache",
+		"lint": "node --import tsx ./scripts/check-agent-frontmatter.ts && nx eslint:lint --skip-nx-cache",
 		"stylelint": "nx stylelint @cuentoneta/app",
 		"test": "nx test --skip-nx-cache",
 		"typecheck": "nx typecheck --skip-nx-cache",

--- a/scripts/check-agent-frontmatter.ts
+++ b/scripts/check-agent-frontmatter.ts
@@ -1,0 +1,69 @@
+/**
+ * Valida el frontmatter de `.claude/agents/*.md`.
+ *
+ * Un `description:` sin comillas que contenga `: ` (dos puntos + espacio) es YAML inválido: el parser
+ * lo lee como un mapping anidado y descarta el agente **sin emitir ningún error**. El agente
+ * simplemente no aparece en el registro de la sesión. Pasó con `documentation-writer` (#1874) y se
+ * repitió al editar `security-auditor` (#1849), en ambos casos sin señal alguna.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const AGENTS_DIR = join(process.cwd(), '.claude', 'agents');
+const REQUIRED_KEYS = ['name', 'description'] as const;
+
+type Problem = { file: string; message: string };
+
+function frontmatterOf(source: string): string | null {
+	const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source);
+	return match ? match[1] : null;
+}
+
+function checkAgent(file: string): Problem[] {
+	const problems: Problem[] = [];
+	const frontmatter = frontmatterOf(readFileSync(join(AGENTS_DIR, file), 'utf8'));
+
+	if (frontmatter === null) {
+		return [{ file, message: 'no tiene frontmatter delimitado por `---`' }];
+	}
+
+	const entries = new Map<string, string>();
+	for (const line of frontmatter.split(/\r?\n/)) {
+		const separator = line.indexOf(':');
+		if (separator > 0 && /^[a-zA-Z]/.test(line)) {
+			entries.set(line.slice(0, separator).trim(), line.slice(separator + 1).trim());
+		}
+	}
+
+	for (const key of REQUIRED_KEYS) {
+		if (!entries.has(key)) {
+			problems.push({ file, message: `le falta la clave \`${key}\`` });
+		}
+	}
+
+	for (const [key, value] of entries) {
+		const unquoted = !/^["'].*["']$/.test(value);
+		if (unquoted && value.includes(': ')) {
+			problems.push({
+				file,
+				message: `\`${key}\` contiene ": " sin comillas — YAML lo lee como mapping y el agente no carga. Usá un guion (—) o entrecomillá el valor.`,
+			});
+		}
+	}
+
+	return problems;
+}
+
+const problems = readdirSync(AGENTS_DIR)
+	.filter((file) => file.endsWith('.md'))
+	.flatMap(checkAgent);
+
+if (problems.length > 0) {
+	for (const { file, message } of problems) {
+		console.error(`✗ .claude/agents/${file} — ${message}`);
+	}
+	console.error(`\n${problems.length} problema(s) de frontmatter. Un agente con frontmatter inválido no carga y nadie se entera.`);
+	process.exit(1);
+}
+
+console.log(`✓ Frontmatter válido en los ${readdirSync(AGENTS_DIR).filter((f) => f.endsWith('.md')).length} agentes`);


### PR DESCRIPTION
> **PR stackeado.** Base: `feat/1874-documentation-writer-registro` (PR #1878), que va sobre #1876.

## Descripción

#1850 es un issue de **evaluación**: su entregable es la medición, no el código. El informe completo —gates cronometrados uno a uno, costo real de las reviews, y los cinco ejes evaluados con su veredicto— está publicado [como comentario en el issue](https://github.com/cuentoneta/cuentoneta/issues/1850#issuecomment-5036706625), que es donde alguien va a buscarlo.

Este PR contiene **lo único accionable que salió de esa medición**: dos líneas en la Fase 4 del `issue-workflow`.

- **Lanzar los gates concurrentemente** en vez de en serie. Son independientes y así los corre CI, donde cada job cuelga de `setup` y va en su propio runner; la Fase 4 era el único lugar que los serializaba. Medido: **105s en serie → 29s en paralelo**.
- **Tras un gate en rojo, re-correr solo el que falló** en vez de todos, salvo que el fix toque superficie compartida.

Closes #1850.

## Por qué el diff es tan chico

Porque la medición dice que casi todo lo demás no conviene tocarse:

- `build` (14s) y `storybook` (29s), que el issue daba por "los caros", están entre los más baratos.
- El costo dominante son las reviews: **368s de media**, 3,5× toda la suite de gates.
- Recortar la carga de referencias del `code-reviewer` sería "hacer menos", que la restricción dura del issue prohíbe explícitamente.

El detalle de cada descarte está en el informe.

## Plan de pruebas

- [x] Gates cronometrados uno a uno en local con `--skip-nx-cache`, todos en verde
- [x] La instrucción nueva se aplicó en la práctica en el PR #1881, corriendo `build`, `storybook` y `stylelint` concurrentemente
- [x] Cambio solo de documentación: exento del requisito de test según `coding-agent-policies.md` Sección 2