### PR TITLE
[#1923] - Un build local del Studio (cms/dist) rompe pnpm stylelint — excluirlo del ignoreFiles

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -73,5 +73,5 @@
 			}
 		}
 	],
-	"ignoreFiles": ["!**/*", "dist/**/*"]
+	"ignoreFiles": ["!**/*", "dist/**/*", "cms/dist/**/*"]
 }

--- a/project.json
+++ b/project.json
@@ -120,7 +120,7 @@
 			"executor": "nx-stylelint:lint",
 			"outputs": ["{options.outputFile}"],
 			"options": {
-				"lintFilePatterns": ["**/*.css"]
+				"lintFilePatterns": ["src/**/*.css"]
 			}
 		},
 		"typecheck": {


### PR DESCRIPTION
## Descripción

- Agrega `cms/dist/**/*` al `ignoreFiles` de `.stylelintrc.json`: tras un `pnpm sanity:build` local, el CSS vendored del Studio (CodeMirror/EasyMDE) entraba al barrido y `pnpm stylelint` fallaba con 266 errores ajenos al código propio (detectado durante la sesión de #1908).
- Acota además `lintFilePatterns` del target `stylelint` de Nx de `**/*.css` a `src/**/*.css` (alcance ampliado a partir de la sugerencia de la code review): todo el CSS versionado vive bajo `src/`, y la allowlist evita mantener la blacklist al día con cada artefacto de build nuevo. El `ignoreFiles` se conserva porque las invocaciones directas y las integraciones de IDE leen `.stylelintrc.json` sin pasar por el target.

Closes #1923.

## Plan de pruebas

- [x] Reproducción real del fallo: con `cms/dist` presente, `pnpm stylelint` falló con 266 errores antes del fix y pasó después — verificado tras cada uno de los dos commits, con el artefacto en disco
- [x] `pnpm exec stylelint "src/**/*.css"` (invocación directa) lintea limpio los 9 archivos CSS versionados
- [x] Gates locales en verde: `test`, `lint`, `stylelint`, `typecheck`, `build`, `storybook:build`, `check:agents` (`test:e2e` omitido: una línea de config de tooling; `studio-build` PASS incidental vía la reproducción)
- [x] Review del `code-reviewer` con veredicto APROBADO; su única sugerencia (la allowlist) quedó incorporada en este PR por decisión del usuario
