### PR TITLE
[#1882] - El doble de LayoutService: renombrado a ControllableLayoutService y paridad de contrato por compilación

### DIFF
--- a/.claude/agents/architecture-advisor.md
+++ b/.claude/agents/architecture-advisor.md
@@ -64,7 +64,7 @@ Primero determiná el change set: corré `git diff --name-only develop...HEAD` (
 - **Regla de dependencia** — las dependencias apuntan hacia adentro (dominio → casos de uso → adaptadores → frameworks). En el backend: el flujo `controller → service → repository` con el mapper (ACL) como frontera que traduce Sanity/GROQ al modelo de dominio
 - **Independencia de capas** — las reglas de negocio no dependen de frameworks ni de la UI; el modelo de dominio no conoce a Sanity
 - **Cruce de fronteras** — los datos cruzan como modelo de dominio mapeado, no como resultados crudos de GROQ; los repos exponen `fetch*()` (crudo) y los services `get*()` (mapeado a dominio)
-- **Testeabilidad** — la lógica de negocio se testea sin dependencias externas (dobles nombrados por comportamiento: `Stub*`/`InMemory*`/`Spy*`, nunca `Mock*`)
+- **Testeabilidad** — la lógica de negocio se testea sin dependencias externas (dobles nombrados por comportamiento: `Stub*`/`Fake*`/`InMemory*`/`Controllable*`/`Spy*`, nunca `Mock*`)
 
 ### Diseño de componentes (acoplamiento entre módulos)
 
@@ -96,7 +96,7 @@ Al evaluar nuevos módulos o endpoints, verificá que el plan incluya:
 - [ ] Módulo bajo `src/api/modules/<dominio>/` con el patrón **controller → service → repository**
 - [ ] Mapper (ACL) en `src/api/_utils/` que traduce GROQ/Sanity al modelo de dominio
 - [ ] Validación con `@hono/zod-validator` y contratos/tipos de dominio acordes
-- [ ] Tests (Vitest + `@test-utils`) con dobles nombrados por comportamiento (`Stub*`/`InMemory*`) para los repos
+- [ ] Tests (Vitest + `@test-utils`) con dobles nombrados por comportamiento (`Stub*`/`Fake*`/`InMemory*`/`Controllable*`/`Spy*`) para los repos
 - [ ] Hono plano, no `OpenAPIHono` (dirección futura no adoptada, #1531); sin Drizzle — la persistencia es Sanity vía `@sanity/client`
 
 ### Convención de providers del frontend (Qualified Implementation)

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -86,7 +86,7 @@ Estos patrones son intencionales y correctos. NO los reportes como problemas:
 - [ ] Open/Closed — extender comportamiento sin modificar lo existente
 - [ ] Liskov Substitution — los subtipos son sustituibles por sus tipos base
 - [ ] Interface Segregation — sin dependencias forzadas sobre interfaces no usadas
-- [ ] Dependency Inversion — depender de abstracciones, no de concreciones (convención **Qualified Implementation**: interfaz con nombre limpio, impls con prefijo `Sanity*`/`Http*`, dobles por comportamiento `Stub*`/`InMemory*`/`Spy*` nunca `Mock*`)
+- [ ] Dependency Inversion — depender de abstracciones, no de concreciones (convención **Qualified Implementation**: interfaz con nombre limpio, impls con prefijo `Sanity*`/`Http*`, dobles por comportamiento `Stub*`/`Fake*`/`InMemory*`/`Controllable*`/`Spy*` nunca `Mock*`)
 
 ### Principios CUPID
 

--- a/.claude/agents/domain-model-advisor.md
+++ b/.claude/agents/domain-model-advisor.md
@@ -108,7 +108,7 @@ Como toda sesión de agente sobre este repo: cargá también `.claude/references
 - [ ] **Sin `enum` de TS** — usar `Object.freeze({...} as const)` para conjuntos cerrados de literales (`ResourceType.slug`, `MediaType`, …).
 - [ ] **Sin barrels** (`index.ts` re-export prohibidos).
 - [ ] **`any` prohibido** sin comentario `// REASON:`.
-- [ ] **Qualified Implementation:** la interfaz lleva el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test se nombran por comportamiento — `Stub*`/`InMemory*`/`Spy*`, **nunca** `Mock*`.
+- [ ] **Qualified Implementation:** la interfaz lleva el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test se nombran por comportamiento — `Stub*`/`Fake*`/`InMemory*`/`Controllable*`/`Spy*`, **nunca** `Mock*`.
 - [ ] Tests con **Vitest** + Angular Testing Library + wrappers de `@test-utils` (prohibido `vi.*` directo).
 
 ## Organización de archivos

--- a/.claude/agents/refactoring-specialist.md
+++ b/.claude/agents/refactoring-specialist.md
@@ -76,7 +76,7 @@ Antes de refactorizar, leé estas referencias del proyecto. Cargalas en **un ún
 - [ ] Los nombres revelan intención (sin abreviaturas ni nombres genéricos).
 - [ ] Convenciones consistentes: archivos `kebab-case`, clases `PascalCase`, métodos `camelCase`, constantes globales `SCREAMING_SNAKE_CASE` y locales `camelCase`.
 - [ ] Variables/métodos booleanos con prefijos `is`, `has`, `can`, `should`.
-- [ ] Interfaces sin prefijo `I`; convención **Qualified Implementation** (`Sanity*`/`Http*`, dobles por comportamiento `Stub*`/`InMemory*`/`Spy*`, nunca `Mock*`).
+- [ ] Interfaces sin prefijo `I`; convención **Qualified Implementation** (`Sanity*`/`Http*`, dobles por comportamiento `Stub*`/`Fake*`/`InMemory*`/`Controllable*`/`Spy*`, nunca `Mock*`).
 
 ### Simplificación
 

--- a/.claude/references/clean-architecture.md
+++ b/.claude/references/clean-architecture.md
@@ -33,7 +33,7 @@ Construir sistemas **mantenibles, testeables e independientes** de los detalles 
 
 - Las reglas de negocio se testean sin UI, sin Sanity y sin servidor web.
 - Los tipos de dominio son objetos planos sin dependencias de framework.
-- Los services se testean sustituyendo el repository por un doble (nombrado por comportamiento — `Stub*`/`InMemory*`, ver más abajo): ver los `*.service.spec.ts` existentes (`content.service.spec.ts`, `sitemap.service.spec.ts`).
+- Los services se testean sustituyendo el repository por un doble (nombrado por comportamiento — `Stub*`/`Fake*`, ver más abajo): ver los `*.service.spec.ts` existentes (`content.service.spec.ts`, `sitemap.service.spec.ts`).
 
 ### Cruce de fronteras
 
@@ -83,7 +83,9 @@ La interfaz lleva el **nombre limpio** (la responsabilidad), y la **implementaci
 El **doble de test** se nombra por lo que **es**, no con el término vago `Mock*`:
 
 - **`Stub*`** — devuelve valores fijos e ignora la entrada. Es el caso de los API providers del front: `StubStoryApi.getBySlug()` devuelve siempre el mismo `storyMock`, sin mirar el slug. No hay nada "en memoria" que consultar, así que llamarlo `InMemory*` prometería una implementación que no existe.
-- **`InMemory*`** — un _fake_: mantiene estado real en memoria y reacciona a él. `InMemoryLayoutService` es el ejemplo: tiene un `viewport` signal y `biggerThan()` compara anchos reales contra el viewport actual. Reservado a los dobles que **de verdad** implementan la lógica.
+- **`Fake*`** — la **categoría**: una implementación real con un atajo (sí ejecuta lógica de verdad, pero se salta la dependencia costosa o externa). Se califica por lo que sustituye:
+  - **`InMemory*`** — sustituye **almacenamiento**: un repository/DB real reemplazado por una lista en memoria. `InMemoryStoryRepository` guarda datos reales y los consulta con lógica real, solo que sin Sanity de por medio.
+  - **`Controllable*`** (o `Static*`, según el mecanismo) — sustituye un **entorno** cuyo input el test necesita fijar (viewport, reloj, random, geolocalización). `ControllableLayoutService` es el ejemplo: no reemplaza un almacén de datos, fija el viewport que el real (`WindowLayoutService`) leería de `window`. "En memoria" no distingue nada acá — todo objeto guarda su estado en memoria; lo que importa es que el input lo fija el test, no el entorno real.
 - **`Spy*`** — registra las llamadas recibidas, cuando el test las inspecciona.
 
 El **archivo** sigue siendo `<dominio>.mock.ts` y la **factory** `provide<X>ApiMock()`: ahí "mock" nombra genéricamente al proveedor del doble, no reclama una categoría de la taxonomía.
@@ -100,24 +102,24 @@ El **archivo** sigue siendo `<dominio>.mock.ts` y la **factory** `provide<X>ApiM
 | Service (impl. única)    | `StoryService`           | `StoryService` (mismo nombre) | `InMemoryStoryService`        |
 
 - Prefijo **`Sanity*`** para implementaciones de repository respaldadas por Sanity/GROQ.
-- El doble se nombra por su comportamiento (`Stub*` / `InMemory*` / `Spy*`), **jamás `Mock*`**. Un repository de test con datos cargados en memoria sí es un `InMemory*Repository` (un fake); uno que devuelve una lista fija es un `Stub*Repository`.
+- El doble se nombra por su comportamiento (`Stub*` / `Fake*` — `InMemory*` para almacenamiento — / `Spy*`), **jamás `Mock*`**. Un repository de test con datos cargados en memoria sí es un `InMemory*Repository` (un fake de almacenamiento); uno que devuelve una lista fija es un `Stub*Repository`.
 - Los services de implementación única **conservan el nombre de la interfaz** (sin prefijo, sin sufijo `Impl`).
 
 > Nota sobre el estado actual: hoy los módulos backend exponen funciones (`getStoryBySlug`, `fetchStories`) más que clases con interfaz explícita, así que **los nombres de esta tabla son ilustrativos de la convención, no símbolos existentes** — las clases llegan con #1503. La convención rige al introducir abstracciones de repository/service o sus dobles de test, y es la dirección a la que tienden los `*.service.spec.ts`.
 
 ### Frontend
 
-| Rol                   | Interfaz + token (`InjectionToken`) | Implementación     | Doble de test           |
-| --------------------- | ----------------------------------- | ------------------ | ----------------------- |
-| API de stories        | `StoryApi`                          | `HttpStoryApi`     | `StubStoryApi`          |
-| API de autores        | `AuthorApi`                         | `HttpAuthorApi`    | `StubAuthorApi`         |
-| API de storylists     | `StorylistApi`                      | `HttpStorylistApi` | `StubStorylistApi`      |
-| Service (impl. única) | `LayoutService` (sin token)         | `LayoutService`    | `InMemoryLayoutService` |
+| Rol                   | Interfaz + token (`InjectionToken`) | Implementación        | Doble de test               |
+| --------------------- | ----------------------------------- | --------------------- | --------------------------- |
+| API de stories        | `StoryApi`                          | `HttpStoryApi`        | `StubStoryApi`              |
+| API de autores        | `AuthorApi`                         | `HttpAuthorApi`       | `StubAuthorApi`             |
+| API de storylists     | `StorylistApi`                      | `HttpStorylistApi`    | `StubStorylistApi`          |
+| Service (impl. única) | `LayoutService` (token homónimo)    | `WindowLayoutService` | `ControllableLayoutService` |
 
-> Los dobles de API son **`Stub*`** (devuelven canned, ignoran la entrada); el de `LayoutService` es **`InMemory*`** porque mantiene un viewport en memoria. La diferencia no es de capa sino de comportamiento del doble — ver la taxonomía de arriba.
+> Los dobles de API son **`Stub*`** (devuelven canned, ignoran la entrada); el de `LayoutService` es un **`Fake*` de entorno**, calificado `Controllable*` porque el viewport lo fija el test (`simulateViewport()`), no `window` como en el real (`WindowLayoutService`). No es `InMemory*`: no sustituye almacenamiento, sustituye el navegador. La diferencia no es de capa sino de qué sustituye el doble — ver la taxonomía de arriba.
 
 - Prefijo **`Http*`** para implementaciones de servicios de API basadas en HTTP.
-- Un service de **implementación única** (`LayoutService`, `NavigationFrameService`, `SchemaOrgService`) no necesita interfaz ni token: se inyecta la clase y su doble se nombra por comportamiento — `InMemoryLayoutService` es un fake con estado (`layout.mock.ts`). El par interfaz + `InjectionToken` se reserva a los **API providers**, que sí tienen dos implementaciones intercambiables.
+- Un service **con doble de test** usa el par interfaz + `InjectionToken` homónimo, igual que los API providers: real y doble son dos implementaciones intercambiables del mismo contrato. `LayoutService` es el caso — interfaz + token `LayoutService`, real `WindowLayoutService` (prefijo de mecanismo), doble `ControllableLayoutService` (`layout.mock.ts`). Un service de **implementación única sin doble** (`NavigationFrameService`, `SchemaOrgService`) no necesita ni interfaz ni token: se inyecta la clase directamente.
 - Los tokens son `InjectionToken` planos (sin `providedIn`/`factory`), cableados vía `provide<X>Api()` (real) y `provide<X>ApiMock()` (doble) con `makeEnvironmentProviders`.
 - **Archivos (3 por API provider):**
   - **`<dominio>-api.interface.ts`** — la interfaz `<X>Api` + el `InjectionToken`. El sufijo **`-api`** distingue el archivo de una interfaz del **modelo de dominio**: `author-api.interface.ts` exporta `AuthorApi`, no una interfaz del agregado `Author`.
@@ -128,7 +130,7 @@ El **archivo** sigue siendo `<dominio>.mock.ts` y la **factory** `provide<X>ApiM
 
 - Interfaz sin prefijo `I`, sin excepciones.
 - `Sanity*` para repositories sobre Sanity/GROQ; `Http*` para API services del front.
-- Doble de test nombrado por comportamiento: `Stub*` (canned), `InMemory*` (fake con estado), `Spy*` (registra) — nunca `Mock*`.
+- Doble de test nombrado por comportamiento: `Stub*` (canned), `Fake*` (implementación real con un atajo — `InMemory*` para almacenamiento, `Controllable*` para entorno), `Spy*` (registra) — nunca `Mock*`.
 - Servicio de implementación única → conserva el nombre de la interfaz.
 
 ---

--- a/.claude/references/typescript.md
+++ b/.claude/references/typescript.md
@@ -39,7 +39,7 @@ function describe(type: MediaType): string {
 }
 ```
 
-> **Enforcement activo:** ESLint prohíbe declarar `enum` (`selector: 'TSEnumDeclaration'` dentro de `commonRestrictedSyntax`, en `eslint.config.mjs`), y el repo ya no tiene ninguno: la deuda de migración está saldada. El patrón `Object.freeze` se usa en `src/app/models/content-campaign.model.ts` y `src/app/providers/layout.service.ts`.
+> **Enforcement activo:** ESLint prohíbe declarar `enum` (`selector: 'TSEnumDeclaration'` dentro de `commonRestrictedSyntax`, en `eslint.config.mjs`), y el repo ya no tiene ninguno: la deuda de migración está saldada. El patrón `Object.freeze` se usa en `src/app/models/content-campaign.model.ts` y `src/app/providers/layout.interface.ts`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Reglas no negociables. Una violación requiere justificación explícita.
 ### Naming
 
 - Archivos `kebab-case`; clases `PascalCase`; funciones/métodos `camelCase`; constantes globales `SCREAMING_SNAKE_CASE`, locales `camelCase`.
-- Interfaces **sin** prefijo `I`, sin excepciones. Convención **Qualified Implementation**: la interfaz tiene el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test se nombran por su comportamiento — `Stub*` (devuelve canned), `InMemory*` (fake con estado), `Spy*` (registra) — **nunca** `Mock*` → [`clean-architecture.md`](.claude/references/clean-architecture.md).
+- Interfaces **sin** prefijo `I`, sin excepciones. Convención **Qualified Implementation**: la interfaz tiene el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test se nombran por su comportamiento — `Stub*` (devuelve canned), `Fake*` (implementación real con un atajo; `InMemory*` para lo que sustituye **almacenamiento**, `Controllable*` para lo que sustituye un **entorno**), `Spy*` (registra) — **nunca** `Mock*` → [`clean-architecture.md`](.claude/references/clean-architecture.md).
 - **API providers del frontend:** el archivo de la interfaz lleva el sufijo `-api` — `<dominio>-api.interface.ts` (export `<X>Api`) — para distinguirlo de una interfaz del modelo de dominio. La impl y el doble viven en `<dominio>.provider.ts` (`Http<X>Api` + `provide<X>Api()`) y `<dominio>.mock.ts` (`Stub<X>Api` — devuelve canned — + `provide<X>ApiMock()`). Ver [`clean-architecture.md`](.claude/references/clean-architecture.md).
 
 ### Comentarios

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -79,7 +79,8 @@ const viRestrictedSyntax = [
 	})),
 	{
 		selector: 'CallExpression[callee.object.name="vi"][callee.property.name="mock"]',
-		message: 'vi.mock() está prohibido. Usá inyección de dependencias y dobles de test (Stub*/Fake*/Spy*) en su lugar.',
+		message:
+			'vi.mock() está prohibido. Usá inyección de dependencias y dobles de test (Stub*/Fake*/InMemory*/Spy*) en su lugar.',
 	},
 	{
 		selector: 'CallExpression[callee.object.name="vi"][callee.property.name="mocked"]',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -79,7 +79,7 @@ const viRestrictedSyntax = [
 	})),
 	{
 		selector: 'CallExpression[callee.object.name="vi"][callee.property.name="mock"]',
-		message: 'vi.mock() está prohibido. Usá inyección de dependencias y dobles InMemory* en su lugar.',
+		message: 'vi.mock() está prohibido. Usá inyección de dependencias y dobles de test (Stub*/Fake*/Spy*) en su lugar.',
 	},
 	{
 		selector: 'CallExpression[callee.object.name="vi"][callee.property.name="mocked"]',

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -7,6 +7,8 @@ import { FooterComponent } from '@components/footer/footer.component';
 import { AnalyticsService } from './providers/analytics/analytics.service';
 import { AnalyticsMockService } from './providers/analytics/analytics.mock.service';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { LayoutService } from './providers/layout.interface';
+import { ControllableLayoutService } from './providers/layout.mock';
 
 describe('AppComponent', () => {
 	const setup = async () => {
@@ -16,6 +18,7 @@ describe('AppComponent', () => {
 				provideRouter([]),
 				{ provide: AnalyticsService, useClass: AnalyticsMockService },
 				provideNoopAnimations(),
+				{ provide: LayoutService, useValue: new ControllableLayoutService() },
 			],
 		});
 	};

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,7 +7,7 @@ import { environment } from './environments/environment';
 
 // Services
 import { AnalyticsService } from './providers/analytics/analytics.service';
-import { LayoutService } from './providers/layout.service';
+import { LayoutService } from './providers/layout.interface';
 
 @Component({
 	selector: 'cuentoneta-root',

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -18,6 +18,9 @@ import { provideStoryApi } from './providers/story.provider';
 import { provideStorylistApi } from './providers/storylist.provider';
 import { providePushNotificationsApi } from './providers/push-notifications.provider';
 
+// Layout
+import { provideLayout } from './providers/layout.provider';
+
 // SEO providers
 import { provideSchemaOrgInitializer } from './providers/schema-org.initializer';
 
@@ -46,6 +49,7 @@ export const appConfig: ApplicationConfig = {
 		provideStoryApi(),
 		provideStorylistApi(),
 		providePushNotificationsApi(),
+		provideLayout(),
 
 		// SEO providers
 		provideSchemaOrgInitializer(),

--- a/src/app/components/carousel/carousel.component.spec.ts
+++ b/src/app/components/carousel/carousel.component.spec.ts
@@ -6,13 +6,13 @@ import { CarouselComponent } from './carousel.component';
 
 // Mocks
 import { contentCampaignMock } from '@mocks/content-campaign.mock';
-import { InMemoryLayoutService } from '../../providers/layout.mock';
+import { ControllableLayoutService } from '../../providers/layout.mock';
 import { LayoutService } from '../../providers/layout.interface';
 import type { Viewport } from '@utils/screen.utils';
 
-function layoutAt(viewport: Viewport): InMemoryLayoutService {
-	const layout = new InMemoryLayoutService();
-	layout.setViewport(viewport);
+function layoutAt(viewport: Viewport): ControllableLayoutService {
+	const layout = new ControllableLayoutService();
+	layout.simulateViewport(viewport);
 	return layout;
 }
 

--- a/src/app/components/carousel/carousel.component.spec.ts
+++ b/src/app/components/carousel/carousel.component.spec.ts
@@ -10,26 +10,23 @@ import { ControllableLayoutService } from '../../providers/layout.mock';
 import { LayoutService } from '../../providers/layout.interface';
 import type { Viewport } from '@utils/screen.utils';
 
-function layoutAt(viewport: Viewport): ControllableLayoutService {
+function setup(viewport: Viewport = 'md') {
 	const layout = new ControllableLayoutService();
 	layout.simulateViewport(viewport);
-	return layout;
+	return render(CarouselComponent, {
+		inputs: { slides: contentCampaignMock },
+		providers: [{ provide: LayoutService, useValue: layout }],
+	});
 }
 
 describe('CarouselComponent', () => {
 	it('should render the component', async () => {
-		const { container } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { container } = await setup();
 		expect(container).toBeInTheDocument();
 	});
 
 	it('should receive and render slides correctly', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 		// Verificar que el componente recibe el número correcto de diapositivas
 		expect(fixture.componentInstance.slides()).toHaveLength(contentCampaignMock.length);
 		// Verificar que exactamente una diapositiva se renderiza (diapositiva activa)
@@ -38,10 +35,7 @@ describe('CarouselComponent', () => {
 	});
 
 	it('should apply xs viewport-specific classes correctly', async () => {
-		await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('xs') }],
-		});
+		await setup('xs');
 		const slideLinks = screen.getAllByRole('link');
 		slideLinks.forEach((link) => {
 			expect(link).toHaveClass('sm:hidden');
@@ -49,10 +43,7 @@ describe('CarouselComponent', () => {
 	});
 
 	it('should apply md viewport-specific classes correctly', async () => {
-		await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		await setup('md');
 		const slideLinks = screen.getAllByRole('link');
 		slideLinks.forEach((link) => {
 			expect(link).toHaveClass('max-sm:hidden');
@@ -61,10 +52,7 @@ describe('CarouselComponent', () => {
 
 	// Pruebas de navegación
 	it('should navigate to next slide', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 
 		const component = fixture.componentInstance;
 		const initialIndex = component.activeIndex();
@@ -77,10 +65,7 @@ describe('CarouselComponent', () => {
 	});
 
 	it('should navigate to previous slide', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 
 		const component = fixture.componentInstance;
 		// Comenzar en la diapositiva 1
@@ -97,10 +82,7 @@ describe('CarouselComponent', () => {
 	});
 
 	it('should loop to first slide when at end', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 
 		const component = fixture.componentInstance;
 		const lastIndex = contentCampaignMock.length - 1;
@@ -120,10 +102,7 @@ describe('CarouselComponent', () => {
 	});
 
 	it('should loop to last slide when at start', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 
 		const component = fixture.componentInstance;
 		expect(component.activeIndex()).toBe(0);
@@ -136,10 +115,7 @@ describe('CarouselComponent', () => {
 	});
 
 	it('should not allow navigation while transitioning', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 
 		const component = fixture.componentInstance;
 		expect(component.activeIndex()).toBe(0);
@@ -159,10 +135,7 @@ describe('CarouselComponent', () => {
 
 	// Pruebas de reproducción automática
 	it('should start with auto-play enabled', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 
 		const component = fixture.componentInstance;
 		// Auto-play is enabled when isPaused is false
@@ -170,10 +143,7 @@ describe('CarouselComponent', () => {
 	});
 
 	it('should pause auto-play when paused', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 
 		const component = fixture.componentInstance;
 		expect(component.isPaused()).toBe(false);
@@ -184,10 +154,7 @@ describe('CarouselComponent', () => {
 	});
 
 	it('should resume auto-play when resumed', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 
 		const component = fixture.componentInstance;
 		component.pauseAutoPlay();
@@ -200,10 +167,7 @@ describe('CarouselComponent', () => {
 
 	// Pruebas de accesibilidad
 	it('should have proper ARIA attributes on navigation buttons', async () => {
-		await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		await setup();
 
 		const prevButton = screen.getByLabelText('Previous slide');
 		const nextButton = screen.getByLabelText('Next slide');
@@ -213,10 +177,7 @@ describe('CarouselComponent', () => {
 	});
 
 	it('should have proper ARIA attributes on indicators', async () => {
-		await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		await setup();
 
 		const indicators = screen
 			.getAllByRole('button')
@@ -234,10 +195,7 @@ describe('CarouselComponent', () => {
 	});
 
 	it('should update aria-current when slide changes', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 
 		const component = fixture.componentInstance;
 
@@ -256,10 +214,7 @@ describe('CarouselComponent', () => {
 
 	// Pruebas de signals computadas
 	it('should return active slide correctly based on activeIndex signal', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 
 		const [firstSlide, secondSlide] = [contentCampaignMock[0], contentCampaignMock[1]];
 
@@ -273,20 +228,14 @@ describe('CarouselComponent', () => {
 	});
 
 	it('should show controls on desktop viewport', async () => {
-		await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		await setup();
 
 		expect(screen.getByLabelText('Previous slide')).toBeInTheDocument();
 		expect(screen.getByLabelText('Next slide')).toBeInTheDocument();
 	});
 
 	it('should hide controls on mobile viewport', async () => {
-		await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('xs') }],
-		});
+		await setup('xs');
 
 		expect(screen.queryByLabelText('Previous slide')).not.toBeInTheDocument();
 		expect(screen.queryByLabelText('Next slide')).not.toBeInTheDocument();
@@ -294,10 +243,7 @@ describe('CarouselComponent', () => {
 
 	// Pruebas de señal de dirección
 	it('should set direction signal when navigating', async () => {
-		const { fixture } = await render(CarouselComponent, {
-			inputs: { slides: contentCampaignMock },
-			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-		});
+		const { fixture } = await setup();
 
 		const component = fixture.componentInstance;
 
@@ -344,10 +290,7 @@ describe('CarouselComponent', () => {
 		}
 
 		it('should navigate to next slide on left swipe', async () => {
-			const { fixture } = await render(CarouselComponent, {
-				inputs: { slides: contentCampaignMock },
-				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-			});
+			const { fixture } = await setup();
 
 			const component = fixture.componentInstance;
 			const element = fixture.nativeElement;
@@ -359,10 +302,7 @@ describe('CarouselComponent', () => {
 		});
 
 		it('should navigate to previous slide on right swipe', async () => {
-			const { fixture } = await render(CarouselComponent, {
-				inputs: { slides: contentCampaignMock },
-				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-			});
+			const { fixture } = await setup();
 
 			const component = fixture.componentInstance;
 			const element = fixture.nativeElement;
@@ -378,10 +318,7 @@ describe('CarouselComponent', () => {
 		});
 
 		it('should not navigate if swipe distance is below threshold', async () => {
-			const { fixture } = await render(CarouselComponent, {
-				inputs: { slides: contentCampaignMock },
-				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-			});
+			const { fixture } = await setup();
 
 			const component = fixture.componentInstance;
 			const element = fixture.nativeElement;
@@ -394,10 +331,7 @@ describe('CarouselComponent', () => {
 		});
 
 		it('should pause auto-play during swipe', async () => {
-			const { fixture } = await render(CarouselComponent, {
-				inputs: { slides: contentCampaignMock },
-				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-			});
+			const { fixture } = await setup();
 
 			const component = fixture.componentInstance;
 			const element = fixture.nativeElement;
@@ -409,10 +343,7 @@ describe('CarouselComponent', () => {
 		});
 
 		it('should resume auto-play after swipe ends', async () => {
-			const { fixture } = await render(CarouselComponent, {
-				inputs: { slides: contentCampaignMock },
-				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-			});
+			const { fixture } = await setup();
 
 			const component = fixture.componentInstance;
 			const element = fixture.nativeElement;
@@ -424,10 +355,7 @@ describe('CarouselComponent', () => {
 		});
 
 		it('should not navigate while transitioning', async () => {
-			const { fixture } = await render(CarouselComponent, {
-				inputs: { slides: contentCampaignMock },
-				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-			});
+			const { fixture } = await setup();
 
 			const component = fixture.componentInstance;
 			const element = fixture.nativeElement;
@@ -448,10 +376,7 @@ describe('CarouselComponent', () => {
 	// Pruebas de transiciones con dos diapositivas
 	describe('Dual-slide transitions', () => {
 		it('should set previousIndex when navigating', async () => {
-			const { fixture } = await render(CarouselComponent, {
-				inputs: { slides: contentCampaignMock },
-				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-			});
+			const { fixture } = await setup();
 
 			const component = fixture.componentInstance;
 			expect(component.previousIndex()).toBeNull();
@@ -466,10 +391,7 @@ describe('CarouselComponent', () => {
 		});
 
 		it('should clear previousIndex after transition completes', async () => {
-			const { fixture } = await render(CarouselComponent, {
-				inputs: { slides: contentCampaignMock },
-				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-			});
+			const { fixture } = await setup();
 
 			const component = fixture.componentInstance;
 
@@ -486,10 +408,7 @@ describe('CarouselComponent', () => {
 		});
 
 		it('should render both slides during transition', async () => {
-			const { fixture } = await render(CarouselComponent, {
-				inputs: { slides: contentCampaignMock },
-				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-			});
+			const { fixture } = await setup();
 
 			const component = fixture.componentInstance;
 
@@ -506,10 +425,7 @@ describe('CarouselComponent', () => {
 		});
 
 		it('should render only one slide when not transitioning', async () => {
-			const { fixture } = await render(CarouselComponent, {
-				inputs: { slides: contentCampaignMock },
-				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
-			});
+			const { fixture } = await setup();
 
 			const component = fixture.componentInstance;
 

--- a/src/app/components/carousel/carousel.component.spec.ts
+++ b/src/app/components/carousel/carousel.component.spec.ts
@@ -7,7 +7,7 @@ import { CarouselComponent } from './carousel.component';
 // Mocks
 import { contentCampaignMock } from '@mocks/content-campaign.mock';
 import { InMemoryLayoutService } from '../../providers/layout.mock';
-import { LayoutService } from '../../providers/layout.service';
+import { LayoutService } from '../../providers/layout.interface';
 import type { Viewport } from '@utils/screen.utils';
 
 function layoutAt(viewport: Viewport): InMemoryLayoutService {
@@ -20,6 +20,7 @@ describe('CarouselComponent', () => {
 	it('should render the component', async () => {
 		const { container } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 		expect(container).toBeInTheDocument();
 	});
@@ -27,6 +28,7 @@ describe('CarouselComponent', () => {
 	it('should receive and render slides correctly', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 		// Verificar que el componente recibe el número correcto de diapositivas
 		expect(fixture.componentInstance.slides()).toHaveLength(contentCampaignMock.length);
@@ -61,6 +63,7 @@ describe('CarouselComponent', () => {
 	it('should navigate to next slide', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const component = fixture.componentInstance;
@@ -76,6 +79,7 @@ describe('CarouselComponent', () => {
 	it('should navigate to previous slide', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const component = fixture.componentInstance;
@@ -95,6 +99,7 @@ describe('CarouselComponent', () => {
 	it('should loop to first slide when at end', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const component = fixture.componentInstance;
@@ -117,6 +122,7 @@ describe('CarouselComponent', () => {
 	it('should loop to last slide when at start', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const component = fixture.componentInstance;
@@ -132,6 +138,7 @@ describe('CarouselComponent', () => {
 	it('should not allow navigation while transitioning', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const component = fixture.componentInstance;
@@ -154,6 +161,7 @@ describe('CarouselComponent', () => {
 	it('should start with auto-play enabled', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const component = fixture.componentInstance;
@@ -164,6 +172,7 @@ describe('CarouselComponent', () => {
 	it('should pause auto-play when paused', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const component = fixture.componentInstance;
@@ -177,6 +186,7 @@ describe('CarouselComponent', () => {
 	it('should resume auto-play when resumed', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const component = fixture.componentInstance;
@@ -205,6 +215,7 @@ describe('CarouselComponent', () => {
 	it('should have proper ARIA attributes on indicators', async () => {
 		await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const indicators = screen
@@ -225,6 +236,7 @@ describe('CarouselComponent', () => {
 	it('should update aria-current when slide changes', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const component = fixture.componentInstance;
@@ -246,6 +258,7 @@ describe('CarouselComponent', () => {
 	it('should return active slide correctly based on activeIndex signal', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const [firstSlide, secondSlide] = [contentCampaignMock[0], contentCampaignMock[1]];
@@ -283,6 +296,7 @@ describe('CarouselComponent', () => {
 	it('should set direction signal when navigating', async () => {
 		const { fixture } = await render(CarouselComponent, {
 			inputs: { slides: contentCampaignMock },
+			providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 		});
 
 		const component = fixture.componentInstance;
@@ -332,6 +346,7 @@ describe('CarouselComponent', () => {
 		it('should navigate to next slide on left swipe', async () => {
 			const { fixture } = await render(CarouselComponent, {
 				inputs: { slides: contentCampaignMock },
+				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 			});
 
 			const component = fixture.componentInstance;
@@ -346,6 +361,7 @@ describe('CarouselComponent', () => {
 		it('should navigate to previous slide on right swipe', async () => {
 			const { fixture } = await render(CarouselComponent, {
 				inputs: { slides: contentCampaignMock },
+				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 			});
 
 			const component = fixture.componentInstance;
@@ -364,6 +380,7 @@ describe('CarouselComponent', () => {
 		it('should not navigate if swipe distance is below threshold', async () => {
 			const { fixture } = await render(CarouselComponent, {
 				inputs: { slides: contentCampaignMock },
+				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 			});
 
 			const component = fixture.componentInstance;
@@ -379,6 +396,7 @@ describe('CarouselComponent', () => {
 		it('should pause auto-play during swipe', async () => {
 			const { fixture } = await render(CarouselComponent, {
 				inputs: { slides: contentCampaignMock },
+				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 			});
 
 			const component = fixture.componentInstance;
@@ -393,6 +411,7 @@ describe('CarouselComponent', () => {
 		it('should resume auto-play after swipe ends', async () => {
 			const { fixture } = await render(CarouselComponent, {
 				inputs: { slides: contentCampaignMock },
+				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 			});
 
 			const component = fixture.componentInstance;
@@ -407,6 +426,7 @@ describe('CarouselComponent', () => {
 		it('should not navigate while transitioning', async () => {
 			const { fixture } = await render(CarouselComponent, {
 				inputs: { slides: contentCampaignMock },
+				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 			});
 
 			const component = fixture.componentInstance;
@@ -430,6 +450,7 @@ describe('CarouselComponent', () => {
 		it('should set previousIndex when navigating', async () => {
 			const { fixture } = await render(CarouselComponent, {
 				inputs: { slides: contentCampaignMock },
+				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 			});
 
 			const component = fixture.componentInstance;
@@ -447,6 +468,7 @@ describe('CarouselComponent', () => {
 		it('should clear previousIndex after transition completes', async () => {
 			const { fixture } = await render(CarouselComponent, {
 				inputs: { slides: contentCampaignMock },
+				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 			});
 
 			const component = fixture.componentInstance;
@@ -466,6 +488,7 @@ describe('CarouselComponent', () => {
 		it('should render both slides during transition', async () => {
 			const { fixture } = await render(CarouselComponent, {
 				inputs: { slides: contentCampaignMock },
+				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 			});
 
 			const component = fixture.componentInstance;
@@ -485,6 +508,7 @@ describe('CarouselComponent', () => {
 		it('should render only one slide when not transitioning', async () => {
 			const { fixture } = await render(CarouselComponent, {
 				inputs: { slides: contentCampaignMock },
+				providers: [{ provide: LayoutService, useValue: layoutAt('md') }],
 			});
 
 			const component = fixture.componentInstance;

--- a/src/app/components/carousel/carousel.component.ts
+++ b/src/app/components/carousel/carousel.component.ts
@@ -16,7 +16,7 @@ import { CarouselControlsComponent } from './carousel-controls.component';
 import { ContentCampaign, ContentCampaignViewport } from '@models/content-campaign.model';
 
 // Servicios
-import { LayoutService } from '../../providers/layout.service';
+import { LayoutService } from '../../providers/layout.interface';
 import { CarouselStateService } from './carousel-state.service';
 import { CarouselGestureService } from './carousel-gesture.service';
 

--- a/src/app/pages/story/story.component.spec.ts
+++ b/src/app/pages/story/story.component.spec.ts
@@ -15,7 +15,7 @@ import StoryComponent from './story.component';
 import { storyMock } from '@mocks/story.mock';
 import { provideStoryApiMock } from '../../providers/story.mock';
 import { InMemoryLayoutService } from '../../providers/layout.mock';
-import { LayoutService } from '../../providers/layout.service';
+import { LayoutService } from '../../providers/layout.interface';
 
 describe('StoryComponent', () => {
 	const setup = async () => {

--- a/src/app/pages/story/story.component.spec.ts
+++ b/src/app/pages/story/story.component.spec.ts
@@ -30,7 +30,7 @@ describe('StoryComponent', () => {
 				MockShareContentComponent,
 				MockStoryNavigationBarComponent,
 			],
-			providers: [provideStoryApiMock()],
+			providers: [provideStoryApiMock(), { provide: LayoutService, useValue: new ControllableLayoutService() }],
 			inputs: {
 				slug: storyMock.slug,
 			},

--- a/src/app/pages/story/story.component.spec.ts
+++ b/src/app/pages/story/story.component.spec.ts
@@ -14,7 +14,7 @@ import { Story } from '@models/story.model';
 import StoryComponent from './story.component';
 import { storyMock } from '@mocks/story.mock';
 import { provideStoryApiMock } from '../../providers/story.mock';
-import { InMemoryLayoutService } from '../../providers/layout.mock';
+import { ControllableLayoutService } from '../../providers/layout.mock';
 import { LayoutService } from '../../providers/layout.interface';
 
 describe('StoryComponent', () => {
@@ -44,10 +44,10 @@ describe('StoryComponent', () => {
 });
 
 describe('StoryComponent - headerPosition', () => {
-	let mockLayoutService: InMemoryLayoutService;
+	let mockLayoutService: ControllableLayoutService;
 
 	const setup = async () => {
-		mockLayoutService = new InMemoryLayoutService();
+		mockLayoutService = new ControllableLayoutService();
 		const view = await render(StoryComponent, {
 			componentImports: [
 				CommonModule,
@@ -70,21 +70,21 @@ describe('StoryComponent - headerPosition', () => {
 
 	it('derives top-header-height when viewport is larger than xs (covers SSR, which fixes viewport to md)', async () => {
 		const { headerPosition } = await setup();
-		mockLayoutService.setViewport('lg');
+		mockLayoutService.simulateViewport('lg');
 
 		expect(headerPosition()).toBe('top-header-height');
 	});
 
 	it('derives top-header-height on xs while the header is visible (initial state before any scroll)', async () => {
 		const { headerPosition } = await setup();
-		mockLayoutService.setViewport('xs');
+		mockLayoutService.simulateViewport('xs');
 
 		expect(headerPosition()).toBe('top-header-height');
 	});
 
 	it('derives top-0 on xs when the header is hidden after scrolling down', async () => {
 		const { headerPosition } = await setup();
-		mockLayoutService.setViewport('xs');
+		mockLayoutService.simulateViewport('xs');
 		mockLayoutService.isHeaderVisible.set(false);
 
 		expect(headerPosition()).toBe('top-0');
@@ -92,11 +92,11 @@ describe('StoryComponent - headerPosition', () => {
 
 	it('recomputes to top-header-height when viewport grows past xs while the header is hidden', async () => {
 		const { headerPosition } = await setup();
-		mockLayoutService.setViewport('xs');
+		mockLayoutService.simulateViewport('xs');
 		mockLayoutService.isHeaderVisible.set(false);
 		expect(headerPosition()).toBe('top-0');
 
-		mockLayoutService.setViewport('lg');
+		mockLayoutService.simulateViewport('lg');
 
 		expect(headerPosition()).toBe('top-header-height');
 	});

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -11,7 +11,8 @@ import { ssrBlockingRxResource } from '@utils/ssr-resource';
 
 // Services
 import { StoryApi } from '../../providers/story-api.interface';
-import { LayoutService } from '../../providers/layout.service';
+import { LayoutService } from '../../providers/layout.interface';
+import { WindowLayoutService } from '../../providers/layout.provider';
 
 // SEO
 import { StoryMetaTagsDirective } from './story-meta-tags.directive';
@@ -55,7 +56,7 @@ import { faSolidArrowRightLong } from '@ng-icons/font-awesome/solid';
 	],
 	providers: [
 		provideIcons({ faSolidArrowRightLong }),
-		LayoutService,
+		{ provide: LayoutService, useClass: WindowLayoutService },
 		{ provide: STORY_HOST, useExisting: forwardRef(() => StoryComponent) },
 	],
 	host: { class: 'grid md:grid-rows-[8px_1fr]' },

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -12,7 +12,6 @@ import { ssrBlockingRxResource } from '@utils/ssr-resource';
 // Services
 import { StoryApi } from '../../providers/story-api.interface';
 import { LayoutService } from '../../providers/layout.interface';
-import { WindowLayoutService } from '../../providers/layout.provider';
 
 // SEO
 import { StoryMetaTagsDirective } from './story-meta-tags.directive';
@@ -56,7 +55,6 @@ import { faSolidArrowRightLong } from '@ng-icons/font-awesome/solid';
 	],
 	providers: [
 		provideIcons({ faSolidArrowRightLong }),
-		{ provide: LayoutService, useClass: WindowLayoutService },
 		{ provide: STORY_HOST, useExisting: forwardRef(() => StoryComponent) },
 	],
 	host: { class: 'grid md:grid-rows-[8px_1fr]' },

--- a/src/app/providers/layout.interface.ts
+++ b/src/app/providers/layout.interface.ts
@@ -10,10 +10,11 @@ export type Direction = (typeof Direction)[keyof typeof Direction];
 // `inject(LayoutService)` intacto y la interfaz es la superficie contra la cual el compilador exige
 // paridad entre real y doble.
 export interface LayoutService {
+	// La cara pública de la visibilidad del header es el **signal**; el observable que lo alimenta es
+	// un detalle de implementación privado del real (ver `WindowLayoutService`).
 	readonly isHeaderVisible: Signal<boolean>;
 	readonly userHasScrolled$: Observable<Direction>;
 	readonly viewportHasChanged$: Observable<Event | null>;
-	readonly isHeaderVisible$: Observable<boolean>;
 	isPlatformBrowser(): boolean;
 	isPlatformServer(): boolean;
 	setViewport(): void;

--- a/src/app/providers/layout.interface.ts
+++ b/src/app/providers/layout.interface.ts
@@ -1,0 +1,25 @@
+import { InjectionToken, Signal } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Viewport } from '@utils/screen.utils';
+
+export const Direction = Object.freeze({ Up: 'Up', Down: 'Down' } as const);
+export type Direction = (typeof Direction)[keyof typeof Direction];
+
+// Contrato del layout/viewport. La implementación real (`WindowLayoutService`) lo deriva de `window`;
+// el doble de test (`ControllableLayoutService`) fija el viewport a mano. El token homónimo deja cada
+// `inject(LayoutService)` intacto y la interfaz es la superficie contra la cual el compilador exige
+// paridad entre real y doble.
+export interface LayoutService {
+	readonly isHeaderVisible: Signal<boolean>;
+	readonly userHasScrolled$: Observable<Direction>;
+	readonly viewportHasChanged$: Observable<Event | null>;
+	readonly isHeaderVisible$: Observable<boolean>;
+	isPlatformBrowser(): boolean;
+	isPlatformServer(): boolean;
+	setViewport(): void;
+	biggerThan(test: Viewport): boolean;
+	smallerThan(test: Viewport): boolean;
+	isActual(test: Viewport): boolean;
+}
+
+export const LayoutService = new InjectionToken<LayoutService>('LayoutService');

--- a/src/app/providers/layout.mock.ts
+++ b/src/app/providers/layout.mock.ts
@@ -1,7 +1,7 @@
 import { Injectable, signal } from '@angular/core';
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 import { Viewport, VIEWPORT_WIDTHS_NUMERIC } from '@utils/screen.utils';
-import { LayoutService } from './layout.service';
+import { LayoutService } from './layout.interface';
 
 @Injectable({ providedIn: 'root' })
 export class InMemoryLayoutService {

--- a/src/app/providers/layout.mock.ts
+++ b/src/app/providers/layout.mock.ts
@@ -1,24 +1,62 @@
-import { Injectable, signal } from '@angular/core';
-import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
-import { Viewport, VIEWPORT_WIDTHS_NUMERIC } from '@utils/screen.utils';
-import { LayoutService } from './layout.interface';
+import { EnvironmentProviders, Injectable, makeEnvironmentProviders, signal, type WritableSignal } from '@angular/core';
+import { EMPTY, Observable } from 'rxjs';
+import { Viewport, compareViewports } from '@utils/screen.utils';
+import { Direction, LayoutService } from './layout.interface';
 
+/**
+ * Doble de test de `LayoutService`. Se califica `Controllable*` —no `InMemory*`— porque no sustituye
+ * almacenamiento sino el **entorno del navegador**: el viewport lo fija el test con `simulateViewport()`
+ * en vez de derivarlo de `window` como hace el real (`WindowLayoutService`).
+ *
+ * `implements LayoutService` obliga a cubrir la superficie completa del contrato; su `biggerThan`/
+ * `smallerThan`/`isActual` delegan en la misma `compareViewports()` que el real, así que su
+ * comportamiento —incluido el error ante un viewport inválido— es idéntico por construcción.
+ */
 @Injectable({ providedIn: 'root' })
-export class InMemoryLayoutService {
-	public readonly viewport = signal<Viewport>('lg');
+export class ControllableLayoutService implements LayoutService {
+	private readonly viewport: WritableSignal<Viewport> = signal('lg');
+
 	public readonly isHeaderVisible = signal(true);
 
-	public setViewport(viewport: Viewport): void {
+	// Streams inertes: el doble controla estado puntual, no simula flujos de scroll/resize. Ningún
+	// consumidor los lee sobre el doble; tipan el contrato y nada más.
+	public readonly userHasScrolled$: Observable<Direction> = EMPTY;
+	public readonly viewportHasChanged$: Observable<Event | null> = EMPTY;
+	public readonly isHeaderVisible$: Observable<boolean> = EMPTY;
+
+	public isPlatformBrowser(): boolean {
+		return true;
+	}
+
+	public isPlatformServer(): boolean {
+		return false;
+	}
+
+	/** Operación del **contrato**: en el real detecta el viewport desde `window`; el doble no tiene entorno que detectar. */
+	public setViewport(): void {
+		// no-op: el viewport del doble se fija con `simulateViewport()`, no se detecta.
+	}
+
+	/** Operación **propia del doble** (fuera del contrato): fija el viewport que el test quiere simular. */
+	public simulateViewport(viewport: Viewport): void {
 		this.viewport.set(viewport);
 	}
 
 	public biggerThan(test: Viewport): boolean {
-		return VIEWPORT_WIDTHS_NUMERIC[this.viewport()] > VIEWPORT_WIDTHS_NUMERIC[test];
+		return compareViewports(this.viewport(), test) > 0;
+	}
+
+	public smallerThan(test: Viewport): boolean {
+		return compareViewports(this.viewport(), test) < 0;
+	}
+
+	public isActual(test: Viewport): boolean {
+		return compareViewports(this.viewport(), test) === 0;
 	}
 }
 
 export function provideLayoutServiceMock(
-	service: InMemoryLayoutService = new InMemoryLayoutService(),
+	service: ControllableLayoutService = new ControllableLayoutService(),
 ): EnvironmentProviders {
 	return makeEnvironmentProviders([{ provide: LayoutService, useValue: service }]);
 }

--- a/src/app/providers/layout.mock.ts
+++ b/src/app/providers/layout.mock.ts
@@ -23,7 +23,6 @@ export class ControllableLayoutService implements LayoutService {
 	// consumidor los lee sobre el doble; tipan el contrato y nada más.
 	public readonly userHasScrolled$: Observable<Direction> = EMPTY;
 	public readonly viewportHasChanged$: Observable<Event | null> = EMPTY;
-	public readonly isHeaderVisible$: Observable<boolean> = EMPTY;
 
 	public isPlatformBrowser(): boolean {
 		return true;

--- a/src/app/providers/layout.mock.ts
+++ b/src/app/providers/layout.mock.ts
@@ -1,26 +1,24 @@
-import { signal, type WritableSignal } from '@angular/core';
+import { Injectable, signal, type WritableSignal } from '@angular/core';
 import { EMPTY, Observable } from 'rxjs';
 import { Viewport, compareViewports } from '@utils/screen.utils';
 import { Direction, LayoutService } from './layout.interface';
 
 /**
- * Doble de test de `LayoutService`. Se califica `Controllable*` —no `InMemory*`— porque no sustituye
- * almacenamiento sino el **entorno del navegador**: el viewport lo fija el test con `simulateViewport()`
+ * Doble de test de `LayoutService`: el viewport lo fija el test con `simulateViewport()`
  * en vez de derivarlo de `window` como hace el real (`WindowLayoutService`).
  *
  * `implements LayoutService` obliga a cubrir la superficie completa del contrato; su `biggerThan`/
  * `smallerThan`/`isActual` delegan en la misma `compareViewports()` que el real, así que su
  * comportamiento —incluido el error ante un viewport inválido— es idéntico por construcción.
  */
-// Sin `@Injectable`: no tiene dependencias inyectadas y se instancia a mano (`new`) para proveerlo con
-// `useValue` en los specs. No es un servicio del árbol de DI.
+@Injectable({
+	providedIn: 'root',
+})
 export class ControllableLayoutService implements LayoutService {
 	private readonly viewport: WritableSignal<Viewport> = signal('lg');
 
 	public readonly isHeaderVisible = signal(true);
 
-	// Streams inertes: el doble controla estado puntual, no simula flujos de scroll/resize. Ningún
-	// consumidor los lee sobre el doble; tipan el contrato y nada más.
 	public readonly userHasScrolled$: Observable<Direction> = EMPTY;
 	public readonly viewportHasChanged$: Observable<Event | null> = EMPTY;
 

--- a/src/app/providers/layout.mock.ts
+++ b/src/app/providers/layout.mock.ts
@@ -1,4 +1,4 @@
-import { EnvironmentProviders, Injectable, makeEnvironmentProviders, signal, type WritableSignal } from '@angular/core';
+import { signal, type WritableSignal } from '@angular/core';
 import { EMPTY, Observable } from 'rxjs';
 import { Viewport, compareViewports } from '@utils/screen.utils';
 import { Direction, LayoutService } from './layout.interface';
@@ -12,7 +12,8 @@ import { Direction, LayoutService } from './layout.interface';
  * `smallerThan`/`isActual` delegan en la misma `compareViewports()` que el real, así que su
  * comportamiento —incluido el error ante un viewport inválido— es idéntico por construcción.
  */
-@Injectable({ providedIn: 'root' })
+// Sin `@Injectable`: no tiene dependencias inyectadas y se instancia a mano (`new`) para proveerlo con
+// `useValue` en los specs. No es un servicio del árbol de DI.
 export class ControllableLayoutService implements LayoutService {
 	private readonly viewport: WritableSignal<Viewport> = signal('lg');
 
@@ -53,10 +54,4 @@ export class ControllableLayoutService implements LayoutService {
 	public isActual(test: Viewport): boolean {
 		return compareViewports(this.viewport(), test) === 0;
 	}
-}
-
-export function provideLayoutServiceMock(
-	service: ControllableLayoutService = new ControllableLayoutService(),
-): EnvironmentProviders {
-	return makeEnvironmentProviders([{ provide: LayoutService, useValue: service }]);
 }

--- a/src/app/providers/layout.provider.spec.ts
+++ b/src/app/providers/layout.provider.spec.ts
@@ -3,8 +3,14 @@ import { TestBed } from '@angular/core/testing';
 import { WindowLayoutService } from './layout.provider';
 import { Direction, type LayoutService } from './layout.interface';
 import { WINDOW } from './window';
-import { map, of } from 'rxjs';
+import { map, of, type Observable } from 'rxjs';
 import { Viewport } from '@utils/screen.utils';
+
+// `isHeaderVisible$` es privado: es el detalle que alimenta el signal público `isHeaderVisible`. Se
+// accede acá para probar la política de visibilidad del header —la lógica que el signal deriva— sin
+// exponer el observable en el contrato.
+const headerVisibility$ = (svc: WindowLayoutService): Observable<boolean> =>
+	(svc as unknown as { readonly isHeaderVisible$: Observable<boolean> }).isHeaderVisible$;
 
 describe('WindowLayoutService', () => {
 	let service: WindowLayoutService;
@@ -66,13 +72,13 @@ describe('WindowLayoutService', () => {
 			}));
 	});
 
-	describe('isHeaderVisible$', () => {
+	describe('política de visibilidad del header (deriva el signal isHeaderVisible)', () => {
 		it('should emit true when the user scrolls up', () =>
 			new Promise<void>((resolve) => {
 				const scrollEvents = of([1200, 500]).pipe(map(([prev, curr]) => (curr < prev ? Direction.Up : Direction.Down)));
 				spyOn(service, 'userHasScrolled$', 'get').mockReturnValue(scrollEvents);
 
-				service.isHeaderVisible$.subscribe((isVisible) => {
+				headerVisibility$(service).subscribe((isVisible) => {
 					expect(isVisible).toBe(true);
 					resolve();
 				});
@@ -85,7 +91,7 @@ describe('WindowLayoutService', () => {
 				const scrollEvents = of([500, 1000]).pipe(map(([prev, curr]) => (curr < prev ? Direction.Up : Direction.Down)));
 				spyOn(service, 'userHasScrolled$', 'get').mockReturnValue(scrollEvents);
 
-				service.isHeaderVisible$.subscribe((isVisible) => {
+				headerVisibility$(service).subscribe((isVisible) => {
 					expect(isVisible).toBe(false);
 					resolve();
 				});
@@ -98,7 +104,7 @@ describe('WindowLayoutService', () => {
 				const scrollEvents = of([500, 1000]).pipe(map(([prev, curr]) => (curr < prev ? Direction.Up : Direction.Down)));
 				spyOn(service, 'userHasScrolled$', 'get').mockReturnValue(scrollEvents);
 
-				service.isHeaderVisible$.subscribe((isVisible) => {
+				headerVisibility$(service).subscribe((isVisible) => {
 					expect(isVisible).toBe(true);
 					resolve();
 				});
@@ -110,7 +116,7 @@ describe('WindowLayoutService', () => {
 				const scrollEvents = of([500, 1000]).pipe(map(([prev, curr]) => (curr < prev ? Direction.Up : Direction.Down)));
 				spyOn(service, 'userHasScrolled$', 'get').mockReturnValue(scrollEvents);
 
-				service.isHeaderVisible$.subscribe((isVisible) => {
+				headerVisibility$(service).subscribe((isVisible) => {
 					expect(isVisible).toBe(true);
 					resolve();
 				});

--- a/src/app/providers/layout.provider.spec.ts
+++ b/src/app/providers/layout.provider.spec.ts
@@ -1,12 +1,13 @@
 import { fn, spyOn, type Mock } from '@test-utils';
 import { TestBed } from '@angular/core/testing';
-import { LayoutService, Direction } from './layout.service';
+import { WindowLayoutService } from './layout.provider';
+import { Direction, type LayoutService } from './layout.interface';
 import { WINDOW } from './window';
 import { map, of } from 'rxjs';
 import { Viewport } from '@utils/screen.utils';
 
-describe('LayoutService', () => {
-	let service: LayoutService;
+describe('WindowLayoutService', () => {
+	let service: WindowLayoutService;
 	let mockWindow: {
 		scrollY: number;
 		innerWidth: number;
@@ -31,10 +32,10 @@ describe('LayoutService', () => {
 		};
 
 		TestBed.configureTestingModule({
-			providers: [LayoutService, { provide: WINDOW, useValue: mockWindow }],
+			providers: [WindowLayoutService, { provide: WINDOW, useValue: mockWindow }],
 		});
 
-		service = TestBed.inject(LayoutService);
+		service = TestBed.inject(WindowLayoutService);
 	});
 
 	it('should be created', () => {
@@ -201,5 +202,16 @@ describe('LayoutService', () => {
 				expect(service.isActual('xl')).toBe(true);
 			});
 		});
+	});
+});
+
+describe('WindowLayoutService — paridad de superficie con el contrato LayoutService', () => {
+	it('mantiene cada miembro público de WindowLayoutService cubierto por la interfaz LayoutService', () => {
+		// Si WindowLayoutService gana un miembro público que LayoutService no declara, `ExtraPublicMembers`
+		// deja de ser `never`, el tipo del literal `true` no calza contra `false` y esta asignación rompe el
+		// typecheck con TS2322 — la señal de divergencia que antes no existía.
+		type ExtraPublicMembers = Exclude<keyof WindowLayoutService, keyof LayoutService>;
+		const parityHolds: ExtraPublicMembers extends never ? true : false = true;
+		expect(parityHolds).toBe(true);
 	});
 });

--- a/src/app/providers/layout.provider.ts
+++ b/src/app/providers/layout.provider.ts
@@ -63,7 +63,7 @@ export class WindowLayoutService implements LayoutService {
 		return this._viewportHasChanged$;
 	}
 
-	public get isHeaderVisible$() {
+	private get isHeaderVisible$() {
 		return combineLatest([this.viewportHasChanged$, this.userHasScrolled$]).pipe(
 			map(([hasChanged, direction]) => {
 				if (hasChanged) {

--- a/src/app/providers/layout.provider.ts
+++ b/src/app/providers/layout.provider.ts
@@ -1,4 +1,12 @@
-import { inject, Injectable, PLATFORM_ID, signal, type WritableSignal } from '@angular/core';
+import {
+	EnvironmentProviders,
+	inject,
+	Injectable,
+	makeEnvironmentProviders,
+	PLATFORM_ID,
+	signal,
+	type WritableSignal,
+} from '@angular/core';
 import { WINDOW } from './window';
 import {
 	combineLatest,
@@ -14,14 +22,12 @@ import {
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { isPlatformBrowser, isPlatformServer } from '@angular/common';
 import { Viewport, VIEWPORT_WIDTHS_NUMERIC, compareViewports } from '@utils/screen.utils';
-
-export const Direction = Object.freeze({ Up: 'Up', Down: 'Down' } as const);
-export type Direction = (typeof Direction)[keyof typeof Direction];
+import { Direction, LayoutService } from './layout.interface';
 
 @Injectable({
 	providedIn: 'root',
 })
-export class LayoutService {
+export class WindowLayoutService implements LayoutService {
 	private readonly window = inject(WINDOW);
 	private readonly platformId = inject(PLATFORM_ID);
 
@@ -127,4 +133,8 @@ export class LayoutService {
 	public isActual(test: Viewport): boolean {
 		return compareViewports(this.viewport(), test) === 0;
 	}
+}
+
+export function provideLayout(): EnvironmentProviders {
+	return makeEnvironmentProviders([{ provide: LayoutService, useExisting: WindowLayoutService }]);
 }


### PR DESCRIPTION
> **PR stackeado.** Base: `refactor/compare-viewports` (PR #1893, la extracción de `compareViewports`). Al mergearse #1893 a `develop`, GitHub reapunta esta base sola.

## Descripción

El doble de `LayoutService` estaba mal nombrado (`InMemoryLayoutService`) y no cumplía el contrato del real, sin nada que lo enforcee. Este PR corrige ambas cosas.

- **Nombre.** `InMemory*` es una metáfora de **almacenamiento**; `LayoutService` fakea el **entorno del navegador** (el viewport de `window`). El doble se califica por su mecanismo —el viewport lo fija el test— en paralelo al real, que lo lee de `window`: `WindowLayoutService` (real) / `ControllableLayoutService` (doble).
- **Paridad por compilación.** Se extrae la interfaz `LayoutService` + `InjectionToken` homónimo (calca `story-api.interface.ts`). Una aserción de tipo en `layout.provider.spec.ts` —`Exclude<keyof WindowLayoutService, keyof LayoutService> extends never`— **rompe el typecheck** si el real gana un miembro público que el contrato no cubre. Los providers de test usan `useValue`, que no impone nada; esta es la señal que no existía.
- **`isHeaderVisible$` es privado.** La cara pública de la visibilidad del header es el **signal** `isHeaderVisible`; el observable que lo alimenta es un detalle de implementación, fuera del contrato.
- **Taxonomía corregida.** #1889 usó `InMemory*` como etiqueta del bucket entero de fakes. Se corrige el corpus: `Fake*` es la categoría; `InMemory*` es el fake de almacenamiento, `Controllable*` el de entorno.

Closes #1882.

## Commits atómicos

1. Contrato `LayoutService` + token + `WindowLayoutService` + `provideLayout()` en `app.config.ts`.
2. Doble `ControllableLayoutService`, superficie completa; `simulateViewport()` fuera del contrato, `setViewport()` no-op.
3. Borrado del provider de `LayoutService` en `StoryComponent` (creaba una segunda instancia del singleton — `headerPosition` leía un `isHeaderVisible` distinto del real).
4. Taxonomía del corpus.
5. Provisión de `LayoutService` en los specs que dependían de la auto-provisión root.
6. Reconciliación de la regla interfaz+token y limpieza del doble (review local).
7. `isHeaderVisible$` privado; el signal `isHeaderVisible` como cara pública.

_(La extracción de `compareViewports` —que real y doble comparten— vive en el PR base #1893.)_

## Decisiones que conviene mirar

- **`ControllableLayoutService`, no `FakeLayoutService`:** se califica por su mecanismo (viewport controlable por el test), en paralelo a `WindowLayoutService`. `InMemory*` habría sido incorrecto — no sustituye un store.
- **El token no tiene factory root** (patrón `StoryApi`). Al dejar de ser `providedIn: 'root'`, los tests que renderizaban componentes con `inject(LayoutService)` sin proveerlo debieron proveerlo explícitamente. Se usó el viewport `'md'`, que es el que jsdom (`innerWidth` 1024) resolvía antes — mismo comportamiento.
- **Los tests de política de visibilidad del header** acceden al ahora-privado `isHeaderVisible$` vía un accesor tipado: es la lógica que el signal público deriva, y manejar los streams de scroll por eventos del DOM era una reescritura frágil.

## Plan de pruebas

- [x] `pnpm exec tsc -p tsconfig.typecheck.json --noEmit` directo — limpio
- [x] **Verificación empírica de la aserción de paridad:** agregar un miembro público a `WindowLayoutService` rompe el typecheck con `TS2322`; revertir → limpio (revalidado tras hacer `isHeaderVisible$` privado)
- [x] `npx vitest run` — **775 passed**, 3 skipped, **exit 0**
- [x] `pnpm build` — el prerender SSR no falla: `app.config.server.ts` hereda `provideLayout()` vía `mergeApplicationConfig`
- [x] `pnpm lint`, `pnpm stylelint`, `pnpm storybook:build`, `pnpm check:agents` — verdes
- [x] Review local aprobada; hallazgos abordados

`e2e` y `studio-build` no se corrieron localmente: el diff no toca flujos E2E ni `cms/`.