### PR TITLE
[#1941] - release-workflow: pausas con AskUserQuestion

### DIFF
--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -38,9 +38,17 @@ Ejemplo: `/release-workflow https://github.com/cuentoneta/cuentoneta/issues/1672
 6. **Reunir el contenido del CHANGELOG:** los issues cerrados del milestone + `git log --oneline <tag-anterior>..develop` para confirmar qué PRs mergearon desde el último tag. Incluir issues sin milestone que hayan shippeado en la ventana (hijos de epics); excluir los que pertenecen a un milestone futuro.
 7. Escribir `workspace/RELEASE.md` con: versión target, estado del milestone, migraciones de Sanity (pendientes / ya corridas), delta de documentación, y el **borrador de la entrada de CHANGELOG** (prosa + cambios agrupados por tema, replicando el formato de la sección anterior en `CHANGELOG.md`).
 
-**⏸ PAUSA — requiere aprobación del usuario.**
+**⏸ PAUSA — decisión vía `AskUserQuestion`.**
 
-> El alcance del release y el borrador del CHANGELOG están en `workspace/RELEASE.md`. Revisalo y respondé **aprobar**, o dame feedback sobre la agrupación/prosa.
+- `question`: "El alcance del release y el borrador del CHANGELOG están en `workspace/RELEASE.md`. ¿Cómo seguimos?"
+- `header`: `Release`
+- `options` (la recomendada primero): **Aprobar** — el alcance y el borrador quedan tal cual y se avanza a la Fase 2; **Dar feedback** — el orquestador pide el texto del feedback a continuación. La opción **"Other"** (automática) transporta el feedback directamente en un solo paso — la vía preferida cuando el usuario ya sabe qué cambiar (alcance, agrupación o prosa).
+
+Ramificación tras la respuesta:
+
+- **Aprobar** → avanzar a la Fase 2.
+- **Dar feedback** → pedir el texto del feedback al usuario y tratarlo igual que Other.
+- **Other** (feedback) → ajustar `workspace/RELEASE.md` según lo indicado (alcance del release, o agrupación/prosa del CHANGELOG) y repetir la pausa, iterando hasta un "Aprobar".
 
 ---
 
@@ -76,9 +84,17 @@ Formato de commit: `[#<issue>] - <qué cambió>` (español). Cada commit deja el
 
 Anotar los resultados en `workspace/RELEASE.md`. Si algo falla: diagnosticar, arreglar con un commit atómico y re-verificar.
 
-**⏸ PAUSA — requiere decisión del usuario.**
+**⏸ PAUSA — decisión vía `AskUserQuestion`.**
 
-> Verificación completa en `workspace/RELEASE.md`. Respondé **proceder** para abrir el PR, o dame feedback.
+- `question`: "Verificación completa en `workspace/RELEASE.md`. ¿Cómo seguimos?"
+- `header`: `Verificación`
+- `options` (la recomendada primero): **Proceder** — abrir el PR de release (Fase 4); **Dar feedback** — el orquestador pide el texto del feedback a continuación. La opción **"Other"** (automática) transporta directamente el ajuste pedido.
+
+Ramificación tras la respuesta:
+
+- **Proceder** → avanzar a la Fase 4 (Ship + handoff manual).
+- **Dar feedback** → pedir el texto del feedback al usuario y tratarlo igual que Other.
+- **Other** (feedback) → aplicar el ajuste indicado sobre la verificación o el contenido preparado (con commit atómico si toca archivos versionados), re-verificar lo afectado y repetir la pausa.
 
 ---
 


### PR DESCRIPTION
## Descripción

- Migra las **2 únicas pausas** de `release-workflow` (aprobación del alcance/CHANGELOG en Fase 1→2, y decisión de abrir el PR en Fase 3→4) al formato `AskUserQuestion` que #1916 estableció en `issue-workflow`: `question`, `header` corto, `options` con la recomendada primero (2 explícitas — el mínimo del contrato de la herramienta), la vía "Other" documentada como transporte directo del feedback, y sección "Ramificación tras la respuesta". La semántica del flujo de release no cambia.
- Headers propios del skill (`Release`, `Verificación`) en vez de reusar los de `issue-workflow`, para no ambiguar si un log combina sesiones de ambos skills.
- Las demás menciones de confirmación del skill (migraciones de Sanity ya corridas, omitir el handoff) son notas condicionales, no bifurcaciones de fase — quedan en texto libre por el mismo criterio de #1916, deliberadamente.

Closes #1941.
Parte de #1907.

## Plan de pruebas

- [x] `pnpm check:agents` en verde; cero residuos de "Respondé **X**" en el skill
- [x] Verificado contra `issue-workflow/SKILL.md` como referencia de formato: mismo patrón de tres partes + ramificación, mínimo de 2 opciones explícitas en ambas pausas
- [x] Gates locales en verde en worktree aislado: `test`, `lint`, `stylelint`, typecheck (tsc directo), `build`, `storybook:build` (`test:e2e` y `studio-build` omitidos: un solo `.md`)
- [x] Review del `code-reviewer` con veredicto APROBADO — 0 críticos, 0 advertencias, 1 sugerencia (tildes del mensaje de commit) corregida en la rama reescribiendo el commit sin pushear vía mensaje en archivo UTF-8
