### PR TITLE
[#1919] - issue-workflow Fase 4: ship con Críticos abiertos requiere disposición confirmada

### DIFF
--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -175,6 +175,7 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 
 1. `git push -u origin feat/<number>-<kebab>`.
 2. Crear el PR con `gh pr create` (base `develop`, milestone del issue):
+   - **Precondición:** ningún Crítico de `workspace/<number>/CODE_REVIEW.md` ni `workspace/<number>/SECURITY_REVIEW.md` sin **disposición** (definida en la pausa de la Fase 4). Si lo hay, no crear el PR: volver a la Fase 5, o a la vía "Disponer y ship" de la Fase 4.
    - Título: `[#<issue>] - <título del issue>`.
    - Cuerpo (en **español**):
 
@@ -222,5 +223,6 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 - Nunca prefijar comandos git con `cd` — el working dir ya está en la raíz.
 - Nunca abrir el PR antes de que pasen los gates de CI y haya corrido el `code-reviewer`.
 - Nunca abrir el PR sin el keyword de cierre (`Closes #<issue>`) en el cuerpo enlazando el issue de origen.
+- Nunca abrir el PR con un Crítico sin disposición confirmada — definición en la pausa de la Fase 4; verificación en la Fase 6 paso 2.
 - Nunca saltear la fase Plan — aun cambios triviales se benefician de un plan breve.
 - Aplican siempre las reglas de [`.claude/references/coding-agent-policies.md`](../../references/coding-agent-policies.md): sin framings de mantenedor único, sin "salteá el test por ser chico" (salvo cambios solo-doc), sin diferir la review más allá de abrir el PR, y sin comentarios redundantes (Sección 3).

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -143,12 +143,14 @@ No avanzar a la Fase 3 sin una respuesta "Aprobar".
 
 **⏸ PAUSA — decisión vía `AskUserQuestion`.**
 
-- `question`: "Review completa en `workspace/<number>/CODE_REVIEW.md` (y `workspace/<number>/SECURITY_REVIEW.md` si corrió el auditor). ¿Cómo seguimos?" — si hay Críticos abiertos, incluir cuántos en el texto de la pregunta.
-- `header`: `Review`
-- `options` (la recomendada primero): **Proceder** — ir a la Fase 5 y abordar los hallazgos por prioridad (Críticos primero); **Ship** — no hay nada bloqueante: saltar la Fase 5 e ir directo a la Fase 6.
-- La opción **"Other"** (automática) cubre instrucciones libres — p. ej. abordar solo un subconjunto de hallazgos, descartar las sugerencias o diferir alguno: el orquestador ejecuta la Fase 5 según lo indicado.
+Antes de armar las `options`, revisar la columna **Estado** de los Críticos en ambos archivos de hallazgos. Un Crítico tiene **disposición** si su Estado es _Corregido_, _Descartado_, _Diferido_ (con el issue ya creado tras confirmación — política de la Fase 5 paso 4) o _No se corrige_ confirmado explícitamente por el usuario; _Detectado_ y _En progreso_ son **sin disposición** (vocabulario canónico: `code-reviewer.md` → "Estados de la columna 'Estado'").
 
-> Nota: bloquear "Ship" mecánicamente ante Críticos abiertos es un cambio aparte (#1919, pendiente) — hoy la pausa solo los hace visibles en la pregunta; cuando #1919 se implemente, este es el punto donde aplicaría el bloqueo.
+- `question`: "Review completa en `workspace/<number>/CODE_REVIEW.md` (y `workspace/<number>/SECURITY_REVIEW.md` si corrió el auditor). ¿Cómo seguimos?" — incluir el conteo de hallazgos por severidad y, si hay Críticos sin disposición, cuántos son y que "Ship" no está disponible hasta resolverlos.
+- `header`: `Review`
+- `options` (la recomendada primero), según el estado de los Críticos:
+  - **Sin Críticos, o todos con disposición:** **Proceder** — ir a la Fase 5 y abordar los hallazgos por prioridad; **Ship** — no hay nada bloqueante: saltar la Fase 5 e ir directo a la Fase 6.
+  - **Algún Crítico sin disposición:** **Proceder** — ir a la Fase 5 y abordarlos; **Disponer y ship** — resolver la disposición de cada Crítico abierto ahí mismo (Diferir —proponiendo el issue y esperando confirmación—, Descartar o No se corrige, actualizando su Estado) y recién entonces saltar a la Fase 6. **"Ship" a secas no se ofrece en esta rama.**
+- La opción **"Other"** (automática) cubre instrucciones libres — p. ej. abordar solo un subconjunto de hallazgos, descartar las sugerencias o diferir alguno: el orquestador ejecuta la Fase 5 según lo indicado, respetando igualmente la precondición de disposición para shipear.
 
 ---
 


### PR DESCRIPTION
## Descripción

- La pausa de la Fase 4 define **disposición** de un Crítico una sola vez, con el vocabulario canónico de estados: *Corregido*, *Descartado*, *Diferido* (con issue creado tras confirmación) o *No se corrige* confirmado; *Detectado*/*En progreso* no cuentan. La `question` reporta el conteo por severidad y, si hay Críticos sin disposición, cuántos son.
- Las `options` de la pausa se bifurcan: con todos los Críticos dispuestos (o sin Críticos), **Proceder**/**Ship**; con alguno sin disposición, "Ship" se retira y aparece **Disponer y ship**, que resuelve la disposición de cada Crítico ahí mismo antes de saltar a la Fase 6 — ambas ramas respetan el mínimo de 2 opciones de `AskUserQuestion` (lección de #1916). Reemplaza la nota "#1919, pendiente" que #1916 dejó anclada en este punto exacto.
- La Fase 6 paso 2 gana la precondición (no crear el PR con un Crítico sin disposición) y "Restricciones" el bullet espejo — ambos como punteros a la definición única de la Fase 4, sin redefinirla (evita la doble fuente que corrigió #1909).

Closes #1919.
Parte de #1907.

## Plan de pruebas

- [x] `pnpm check:agents` en verde tras cada commit; sin residuos de la nota "#1919, pendiente"
- [x] Verificado que ninguna rama de la pausa queda con menos de 2 opciones explícitas y que "Disponer y ship → Diferir" es consistente con la política de la Fase 5 paso 4 (proponer el issue y esperar confirmación)
- [x] Dogfooding: las pausas de esta misma sesión (plan y review) corrieron con `AskUserQuestion` y la de review aplicó la regla de disposición nueva
- [x] Gates locales en verde en worktree aislado: `test`, `lint`, `stylelint`, typecheck (tsc directo), `build`, `storybook:build`, `check:agents` (`test:e2e` y `studio-build` omitidos: un solo `.md`)
- [x] Review del `code-reviewer` con veredicto APROBADO, sin hallazgos — verificó además que la definición de disposición vive en un único lugar y los otros dos puntos son punteros reales
