### PR TITLE
[#1903] - Renombra StoryHeroHeader a LiteraryWorkHeroHeader (2/4)

### DIFF
--- a/src/app/components/literary-work-hero-header/literary-work-hero-header-skeleton.component.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header-skeleton.component.ts
@@ -6,7 +6,7 @@ import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton
 /**
  * Estado de carga (esqueleto) de LiteraryWorkHeroHeaderComponent. Replica la banda oscura del hero y la
  * grilla portada + metadatos con placeholders de cuentoneta-skeleton para evitar saltos de layout
- * mientras la story carga. Los placeholders usan neutral-700 para contrastar sobre el fondo oscuro.
+ * mientras la obra carga. Los placeholders usan neutral-700 para contrastar sobre el fondo oscuro.
  */
 @Component({
 	selector: 'cuentoneta-literary-work-hero-header-skeleton',

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header-skeleton.component.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header-skeleton.component.ts
@@ -4,12 +4,12 @@ import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton.component';
 
 /**
- * Estado de carga (esqueleto) de StoryHeroHeaderComponent. Replica la banda oscura del hero y la
+ * Estado de carga (esqueleto) de LiteraryWorkHeroHeaderComponent. Replica la banda oscura del hero y la
  * grilla portada + metadatos con placeholders de cuentoneta-skeleton para evitar saltos de layout
  * mientras la story carga. Los placeholders usan neutral-700 para contrastar sobre el fondo oscuro.
  */
 @Component({
-	selector: 'cuentoneta-story-hero-header-skeleton',
+	selector: 'cuentoneta-literary-work-hero-header-skeleton',
 	imports: [SkeletonComponent, CoverImageSkeletonComponent],
 	host: { class: 'relative block overflow-hidden bg-neutral-900' },
 	template: `
@@ -29,4 +29,4 @@ import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton
 		</div>
 	`,
 })
-export class StoryHeroHeaderSkeletonComponent {}
+export class LiteraryWorkHeroHeaderSkeletonComponent {}

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header.component.spec.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header.component.spec.ts
@@ -2,10 +2,10 @@ import { render, screen } from '@testing-library/angular';
 
 import type { Story } from '@models/story.model';
 import type { Tag } from '@models/tag.model';
-import { StoryHeroHeaderComponent } from './story-hero-header.component';
+import { LiteraryWorkHeroHeaderComponent } from './literary-work-hero-header.component';
 import { palacioNueveFronterasStoryMock } from '../../mocks/onoff/el-palacio-de-las-nueve-fronteras.mock';
 
-describe('StoryHeroHeaderComponent', () => {
+describe('LiteraryWorkHeroHeaderComponent', () => {
 	const tags: Tag[] = [
 		{ title: 'Novela', slug: 'novela', shortDescription: '', description: [] },
 		{ title: 'Metaficción', slug: 'metaficcion', shortDescription: '', description: [] },
@@ -13,56 +13,56 @@ describe('StoryHeroHeaderComponent', () => {
 	const story: Story = { ...palacioNueveFronterasStoryMock, tags };
 
 	it('should render the story title as the heading', async () => {
-		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		await render(LiteraryWorkHeroHeaderComponent, { inputs: { story } });
 		expect(screen.getByRole('heading', { name: story.title })).toBeInTheDocument();
 	});
 
 	it('should link the author block to the author profile, exposing just the author name', async () => {
-		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		await render(LiteraryWorkHeroHeaderComponent, { inputs: { story } });
 		// El avatar es decorativo (alt vacío): el único nombre accesible del enlace es el del autor.
 		const link = screen.getByRole('link', { name: story.author.name });
 		expect(link).toHaveAttribute('href', expect.stringContaining(`/author/${story.author.slug}`));
 	});
 
 	it('should render the blurred background from the cover requested at 1920px width', async () => {
-		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		await render(LiteraryWorkHeroHeaderComponent, { inputs: { story } });
 		expect(screen.getByTestId('hero-background')).toHaveAttribute('src', expect.stringContaining('w=1920'));
 	});
 
 	it('should not render the background when the story has no cover', async () => {
-		await render(StoryHeroHeaderComponent, { inputs: { story: { ...story, coverImage: '' } } });
+		await render(LiteraryWorkHeroHeaderComponent, { inputs: { story: { ...story, coverImage: '' } } });
 		expect(screen.queryByTestId('hero-background')).not.toBeInTheDocument();
 	});
 
 	it('should render the original publication with its prefix', async () => {
-		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		await render(LiteraryWorkHeroHeaderComponent, { inputs: { story } });
 		expect(screen.getByTestId('publication')).toHaveTextContent(`Publicado en: ${story.originalPublication}`);
 	});
 
 	it('should render all the story tags', async () => {
-		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		await render(LiteraryWorkHeroHeaderComponent, { inputs: { story } });
 		for (const tag of tags) {
 			expect(screen.getByText(tag.title)).toBeInTheDocument();
 		}
 	});
 
 	it('should render the foreground cover image when the story has a cover', async () => {
-		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		await render(LiteraryWorkHeroHeaderComponent, { inputs: { story } });
 		expect(screen.getByTestId('cover-image')).toBeInTheDocument();
 	});
 
 	it('should render the cover placeholder when the story has no cover', async () => {
-		await render(StoryHeroHeaderComponent, { inputs: { story: { ...story, coverImage: '' } } });
+		await render(LiteraryWorkHeroHeaderComponent, { inputs: { story: { ...story, coverImage: '' } } });
 		expect(screen.getByTestId('cover-placeholder')).toBeInTheDocument();
 	});
 
 	it('should render the skeleton when no story is provided', async () => {
-		await render(StoryHeroHeaderComponent);
+		await render(LiteraryWorkHeroHeaderComponent);
 		expect(screen.getByTestId('skeleton')).toBeInTheDocument();
 	});
 
 	it('should not render the skeleton once a story is provided', async () => {
-		await render(StoryHeroHeaderComponent, { inputs: { story } });
+		await render(LiteraryWorkHeroHeaderComponent, { inputs: { story } });
 		expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument();
 	});
 });

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header.component.stories.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header.component.stories.ts
@@ -19,7 +19,7 @@ const meta: Meta<LiteraryWorkHeroHeaderComponent> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>Banda superior (hero) de la página de una historia. Usa la misma portada del cuento como fondo difuminado con una capa de opacidad y, en primer plano, presenta la portada nítida, los tags, el autor, el título y la colección/año de publicación originales.</p><p>El fondo no es otra imagen: es la misma <code>coverImage</code> pedida al CDN en una talla mayor (1920px de ancho) para cubrir el ancho completo del hero.</p><p>Recibe el <code>Story</code> completo como único input; cuando no se provee, renderiza su propio estado de carga (skeleton).</p><p>Se compone de <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> (portada en primer plano), <a href="./?path=/docs/componentes-v3-tagslist--docs" target="_top"><strong>TagsList</strong></a> (tags de la obra, variante <code>gray</code>) e <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar del autor).</p></div>`,
+				component: `<div><p>Banda superior (hero) de la página de una obra. Usa la misma portada de la obra como fondo difuminado con una capa de opacidad y, en primer plano, presenta la portada nítida, los tags, el autor, el título y la colección/año de publicación originales.</p><p>El fondo no es otra imagen: es la misma <code>coverImage</code> pedida al CDN en una talla mayor (1920px de ancho) para cubrir el ancho completo del hero.</p><p>Recibe el <code>Story</code> completo como único input; cuando no se provee, renderiza su propio estado de carga (skeleton).</p><p>Se compone de <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> (portada en primer plano), <a href="./?path=/docs/componentes-v3-tagslist--docs" target="_top"><strong>TagsList</strong></a> (tags de la obra, variante <code>gray</code>) e <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar del autor).</p></div>`,
 			},
 		},
 		layout: 'fullscreen',
@@ -27,7 +27,7 @@ const meta: Meta<LiteraryWorkHeroHeaderComponent> = {
 	argTypes: {
 		story: {
 			control: { type: 'object' },
-			description: 'Historia completa a partir de la cual se derivan portada, tags, autor, título y publicación',
+			description: 'Obra completa a partir de la cual se derivan portada, tags, autor, título y publicación',
 			table: { type: { summary: 'Story' }, defaultValue: { summary: 'undefined' } },
 		},
 	},

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header.component.stories.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header.component.stories.ts
@@ -1,14 +1,14 @@
 import { applicationConfig, argsToTemplate, Meta, StoryObj } from '@storybook/angular';
 import { provideRouter } from '@angular/router';
 
-import { StoryHeroHeaderComponent } from './story-hero-header.component';
+import { LiteraryWorkHeroHeaderComponent } from './literary-work-hero-header.component';
 import { onoffStoriesMock } from '../../mocks/onoff-stories.mock';
 import { palacioNueveFronterasStoryMock } from '../../mocks/onoff/el-palacio-de-las-nueve-fronteras.mock';
 import { literaryWorkSelectArgType } from '../../mocks/onoff-corpus.storybook';
 
-const meta: Meta<StoryHeroHeaderComponent> = {
-	component: StoryHeroHeaderComponent,
-	title: 'Componentes V3/StoryHeroHeader',
+const meta: Meta<LiteraryWorkHeroHeaderComponent> = {
+	component: LiteraryWorkHeroHeaderComponent,
+	title: 'Componentes V3/LiteraryWorkHeroHeader',
 	tags: ['autodocs'],
 	decorators: [
 		applicationConfig({
@@ -34,9 +34,9 @@ const meta: Meta<StoryHeroHeaderComponent> = {
 };
 
 export default meta;
-type Story = StoryObj<StoryHeroHeaderComponent>;
+type Story = StoryObj<LiteraryWorkHeroHeaderComponent>;
 
-export const Interactiva: StoryObj<StoryHeroHeaderComponent & { storyIndex: number }> = {
+export const Interactiva: StoryObj<LiteraryWorkHeroHeaderComponent & { storyIndex: number }> = {
 	argTypes: {
 		storyIndex: {
 			...literaryWorkSelectArgType,
@@ -46,7 +46,7 @@ export const Interactiva: StoryObj<StoryHeroHeaderComponent & { storyIndex: numb
 	},
 	render: (args) => ({
 		props: { ...args, stories: onoffStoriesMock },
-		template: `<cuentoneta-story-hero-header [story]="stories[storyIndex]" />`,
+		template: `<cuentoneta-literary-work-hero-header [story]="stories[storyIndex]" />`,
 	}),
 	args: { storyIndex: 0 },
 	parameters: {
@@ -62,7 +62,7 @@ export const Interactiva: StoryObj<StoryHeroHeaderComponent & { storyIndex: numb
 export const Default: Story = {
 	render: (args) => ({
 		props: args,
-		template: `<cuentoneta-story-hero-header ${argsToTemplate(args)} />`,
+		template: `<cuentoneta-literary-work-hero-header ${argsToTemplate(args)} />`,
 	}),
 	args: { story: palacioNueveFronterasStoryMock },
 	parameters: {
@@ -75,11 +75,11 @@ export const Default: Story = {
 };
 
 // El hero renderiza su propio skeleton cuando no recibe story, así que basta una única instancia.
-export const Estados: StoryObj<StoryHeroHeaderComponent & { loading: boolean }> = {
+export const Estados: StoryObj<LiteraryWorkHeroHeaderComponent & { loading: boolean }> = {
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
 	render: (args) => ({
 		props: args,
-		template: `<cuentoneta-story-hero-header [story]="loading ? undefined : story" />`,
+		template: `<cuentoneta-literary-work-hero-header [story]="loading ? undefined : story" />`,
 	}),
 	args: { loading: true, story: palacioNueveFronterasStoryMock },
 	parameters: {

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header.component.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header.component.ts
@@ -9,17 +9,17 @@ import { CoverImageComponent } from '../cover-image/cover-image.component';
 import { ImageProfileComponent } from '../image-profile/image-profile.component';
 import { TagComponent } from '../tag/tag.component';
 import { TagsListComponent } from '../tags-list/tags-list.component';
-import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.component';
+import { LiteraryWorkHeroHeaderSkeletonComponent } from './literary-work-hero-header-skeleton.component';
 
 /**
- * Hero de la página Story (Design System v3): banda superior del cuento con la MISMA portada de fondo
+ * Hero de la página de una obra (Design System v3): banda superior con la MISMA portada de fondo
  * difuminada + capa de opacidad, y en primer plano la portada nítida (`CoverImage`), los tags (`TagsList`),
  * el autor (`ImageProfile` + nombre, enlace al perfil), el título y "Publicado en: <colección> (<año>)".
  *
  * Recibe el `Story` completo como único input; ausente ⇒ renderiza su propio skeleton.
  */
 @Component({
-	selector: 'cuentoneta-story-hero-header',
+	selector: 'cuentoneta-literary-work-hero-header',
 	imports: [
 		NgOptimizedImage,
 		RouterLink,
@@ -27,7 +27,7 @@ import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.c
 		ImageProfileComponent,
 		TagComponent,
 		TagsListComponent,
-		StoryHeroHeaderSkeletonComponent,
+		LiteraryWorkHeroHeaderSkeletonComponent,
 	],
 	host: { class: 'relative block overflow-hidden bg-neutral-900' },
 	template: `
@@ -72,11 +72,11 @@ import { StoryHeroHeaderSkeletonComponent } from './story-hero-header-skeleton.c
 				</div>
 			</div>
 		} @else {
-			<cuentoneta-story-hero-header-skeleton data-testid="skeleton" />
+			<cuentoneta-literary-work-hero-header-skeleton data-testid="skeleton" />
 		}
 	`,
 })
-export class StoryHeroHeaderComponent {
+export class LiteraryWorkHeroHeaderComponent {
 	protected readonly appRoutes = AppRoutes;
 
 	public readonly story = input<Story>();


### PR DESCRIPTION
## Descripción

Segunda de la serie de PRs chicas que renombran, de a un componente por vez, los building blocks del Design System V3 que referencian a `Story` para reflejar el dominio `LiteraryWork` (#1481), buscando que cada review humana sea manejable. La PR 1 (#1943, `MediaSelectors`) ya está mergeada.

Esta PR cubre **solo** el rename `StoryHeroHeader → LiteraryWorkHeroHeader`:

- Renombra el componente y su skeleton: carpeta, archivos, clases (`StoryHeroHeaderComponent`/`StoryHeroHeaderSkeletonComponent` → `LiteraryWorkHeroHeaderComponent`/`LiteraryWorkHeroHeaderSkeletonComponent`), selectores (`cuentoneta-story-hero-header`(-skeleton) → `cuentoneta-literary-work-hero-header`(-skeleton)), título y `kind-id` de Storybook.
- **Mantiene deliberadamente el binding a `Story`**: el input sigue siendo `input<Story>()`, el import `type { Story }`, los mocks y las variables locales. El rebind del modelo a `LiteraryWork` es de una PR/issue posterior. El componente aún no está cableado a ninguna página, así que no hay consumidores ni cross-links que actualizar.

Refs #1903 (2 de 4 — el `Closes` va en la última PR de la serie).
Parte de #1481.

## Plan de pruebas

- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm storybook:build`
- [x] `pnpm stylelint`
- [x] `pnpm check:agents`
- [x] git detecta los 4 archivos como `rename` (no borrado + alta)
- [x] Sin referencias stale a `StoryHeroHeader` / `story-hero-header` en `src/`, `.claude/` ni `docs/`
- [x] Code review: APROBADO sin hallazgos
