### PR TITLE
Corrige la taxonomía de dobles de test en el corpus (Fake* categoría, InMemory* solo almacenamiento)

### DIFF
--- a/.claude/agents/architecture-advisor.md
+++ b/.claude/agents/architecture-advisor.md
@@ -64,7 +64,7 @@ Primero determiná el change set: corré `git diff --name-only develop...HEAD` (
 - **Regla de dependencia** — las dependencias apuntan hacia adentro (dominio → casos de uso → adaptadores → frameworks). En el backend: el flujo `controller → service → repository` con el mapper (ACL) como frontera que traduce Sanity/GROQ al modelo de dominio
 - **Independencia de capas** — las reglas de negocio no dependen de frameworks ni de la UI; el modelo de dominio no conoce a Sanity
 - **Cruce de fronteras** — los datos cruzan como modelo de dominio mapeado, no como resultados crudos de GROQ; los repos exponen `fetch*()` (crudo) y los services `get*()` (mapeado a dominio)
-- **Testeabilidad** — la lógica de negocio se testea sin dependencias externas (dobles nombrados por comportamiento: `Stub*`/`InMemory*`/`Spy*`, nunca `Mock*`)
+- **Testeabilidad** — la lógica de negocio se testea sin dependencias externas (dobles nombrados por comportamiento: `Stub*`/`Fake*`/`InMemory*`/`Controllable*`/`Spy*`, nunca `Mock*`)
 
 ### Diseño de componentes (acoplamiento entre módulos)
 
@@ -96,7 +96,7 @@ Al evaluar nuevos módulos o endpoints, verificá que el plan incluya:
 - [ ] Módulo bajo `src/api/modules/<dominio>/` con el patrón **controller → service → repository**
 - [ ] Mapper (ACL) en `src/api/_utils/` que traduce GROQ/Sanity al modelo de dominio
 - [ ] Validación con `@hono/zod-validator` y contratos/tipos de dominio acordes
-- [ ] Tests (Vitest + `@test-utils`) con dobles nombrados por comportamiento (`Stub*`/`InMemory*`) para los repos
+- [ ] Tests (Vitest + `@test-utils`) con dobles nombrados por comportamiento (`Stub*`/`Fake*`/`InMemory*`/`Controllable*`/`Spy*`) para los repos
 - [ ] Hono plano, no `OpenAPIHono` (dirección futura no adoptada, #1531); sin Drizzle — la persistencia es Sanity vía `@sanity/client`
 
 ### Convención de providers del frontend (Qualified Implementation)

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -86,7 +86,7 @@ Estos patrones son intencionales y correctos. NO los reportes como problemas:
 - [ ] Open/Closed — extender comportamiento sin modificar lo existente
 - [ ] Liskov Substitution — los subtipos son sustituibles por sus tipos base
 - [ ] Interface Segregation — sin dependencias forzadas sobre interfaces no usadas
-- [ ] Dependency Inversion — depender de abstracciones, no de concreciones (convención **Qualified Implementation**: interfaz con nombre limpio, impls con prefijo `Sanity*`/`Http*`, dobles por comportamiento `Stub*`/`InMemory*`/`Spy*` nunca `Mock*`)
+- [ ] Dependency Inversion — depender de abstracciones, no de concreciones (convención **Qualified Implementation**: interfaz con nombre limpio, impls con prefijo `Sanity*`/`Http*`, dobles por comportamiento `Stub*`/`Fake*`/`InMemory*`/`Controllable*`/`Spy*` nunca `Mock*`)
 
 ### Principios CUPID
 

--- a/.claude/agents/domain-model-advisor.md
+++ b/.claude/agents/domain-model-advisor.md
@@ -108,7 +108,7 @@ Como toda sesión de agente sobre este repo: cargá también `.claude/references
 - [ ] **Sin `enum` de TS** — usar `Object.freeze({...} as const)` para conjuntos cerrados de literales (`ResourceType.slug`, `MediaType`, …).
 - [ ] **Sin barrels** (`index.ts` re-export prohibidos).
 - [ ] **`any` prohibido** sin comentario `// REASON:`.
-- [ ] **Qualified Implementation:** la interfaz lleva el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test se nombran por comportamiento — `Stub*`/`InMemory*`/`Spy*`, **nunca** `Mock*`.
+- [ ] **Qualified Implementation:** la interfaz lleva el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test se nombran por comportamiento — `Stub*`/`Fake*`/`InMemory*`/`Controllable*`/`Spy*`, **nunca** `Mock*`.
 - [ ] Tests con **Vitest** + Angular Testing Library + wrappers de `@test-utils` (prohibido `vi.*` directo).
 
 ## Organización de archivos

--- a/.claude/agents/refactoring-specialist.md
+++ b/.claude/agents/refactoring-specialist.md
@@ -76,7 +76,7 @@ Antes de refactorizar, leé estas referencias del proyecto. Cargalas en **un ún
 - [ ] Los nombres revelan intención (sin abreviaturas ni nombres genéricos).
 - [ ] Convenciones consistentes: archivos `kebab-case`, clases `PascalCase`, métodos `camelCase`, constantes globales `SCREAMING_SNAKE_CASE` y locales `camelCase`.
 - [ ] Variables/métodos booleanos con prefijos `is`, `has`, `can`, `should`.
-- [ ] Interfaces sin prefijo `I`; convención **Qualified Implementation** (`Sanity*`/`Http*`, dobles por comportamiento `Stub*`/`InMemory*`/`Spy*`, nunca `Mock*`).
+- [ ] Interfaces sin prefijo `I`; convención **Qualified Implementation** (`Sanity*`/`Http*`, dobles por comportamiento `Stub*`/`Fake*`/`InMemory*`/`Controllable*`/`Spy*`, nunca `Mock*`).
 
 ### Simplificación
 

--- a/.claude/references/clean-architecture.md
+++ b/.claude/references/clean-architecture.md
@@ -33,7 +33,7 @@ Construir sistemas **mantenibles, testeables e independientes** de los detalles 
 
 - Las reglas de negocio se testean sin UI, sin Sanity y sin servidor web.
 - Los tipos de dominio son objetos planos sin dependencias de framework.
-- Los services se testean sustituyendo el repository por un doble (nombrado por comportamiento — `Stub*`/`InMemory*`, ver más abajo): ver los `*.service.spec.ts` existentes (`content.service.spec.ts`, `sitemap.service.spec.ts`).
+- Los services se testean sustituyendo el repository por un doble (nombrado por comportamiento — `Stub*`/`Fake*`, ver más abajo): ver los `*.service.spec.ts` existentes (`content.service.spec.ts`, `sitemap.service.spec.ts`).
 
 ### Cruce de fronteras
 
@@ -83,7 +83,9 @@ La interfaz lleva el **nombre limpio** (la responsabilidad), y la **implementaci
 El **doble de test** se nombra por lo que **es**, no con el término vago `Mock*`:
 
 - **`Stub*`** — devuelve valores fijos e ignora la entrada. Es el caso de los API providers del front: `StubStoryApi.getBySlug()` devuelve siempre el mismo `storyMock`, sin mirar el slug. No hay nada "en memoria" que consultar, así que llamarlo `InMemory*` prometería una implementación que no existe.
-- **`InMemory*`** — un _fake_: mantiene estado real en memoria y reacciona a él. `InMemoryLayoutService` es el ejemplo: tiene un `viewport` signal y `biggerThan()` compara anchos reales contra el viewport actual. Reservado a los dobles que **de verdad** implementan la lógica.
+- **`Fake*`** — la **categoría**: una implementación real con un atajo (sí ejecuta lógica de verdad, pero se salta la dependencia costosa o externa). Se califica por lo que sustituye:
+  - **`InMemory*`** — sustituye **almacenamiento**: un repository/DB real reemplazado por una lista en memoria. `InMemoryStoryRepository` guarda datos reales y los consulta con lógica real, solo que sin Sanity de por medio.
+  - **`Controllable*`** (o `Static*`, según el mecanismo) — sustituye un **entorno** cuyo input el test necesita fijar (viewport, reloj, random, geolocalización). `ControllableLayoutService` es el ejemplo: no reemplaza un almacén de datos, fija el viewport que el real (`WindowLayoutService`) leería de `window`. "En memoria" no distingue nada acá — todo objeto guarda su estado en memoria; lo que importa es que el input lo fija el test, no el entorno real.
 - **`Spy*`** — registra las llamadas recibidas, cuando el test las inspecciona.
 
 El **archivo** sigue siendo `<dominio>.mock.ts` y la **factory** `provide<X>ApiMock()`: ahí "mock" nombra genéricamente al proveedor del doble, no reclama una categoría de la taxonomía.
@@ -100,24 +102,24 @@ El **archivo** sigue siendo `<dominio>.mock.ts` y la **factory** `provide<X>ApiM
 | Service (impl. única)    | `StoryService`           | `StoryService` (mismo nombre) | `InMemoryStoryService`        |
 
 - Prefijo **`Sanity*`** para implementaciones de repository respaldadas por Sanity/GROQ.
-- El doble se nombra por su comportamiento (`Stub*` / `InMemory*` / `Spy*`), **jamás `Mock*`**. Un repository de test con datos cargados en memoria sí es un `InMemory*Repository` (un fake); uno que devuelve una lista fija es un `Stub*Repository`.
+- El doble se nombra por su comportamiento (`Stub*` / `Fake*` — `InMemory*` para almacenamiento — / `Spy*`), **jamás `Mock*`**. Un repository de test con datos cargados en memoria sí es un `InMemory*Repository` (un fake de almacenamiento); uno que devuelve una lista fija es un `Stub*Repository`.
 - Los services de implementación única **conservan el nombre de la interfaz** (sin prefijo, sin sufijo `Impl`).
 
 > Nota sobre el estado actual: hoy los módulos backend exponen funciones (`getStoryBySlug`, `fetchStories`) más que clases con interfaz explícita, así que **los nombres de esta tabla son ilustrativos de la convención, no símbolos existentes** — las clases llegan con #1503. La convención rige al introducir abstracciones de repository/service o sus dobles de test, y es la dirección a la que tienden los `*.service.spec.ts`.
 
 ### Frontend
 
-| Rol                   | Interfaz + token (`InjectionToken`) | Implementación     | Doble de test           |
-| --------------------- | ----------------------------------- | ------------------ | ----------------------- |
-| API de stories        | `StoryApi`                          | `HttpStoryApi`     | `StubStoryApi`          |
-| API de autores        | `AuthorApi`                         | `HttpAuthorApi`    | `StubAuthorApi`         |
-| API de storylists     | `StorylistApi`                      | `HttpStorylistApi` | `StubStorylistApi`      |
-| Service (impl. única) | `LayoutService` (sin token)         | `LayoutService`    | `InMemoryLayoutService` |
+| Rol                   | Interfaz + token (`InjectionToken`) | Implementación        | Doble de test               |
+| --------------------- | ----------------------------------- | --------------------- | --------------------------- |
+| API de stories        | `StoryApi`                          | `HttpStoryApi`        | `StubStoryApi`              |
+| API de autores        | `AuthorApi`                         | `HttpAuthorApi`       | `StubAuthorApi`             |
+| API de storylists     | `StorylistApi`                      | `HttpStorylistApi`    | `StubStorylistApi`          |
+| Service (impl. única) | `LayoutService` (token homónimo)    | `WindowLayoutService` | `ControllableLayoutService` |
 
-> Los dobles de API son **`Stub*`** (devuelven canned, ignoran la entrada); el de `LayoutService` es **`InMemory*`** porque mantiene un viewport en memoria. La diferencia no es de capa sino de comportamiento del doble — ver la taxonomía de arriba.
+> Los dobles de API son **`Stub*`** (devuelven canned, ignoran la entrada); el de `LayoutService` es un **`Fake*` de entorno**, calificado `Controllable*` porque el viewport lo fija el test (`simulateViewport()`), no `window` como en el real (`WindowLayoutService`). No es `InMemory*`: no sustituye almacenamiento, sustituye el navegador. La diferencia no es de capa sino de qué sustituye el doble — ver la taxonomía de arriba.
 
 - Prefijo **`Http*`** para implementaciones de servicios de API basadas en HTTP.
-- Un service de **implementación única** (`LayoutService`, `NavigationFrameService`, `SchemaOrgService`) no necesita interfaz ni token: se inyecta la clase y su doble se nombra por comportamiento — `InMemoryLayoutService` es un fake con estado (`layout.mock.ts`). El par interfaz + `InjectionToken` se reserva a los **API providers**, que sí tienen dos implementaciones intercambiables.
+- Un service **con doble de test** usa el par interfaz + `InjectionToken` homónimo, igual que los API providers: real y doble son dos implementaciones intercambiables del mismo contrato. `LayoutService` es el caso — interfaz + token `LayoutService`, real `WindowLayoutService` (prefijo de mecanismo), doble `ControllableLayoutService` (`layout.mock.ts`). Un service de **implementación única sin doble** (`NavigationFrameService`, `SchemaOrgService`) no necesita ni interfaz ni token: se inyecta la clase directamente.
 - Los tokens son `InjectionToken` planos (sin `providedIn`/`factory`), cableados vía `provide<X>Api()` (real) y `provide<X>ApiMock()` (doble) con `makeEnvironmentProviders`.
 - **Archivos (3 por API provider):**
   - **`<dominio>-api.interface.ts`** — la interfaz `<X>Api` + el `InjectionToken`. El sufijo **`-api`** distingue el archivo de una interfaz del **modelo de dominio**: `author-api.interface.ts` exporta `AuthorApi`, no una interfaz del agregado `Author`.
@@ -128,7 +130,7 @@ El **archivo** sigue siendo `<dominio>.mock.ts` y la **factory** `provide<X>ApiM
 
 - Interfaz sin prefijo `I`, sin excepciones.
 - `Sanity*` para repositories sobre Sanity/GROQ; `Http*` para API services del front.
-- Doble de test nombrado por comportamiento: `Stub*` (canned), `InMemory*` (fake con estado), `Spy*` (registra) — nunca `Mock*`.
+- Doble de test nombrado por comportamiento: `Stub*` (canned), `Fake*` (implementación real con un atajo — `InMemory*` para almacenamiento, `Controllable*` para entorno), `Spy*` (registra) — nunca `Mock*`.
 - Servicio de implementación única → conserva el nombre de la interfaz.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Reglas no negociables. Una violación requiere justificación explícita.
 ### Naming
 
 - Archivos `kebab-case`; clases `PascalCase`; funciones/métodos `camelCase`; constantes globales `SCREAMING_SNAKE_CASE`, locales `camelCase`.
-- Interfaces **sin** prefijo `I`, sin excepciones. Convención **Qualified Implementation**: la interfaz tiene el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test se nombran por su comportamiento — `Stub*` (devuelve canned), `InMemory*` (fake con estado), `Spy*` (registra) — **nunca** `Mock*` → [`clean-architecture.md`](.claude/references/clean-architecture.md).
+- Interfaces **sin** prefijo `I`, sin excepciones. Convención **Qualified Implementation**: la interfaz tiene el nombre limpio; las implementaciones llevan prefijo de tecnología (`Sanity*`, `Http*`) y los dobles de test se nombran por su comportamiento — `Stub*` (devuelve canned), `Fake*` (implementación real con un atajo; `InMemory*` para lo que sustituye **almacenamiento**, `Controllable*` para lo que sustituye un **entorno**), `Spy*` (registra) — **nunca** `Mock*` → [`clean-architecture.md`](.claude/references/clean-architecture.md).
 - **API providers del frontend:** el archivo de la interfaz lleva el sufijo `-api` — `<dominio>-api.interface.ts` (export `<X>Api`) — para distinguirlo de una interfaz del modelo de dominio. La impl y el doble viven en `<dominio>.provider.ts` (`Http<X>Api` + `provide<X>Api()`) y `<dominio>.mock.ts` (`Stub<X>Api` — devuelve canned — + `provide<X>ApiMock()`). Ver [`clean-architecture.md`](.claude/references/clean-architecture.md).
 
 ### Comentarios


### PR DESCRIPTION
> **PR stackeado.** Base: `feat/1882-layout-service-contract-parity` (PR #1890), que a su vez va sobre #1893. Al mergearse los de abajo, GitHub reapunta esta base sola. Sin issue asociado.

## Descripción

#1889 introdujo la taxonomía de dobles usando `InMemory*` como etiqueta del **bucket entero de fakes**. Es impreciso: en la taxonomía (Meszaros/Fowler) la categoría es **Fake**; `InMemory*` es apenas *un tipo* de fake —el que sustituye **almacenamiento**—. Un fake de **entorno** (viewport, reloj, random) se nombra por su mecanismo.

Se corrige el corpus:

- **`Stub*`** — devuelve canned, ignora la entrada.
- **`Fake*`** — la categoría (implementación real con un atajo). Subtipos: `InMemory*` (almacenamiento), `Controllable*` (entorno, input fijado por el test).
- **`Spy*`** — registra.
- Nunca **`Mock*`**.

La tabla de frontend pasa a `WindowLayoutService` / `ControllableLayoutService` (el doble de `LayoutService`, un fake de entorno). Se reconcilia además la regla de interfaz+token: un service la usa cuando tiene un doble —real + doble son dos implementaciones—, no solo los API providers.

## Por qué es un PR aparte, y por qué va _encima_ de #1890 (no como base)

Es documentación pura (`clean-architecture.md`, `CLAUDE.md`, 4 agentes), separada del código de #1890 por el mismo criterio que #1893 separó `compareViewports`.

A diferencia de #1893, **este va apilado encima** de #1890, no como base: la doc **referencia el código nuevo** (la tabla nombra `ControllableLayoutService`/`WindowLayoutService`, que solo existen en #1890). Un PR de doc basado en `develop` describiría clases inexistentes.

Nota de alcance: el fix de referencia de `typescript.md` (`layout.service.ts` → `layout.interface.ts`) **no** está acá —quedó en #1890— porque es consecuencia del rename del archivo, no de la taxonomía, y sin él `check-agents` de #1890 quedaría rojo (citaría un path renombrado).

## Plan de pruebas

- [x] `pnpm check:agents` — verde: anclas a `CLAUDE.md` y rutas citadas resuelven
- [x] `grep -rn InMemoryLayoutService CLAUDE.md .claude/` — 0 resultados
- [x] Cambio solo de documentación: exento del requisito de test según `coding-agent-policies.md` Sección 2