### PR TITLE
Extrae la comparación de viewports a una función pura compartida (compareViewports)

### DIFF
--- a/src/app/providers/layout.service.ts
+++ b/src/app/providers/layout.service.ts
@@ -13,7 +13,7 @@ import {
 } from 'rxjs';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { isPlatformBrowser, isPlatformServer } from '@angular/common';
-import { Viewport, VIEWPORT_WIDTHS_NUMERIC } from '@utils/screen.utils';
+import { Viewport, VIEWPORT_WIDTHS_NUMERIC, compareViewports } from '@utils/screen.utils';
 
 export const Direction = Object.freeze({ Up: 'Up', Down: 'Down' } as const);
 export type Direction = (typeof Direction)[keyof typeof Direction];
@@ -113,14 +113,7 @@ export class LayoutService {
 	 * @param test
 	 */
 	public biggerThan(test: Viewport): boolean {
-		const currentWidth = VIEWPORT_WIDTHS_NUMERIC[this.viewport()];
-		const testWidth = VIEWPORT_WIDTHS_NUMERIC[test];
-
-		if (currentWidth === undefined || testWidth === undefined) {
-			throw new Error(`Viewport inválido: ${test}`);
-		}
-
-		return currentWidth > testWidth;
+		return compareViewports(this.viewport(), test) > 0;
 	}
 
 	/**
@@ -128,24 +121,10 @@ export class LayoutService {
 	 * @param test
 	 */
 	public smallerThan(test: Viewport): boolean {
-		const currentWidth = VIEWPORT_WIDTHS_NUMERIC[this.viewport()];
-		const testWidth = VIEWPORT_WIDTHS_NUMERIC[test];
-
-		if (currentWidth === undefined || testWidth === undefined) {
-			throw new Error(`Viewport inválido: ${test}`);
-		}
-
-		return currentWidth < testWidth;
+		return compareViewports(this.viewport(), test) < 0;
 	}
 
 	public isActual(test: Viewport): boolean {
-		const currentWidth = VIEWPORT_WIDTHS_NUMERIC[this.viewport()];
-		const testWidth = VIEWPORT_WIDTHS_NUMERIC[test];
-
-		if (currentWidth === undefined || testWidth === undefined) {
-			throw new Error(`Viewport inválido: ${test}`);
-		}
-
-		return currentWidth === testWidth;
+		return compareViewports(this.viewport(), test) === 0;
 	}
 }

--- a/src/app/utils/screen.utils.spec.ts
+++ b/src/app/utils/screen.utils.spec.ts
@@ -1,0 +1,20 @@
+import { compareViewports } from './screen.utils';
+import type { Viewport } from './screen.utils';
+
+describe('compareViewports', () => {
+	it('returns a negative number when current is narrower than test', () => {
+		expect(compareViewports('sm', 'lg')).toBeLessThan(0);
+	});
+
+	it('returns a positive number when current is wider than test', () => {
+		expect(compareViewports('lg', 'sm')).toBeGreaterThan(0);
+	});
+
+	it('returns 0 when both viewports are equal', () => {
+		expect(compareViewports('md', 'md')).toBe(0);
+	});
+
+	it('throws on an invalid viewport', () => {
+		expect(() => compareViewports('lg', 'invalid' as Viewport)).toThrow('Viewport inválido: invalid');
+	});
+});

--- a/src/app/utils/screen.utils.ts
+++ b/src/app/utils/screen.utils.ts
@@ -16,3 +16,22 @@ export const VIEWPORT_WIDTHS_PX: Record<Viewport, string> = {
 	lg: '1240px',
 	xl: '1536px',
 };
+
+/**
+ * Compara dos viewports por su ancho. Negativo si `current` es más angosto que `test`, positivo si es
+ * más ancho, 0 si son iguales. Lanza ante un viewport inválido.
+ *
+ * Fuente única de la comparación: la consumen tanto el real (`WindowLayoutService`) como el doble
+ * (`ControllableLayoutService`), de modo que su comportamiento —incluido el error— sea idéntico por
+ * construcción y no por convención.
+ */
+export function compareViewports(current: Viewport, test: Viewport): number {
+	const currentWidth = VIEWPORT_WIDTHS_NUMERIC[current];
+	const testWidth = VIEWPORT_WIDTHS_NUMERIC[test];
+
+	if (currentWidth === undefined || testWidth === undefined) {
+		throw new Error(`Viewport inválido: ${test}`);
+	}
+
+	return currentWidth - testWidth;
+}


### PR DESCRIPTION
> Sin issue asociado. Se separa del PR #1890 (contrato de `LayoutService`) para que este refactor puro aterrice independiente; #1890 se rebasea encima.

## Descripción

`LayoutService.biggerThan`/`smallerThan`/`isActual` repetían el mismo lookup + `throw` contra `VIEWPORT_WIDTHS_NUMERIC`, tres veces. Se extrae a **`compareViewports(current, test)`** en `screen.utils.ts`, que devuelve el signo de la diferencia de anchos y lanza ante un viewport inválido con el mismo mensaje. Los tres métodos pasan a delegar en ella.

Es una función pura, sin dependencias, con su propio spec. No cambia comportamiento observable: el spec de `LayoutService` sigue en verde sin tocarse. Habilita que el real y su doble (en #1890) compartan la comparación —comportamiento idéntico por construcción, incluido el error—, pero el valor de-duplicador se sostiene por sí solo.

## Plan de pruebas

- [x] `pnpm exec tsc -p tsconfig.typecheck.json --noEmit` directo — limpio
- [x] `npx vitest run screen.utils.spec.ts layout.service.spec.ts` — 20 passed, exit 0
- [x] `pnpm lint` sobre los archivos nuevos — verde
- [x] El mensaje del `throw` (`Viewport inválido: ${test}`) es idéntico al preexistente — extracción literal, no regresión

Cambio acotado a `src/`; sin impacto en documentación, schemas, contratos ni `cms/`.