### PR TITLE
[#1909] - issue-workflow: unificar el vocabulario de estados de hallazgos entre la Fase 5 y el code-reviewer

### DIFF
--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -120,7 +120,7 @@ Observaciones de seguridad y sugerencias de hardening.
 | #   | Archivo | Línea | Hallazgo | Estado |
 | --- | ------- | ----- | -------- | ------ |
 
-> La columna **Estado** usa el vocabulario canónico documentado en `code-reviewer.md` (Detectado / En progreso / Corregido / Descartado / Diferido / No se corrige / Requiere test E2E).
+> La columna **Estado** usa el vocabulario canónico documentado en [`code-reviewer.md`](code-reviewer.md) (Detectado / En progreso / Corregido / Descartado / Diferido / No se corrige / Requiere test E2E).
 
 ### Veredicto
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -103,22 +103,24 @@ Descripción breve de qué se auditó y la postura de seguridad general.
 
 Problemas que deben resolverse antes del merge — vectores de explotación activos.
 
-| #   | Archivo | Línea | Vulnerabilidad | Categoría OWASP | Fix | Resuelto |
-| --- | ------- | ----- | -------------- | --------------- | --- | -------- |
+| #   | Archivo | Línea | Vulnerabilidad | Categoría OWASP | Fix | Estado |
+| --- | ------- | ----- | -------------- | --------------- | --- | ------ |
 
 ### Advertencias de seguridad (Should Fix)
 
 Patrones que debilitan la postura de seguridad pero no son explotables de inmediato.
 
-| #   | Archivo | Línea | Problema | Recomendación | Resuelto |
-| --- | ------- | ----- | -------- | ------------- | -------- |
+| #   | Archivo | Línea | Problema | Recomendación | Estado |
+| --- | ------- | ----- | -------- | ------------- | ------ |
 
 ### Hallazgos informativos
 
 Observaciones de seguridad y sugerencias de hardening.
 
-| #   | Archivo | Línea | Hallazgo | Resuelto |
-| --- | ------- | ----- | -------- | -------- |
+| #   | Archivo | Línea | Hallazgo | Estado |
+| --- | ------- | ----- | -------- | ------ |
+
+> La columna **Estado** usa el vocabulario canónico documentado en `code-reviewer.md` (Detectado / En progreso / Corregido / Descartado / Diferido / No se corrige / Requiere test E2E).
 
 ### Veredicto
 

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -98,11 +98,11 @@ No avanzar a la Fase 3 sin aprobación explícita.
 **Propósito:** abordar los hallazgos con commits atómicos.
 
 1. Abordar cada **Crítico** y **Advertencia** de `workspace/CODE_REVIEW.md` — y de `workspace/SECURITY_REVIEW.md` si corrió el auditor — por prioridad (Críticos primero).
-2. Tras cada fix, actualizar la columna **Abordado** en el archivo al que pertenece el hallazgo (Fixed / Discarded / Deferred / Won't Fix).
+2. Tras cada fix, actualizar la columna **Estado** en el archivo al que pertenece el hallazgo (`CODE_REVIEW.md` o `SECURITY_REVIEW.md`), con los valores canónicos del `code-reviewer` (Detectado / En progreso / Corregido / Descartado / Diferido / No se corrige / Requiere test E2E).
 3. Un commit atómico por fix. El mensaje describe el **cambio real**, nunca referencia el número de hallazgo.
    - ✅ `[#1234] - Acota la constante al cuerpo de la función — estaba a nivel de módulo`
    - ❌ `[#1234] - Arregla el hallazgo #2`
-4. Si un hallazgo se **difiere**, proponer el issue al usuario y **esperar su confirmación** antes de crearlo (`gh issue create`); una vez creado, poner la URL en la columna Abordado. Crear un issue es una acción hacia afuera: la misma política rige en la Fase 6.
+4. Si un hallazgo se **difiere**, proponer el issue al usuario y **esperar su confirmación** antes de crearlo (`gh issue create`); una vez creado, anotar su URL junto al valor **Diferido** en la columna **Estado**. Crear un issue es una acción hacia afuera: la misma política rige en la Fase 6.
 5. Tras abordar Críticos y Advertencias, re-correr los gates de CI. Arreglar regresiones.
 6. Las **Sugerencias** son opcionales: presentarlas y dejar que el usuario decida.
 


### PR DESCRIPTION
## Descripción

- Unifica el vocabulario de estados de hallazgos en el del `code-reviewer` — columna **Estado** con sus 7 valores en español (*Detectado / En progreso / Corregido / Descartado / Diferido / No se corrige / Requiere test E2E*) — que queda como fuente canónica única. La Fase 5 del skill pedía actualizar una columna "Abordado" con 4 valores en inglés que no existe en las tablas reales.
- Incluye el tercer vocabulario detectado durante la implementación: las tablas del `security-auditor` renombran su columna "Resuelto" → "Estado" y remiten al vocabulario canónico con un enlace navegable, sin duplicar la tabla de significados (evita una segunda fuente de verdad — el defecto que originó el issue).
- Conserva la cláusula "en el archivo al que pertenece el hallazgo" de #1908; el paso 4 de la Fase 5 ahora anota la URL del issue diferido junto al valor **Diferido**.

Closes #1909.
Parte de #1907.

## Plan de pruebas

- [x] `pnpm check:agents` en verde tras cada commit (frontmatter, anclas y rutas citadas)
- [x] Grep de residuos: sin menciones de "Abordado"/"Fixed"/"Won't Fix"/columna "Resuelto" en el árbol versionado (quedan solo la frase legítima "Resuelto y verificado" del valor *Corregido* y `domain-model-advisor.md`, fuera de alcance por no ser invocado por la Fase 5)
- [x] Los 7 valores citados en `SKILL.md` y en la nota del auditor coinciden literal y ordenadamente con la tabla canónica de `code-reviewer.md`
- [x] Gates locales en verde: `test`, `lint`, `stylelint`, `typecheck`, `build`, `storybook:build` (`test:e2e` y `studio-build` omitidos: solo Markdown de `.claude/`)
- [x] Review del `code-reviewer` con veredicto APROBADO; su única sugerencia (enlace navegable) aplicada en esta rama por decisión del usuario
