### PR TITLE
Nombra los dobles de test por comportamiento: Stub* para los canned, InMemory* para el fake real

### DIFF
--- a/.claude/agents/architecture-advisor.md
+++ b/.claude/agents/architecture-advisor.md
@@ -64,7 +64,7 @@ Primero determiná el change set: corré `git diff --name-only develop...HEAD` (
 - **Regla de dependencia** — las dependencias apuntan hacia adentro (dominio → casos de uso → adaptadores → frameworks). En el backend: el flujo `controller → service → repository` con el mapper (ACL) como frontera que traduce Sanity/GROQ al modelo de dominio
 - **Independencia de capas** — las reglas de negocio no dependen de frameworks ni de la UI; el modelo de dominio no conoce a Sanity
 - **Cruce de fronteras** — los datos cruzan como modelo de dominio mapeado, no como resultados crudos de GROQ; los repos exponen `fetch*()` (crudo) y los services `get*()` (mapeado a dominio)
-- **Testeabilidad** — la lógica de negocio se testea sin dependencias externas (dobles `InMemory*`, nunca `Mock*`)
+- **Testeabilidad** — la lógica de negocio se testea sin dependencias externas (dobles nombrados por comportamiento: `Stub*`/`InMemory*`/`Spy*`, nunca `Mock*`)
 
 ### Diseño de componentes (acoplamiento entre módulos)
 
@@ -96,14 +96,14 @@ Al evaluar nuevos módulos o endpoints, verificá que el plan incluya:
 - [ ] Módulo bajo `src/api/modules/<dominio>/` con el patrón **controller → service → repository**
 - [ ] Mapper (ACL) en `src/api/_utils/` que traduce GROQ/Sanity al modelo de dominio
 - [ ] Validación con `@hono/zod-validator` y contratos/tipos de dominio acordes
-- [ ] Tests (Vitest + `@test-utils`) con dobles `InMemory*` para los repos
+- [ ] Tests (Vitest + `@test-utils`) con dobles nombrados por comportamiento (`Stub*`/`InMemory*`) para los repos
 - [ ] Hono plano, no `OpenAPIHono` (dirección futura no adoptada, #1531); sin Drizzle — la persistencia es Sanity vía `@sanity/client`
 
 ### Convención de providers del frontend (Qualified Implementation)
 
 - Interfaz de API con sufijo `-api`: `<dominio>-api.interface.ts` (export `<X>Api`)
 - Implementación + factory en `<dominio>.provider.ts` (`Http<X>Api` + `provide<X>Api()`)
-- Doble de test en `<dominio>.mock.ts` (`InMemory<X>Api` + `provide<X>ApiMock()`)
+- Doble de test en `<dominio>.mock.ts` (`Stub<X>Api` + `provide<X>ApiMock()`)
 
 ## Restricciones duras a vigilar (de CLAUDE.md)
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -86,7 +86,7 @@ Estos patrones son intencionales y correctos. NO los reportes como problemas:
 - [ ] Open/Closed — extender comportamiento sin modificar lo existente
 - [ ] Liskov Substitution — los subtipos son sustituibles por sus tipos base
 - [ ] Interface Segregation — sin dependencias forzadas sobre interfaces no usadas
-- [ ] Dependency Inversion — depender de abstracciones, no de concreciones (convención **Qualified Implementation**: interfaz con nombre limpio, impls con prefijo `Sanity*`/`Http*`, dobles `InMemory*` nunca `Mock*`)
+- [ ] Dependency Inversion — depender de abstracciones, no de concreciones (convención **Qualified Implementation**: interfaz con nombre limpio, impls con prefijo `Sanity*`/`Http*`, dobles por comportamiento `Stub*`/`InMemory*`/`Spy*` nunca `Mock*`)
 
 ### Principios CUPID
 

--- a/.claude/agents/domain-model-advisor.md
+++ b/.claude/agents/domain-model-advisor.md
@@ -108,7 +108,7 @@ Como toda sesión de agente sobre este repo: cargá también `.claude/references
 - [ ] **Sin `enum` de TS** — usar `Object.freeze({...} as const)` para conjuntos cerrados de literales (`ResourceType.slug`, `MediaType`, …).
 - [ ] **Sin barrels** (`index.ts` re-export prohibidos).
 - [ ] **`any` prohibido** sin comentario `// REASON:`.
-- [ ] **Qualified Implementation:** la interfaz lleva el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test son `InMemory*` (**nunca** `Mock*`).
+- [ ] **Qualified Implementation:** la interfaz lleva el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test se nombran por comportamiento — `Stub*`/`InMemory*`/`Spy*`, **nunca** `Mock*`.
 - [ ] Tests con **Vitest** + Angular Testing Library + wrappers de `@test-utils` (prohibido `vi.*` directo).
 
 ## Organización de archivos

--- a/.claude/agents/refactoring-specialist.md
+++ b/.claude/agents/refactoring-specialist.md
@@ -76,7 +76,7 @@ Antes de refactorizar, leé estas referencias del proyecto. Cargalas en **un ún
 - [ ] Los nombres revelan intención (sin abreviaturas ni nombres genéricos).
 - [ ] Convenciones consistentes: archivos `kebab-case`, clases `PascalCase`, métodos `camelCase`, constantes globales `SCREAMING_SNAKE_CASE` y locales `camelCase`.
 - [ ] Variables/métodos booleanos con prefijos `is`, `has`, `can`, `should`.
-- [ ] Interfaces sin prefijo `I`; convención **Qualified Implementation** (`Sanity*`/`Http*`, dobles `InMemory*`, nunca `Mock*`).
+- [ ] Interfaces sin prefijo `I`; convención **Qualified Implementation** (`Sanity*`/`Http*`, dobles por comportamiento `Stub*`/`InMemory*`/`Spy*`, nunca `Mock*`).
 
 ### Simplificación
 

--- a/.claude/references/clean-architecture.md
+++ b/.claude/references/clean-architecture.md
@@ -33,7 +33,7 @@ Construir sistemas **mantenibles, testeables e independientes** de los detalles 
 
 - Las reglas de negocio se testean sin UI, sin Sanity y sin servidor web.
 - Los tipos de dominio son objetos planos sin dependencias de framework.
-- Los services se testean sustituyendo el repository por un doble en memoria (`InMemory*`, ver más abajo): ver los `*.service.spec.ts` existentes (`content.service.spec.ts`, `sitemap.service.spec.ts`).
+- Los services se testean sustituyendo el repository por un doble (nombrado por comportamiento — `Stub*`/`InMemory*`, ver más abajo): ver los `*.service.spec.ts` existentes (`content.service.spec.ts`, `sitemap.service.spec.ts`).
 
 ### Cruce de fronteras
 
@@ -78,7 +78,15 @@ Angular **signals-first** (sin NgRx). Los componentes y servicios consumen **mod
 
 ## Qualified Implementation (convención de nombres)
 
-La interfaz lleva el **nombre limpio** (la responsabilidad), y la **implementación** lleva un **prefijo de tecnología/propósito**. El doble de test es siempre `InMemory*` — **nunca `Mock*`**.
+La interfaz lleva el **nombre limpio** (la responsabilidad), y la **implementación** lleva un **prefijo de tecnología/propósito** (`Sanity*`, `Http*`).
+
+El **doble de test** se nombra por lo que **es**, no con el término vago `Mock*`:
+
+- **`Stub*`** — devuelve valores fijos e ignora la entrada. Es el caso de los API providers del front: `StubStoryApi.getBySlug()` devuelve siempre el mismo `storyMock`, sin mirar el slug. No hay nada "en memoria" que consultar, así que llamarlo `InMemory*` prometería una implementación que no existe.
+- **`InMemory*`** — un _fake_: mantiene estado real en memoria y reacciona a él. `InMemoryLayoutService` es el ejemplo: tiene un `viewport` signal y `biggerThan()` compara anchos reales contra el viewport actual. Reservado a los dobles que **de verdad** implementan la lógica.
+- **`Spy*`** — registra las llamadas recibidas, cuando el test las inspecciona.
+
+El **archivo** sigue siendo `<dominio>.mock.ts` y la **factory** `provide<X>ApiMock()`: ahí "mock" nombra genéricamente al proveedor del doble, no reclama una categoría de la taxonomía.
 
 **Regla del prefijo `I`:** la interfaz **nunca** lleva prefijo `I` (no `IStoryRepository`), sin excepciones. Si una clase necesitara el mismo nombre que la interfaz, el problema es el **nombre de la clase**, no el de la interfaz: la implementación se califica (`Sanity*`, `Http*`, `InMemory*`), o directamente no se declara la clase — ver el caso de los modelos de dominio en [`domain-model.md`](domain-model.md).
 
@@ -92,33 +100,35 @@ La interfaz lleva el **nombre limpio** (la responsabilidad), y la **implementaci
 | Service (impl. única)    | `StoryService`           | `StoryService` (mismo nombre) | `InMemoryStoryService`        |
 
 - Prefijo **`Sanity*`** para implementaciones de repository respaldadas por Sanity/GROQ.
-- Prefijo **`InMemory*`** para **todos** los dobles de test (jamás `Mock*`).
+- El doble se nombra por su comportamiento (`Stub*` / `InMemory*` / `Spy*`), **jamás `Mock*`**. Un repository de test con datos cargados en memoria sí es un `InMemory*Repository` (un fake); uno que devuelve una lista fija es un `Stub*Repository`.
 - Los services de implementación única **conservan el nombre de la interfaz** (sin prefijo, sin sufijo `Impl`).
 
 > Nota sobre el estado actual: hoy los módulos backend exponen funciones (`getStoryBySlug`, `fetchStories`) más que clases con interfaz explícita, así que **los nombres de esta tabla son ilustrativos de la convención, no símbolos existentes** — las clases llegan con #1503. La convención rige al introducir abstracciones de repository/service o sus dobles de test, y es la dirección a la que tienden los `*.service.spec.ts`.
 
 ### Frontend
 
-| Rol               | Interfaz + token (`InjectionToken`) | Implementación     | Doble de test          |
-| ----------------- | ----------------------------------- | ------------------ | ---------------------- |
-| API de stories    | `StoryApi`                          | `HttpStoryApi`     | `InMemoryStoryApi`     |
-| API de autores    | `AuthorApi`                         | `HttpAuthorApi`    | `InMemoryAuthorApi`    |
-| API de storylists | `StorylistApi`                      | `HttpStorylistApi` | `InMemoryStorylistApi` |
-| Service (impl. única) | `LayoutService` (sin token)     | `LayoutService`    | `InMemoryLayoutService` |
+| Rol                   | Interfaz + token (`InjectionToken`) | Implementación     | Doble de test           |
+| --------------------- | ----------------------------------- | ------------------ | ----------------------- |
+| API de stories        | `StoryApi`                          | `HttpStoryApi`     | `StubStoryApi`          |
+| API de autores        | `AuthorApi`                         | `HttpAuthorApi`    | `StubAuthorApi`         |
+| API de storylists     | `StorylistApi`                      | `HttpStorylistApi` | `StubStorylistApi`      |
+| Service (impl. única) | `LayoutService` (sin token)         | `LayoutService`    | `InMemoryLayoutService` |
+
+> Los dobles de API son **`Stub*`** (devuelven canned, ignoran la entrada); el de `LayoutService` es **`InMemory*`** porque mantiene un viewport en memoria. La diferencia no es de capa sino de comportamiento del doble — ver la taxonomía de arriba.
 
 - Prefijo **`Http*`** para implementaciones de servicios de API basadas en HTTP.
-- Un service de **implementación única** (`LayoutService`, `NavigationFrameService`, `SchemaOrgService`) no necesita interfaz ni token: se inyecta la clase y su doble es `InMemory*` (`layout.mock.ts`). El par interfaz + `InjectionToken` se reserva a los **API providers**, que sí tienen dos implementaciones intercambiables.
+- Un service de **implementación única** (`LayoutService`, `NavigationFrameService`, `SchemaOrgService`) no necesita interfaz ni token: se inyecta la clase y su doble se nombra por comportamiento — `InMemoryLayoutService` es un fake con estado (`layout.mock.ts`). El par interfaz + `InjectionToken` se reserva a los **API providers**, que sí tienen dos implementaciones intercambiables.
 - Los tokens son `InjectionToken` planos (sin `providedIn`/`factory`), cableados vía `provide<X>Api()` (real) y `provide<X>ApiMock()` (doble) con `makeEnvironmentProviders`.
 - **Archivos (3 por API provider):**
   - **`<dominio>-api.interface.ts`** — la interfaz `<X>Api` + el `InjectionToken`. El sufijo **`-api`** distingue el archivo de una interfaz del **modelo de dominio**: `author-api.interface.ts` exporta `AuthorApi`, no una interfaz del agregado `Author`.
   - `<dominio>.provider.ts` — `Http<X>Api implements <X>Api` + `provide<X>Api()`.
-  - `<dominio>.mock.ts` — `InMemory<X>Api` + `provide<X>ApiMock()`.
+  - `<dominio>.mock.ts` — `Stub<X>Api` (los API providers devuelven canned) + `provide<X>ApiMock()`.
 
 **Resumen de reglas:**
 
 - Interfaz sin prefijo `I`, sin excepciones.
 - `Sanity*` para repositories sobre Sanity/GROQ; `Http*` para API services del front.
-- `InMemory*` para todo doble de test — nunca `Mock*`.
+- Doble de test nombrado por comportamiento: `Stub*` (canned), `InMemory*` (fake con estado), `Spy*` (registra) — nunca `Mock*`.
 - Servicio de implementación única → conserva el nombre de la interfaz.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,8 @@ Reglas no negociables. Una violación requiere justificación explícita.
 ### Naming
 
 - Archivos `kebab-case`; clases `PascalCase`; funciones/métodos `camelCase`; constantes globales `SCREAMING_SNAKE_CASE`, locales `camelCase`.
-- Interfaces **sin** prefijo `I`, sin excepciones. Convención **Qualified Implementation**: la interfaz tiene el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test son `InMemory*` (**nunca** `Mock*`).
-- **API providers del frontend:** el archivo de la interfaz lleva el sufijo `-api` — `<dominio>-api.interface.ts` (export `<X>Api`) — para distinguirlo de una interfaz del modelo de dominio. La impl y el doble viven en `<dominio>.provider.ts` (`Http<X>Api` + `provide<X>Api()`) y `<dominio>.mock.ts` (`InMemory<X>Api` + `provide<X>ApiMock()`). Ver [`clean-architecture.md`](.claude/references/clean-architecture.md).
+- Interfaces **sin** prefijo `I`, sin excepciones. Convención **Qualified Implementation**: la interfaz tiene el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test se nombran por su comportamiento — `Stub*` (devuelve canned), `InMemory*` (fake con estado), `Spy*` (registra) — **nunca** `Mock*` → [`clean-architecture.md`](.claude/references/clean-architecture.md).
+- **API providers del frontend:** el archivo de la interfaz lleva el sufijo `-api` — `<dominio>-api.interface.ts` (export `<X>Api`) — para distinguirlo de una interfaz del modelo de dominio. La impl y el doble viven en `<dominio>.provider.ts` (`Http<X>Api` + `provide<X>Api()`) y `<dominio>.mock.ts` (`Stub<X>Api` — devuelve canned — + `provide<X>ApiMock()`). Ver [`clean-architecture.md`](.claude/references/clean-architecture.md).
 
 ### Comentarios
 

--- a/src/app/providers/author.mock.ts
+++ b/src/app/providers/author.mock.ts
@@ -7,7 +7,7 @@ import { AuthorProfile, AuthorTeaser } from '@models/author.model';
 import { authorMock, authorTeaserMock } from '@mocks/author.mock';
 import { AuthorApi } from './author-api.interface';
 
-export class InMemoryAuthorApi implements AuthorApi {
+export class StubAuthorApi implements AuthorApi {
 	public getAll(): Observable<AuthorTeaser[]> {
 		return of([authorTeaserMock]);
 	}
@@ -17,6 +17,6 @@ export class InMemoryAuthorApi implements AuthorApi {
 	}
 }
 
-export function provideAuthorApiMock(api: AuthorApi = new InMemoryAuthorApi()): EnvironmentProviders {
+export function provideAuthorApiMock(api: AuthorApi = new StubAuthorApi()): EnvironmentProviders {
 	return makeEnvironmentProviders([{ provide: AuthorApi, useValue: api }]);
 }

--- a/src/app/providers/content.mock.ts
+++ b/src/app/providers/content.mock.ts
@@ -6,7 +6,7 @@ import { Observable, of } from 'rxjs';
 import { LandingPageContent } from '@models/landing-page-content.model';
 import { ContentApi } from './content-api.interface';
 
-export class InMemoryContentApi implements ContentApi {
+export class StubContentApi implements ContentApi {
 	public getLandingPageContent(): Observable<LandingPageContent> {
 		const landingPageContent: LandingPageContent = {
 			_id: '',
@@ -20,6 +20,6 @@ export class InMemoryContentApi implements ContentApi {
 	}
 }
 
-export function provideContentApiMock(api: ContentApi = new InMemoryContentApi()): EnvironmentProviders {
+export function provideContentApiMock(api: ContentApi = new StubContentApi()): EnvironmentProviders {
 	return makeEnvironmentProviders([{ provide: ContentApi, useValue: api }]);
 }

--- a/src/app/providers/contributor.mock.ts
+++ b/src/app/providers/contributor.mock.ts
@@ -6,7 +6,7 @@ import { Observable, of } from 'rxjs';
 import { Contributor, ContributorArea } from '@models/contributor.model';
 import { ContributorApi } from './contributor-api.interface';
 
-export class InMemoryContributorApi implements ContributorApi {
+export class StubContributorApi implements ContributorApi {
 	public getAll(): Observable<Contributor[]> {
 		return of([]);
 	}
@@ -16,6 +16,6 @@ export class InMemoryContributorApi implements ContributorApi {
 	}
 }
 
-export function provideContributorApiMock(api: ContributorApi = new InMemoryContributorApi()): EnvironmentProviders {
+export function provideContributorApiMock(api: ContributorApi = new StubContributorApi()): EnvironmentProviders {
 	return makeEnvironmentProviders([{ provide: ContributorApi, useValue: api }]);
 }

--- a/src/app/providers/push-notifications.mock.ts
+++ b/src/app/providers/push-notifications.mock.ts
@@ -3,14 +3,14 @@ import { Observable, of } from 'rxjs';
 
 import { PushNotificationsApi } from './push-notifications-api.interface';
 
-export class InMemoryPushNotificationsApi implements PushNotificationsApi {
+export class StubPushNotificationsApi implements PushNotificationsApi {
 	public getAppId(): Observable<string> {
 		return of('');
 	}
 }
 
 export function providePushNotificationsApiMock(
-	api: PushNotificationsApi = new InMemoryPushNotificationsApi(),
+	api: PushNotificationsApi = new StubPushNotificationsApi(),
 ): EnvironmentProviders {
 	return makeEnvironmentProviders([{ provide: PushNotificationsApi, useValue: api }]);
 }

--- a/src/app/providers/story.mock.ts
+++ b/src/app/providers/story.mock.ts
@@ -7,7 +7,7 @@ import { Story, StoryNavigationTeaser, StoryTeaser, StoryTeaserWithAuthor } from
 import { storyMock, storyNavigationTeaserMock, storyTeaserMock, storyTeaserWithAuthorMock } from '@mocks/story.mock';
 import { StoryApi } from './story-api.interface';
 
-export class InMemoryStoryApi implements StoryApi {
+export class StubStoryApi implements StoryApi {
 	public getBySlug(): Observable<Story> {
 		return of(storyMock);
 	}
@@ -25,6 +25,6 @@ export class InMemoryStoryApi implements StoryApi {
 	}
 }
 
-export function provideStoryApiMock(api: StoryApi = new InMemoryStoryApi()): EnvironmentProviders {
+export function provideStoryApiMock(api: StoryApi = new StubStoryApi()): EnvironmentProviders {
 	return makeEnvironmentProviders([{ provide: StoryApi, useValue: api }]);
 }

--- a/src/app/providers/storylist.mock.ts
+++ b/src/app/providers/storylist.mock.ts
@@ -7,7 +7,7 @@ import { Storylist, StorylistStoriesNavigationTeasers } from '@models/storylist.
 import { storylistMock, storylistNavigationTeaserMock } from '@mocks/storylist.mock';
 import { StorylistApi } from './storylist-api.interface';
 
-export class InMemoryStorylistApi implements StorylistApi {
+export class StubStorylistApi implements StorylistApi {
 	public get(): Observable<Storylist> {
 		return of(storylistMock);
 	}
@@ -17,6 +17,6 @@ export class InMemoryStorylistApi implements StorylistApi {
 	}
 }
 
-export function provideStorylistApiMock(api: StorylistApi = new InMemoryStorylistApi()): EnvironmentProviders {
+export function provideStorylistApiMock(api: StorylistApi = new StubStorylistApi()): EnvironmentProviders {
 	return makeEnvironmentProviders([{ provide: StorylistApi, useValue: api }]);
 }


### PR DESCRIPTION
> Sin issue asociado, siguiendo el criterio de los PRs recientes de config.

## El problema

El corpus mandaba `InMemory*` para **todos** los dobles de test, sin excepción (5+ sitios). Pero `InMemory*` es un término preciso de la taxonomía de dobles (Meszaros/Fowler): un **fake**, una implementación con estado real en memoria. **6 de los 7 dobles del repo no son eso.**

| Doble | Qué hace | Es un… |
| ----- | -------- | ------ |
| `StubStoryApi` (y los otros 5 API providers) | `getBySlug()` devuelve siempre el mismo `storyMock`, **ignora el slug** | **stub** |
| `InMemoryLayoutService` | tiene un `viewport` signal; `biggerThan()` compara anchos reales contra él | **fake** genuino |

Llamar `InMemory*` a un stub promete un store en memoria que no existe. Como lo planteó el usuario: `InMemory*` corresponde a *cierto tipo* de doble, y el corpus no coincidía con la nomenclatura que hace justicia a cada caso.

## El cambio

**Los dobles se nombran por lo que son**, nunca `Mock*` para la clase:

- **`Stub*`** — devuelve valores fijos, ignora la entrada (los 6 API providers).
- **`InMemory*`** — un fake con estado real (`InMemoryLayoutService`).
- **`Spy*`** — registra las llamadas, cuando el test las inspecciona.

Renombradas las 6 clases `InMemory*Api` → `Stub*Api`. Cada una se usaba **solo dentro de su propio `.mock.ts`** (declaración + arg por defecto de la factory), cero imports externos — rename de riesgo nulo.

El **archivo `.mock.ts`** y la **factory `provide*ApiMock()`** no cambian: ahí "mock" nombra genéricamente al proveedor del doble, no reclama una categoría de la taxonomía.

## Corpus actualizado

`clean-architecture.md` (regla + tablas + resumen), `CLAUDE.md` (Naming), y los agentes `architecture-advisor`, `code-reviewer`, `domain-model-advisor`, `refactoring-specialist` — todos pasan de "dobles `InMemory*`, nunca `Mock*`" a la taxonomía por comportamiento.

## Plan de pruebas

- [x] `npx vitest run` — **770 passed**, 3 skipped; el rename no altera comportamiento y ningún spec necesitó tocarse
- [x] `pnpm exec tsc -p tsconfig.typecheck.json --noEmit` directo — limpio
- [x] `pnpm lint` — verde
- [x] `pnpm check:agents` — anclas y rutas del corpus siguen resolviendo
- [x] Grep de verificación: cero `InMemory*Api` restantes; `InMemoryLayoutService` (el fake) intacto