### PR TITLE
[#1891] - Actualiza storylistMock al corpus de Onoff y ajusta los tests dependientes

### DIFF
--- a/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.spec.ts
+++ b/src/app/components/storylist-navigation-frame/storylist-navigation-frame.component.spec.ts
@@ -53,7 +53,8 @@ describe('StorylistNavigationFrameComponent', () => {
 		const view = await setup();
 		view.detectChanges();
 		expect(screen.getByText(storylistMock.stories[0].title)).toBeInTheDocument();
-		expect(screen.getByText(storylistMock.stories[0].author.name)).toBeInTheDocument();
+		// Las obras del corpus Onoff comparten autor, así que el nombre aparece una vez por historia.
+		expect(screen.getAllByText(storylistMock.stories[0].author.name).length).toBeGreaterThan(0);
 	});
 
 	test('should not fetch navigation teasers when navigationSlug is empty', async () => {

--- a/src/app/mocks/storylist.mock.ts
+++ b/src/app/mocks/storylist.mock.ts
@@ -1,13 +1,14 @@
 import { Storylist, StorylistStoriesNavigationTeasers, StorylistTeaser } from '@models/storylist.model';
 import { tagMock } from './tag.mocks';
 import { storyNavigationTeaserWithAuthor } from './story.mock';
+import { onoffStoryTeasersMock } from './onoff-story-teasers.mock';
 
 // Colección — la obsesión de Onoff por el orden y el tiempo (Geometría, el desvelo). Proyección completa (Storylist).
 export const storylistMock: Storylist = {
 	_id: 'onoff-geometrias-del-desvelo',
 	title: 'Geometrías del desvelo',
 	slug: 'geometrias-del-desvelo',
-	count: 1,
+	count: 3,
 	media: [],
 	tabs: [],
 	description: [
@@ -34,7 +35,7 @@ export const storylistMock: Storylist = {
 	config: {
 		showAuthors: true,
 	},
-	stories: [storyNavigationTeaserWithAuthor],
+	stories: onoffStoryTeasersMock.slice(0, 3),
 };
 
 // Colección — la obsesión de Onoff por el orden y el tiempo (Geometría, el desvelo). Teaser con portada editorial propia → imagery representative.

--- a/src/app/pages/storylist/storylist.schema.spec.ts
+++ b/src/app/pages/storylist/storylist.schema.spec.ts
@@ -21,15 +21,13 @@ describe('buildStorylistCollectionSchema', () => {
 			inLanguage: 'es-AR',
 			mainEntity: {
 				'@type': 'ItemList',
-				numberOfItems: 1,
-				itemListElement: [
-					{
-						'@type': 'ListItem',
-						position: 1,
-						url: 'https://www.cuentoneta.ar/story/el-espejo-del-tiempo',
-						name: 'El espejo del tiempo',
-					},
-				],
+				numberOfItems: storylistMock.stories.length,
+				itemListElement: storylistMock.stories.map((story, index) => ({
+					'@type': 'ListItem',
+					position: index + 1,
+					url: `https://www.cuentoneta.ar/story/${story.slug}`,
+					name: story.title,
+				})),
 			},
 		});
 	});


### PR DESCRIPTION
Actualiza el corpus de mocks compartido y los tests dependientes para trabajar con las 3 historias reales de **Onoff** en lugar de un `storylistMock` de una sola historia. Extraído del spike de **CollectionPage V3** (#1826): son cambios independientes del blueprint `noindex` y facilitan seguir adaptando el prototipo sobre datos más realistas.

## Cambios

- **`storylist.mock.ts`** — `storylistMock` pasa de `storyNavigationTeaserWithAuthor` (`count: 1`) al corpus de Onoff: `onoffStoryTeasersMock.slice(0, 3)` con `count: 3`.
- **`storylist-navigation-frame.component.spec.ts`** — las obras del corpus Onoff comparten autor, así que el nombre aparece una vez por historia; la aserción pasa de `getByText` a `getAllByText(...).length > 0`.
- **`storylist.schema.spec.ts`** — la aserción del `ItemList` deja de hardcodear una sola historia y se deriva de `storylistMock.stories` con `.map()`, robusta ante el tamaño del corpus.

## Verificación

- `test` (specs que consumen `storylistMock`), `typecheck` y `lint` en verde.

Closes #1891
