### PR TITLE
[#1912] - issue-workflow: artefactos por issue en workspace/<número>/ y reanudación del flujo

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -142,7 +142,7 @@ Estos patrones son intencionales y correctos. NO los reportes como problemas:
 
 ## Ruta de salida
 
-La Fase 4 del skill [`issue-workflow`](../skills/issue-workflow/SKILL.md) te pasa la ruta completa en la delegación: `workspace/<número>/CODE_REVIEW.md`. Si te invocan sin número de issue (proactivamente o a demanda, fuera del skill), usá el fallback plano `workspace/CODE_REVIEW.md` y aclará en el resumen final de tu respuesta que usaste el fallback.
+La Fase 4 del skill [`issue-workflow`](../skills/issue-workflow/SKILL.md) te pasa la ruta completa en la delegación: `workspace/<number>/CODE_REVIEW.md`. Si te invocan sin número de issue (proactivamente o a demanda, fuera del skill), usá el fallback plano `workspace/CODE_REVIEW.md` y aclará en el resumen final de tu respuesta que usaste el fallback.
 
 ## Formato de salida
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -140,9 +140,13 @@ Estos patrones son intencionales y correctos. NO los reportes como problemas:
 - [ ] Las stories que necesitan providers usan los decorators `applicationConfig` o `moduleMetadata`
 - [ ] Los componentes cuyos `input()` signals, estados visuales o API pública cambian tienen sus stories actualizadas
 
+## Ruta de salida
+
+La Fase 4 del skill [`issue-workflow`](../skills/issue-workflow/SKILL.md) te pasa la ruta completa en la delegación: `workspace/<número>/CODE_REVIEW.md`. Si te invocan sin número de issue (proactivamente o a demanda, fuera del skill), usá el fallback plano `workspace/CODE_REVIEW.md` y aclará en el resumen final de tu respuesta que usaste el fallback.
+
 ## Formato de salida
 
-Escribí la review en `workspace/CODE_REVIEW.md`, **en español**.
+Escribí la review en la ruta de salida indicada arriba, **en español**.
 
 ### Resumen
 

--- a/.claude/agents/plan-writer.md
+++ b/.claude/agents/plan-writer.md
@@ -1,6 +1,6 @@
 ---
 name: plan-writer
-description: Arquitecto de software que diseña planes de implementación para La Cuentoneta. Usar al entrar en modo plan o en la Fase 2 del skill issue-workflow, para explorar el código, definir un enfoque y producir un plan escrito en workspace/<número>/PLAN.md para aprobación del usuario.
+description: Arquitecto de software que diseña planes de implementación para La Cuentoneta. Usar al entrar en modo plan o en la Fase 2 del skill issue-workflow, para explorar el código, definir un enfoque y producir un plan escrito en workspace/<number>/PLAN.md para aprobación del usuario.
 tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 ---
@@ -70,7 +70,7 @@ Primero determiná el change set: corré `git diff --name-only develop...HEAD` (
 
 ## Ruta de salida
 
-El orquestador (Fase 2 del skill [`issue-workflow`](../skills/issue-workflow/SKILL.md)) te pasa la ruta completa en la delegación: `workspace/<número>/PLAN.md`. Si te invocan sin número de issue (modo plan ad-hoc, fuera del skill), usá el fallback plano `workspace/PLAN.md` y aclará en el resumen final de tu respuesta que usaste el fallback.
+El orquestador (Fase 2 del skill [`issue-workflow`](../skills/issue-workflow/SKILL.md)) te pasa la ruta completa en la delegación: `workspace/<number>/PLAN.md`. Si te invocan sin número de issue (modo plan ad-hoc, fuera del skill), usá el fallback plano `workspace/PLAN.md` y aclará en el resumen final de tu respuesta que usaste el fallback.
 
 ## Formato de salida
 
@@ -78,7 +78,7 @@ Escribí el plan en la ruta de salida con esta estructura:
 
 # Plan de implementación: <Título>
 
-**Issue:** #<número> (si aplica)
+**Issue:** #<number> (si aplica)
 **Rama:** feat/<id_issue>-<descripcion-en-kebab-case> (desde `develop`)
 **Fecha:** <YYYY-MM-DD>
 

--- a/.claude/agents/plan-writer.md
+++ b/.claude/agents/plan-writer.md
@@ -1,6 +1,6 @@
 ---
 name: plan-writer
-description: Arquitecto de software que diseña planes de implementación para La Cuentoneta. Usar al entrar en modo plan o en la Fase 2 del skill issue-workflow, para explorar el código, definir un enfoque y producir un plan escrito en workspace/PLAN.md para aprobación del usuario.
+description: Arquitecto de software que diseña planes de implementación para La Cuentoneta. Usar al entrar en modo plan o en la Fase 2 del skill issue-workflow, para explorar el código, definir un enfoque y producir un plan escrito en workspace/<número>/PLAN.md para aprobación del usuario.
 tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 ---
@@ -66,11 +66,15 @@ Primero determiná el change set: corré `git diff --name-only develop...HEAD` (
 5. **Evaluar enfoques** — Considerar varias opciones cuando hay trade-offs; recomendar una con su justificación
 6. **Diseñar los pasos de implementación** — Descomponer en pasos ordenados y accionables
 7. **Verificar restricciones** — Comprobar que el plan respeta las restricciones duras de `CLAUDE.md` (largo de función/archivo, complejidad, sin `enum`, sin lifecycle hooks, signals-first, wrappers de `@test-utils`, etc.), SOLID, CUPID y los guiding principles
-8. **Escribir el plan** — Guardar en `workspace/PLAN.md` con el formato de abajo
+8. **Escribir el plan** — Guardar en la ruta de salida (ver abajo) con el formato de abajo
+
+## Ruta de salida
+
+El orquestador (Fase 2 del skill [`issue-workflow`](../skills/issue-workflow/SKILL.md)) te pasa la ruta completa en la delegación: `workspace/<número>/PLAN.md`. Si te invocan sin número de issue (modo plan ad-hoc, fuera del skill), usá el fallback plano `workspace/PLAN.md` y aclará en el resumen final de tu respuesta que usaste el fallback.
 
 ## Formato de salida
 
-Escribí el plan en `workspace/PLAN.md` con esta estructura:
+Escribí el plan en la ruta de salida con esta estructura:
 
 # Plan de implementación: <Título>
 
@@ -99,13 +103,13 @@ Escribí el plan en `workspace/PLAN.md` con esta estructura:
 
 ## Pasos de implementación
 
-### Paso 1: <Título>
+### Paso 1: <Título> [ ]
 
 - **Archivos:** `ruta/al/archivo.ts`
 - **Acción:** Crear / Modificar / Eliminar
 - **Detalle:** <Qué hacer y por qué>
 
-### Paso 2: <Título>
+### Paso 2: <Título> [ ]
 
 ...
 
@@ -136,6 +140,7 @@ Listar los gates de CI definidos en la sección [Comandos comunes](../../CLAUDE.
 
 ## Guías
 
+- El marcador `[ ]` del título de cada paso lo marca `[x]` la Fase 3 del skill al commitear ese paso — escribí el plan siempre con todos en `[ ]`
 - Mantené los pasos chicos y verificables de forma independiente
 - Cada paso debe dejar un estado funcional (sin estados intermedios a medio romper)
 - Referenciá rutas de archivo y números de línea específicos cuando sea relevante

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -91,9 +91,13 @@ Antes de auditar, leé estas referencias para tener el contexto completo. Cargal
 - [ ] `pnpm audit` no reporta paquetes con CVEs críticos
 - [ ] Dependencias pineadas a versiones específicas
 
+## Ruta de salida
+
+La Fase 4 del skill [`issue-workflow`](../skills/issue-workflow/SKILL.md) te pasa la ruta completa en la delegación: `workspace/<número>/SECURITY_REVIEW.md`. Si te invocan a demanda sin número de issue, usá el fallback plano `workspace/SECURITY_REVIEW.md` y aclará en el resumen final de tu respuesta que usaste el fallback.
+
 ## Formato de salida
 
-Escribí los hallazgos en `workspace/SECURITY_REVIEW.md`, bajo el título **"Auditoría de seguridad"**. Es tu archivo propio — el `code-reviewer` escribe el suyo en `workspace/CODE_REVIEW.md`. Presentá además el resumen en la respuesta.
+Escribí los hallazgos en la ruta de salida indicada arriba, bajo el título **"Auditoría de seguridad"**. Es tu archivo propio — el `code-reviewer` escribe el suyo (`CODE_REVIEW.md`). Presentá además el resumen en la respuesta.
 
 ### Resumen
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -93,7 +93,7 @@ Antes de auditar, leé estas referencias para tener el contexto completo. Cargal
 
 ## Ruta de salida
 
-La Fase 4 del skill [`issue-workflow`](../skills/issue-workflow/SKILL.md) te pasa la ruta completa en la delegación: `workspace/<número>/SECURITY_REVIEW.md`. Si te invocan a demanda sin número de issue, usá el fallback plano `workspace/SECURITY_REVIEW.md` y aclará en el resumen final de tu respuesta que usaste el fallback.
+La Fase 4 del skill [`issue-workflow`](../skills/issue-workflow/SKILL.md) te pasa la ruta completa en la delegación: `workspace/<number>/SECURITY_REVIEW.md`. Si te invocan a demanda sin número de issue, usá el fallback plano `workspace/SECURITY_REVIEW.md` y aclará en el resumen final de tu respuesta que usaste el fallback.
 
 ## Formato de salida
 

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -29,16 +29,20 @@ Corre siempre, en toda invocación, con el número de issue extraído de la URL.
 2. `workspace/<number>/PLAN.md` — ¿existe el plan? Si existe, contar sus marcadores de paso `[ ]` vs. `[x]`.
 3. `workspace/<number>/CODE_REVIEW.md` y/o `workspace/<number>/SECURITY_REVIEW.md` — ¿existe la review?
 4. Si la rama existe: `git rev-list --count develop..<rama>` — ¿cuántos commits tiene sobre `develop`?
+5. Si la rama existe: `gh pr list --head feat/<number>-<kebab> --state open` — ¿hay un PR abierto de esa rama?
 
-| Rama | `PLAN.md`       | Review | Commits | Interpretación → fase sugerida                                                                                                                                                                 |
-| ---- | --------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| No   | No              | —      | —       | Sesión nueva (caso normal) → **Fase 1**, sin pausa ni mensaje adicional                                                                                                                        |
-| Sí   | No              | —      | 0       | La sesión murió antes de escribir el plan → **Fase 2**                                                                                                                                         |
-| Sí   | No              | —      | >0      | Inconsistente (commits sin plan) → pausar y preguntar: reconstruir el plan a partir del diff existente vía `plan-writer`, o ir directo a Fase 4 tratando los commits como implementación hecha |
-| Sí   | Sí, todo `[ ]`  | —      | 0       | Plan escrito, sin aprobar/implementar → **Fase 2**, re-presentando el plan existente sin re-delegar en `plan-writer`                                                                           |
-| Sí   | Sí, algún `[x]` | —      | >0      | Implementación en curso → **Fase 3**, retomando en el primer paso `[ ]`                                                                                                                        |
-| Sí   | Sí              | Sí     | >0      | Review ya escrita → **Fase 5**, abordando los hallazgos con Estado pendiente                                                                                                                   |
-| No   | Sí              | —      | —       | El plan sobrevivió pero la rama no → recrear la rama (Fase 1) y re-confirmar el plan existente en **Fase 2**, sin regenerarlo                                                                  |
+| Rama | `PLAN.md`                  | Review | Commits | Interpretación → fase sugerida                                                                                                |
+| ---- | -------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| No   | No                         | —      | —       | Sesión nueva (caso normal) → **Fase 1**, sin pausa ni mensaje adicional                                                       |
+| Sí   | No                         | —      | 0       | La sesión murió antes de escribir el plan → **Fase 2**                                                                        |
+| Sí   | No                         | —      | >0      | Inconsistente (commits sin plan) → pausa con respuestas propias: **reconstruir** / **revisar** (ver abajo)                    |
+| Sí   | Sí, todo `[ ]`             | —      | 0       | Plan escrito, sin aprobar/implementar → **Fase 2**, re-presentando el plan existente sin re-delegar en `plan-writer`          |
+| Sí   | Sí, algún `[x]` (no todos) | —      | >0      | Implementación en curso → **Fase 3**, retomando en el primer paso `[ ]`                                                       |
+| Sí   | Sí, todo `[x]`             | No     | >0      | Implementación terminada, sin review → **Fase 4**                                                                             |
+| Sí   | Sí                         | Sí     | >0      | Review ya escrita → **Fase 5**, abordando los hallazgos con Estado pendiente                                                  |
+| No   | Sí                         | —      | —       | El plan sobrevivió pero la rama no → recrear la rama (Fase 1) y re-confirmar el plan existente en **Fase 2**, sin regenerarlo |
+
+Si además existe un **PR abierto** para la rama (señal 5), el flujo ya completó la **Fase 6**: reportar la URL del PR y pausar — el trabajo restante, si lo hay, es abordar feedback de ese PR, no re-ejecutar el flujo.
 
 Si se detecta cualquier señal:
 
@@ -48,6 +52,11 @@ Si se detecta cualquier señal:
 
 - **reanudar** → saltar a la fase sugerida por la tabla, reusando los artefactos existentes sin sobrescribirlos.
 - **rehacer** → flujo normal desde la Fase 1. No borra `workspace/<number>/` ni la rama existente: antes de cada punto que sobrescribiría un artefacto existente (recrear la rama en Fase 1, reescribir `PLAN.md` en Fase 2), confirmar explícitamente con el usuario — nunca pisar en silencio.
+
+El caso **commits sin plan** usa un par de respuestas propio — ni "reanudar" ni "rehacer" describen esa situación:
+
+- **reconstruir** → delegar en `plan-writer` la reconstrucción del plan a partir del diff existente y seguir el flujo desde la Fase 2.
+- **revisar** → tratar los commits como implementación hecha e ir directo a la Fase 4.
 
 ---
 

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -5,7 +5,7 @@ description: Orquesta el ciclo completo de resolución de un issue de GitHub en 
 
 # Issue Workflow
 
-Orquesta el ciclo de vida completo para resolver un issue de GitHub en **cuentoneta**. Cada invocación sobrescribe `workspace/PLAN.md`, `workspace/CODE_REVIEW.md` y — si el diff amerita auditoría de seguridad — `workspace/SECURITY_REVIEW.md`; guardá los artefactos de una sesión previa antes de empezar una nueva. (`workspace/` está gitignoreado.)
+Orquesta el ciclo de vida completo para resolver un issue de GitHub en **cuentoneta**. Los artefactos de cada sesión viven namespaceados por issue en `workspace/<number>/` — `PLAN.md`, `CODE_REVIEW.md` y, si el diff amerita auditoría de seguridad, `SECURITY_REVIEW.md` — así sesiones de issues distintos no se pisan. Re-invocar el mismo issue pasa por la **Fase 0**, que reanuda o rehace con confirmación, nunca sobrescribe en silencio. Los artefactos sueltos de sesiones previas al namespacing que ya están en `workspace/` no se migran ni se borran. (`workspace/` está gitignoreado.)
 
 > **Issues de release:** para los issues de gestión de release (p. ej. "Generar release para versión X") usá el skill dedicado [`release-workflow`](../release-workflow/SKILL.md), que encodea el checklist determinista del release (bump lockstep, CHANGELOG desde el milestone, gatillo `develop → master`) en vez de este flujo de feature.
 
@@ -19,6 +19,38 @@ Ejemplo: `/issue-workflow https://github.com/cuentoneta/cuentoneta/issues/1234`
 
 ---
 
+## Fase 0 — Detección de estado
+
+**Propósito:** detectar trabajo previo sobre el issue y reanudar en la fase que corresponda en vez de re-setupear.
+
+Corre siempre, en toda invocación, con el número de issue extraído de la URL. Señales a relevar:
+
+1. `git branch --list 'feat/<number>-*'` — ¿existe la rama?
+2. `workspace/<number>/PLAN.md` — ¿existe el plan? Si existe, contar sus marcadores de paso `[ ]` vs. `[x]`.
+3. `workspace/<number>/CODE_REVIEW.md` y/o `workspace/<number>/SECURITY_REVIEW.md` — ¿existe la review?
+4. Si la rama existe: `git rev-list --count develop..<rama>` — ¿cuántos commits tiene sobre `develop`?
+
+| Rama | `PLAN.md`       | Review | Commits | Interpretación → fase sugerida                                                                                                                                                                 |
+| ---- | --------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No   | No              | —      | —       | Sesión nueva (caso normal) → **Fase 1**, sin pausa ni mensaje adicional                                                                                                                        |
+| Sí   | No              | —      | 0       | La sesión murió antes de escribir el plan → **Fase 2**                                                                                                                                         |
+| Sí   | No              | —      | >0      | Inconsistente (commits sin plan) → pausar y preguntar: reconstruir el plan a partir del diff existente vía `plan-writer`, o ir directo a Fase 4 tratando los commits como implementación hecha |
+| Sí   | Sí, todo `[ ]`  | —      | 0       | Plan escrito, sin aprobar/implementar → **Fase 2**, re-presentando el plan existente sin re-delegar en `plan-writer`                                                                           |
+| Sí   | Sí, algún `[x]` | —      | >0      | Implementación en curso → **Fase 3**, retomando en el primer paso `[ ]`                                                                                                                        |
+| Sí   | Sí              | Sí     | >0      | Review ya escrita → **Fase 5**, abordando los hallazgos con Estado pendiente                                                                                                                   |
+| No   | Sí              | —      | —       | El plan sobrevivió pero la rama no → recrear la rama (Fase 1) y re-confirmar el plan existente en **Fase 2**, sin regenerarlo                                                                  |
+
+Si se detecta cualquier señal:
+
+**⏸ PAUSA — requiere decisión del usuario.**
+
+> Detecté <lo encontrado: rama con N commits / plan con M de T pasos marcados / review existente>. Una sesión previa llegó hasta la **Fase <X>**. Respondé **reanudar** para continuar ahí reusando los artefactos tal cual están, o **rehacer** para empezar de nuevo desde la Fase 1.
+
+- **reanudar** → saltar a la fase sugerida por la tabla, reusando los artefactos existentes sin sobrescribirlos.
+- **rehacer** → flujo normal desde la Fase 1. No borra `workspace/<number>/` ni la rama existente: antes de cada punto que sobrescribiría un artefacto existente (recrear la rama en Fase 1, reescribir `PLAN.md` en Fase 2), confirmar explícitamente con el usuario — nunca pisar en silencio.
+
+---
+
 ## Fase 1 — Setup
 
 **Propósito:** crear una rama de feature limpia desde `develop` actualizado.
@@ -28,7 +60,7 @@ Ejemplo: `/issue-workflow https://github.com/cuentoneta/cuentoneta/issues/1234`
    - Formato: **`feat/<number>-<titulo-en-kebab-case>`**.
    - Transformación: minúsculas, espacios y no-alfanuméricos → guiones, colapsar guiones consecutivos, recortar guiones de borde, truncar a ~60 caracteres en un límite de palabra.
 3. `git checkout develop && git pull` para asegurar la base actualizada.
-4. `git checkout -b feat/<number>-<kebab>`.
+4. `git checkout -b feat/<number>-<kebab>`. Si la Fase 0 detectó la rama existente y el usuario eligió **rehacer**, confirmar la reutilización y usar `git checkout feat/<number>-<kebab>` (sin `-b`).
 5. Reportar al usuario: número, título y nombre de rama.
 
 ---
@@ -37,13 +69,13 @@ Ejemplo: `/issue-workflow https://github.com/cuentoneta/cuentoneta/issues/1234`
 
 **Propósito:** producir un plan de implementación detallado para aprobación.
 
-1. Delegar al agente **`plan-writer`** pasándole la URL del issue, su descripción y el nombre de rama.
-2. El plan-writer produce `workspace/PLAN.md`.
+1. Delegar al agente **`plan-writer`** pasándole la URL del issue, su descripción, el nombre de rama y la ruta de salida completa (`workspace/<number>/PLAN.md`). Si la Fase 0 reanudó acá con un plan ya escrito, saltear la delegación y pasar directo al resumen.
+2. El plan-writer produce `workspace/<number>/PLAN.md`.
 3. Presentar un resumen breve al usuario (objetivo, enfoque, archivos afectados, decisiones clave).
 
 **⏸ PAUSA — requiere aprobación del usuario.**
 
-> El plan está en `workspace/PLAN.md`. Revisalo y respondé **aprobar** para empezar la implementación, o dame feedback para revisarlo.
+> El plan está en `workspace/<number>/PLAN.md`. Revisalo y respondé **aprobar** para empezar la implementación, o dame feedback para revisarlo.
 
 No avanzar a la Fase 3 sin aprobación explícita.
 
@@ -53,8 +85,8 @@ No avanzar a la Fase 3 sin aprobación explícita.
 
 **Propósito:** ejecutar el plan con commits atómicos.
 
-1. Ejecutar los pasos de `workspace/PLAN.md` en orden.
-2. Un commit atómico por unidad lógica de trabajo.
+1. Ejecutar los pasos de `workspace/<number>/PLAN.md` en orden. Si la Fase 0 reanudó acá, saltear los pasos ya marcados `[x]`.
+2. Un commit atómico por unidad lógica de trabajo. Tras cada commit, marcar `[x]` el checkbox del paso correspondiente en `workspace/<number>/PLAN.md`.
 3. **Scan de impacto en documentación.** Si el cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología de dominio, delegar en el agente **`documentation-writer`** la actualización de `docs/`, `CLAUDE.md` y `.claude/references/`, en el **mismo** commit/PR — lo exige la sección [Scan de impacto en documentación](../../../CLAUDE.md#scan-de-impacto-en-documentación) de `CLAUDE.md`. Si el cambio no toca nada de eso, saltear el paso.
 4. **CHANGELOG:** cuentoneta mantiene `CHANGELOG.md` **por release/versión** (no por PR), al cerrar un milestone. **No** se exige una entrada por issue en este flujo; el tracking del cambio vive en el issue + su milestone. (Esto reemplaza el gate de CHANGELOG del starter.)
 
@@ -83,13 +115,13 @@ No avanzar a la Fase 3 sin aprobación explícita.
    - **Lanzalos concurrentemente**, no uno tras otro: son independientes entre sí y así los corre CI (todos los jobs cuelgan de `setup` y van en runners separados). En serie tardan la **suma**; en paralelo, lo que tarde el más lento. Medido en #1850: 105s → 29s.
    - Si alguno falla: reportar cuál, diagnosticar, arreglar, commitear el fix (reglas de Fase 3) y re-correr **solo el que falló** mientras el resto sigue verde; re-correr todo solo si el fix toca superficie compartida.
 2. **Determinar si el diff toca superficie de seguridad.** La lista de disparadores es la sección **"Cuándo correr"** del agente `security-auditor`: `src/api/**` (endpoints, GROQ, mappers), manejo de contenido externo (PortableText/HTML del CMS, `bypassSecurityTrust*`, fetch a servicios externos, `localStorage`), variables de entorno / secrets / config de Sanity o Clarity, y dependencias (`package.json` / `pnpm-lock.yaml`). Un diff que no toca nada de eso —solo documentación, estilos o UI sin datos externos— **no** la amerita; el auditor también puede invocarse a demanda si surge una preocupación puntual.
-3. **Delegar las reviews — en paralelo si corren ambas.** Si el diff toca superficie de seguridad, lanzar al **`security-auditor`** y al **`code-reviewer`** en el **mismo turno** (ambas delegaciones en una única respuesta, igual que los gates del paso 1): sus reviews son independientes y no comparten archivo de salida. Si no la toca, delegar solo al `code-reviewer`. En ambos casos el `code-reviewer` revisa todos los cambios de la rama vs. `develop` y recibe **el resultado observado de los gates del paso 1** (qué corriste, con qué resultado, y cuáles omitiste por no aplicar al diff) — sin ese dato los vuelve a correr, que es la parte más cara de la review.
-4. Cada agente escribe su propio archivo: el `code-reviewer` en `workspace/CODE_REVIEW.md` y el `security-auditor` en `workspace/SECURITY_REVIEW.md`.
+3. **Delegar las reviews — en paralelo si corren ambas.** Si el diff toca superficie de seguridad, lanzar al **`security-auditor`** y al **`code-reviewer`** en el **mismo turno** (ambas delegaciones en una única respuesta, igual que los gates del paso 1): sus reviews son independientes y no comparten archivo de salida. Si no la toca, delegar solo al `code-reviewer`. Cada delegación incluye la ruta de salida completa del agente (ver paso 4). En ambos casos el `code-reviewer` revisa todos los cambios de la rama vs. `develop` y recibe **el resultado observado de los gates del paso 1** (qué corriste, con qué resultado, y cuáles omitiste por no aplicar al diff) — sin ese dato los vuelve a correr, que es la parte más cara de la review.
+4. Cada agente escribe su propio archivo: el `code-reviewer` en `workspace/<number>/CODE_REVIEW.md` y el `security-auditor` en `workspace/<number>/SECURITY_REVIEW.md`.
 5. Presentar la tabla de hallazgos al usuario (Críticos, Advertencias, Sugerencias), combinando ambos archivos cuando corrió el auditor, e indicando si corrió o por qué no correspondía. Al combinar, cada hallazgo se cita con el número tal como aparece en su documento de origen: los de seguridad llevan el prefijo `S` (p. ej. `S3`) y así no se confunden con los del `code-reviewer` (sin prefijo).
 
 **⏸ PAUSA — requiere decisión del usuario.**
 
-> Review completa en `workspace/CODE_REVIEW.md` (y `workspace/SECURITY_REVIEW.md` si corrió el auditor de seguridad). Respondé **proceder** para abordar los hallazgos, o **ship** si no hay nada bloqueante.
+> Review completa en `workspace/<number>/CODE_REVIEW.md` (y `workspace/<number>/SECURITY_REVIEW.md` si corrió el auditor de seguridad). Respondé **proceder** para abordar los hallazgos, o **ship** si no hay nada bloqueante.
 
 ---
 
@@ -97,7 +129,7 @@ No avanzar a la Fase 3 sin aprobación explícita.
 
 **Propósito:** abordar los hallazgos con commits atómicos.
 
-1. Abordar cada **Crítico** y **Advertencia** de `workspace/CODE_REVIEW.md` — y de `workspace/SECURITY_REVIEW.md` si corrió el auditor — por prioridad (Críticos primero).
+1. Abordar cada **Crítico** y **Advertencia** de `workspace/<number>/CODE_REVIEW.md` — y de `workspace/<number>/SECURITY_REVIEW.md` si corrió el auditor — por prioridad (Críticos primero).
 2. Tras cada fix, actualizar la columna **Estado** en el archivo al que pertenece el hallazgo (`CODE_REVIEW.md` o `SECURITY_REVIEW.md`), con los valores canónicos del `code-reviewer` (Detectado / En progreso / Corregido / Descartado / Diferido / No se corrige / Requiere test E2E).
 3. Un commit atómico por fix. El mensaje describe el **cambio real**, nunca referencia el número de hallazgo.
    - ✅ `[#1234] - Acota la constante al cuerpo de la función — estaba a nivel de módulo`

--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ Thumbs.db
 
 # Planes y artefactos de orquestación de Claude (no se versionan)
 /workflows
-# Artefactos del skill issue-workflow (PLAN.md / CODE_REVIEW.md / SECURITY_REVIEW.md por sesión)
+# Artefactos del skill issue-workflow (workspace/<numero>/{PLAN,CODE_REVIEW,SECURITY_REVIEW}.md por issue; ruta plana como fallback ad-hoc)
 /workspace
 
 # Grabaciones sueltas de referencia en scripts/


### PR DESCRIPTION
## Descripción

- **Namespacing por issue:** los tres artefactos por sesión (`PLAN.md`, `CODE_REVIEW.md`, `SECURITY_REVIEW.md`) pasan a vivir en `workspace/<number>/` — sesiones de issues distintos ya no se pisan y desaparece el workaround de backups manuales. El orquestador pasa la ruta completa en cada delegación; cada agente documenta el patrón canónico en una sección "Ruta de salida" nueva, con fallback plano para invocaciones ad-hoc fuera del skill. Cambio prospectivo: los artefactos sueltos preexistentes no se migran ni se borran.
- **Fase 0 — Detección de estado:** cinco señales (rama, plan y sus checkboxes, review, commits, PR abierto) y una tabla de mapeo señal→fase permiten reanudar una sesión interrumpida donde quedó (plan sin aprobar → Fase 2; implementación a medias → Fase 3 desde el primer paso `[ ]`; terminada sin review → Fase 4; review escrita → Fase 5; PR abierto → reportar y pausar). Pausa textual **reanudar**/**rehacer** — y un par propio **reconstruir**/**revisar** para el caso inconsistente de commits sin plan; "rehacer" nunca pisa artefactos en silencio.
- **Checkboxes de progreso:** la plantilla del `plan-writer` marca cada paso con `[ ]` y la Fase 3 los va marcando `[x]` al commitear — la señal que le permite a la Fase 0 saber exactamente dónde retomar.

**Ampliación de alcance acordada durante la review:** el hallazgo #4 del `code-reviewer` (la Fase 0 no detectaba un PR ya abierto y podía re-proponer fases sobre un flujo ya shipeado) se incorporó a este mismo PR como señal 5 de la Fase 0, por decisión del usuario, en lugar de diferirse a un follow-up.

Closes #1912.
Parte de #1907.

## Plan de pruebas

- [x] `pnpm check:agents` en verde tras cada commit (frontmatter de los 3 agentes, anclas y rutas citadas)
- [x] Grep de residuos: las únicas menciones a rutas planas restantes son los fallbacks intencionales de las secciones "Ruta de salida"; `docs/` y `release-workflow` (namespacea por versión, no por issue) sin impacto
- [x] Mecanismo verificado en vivo: la review de este propio PR se escribió en `workspace/1912/CODE_REVIEW.md` pasando la ruta namespaceada en la delegación (incluida la creación del subdirectorio)
- [x] Gates locales en verde: `test`, `lint`, `stylelint`, `typecheck`, `build`, `storybook:build` (`test:e2e` y `studio-build` omitidos: solo Markdown de `.claude/` + comentario de `.gitignore`)
- [x] Review del `code-reviewer`: APROBADO CON COMENTARIOS — 2 advertencias (hueco en la tabla de la Fase 0; vocabulario de pausa del caso commits-sin-plan) y 2 sugerencias (placeholder `<number>`; señal de PR abierto), las 4 abordadas en esta rama con estado Corregido
