### PR TITLE
[#1935] - Exponer multimedia en las tarjetas de teaser de LiteraryWork

### DIFF
--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -243,7 +243,7 @@ interface LiteraryWork {
 
 	// Recursos Multimedia
 	resources: Resource[]; // Enlaces a recursos externos
-	mediaSources: MediaTypes[]; // Contenido multimedia asociado
+	mediaSources: MediaTypes[]; // Contenido multimedia asociado (vive en LiteraryWorkBase: lo exponen también las vistas de teaser)
 }
 
 interface LiteraryWorkSection {
@@ -281,6 +281,8 @@ Borrador en Sanity → Publicación → Accesible para lectura en /read/:slug
 - `LiteraryWorkTeaser` - Vista resumida: a diferencia de `StoryTeaser` (que vacía `paragraphs`), expone la **primera sección completa** (`teaserSection`) — decisión de diseño del epic #1481
 - `LiteraryWorkNavigationTeaser` - Vista mínima para navegación
 - `LiteraryWorkNavigationTeaserWithAuthors` - Vista mínima con autores resumidos
+
+`mediaSources: MediaTypes[]` vive en `LiteraryWorkBase`, así que **todas** las vistas (incluidas las de teaser/navegación) lo exponen; las tarjetas de listado lo consumen para mostrar los recursos multimedia de la obra.
 
 ---
 

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -243,7 +243,7 @@ interface LiteraryWork {
 
 	// Recursos Multimedia
 	resources: Resource[]; // Enlaces a recursos externos
-	mediaSources: MediaTypes[]; // Contenido multimedia asociado (vive en LiteraryWorkBase: lo exponen también las vistas de teaser)
+	mediaSources: MediaTypes[]; // Contenido multimedia asociado
 }
 
 interface LiteraryWorkSection {
@@ -282,7 +282,7 @@ Borrador en Sanity → Publicación → Accesible para lectura en /read/:slug
 - `LiteraryWorkNavigationTeaser` - Vista mínima para navegación
 - `LiteraryWorkNavigationTeaserWithAuthors` - Vista mínima con autores resumidos
 
-`mediaSources: MediaTypes[]` vive en `LiteraryWorkBase`, así que **todas** las vistas (incluidas las de teaser/navegación) lo exponen; las tarjetas de listado lo consumen para mostrar los recursos multimedia de la obra.
+`mediaSources: MediaTypes[]` **todas** las vistas (incluidas las de teaser/navegación) lo exponen; las tarjetas de listado lo consumen para mostrar los recursos multimedia de la obra.
 
 ---
 

--- a/docs/LITERARY_WORK_DESIGN.md
+++ b/docs/LITERARY_WORK_DESIGN.md
@@ -56,12 +56,12 @@ interface LiteraryWorkBase {
 	readonly totalReadingTime: ReadingTime;
 	readonly sectionCount: number; // total de secciones de la obra (>= 1)
 	readonly tags: readonly Tag[];
+	readonly mediaSources: readonly MediaTypes[]; // en la base: todas las vistas (incl. teaser/navegación) lo exponen
 }
 
 export interface LiteraryWork extends LiteraryWorkBase {
 	readonly authors: readonly Author[]; // 1..N; la obra anónima referencia al author "Anónimo" (ver §10)
 	readonly content: readonly LiteraryWorkSection[]; // >= 1
-	readonly mediaSources: readonly MediaTypes[];
 	readonly resources: readonly Resource[];
 	readonly badLanguage?: boolean;
 	readonly originalPublication: string;

--- a/src/app/models/literary-work.model.ts
+++ b/src/app/models/literary-work.model.ts
@@ -17,13 +17,15 @@ interface LiteraryWorkBase {
 	// y en los teasers puede ser mayor que las secciones transportadas — ver LITERARY_WORK_DESIGN.md §7.
 	readonly sectionCount: number;
 	readonly tags: readonly Tag[];
+	// Las tarjetas de listado (vistas de teaser/navegación) muestran los recursos multimedia
+	// de la obra; por eso el campo vive en la base y no solo en el agregado completo.
+	readonly mediaSources: readonly MediaTypes[];
 }
 
 export interface LiteraryWork extends LiteraryWorkBase {
 	// 1..N; la obra anónima referencia al author "Anónimo" (ver isAnonymous).
 	readonly authors: readonly Author[];
 	readonly content: readonly LiteraryWorkSection[];
-	readonly mediaSources: readonly MediaTypes[];
 	readonly resources: readonly Resource[];
 	readonly badLanguage?: boolean;
 	readonly originalPublication: string;


### PR DESCRIPTION
## Descripción

Mueve `mediaSources: readonly MediaTypes[]` del agregado `LiteraryWork` a **`LiteraryWorkBase`**, de modo que **todas** las vistas —incluidas las de teaser/navegación (`LiteraryWorkTeaser`, `LiteraryWorkNavigationTeaser`, `LiteraryWorkNavigationTeaserWithAuthors`)— expongan los recursos multimedia de la obra. Las tarjetas de listado los consumirán directamente (el input `media: Media[]` de `MediaSelectors` ya existe y **no se toca** — su cableado es #1653).

Reemplaza al enfoque descartado (un input `mediaTypes` liviano + `mediaSourceTypes` en las vistas), que ensuciaba la interfaz de `MediaSelectors` con un tercer modo. Este camino usa el `Media[]` completo directamente, sin cambios al componente.

- **Dominio** (`literary-work.model.ts`): el campo pasa a la base; el agregado lo conserva por herencia. Nada en `develop` construye las vistas de teaser todavía, así que volverlo requerido en ellas no rompe nada.
- **Docs** (`LITERARY_WORK_DESIGN.md` §2, `DOMAIN_MODEL.md`): reflejan que `mediaSources` vive en la base.

Closes #1935. Parte de #1481.

## Plan de pruebas

- [x] Gates verdes: `typecheck` estricto · `test` · `lint` · `build` · `storybook:build` (el cambio es de tipos + docs; sin componente ni `src/api`).
- [x] `code-reviewer`: APROBADO — 0 críticos/advertencias, 1 sugerencia aplicada (comentario del campo parado en su propia lógica, sin referenciar el estado previo).
- [x] Sin superficie de seguridad → sin `security-auditor`.
