### PR TITLE
[#1916] - issue-workflow: pausas con AskUserQuestion e iteración del plan por continuación de agente

### DIFF
--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -146,6 +146,7 @@ No avanzar a la Fase 3 sin una respuesta "Aprobar".
 - `question`: "Review completa en `workspace/<number>/CODE_REVIEW.md` (y `workspace/<number>/SECURITY_REVIEW.md` si corrió el auditor). ¿Cómo seguimos?" — si hay Críticos abiertos, incluir cuántos en el texto de la pregunta.
 - `header`: `Review`
 - `options` (la recomendada primero): **Proceder** — ir a la Fase 5 y abordar los hallazgos por prioridad (Críticos primero); **Ship** — no hay nada bloqueante: saltar la Fase 5 e ir directo a la Fase 6.
+- La opción **"Other"** (automática) cubre instrucciones libres — p. ej. abordar solo un subconjunto de hallazgos, descartar las sugerencias o diferir alguno: el orquestador ejecuta la Fase 5 según lo indicado.
 
 > Nota: bloquear "Ship" mecánicamente ante Críticos abiertos es un cambio aparte (#1919, pendiente) — hoy la pausa solo los hace visibles en la pregunta; cuando #1919 se implemente, este es el punto donde aplicaría el bloqueo.
 

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -87,11 +87,18 @@ El caso **commits sin plan** usa una pregunta propia — ni "reanudar" ni "rehac
 2. El plan-writer produce `workspace/<number>/PLAN.md`.
 3. Presentar un resumen breve al usuario (objetivo, enfoque, archivos afectados, decisiones clave).
 
-**⏸ PAUSA — requiere aprobación del usuario.**
+**⏸ PAUSA — decisión vía `AskUserQuestion`.**
 
-> El plan está en `workspace/<number>/PLAN.md`. Revisalo y respondé **aprobar** para empezar la implementación, o dame feedback para revisarlo.
+- `question`: "El plan está en `workspace/<number>/PLAN.md`. ¿Cómo seguimos?"
+- `header`: `Plan`
+- `options`: solo **Aprobar** — el plan queda tal cual y se avanza a la Fase 3. No agregar una opción "dar feedback": la opción **"Other"** (automática) es la única vía que puede transportar el contenido del feedback.
 
-No avanzar a la Fase 3 sin aprobación explícita.
+Ramaleo tras la respuesta:
+
+- **Aprobar** → avanzar a la Fase 3.
+- **Other** (feedback) → reenviar el texto recibido **a la misma Task del `plan-writer`** delegada en el paso 1 — conserva toda la exploración en contexto — para que revise `workspace/<number>/PLAN.md` en función del feedback y reescriba el plan en el mismo archivo. Nunca editar `PLAN.md` a mano desde el orquestador ni relanzar un `plan-writer` de cero mientras la Task siga disponible. Repetir la pausa tras cada revisión, iterando hasta un "Aprobar". Si la Task original ya no está disponible (p. ej. reanudación vía Fase 0 en una sesión nueva), delegar en un `plan-writer` nuevo pasándole el `PLAN.md` existente más el feedback — revisa sobre lo escrito, no re-explora de cero.
+
+No avanzar a la Fase 3 sin una respuesta "Aprobar".
 
 ---
 

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -35,7 +35,7 @@ Corre siempre, en toda invocación, con el número de issue extraído de la URL.
 | ---- | -------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | No   | No                         | —      | —       | Sesión nueva (caso normal) → **Fase 1**, sin pausa ni mensaje adicional                                                       |
 | Sí   | No                         | —      | 0       | La sesión murió antes de escribir el plan → **Fase 2**                                                                        |
-| Sí   | No                         | —      | >0      | Inconsistente (commits sin plan) → pausa con respuestas propias: **reconstruir** / **revisar** (ver abajo)                    |
+| Sí   | No                         | —      | >0      | Inconsistente (commits sin plan) → pausa con respuestas propias: **Reconstruir** / **Revisar** (ver abajo)                    |
 | Sí   | Sí, todo `[ ]`             | —      | 0       | Plan escrito, sin aprobar/implementar → **Fase 2**, re-presentando el plan existente sin re-delegar en `plan-writer`          |
 | Sí   | Sí, algún `[x]` (no todos) | —      | >0      | Implementación en curso → **Fase 3**, retomando en el primer paso `[ ]`                                                       |
 | Sí   | Sí, todo `[x]`             | No     | >0      | Implementación terminada, sin review → **Fase 4**                                                                             |
@@ -93,7 +93,7 @@ El caso **commits sin plan** usa una pregunta propia — ni "reanudar" ni "rehac
 - `header`: `Plan`
 - `options` (la recomendada primero): **Aprobar** — el plan queda tal cual y se avanza a la Fase 3; **Dar feedback** — el orquestador pide el texto del feedback a continuación. La herramienta exige entre 2 y 4 opciones explícitas — "Aprobar" no puede ir sola. La opción **"Other"** (automática) transporta el feedback directamente en un solo paso y es la vía preferida cuando el usuario ya sabe qué cambiar.
 
-Ramaleo tras la respuesta:
+Ramificación tras la respuesta:
 
 - **Aprobar** → avanzar a la Fase 3.
 - **Dar feedback** → pedir el texto del feedback al usuario y tratarlo igual que Other.

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -91,11 +91,12 @@ El caso **commits sin plan** usa una pregunta propia — ni "reanudar" ni "rehac
 
 - `question`: "El plan está en `workspace/<number>/PLAN.md`. ¿Cómo seguimos?"
 - `header`: `Plan`
-- `options`: solo **Aprobar** — el plan queda tal cual y se avanza a la Fase 3. No agregar una opción "dar feedback": la opción **"Other"** (automática) es la única vía que puede transportar el contenido del feedback.
+- `options` (la recomendada primero): **Aprobar** — el plan queda tal cual y se avanza a la Fase 3; **Dar feedback** — el orquestador pide el texto del feedback a continuación. La herramienta exige entre 2 y 4 opciones explícitas — "Aprobar" no puede ir sola. La opción **"Other"** (automática) transporta el feedback directamente en un solo paso y es la vía preferida cuando el usuario ya sabe qué cambiar.
 
 Ramaleo tras la respuesta:
 
 - **Aprobar** → avanzar a la Fase 3.
+- **Dar feedback** → pedir el texto del feedback al usuario y tratarlo igual que Other.
 - **Other** (feedback) → reenviar el texto recibido **a la misma Task del `plan-writer`** delegada en el paso 1 — conserva toda la exploración en contexto — para que revise `workspace/<number>/PLAN.md` en función del feedback y reescriba el plan en el mismo archivo. Nunca editar `PLAN.md` a mano desde el orquestador ni relanzar un `plan-writer` de cero mientras la Task siga disponible. Repetir la pausa tras cada revisión, iterando hasta un "Aprobar". Si la Task original ya no está disponible (p. ej. reanudación vía Fase 0 en una sesión nueva), delegar en un `plan-writer` nuevo pasándole el `PLAN.md` existente más el feedback — revisa sobre lo escrito, no re-explora de cero.
 
 No avanzar a la Fase 3 sin una respuesta "Aprobar".

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -140,9 +140,13 @@ No avanzar a la Fase 3 sin una respuesta "Aprobar".
 4. Cada agente escribe su propio archivo: el `code-reviewer` en `workspace/<number>/CODE_REVIEW.md` y el `security-auditor` en `workspace/<number>/SECURITY_REVIEW.md`.
 5. Presentar la tabla de hallazgos al usuario (Críticos, Advertencias, Sugerencias), combinando ambos archivos cuando corrió el auditor, e indicando si corrió o por qué no correspondía. Al combinar, cada hallazgo se cita con el número tal como aparece en su documento de origen: los de seguridad llevan el prefijo `S` (p. ej. `S3`) y así no se confunden con los del `code-reviewer` (sin prefijo).
 
-**⏸ PAUSA — requiere decisión del usuario.**
+**⏸ PAUSA — decisión vía `AskUserQuestion`.**
 
-> Review completa en `workspace/<number>/CODE_REVIEW.md` (y `workspace/<number>/SECURITY_REVIEW.md` si corrió el auditor de seguridad). Respondé **proceder** para abordar los hallazgos, o **ship** si no hay nada bloqueante.
+- `question`: "Review completa en `workspace/<number>/CODE_REVIEW.md` (y `workspace/<number>/SECURITY_REVIEW.md` si corrió el auditor). ¿Cómo seguimos?" — si hay Críticos abiertos, incluir cuántos en el texto de la pregunta.
+- `header`: `Review`
+- `options` (la recomendada primero): **Proceder** — ir a la Fase 5 y abordar los hallazgos por prioridad (Críticos primero); **Ship** — no hay nada bloqueante: saltar la Fase 5 e ir directo a la Fase 6.
+
+> Nota: bloquear "Ship" mecánicamente ante Críticos abiertos es un cambio aparte (#1919, pendiente) — hoy la pausa solo los hace visibles en la pregunta; cuando #1919 se implemente, este es el punto donde aplicaría el bloqueo.
 
 ---
 

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -44,14 +44,18 @@ Corre siempre, en toda invocación, con el número de issue extraído de la URL.
 
 Si además existe un **PR abierto** para la rama (señal 5), el flujo ya completó la **Fase 6**: reportar la URL del PR y pausar — el trabajo restante, si lo hay, es abordar feedback de ese PR, no re-ejecutar el flujo.
 
-Si se detecta cualquier señal:
+Si se detecta cualquier señal, pausar con `AskUserQuestion`:
 
-**⏸ PAUSA — requiere decisión del usuario.**
+**⏸ PAUSA — decisión vía `AskUserQuestion`.**
 
-> Detecté <lo encontrado: rama con N commits / plan con M de T pasos marcados / review existente>. Una sesión previa llegó hasta la **Fase <X>**. Respondé **reanudar** para continuar ahí reusando los artefactos tal cual están, o **rehacer** para empezar de nuevo desde la Fase 1.
+- `question`: "Detecté <lo encontrado: rama con N commits / plan con M de T pasos marcados / review existente>. Una sesión previa llegó hasta la Fase <X>. ¿Cómo seguimos?"
+- `header`: `Retomar`
+- `options` (la recomendada primero): **Reanudar** — continuar en la Fase <X> reusando los artefactos tal cual están; **Rehacer** — empezar de nuevo desde la Fase 1, sin borrar nada. La opción **"Other"** (automática) cubre cualquier instrucción libre distinta.
 
-- **reanudar** → saltar a la fase sugerida por la tabla, reusando los artefactos existentes sin sobrescribirlos.
-- **rehacer** → flujo normal desde la Fase 1. No borra `workspace/<number>/` ni la rama existente: antes de cada punto que sobrescribiría un artefacto existente (recrear la rama en Fase 1, reescribir `PLAN.md` en Fase 2), confirmar explícitamente con el usuario — nunca pisar en silencio.
+Semántica de cada respuesta (sin cambios respecto de la tabla):
+
+- **Reanudar** → saltar a la fase sugerida por la tabla, reusando los artefactos existentes sin sobrescribirlos.
+- **Rehacer** → flujo normal desde la Fase 1. No borra `workspace/<number>/` ni la rama existente: antes de cada punto que sobrescribiría un artefacto existente (recrear la rama en Fase 1, reescribir `PLAN.md` en Fase 2), confirmar explícitamente con el usuario — nunca pisar en silencio.
 
 El caso **commits sin plan** usa un par de respuestas propio — ni "reanudar" ni "rehacer" describen esa situación:
 

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -57,10 +57,11 @@ Semántica de cada respuesta (sin cambios respecto de la tabla):
 - **Reanudar** → saltar a la fase sugerida por la tabla, reusando los artefactos existentes sin sobrescribirlos.
 - **Rehacer** → flujo normal desde la Fase 1. No borra `workspace/<number>/` ni la rama existente: antes de cada punto que sobrescribiría un artefacto existente (recrear la rama en Fase 1, reescribir `PLAN.md` en Fase 2), confirmar explícitamente con el usuario — nunca pisar en silencio.
 
-El caso **commits sin plan** usa un par de respuestas propio — ni "reanudar" ni "rehacer" describen esa situación:
+El caso **commits sin plan** usa una pregunta propia — ni "reanudar" ni "rehacer" describen esa situación:
 
-- **reconstruir** → delegar en `plan-writer` la reconstrucción del plan a partir del diff existente y seguir el flujo desde la Fase 2.
-- **revisar** → tratar los commits como implementación hecha e ir directo a la Fase 4.
+- `question`: "Hay <N> commits en la rama pero no existe `workspace/<number>/PLAN.md`. ¿Cómo seguimos?"
+- `header`: `Estado`
+- `options`: **Reconstruir** — delegar en `plan-writer` la reconstrucción del plan a partir del diff existente y seguir el flujo desde la Fase 2; **Revisar** — tratar los commits como implementación hecha e ir directo a la Fase 4. ("Other" cubre cualquier instrucción distinta de esas dos.)
 
 ---
 


### PR DESCRIPTION
## Descripción

- Migra las **4 pausas** del skill (Fase 0 ×2, Fase 2, Fase 4) de texto libre ("respondé **aprobar**…") a especificaciones de `AskUserQuestion`: pregunta, `header` corto y opciones explícitas con la recomendada primero; la opción automática "Other" queda documentada en cada pausa como vía de instrucciones libres. La semántica de reanudar/rehacer/reconstruir/revisar/aprobar/proceder/ship no cambia — solo el mecanismo de la pregunta.
- Define la **iteración del plan por continuación de agente**: el feedback vuelve a la misma Task del `plan-writer` (que conserva su exploración en contexto) para revisar `PLAN.md` en el mismo archivo, iterando hasta un "Aprobar" — nunca editar el plan a mano ni relanzar de cero mientras la Task viva; con fallback de re-delegación (PLAN.md existente + feedback) para reanudaciones en sesión nueva.
- La pausa de Fase 4 hace visibles los Críticos abiertos en la pregunta; el bloqueo mecánico de "Ship" queda explícitamente referido a #1919 (pendiente). La review de esta misma rama detectó y corrigió un bug real de la especificación: el contrato de `AskUserQuestion` exige 2-4 opciones, así que "Aprobar" no podía ir sola en la Fase 2 (se sumó "Dar feedback").

Closes #1916.
Parte de #1907.

## Plan de pruebas

- [x] `pnpm check:agents` en verde tras cada commit
- [x] Sin pausas textuales residuales ("Respondé **X**") en las cuatro pausas migradas; las confirmaciones puntuales de Fases 5/6 quedan deliberadamente en texto libre (documentado en el plan)
- [x] Dogfooding: la pausa de la Fase 4 de esta misma sesión se ejecutó con `AskUserQuestion` real (opciones Proceder/Ship + recomendada primero), validando el diseño en vivo
- [x] Gates locales en verde en worktree aislado: `test`, `lint`, `stylelint`, typecheck (tsc directo), `build`, `storybook:build` (`test:e2e` y `studio-build` omitidos: un solo `.md`)
- [x] Review del `code-reviewer`: APROBADO CON COMENTARIOS — 2 advertencias (vía Other sin documentar en Fase 4; mínimo de opciones del contrato de la herramienta) y 2 sugerencias (terminología, casing), las 4 Corregidas en esta rama
