### PR TITLE
[#1942] - issue-workflow: ejecutar el flujo en un worktree aislado

### DIFF
--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -27,10 +27,10 @@ Ejemplo: `/issue-workflow https://github.com/cuentoneta/cuentoneta/issues/1234`
 
 Corre siempre, antes de cualquier otra señal:
 
-1. `git worktree list` — ¿ya existe un worktree para `.claude/worktrees/<number>`? Si existe, el entorno es **worktree**: reingresar con `EnterWorktree` (`path: .claude/worktrees/<number>`), sin preguntar. Continuar con "Señales de reanudación" desde ahí.
-2. Si no existe: ¿la invocación actual o una directiva vigente de la sesión ya declaró el entorno? Si sí, usarlo sin preguntar.
-3. Si no hay worktree previo ni declaración: pausar con `AskUserQuestion` — ver [Modo worktree](#modo-worktree) → "Cuándo se activa". La respuesta fija el entorno para el resto de la sesión (Fase 1 en adelante).
-4. Si el entorno resuelto es worktree porque ya existía (paso 1): evaluar además la señal de limpieza `gh pr list --head feat/<number>-<kebab> --state merged` — ver [Modo worktree](#modo-worktree) → "Ciclo de vida".
+1. ¿La invocación actual o una directiva vigente de la sesión declaró el entorno ("en un worktree", "en la raíz")? Si sí, usarlo — la declaración tiene prioridad. Si la declaración pide **raíz** pero `git worktree list` ya lista `.claude/worktrees/<number>`, avisar el conflicto y confirmar antes de seguir: la rama y los artefactos del issue pueden vivir en ese worktree.
+2. Sin declaración: si `git worktree list` ya lista `.claude/worktrees/<number>`, el entorno es **worktree** — reingresar con `EnterWorktree` (`path: .claude/worktrees/<number>`), sin preguntar. Continuar con "Señales de reanudación" desde ahí.
+3. Sin declaración ni worktree previo: pausar con `AskUserQuestion` — ver [Modo worktree](#modo-worktree) → "Cuándo se activa". La respuesta fija el entorno para el resto de la sesión (Fase 1 en adelante).
+4. Si el entorno resuelto es worktree y el worktree ya existía (pasos 1-2): evaluar además la señal de limpieza `gh pr list --head feat/<number>-<kebab> --state merged` — ver [Modo worktree](#modo-worktree) → "Ciclo de vida".
 
 ### Señales de reanudación
 
@@ -98,8 +98,8 @@ El caso **commits sin plan** usa una pregunta propia — ni "reanudar" ni "rehac
 
 ### Cuándo se activa
 
-- **Declarado:** si la invocación actual o una directiva vigente de la sesión ya dice dónde trabajar ("en un worktree", "en la raíz"), se respeta sin preguntar.
-- **Reanudación:** si `git worktree list` ya lista un worktree para `.claude/worktrees/<number>`, el entorno es worktree — no se pregunta, se reingresa (Fase 0, Paso 0).
+- **Declarado:** si la invocación actual o una directiva vigente de la sesión ya dice dónde trabajar ("en un worktree", "en la raíz"), se respeta — la declaración tiene prioridad. Si pide raíz habiendo un worktree del issue, la Fase 0 avisa el conflicto y confirma antes de seguir.
+- **Reanudación:** sin declaración, si `git worktree list` ya lista un worktree para `.claude/worktrees/<number>`, el entorno es worktree — no se pregunta, se reingresa (Fase 0, Paso 0).
 - **Sin declarar y sin worktree previo:** Fase 0 pausa con `AskUserQuestion`:
   - `question`: "¿Dónde corremos el flujo para este issue: en un worktree aislado o en la raíz del repo?"
   - `header`: `Entorno`
@@ -131,7 +131,7 @@ En modo raíz, el flujo de Fase 1 queda **igual que hoy**.
 
 - El worktree se **mantiene** al menos hasta que el PR de la Fase 6 mergea — permite reanudar la sesión (Fase 0 lo detecta vía `git worktree list` y reingresa).
 - El **merge ocurre fuera de esta sesión** (evento humano posterior en GitHub); el skill no lo espera ni lo automatiza.
-- **Limpieza:** cuando la Fase 0 resuelve entorno worktree porque ya existía (reanudación), evalúa además `gh pr list --head feat/<number>-<kebab> --state merged`. Si hay un PR mergeado, pausa con `AskUserQuestion` (`header`: `Limpieza`; `question`: "El PR de este issue ya mergeó. ¿Removemos el worktree?"; opciones **Limpiar (recomendada)** — `git worktree remove .claude/worktrees/<number>` + `git branch -d feat/<number>-<kebab>`; **Mantener** — dejarlo como está; "Other" cubre cualquier instrucción distinta). Cualquiera sea la respuesta, la sesión termina ahí — no hay fase siguiente que ejecutar sobre un issue ya mergeado.
+- **Limpieza:** cuando la Fase 0 resuelve entorno worktree porque ya existía (reanudación), evalúa además `gh pr list --head feat/<number>-<kebab> --state merged`. Si hay un PR mergeado, pausa con `AskUserQuestion` (`header`: `Limpieza`; `question`: "El PR de este issue ya mergeó. ¿Removemos el worktree?"; opciones **Limpiar (recomendada)** — `git worktree remove .claude/worktrees/<number>` + `git branch -d feat/<number>-<kebab>`; **Mantener** — dejarlo como está y agregar la marca `<!-- worktree: mantener -->` al final de `workspace/<number>/PLAN.md` para no repreguntar en futuras reanudaciones (la señal de limpieza se saltea si esa marca existe); "Other" cubre cualquier instrucción distinta). Cualquiera sea la respuesta, la sesión termina ahí — no hay fase siguiente que ejecutar sobre un issue ya mergeado.
 - Los artefactos `workspace/<number>/PLAN.md` / `CODE_REVIEW.md` / `SECURITY_REVIEW.md` **viven dentro del worktree** en modo worktree. Una sesión nueva que reingresa vía `EnterWorktree` los encuentra ahí sin buscarlos en la raíz.
 
 ---
@@ -273,7 +273,7 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
    | CI local            | <Verde / Rojo — ver <motivo>>                                     |
    ```
 
-   - `Commits` cuenta solo los de la rama (`git rev-list --count develop..HEAD`).
+   - `Commits` cuenta solo los de la rama (`git rev-list --count <base>..HEAD`, con `<base>` = `develop` en modo raíz y `origin/develop` en modo worktree).
    - `CI local` reporta el resultado de la última corrida de los gates.
 
 ---
@@ -281,7 +281,7 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 ## Restricciones (todas las fases)
 
 - Usar `pnpm <script>` para ejecutar tareas; no construir variantes de `nx` directas a mano.
-- Nunca prefijar comandos git con `cd` — el working dir ya está en la raíz.
+- Nunca prefijar comandos git con `cd` — el working dir ya está resuelto (raíz del repo, o del worktree según el entorno).
 - Nunca abrir el PR antes de que pasen los gates de CI y haya corrido el `code-reviewer`.
 - Nunca abrir el PR sin el keyword de cierre (`Closes #<issue>`) en el cuerpo enlazando el issue de origen.
 - Nunca abrir el PR con un Crítico sin disposición confirmada — definición en la pausa de la Fase 4; verificación en la Fase 6 paso 2.

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -78,15 +78,17 @@ El caso **commits sin plan** usa una pregunta propia — ni "reanudar" ni "rehac
 
 ## Fase 1 — Setup
 
-**Propósito:** crear una rama de feature limpia desde `develop` actualizado.
+**Propósito:** crear una rama de feature limpia desde `develop` actualizado — en el entorno resuelto por la Fase 0 (worktree o raíz).
 
 1. `gh issue view <issue-url> --json number,title` para extraer número y título.
 2. Derivar el nombre de rama (convención del repo):
    - Formato: **`feat/<number>-<titulo-en-kebab-case>`**.
    - Transformación: minúsculas, espacios y no-alfanuméricos → guiones, colapsar guiones consecutivos, recortar guiones de borde, truncar a ~60 caracteres en un límite de palabra.
-3. `git checkout develop && git pull` para asegurar la base actualizada.
-4. `git checkout -b feat/<number>-<kebab>`. Si la Fase 0 detectó la rama existente y el usuario eligió **rehacer**, confirmar la reutilización y usar `git checkout feat/<number>-<kebab>` (sin `-b`).
-5. Reportar al usuario: número, título y nombre de rama.
+3. **Modo raíz** (sin cambios respecto del flujo previo a #1942):
+   - `git checkout develop && git pull` para asegurar la base actualizada.
+   - `git checkout -b feat/<number>-<kebab>`. Si la Fase 0 detectó la rama existente y el usuario eligió **rehacer**, confirmar la reutilización y usar `git checkout feat/<number>-<kebab>` (sin `-b`).
+4. **Modo worktree:** seguir [Modo worktree](#modo-worktree) → "Mecánica de creación" (`git fetch origin`, `git worktree add`, `EnterWorktree`, `pnpm install` + `pnpm run config`).
+5. Reportar al usuario: número, título, nombre de rama y, en modo worktree, la ruta del worktree.
 
 ---
 

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -79,6 +79,50 @@ El caso **commits sin plan** usa una pregunta propia — ni "reanudar" ni "rehac
 
 ---
 
+## Modo worktree
+
+**Propósito:** desde #1942, todo el flujo (implementación, gates, subagentes, ship) puede correr en un **worktree propio** bajo `.claude/worktrees/<number>` en vez del working tree principal, para eliminar colisiones con sesiones paralelas (root u otros worktrees). Esta sección centraliza la mecánica; las Fases 0, 1, 2, 3, 4 y 6 la referencian en vez de repetirla.
+
+### Cuándo se activa
+
+- **Declarado:** si la invocación actual o una directiva vigente de la sesión ya dice dónde trabajar ("en un worktree", "en la raíz"), se respeta sin preguntar.
+- **Reanudación:** si `git worktree list` ya lista un worktree para `.claude/worktrees/<number>`, el entorno es worktree — no se pregunta, se reingresa (Fase 0, Paso 0).
+- **Sin declarar y sin worktree previo:** Fase 0 pausa con `AskUserQuestion`:
+  - `question`: "¿Dónde corremos el flujo para este issue: en un worktree aislado o en la raíz del repo?"
+  - `header`: `Entorno`
+  - `options` (recomendada primero): **Worktree (recomendada)** — aísla esta sesión de cualquier otra corriendo en paralelo en la raíz o en otro worktree (elimina la clase de colisión de #1908 y la narrada en #1942); a cambio, requiere un setup propio (`pnpm install` + `pnpm run config`, `node_modules` propio). **Raíz** — sin setup adicional, reusa lo ya instalado; queda expuesta a colisión si hay otra sesión activa en la raíz. La opción **"Other"** (automática) cubre cualquier instrucción libre distinta de estas dos.
+
+### Mecánica de creación (Fase 1, modo worktree)
+
+1. `git fetch origin`.
+2. `git worktree add .claude/worktrees/<number> -b feat/<number>-<kebab> origin/develop`. Si la Fase 0 detectó una rama `feat/<number>-*` ya existente en la raíz sin worktree propio (sesión previa a #1942, o modo raíz elegido antes), adjuntar el worktree a esa rama en vez de crear una nueva: `git worktree add .claude/worktrees/<number> feat/<number>-<kebab>` (sin `-b`).
+3. Cambiar la sesión al worktree con la herramienta `EnterWorktree` del harness (`path: .claude/worktrees/<number>`). Desde acá el cwd de la sesión —y el de cualquier subagente delegado— ya es el worktree.
+4. Setup de dependencias: `pnpm install` seguido de `pnpm run config` (genera `src/app/environments/environment.ts` y `.env`; el hook `postinstall` ya invoca `pnpm run config`, pero se corre explícito para no depender de que dispare en todos los entornos).
+5. Reportar al usuario: número, título, rama y **ruta del worktree**.
+
+En modo raíz, el flujo de Fase 1 queda **igual que hoy**.
+
+### Ajustes transversales en modo worktree
+
+- **Diffs y rev-list contra `origin/develop`, no `develop` local.** La `develop` local del worktree no se actualiza sola durante la sesión y puede quedar stale frente a merges que ocurren en paralelo en otras sesiones. Toda comparación de rango — la señal de commits de la Fase 0, el diff que exploran los subagentes para decidir qué referencias cargar, el diff final que revisa `code-reviewer` — usa `origin/develop` como base.
+- **Gates de Nx con `NX_NO_CLOUD=true NX_DAEMON=false`.** En Windows, el daemon de Nx y el cliente de Nx Cloud crashean en el teardown de targets corridos desde un worktree — el target reporta "Successfully ran" y el proceso igual sale con código de error (falso rojo); el crash de Nx Cloud además puede pisar el cache compartido (`.nx/cache/cloud/`) del repo principal si hay corridas paralelas. Anteponer ambas variables a **todo** `pnpm <gate>` de Nx corrido desde el worktree: `NX_NO_CLOUD=true NX_DAEMON=false pnpm lint`, y así con `test`, `build`, `test:e2e`, `storybook`, `stylelint`.
+- **Typecheck vía `tsc` directo, no `pnpm typecheck`.** `pnpm typecheck` (`nx typecheck`) puede servir un resultado **stale** del daemon aun con `--skip-nx-cache` y aun con las variables de arriba. En modo worktree, correr `pnpm exec tsc -p tsconfig.typecheck.json --noEmit` directamente.
+- **Node v26 local (si aplica):** los wrappers de Nx de `pnpm test` y `pnpm storybook:build` pueden reportar "Failed tasks" por un crash de teardown de `libuv` **después** de terminar bien (el proyecto pide `engines: ^22.22.3`). Si un gate de test/storybook reporta rojo pero el log previo dice que el target corrió exitosamente, verificar el resultado real con `npx vitest run` directo antes de reportarlo como fallo.
+- **Delegación a subagentes — nota de Modo worktree.** Al delegar en `plan-writer`, `documentation-writer`, `code-reviewer` o `security-auditor` (Fases 2, 3 y 4), agregar a la instrucción de la delegación:
+
+  > "Esta sesión corre en el worktree `.claude/worktrees/<number>` (cwd ya resuelto — no hace falta `cd`). Tu base de diff es `origin/develop`, no `develop` local. Los archivos generados/gitignoreados del setup (`src/app/environments/environment.ts`, `.env`) sí existen tras `pnpm install` + `pnpm run config` aunque no estén versionados — antes de reportar una ruta como faltante, verificá con `git check-ignore <ruta>`."
+
+  Sin esta nota, un subagente puede leer del checkout principal en vez del worktree, diffear contra un `develop` local stale, o marcar como bloqueante un archivo generado que sí existe.
+
+### Ciclo de vida
+
+- El worktree se **mantiene** al menos hasta que el PR de la Fase 6 mergea — permite reanudar la sesión (Fase 0 lo detecta vía `git worktree list` y reingresa).
+- El **merge ocurre fuera de esta sesión** (evento humano posterior en GitHub); el skill no lo espera ni lo automatiza.
+- **Limpieza:** cuando la Fase 0 resuelve entorno worktree porque ya existía (reanudación), evalúa además `gh pr list --head feat/<number>-<kebab> --state merged`. Si hay un PR mergeado, pausa con `AskUserQuestion` (`header`: `Limpieza`; `question`: "El PR de este issue ya mergeó. ¿Removemos el worktree?"; opciones **Limpiar (recomendada)** — `git worktree remove .claude/worktrees/<number>` + `git branch -d feat/<number>-<kebab>`; **Mantener** — dejarlo como está; "Other" cubre cualquier instrucción distinta). Cualquiera sea la respuesta, la sesión termina ahí — no hay fase siguiente que ejecutar sobre un issue ya mergeado.
+- Los artefactos `workspace/<number>/PLAN.md` / `CODE_REVIEW.md` / `SECURITY_REVIEW.md` **viven dentro del worktree** en modo worktree. Una sesión nueva que reingresa vía `EnterWorktree` los encuentra ahí sin buscarlos en la raíz.
+
+---
+
 ## Fase 2 — Plan
 
 **Propósito:** producir un plan de implementación detallado para aprobación.

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -84,7 +84,7 @@ El caso **commits sin plan** usa una pregunta propia — ni "reanudar" ni "rehac
 2. Derivar el nombre de rama (convención del repo):
    - Formato: **`feat/<number>-<titulo-en-kebab-case>`**.
    - Transformación: minúsculas, espacios y no-alfanuméricos → guiones, colapsar guiones consecutivos, recortar guiones de borde, truncar a ~60 caracteres en un límite de palabra.
-3. **Modo raíz** (sin cambios respecto del flujo previo a #1942):
+3. **Modo raíz**:
    - `git checkout develop && git pull` para asegurar la base actualizada.
    - `git checkout -b feat/<number>-<kebab>`. Si la Fase 0 detectó la rama existente y el usuario eligió **rehacer**, confirmar la reutilización y usar `git checkout feat/<number>-<kebab>` (sin `-b`).
 4. **Modo worktree:** seguir [Modo worktree](#modo-worktree) → "Mecánica de creación" (`git fetch origin`, `git worktree add`, `EnterWorktree`, `pnpm install` + `pnpm run config`).
@@ -94,7 +94,7 @@ El caso **commits sin plan** usa una pregunta propia — ni "reanudar" ni "rehac
 
 ## Modo worktree
 
-**Propósito:** desde #1942, todo el flujo (implementación, gates, subagentes, ship) puede correr en un **worktree propio** bajo `.claude/worktrees/<number>` en vez del working tree principal, para eliminar colisiones con sesiones paralelas (root u otros worktrees). Esta sección centraliza la mecánica; las Fases 0, 1, 2, 3, 4 y 6 la referencian en vez de repetirla.
+**Propósito:** todo el flujo (implementación, gates, subagentes, ship) puede correr en un **worktree propio** bajo `.claude/worktrees/<number>` en vez del working tree principal, para eliminar colisiones con sesiones paralelas (root u otros worktrees). Esta sección centraliza la mecánica; las Fases 0, 1, 2, 3, 4 y 6 la referencian en vez de repetirla.
 
 ### Cuándo se activa
 
@@ -103,12 +103,12 @@ El caso **commits sin plan** usa una pregunta propia — ni "reanudar" ni "rehac
 - **Sin declarar y sin worktree previo:** Fase 0 pausa con `AskUserQuestion`:
   - `question`: "¿Dónde corremos el flujo para este issue: en un worktree aislado o en la raíz del repo?"
   - `header`: `Entorno`
-  - `options` (recomendada primero): **Worktree (recomendada)** — aísla esta sesión de cualquier otra corriendo en paralelo en la raíz o en otro worktree (elimina la clase de colisión de #1908 y la narrada en #1942); a cambio, requiere un setup propio (`pnpm install` + `pnpm run config`, `node_modules` propio). **Raíz** — sin setup adicional, reusa lo ya instalado; queda expuesta a colisión si hay otra sesión activa en la raíz. La opción **"Other"** (automática) cubre cualquier instrucción libre distinta de estas dos.
+  - `options` (recomendada primero): **Worktree (recomendada)** — aísla esta sesión de cualquier otra corriendo en paralelo en la raíz o en otro worktree (un checkout externo a mitad de sesión puede invalidar gates o desviar commits a otra rama); a cambio, requiere un setup propio (`pnpm install` + `pnpm run config`, `node_modules` propio). **Raíz** — sin setup adicional, reusa lo ya instalado; queda expuesta a colisión si hay otra sesión activa en la raíz. La opción **"Other"** (automática) cubre cualquier instrucción libre distinta de estas dos.
 
 ### Mecánica de creación (Fase 1, modo worktree)
 
 1. `git fetch origin`.
-2. `git worktree add .claude/worktrees/<number> -b feat/<number>-<kebab> origin/develop`. Si la Fase 0 detectó una rama `feat/<number>-*` ya existente en la raíz sin worktree propio (sesión previa a #1942, o modo raíz elegido antes), adjuntar el worktree a esa rama en vez de crear una nueva: `git worktree add .claude/worktrees/<number> feat/<number>-<kebab>` (sin `-b`).
+2. `git worktree add .claude/worktrees/<number> -b feat/<number>-<kebab> origin/develop`. Si la Fase 0 detectó una rama `feat/<number>-*` ya existente en la raíz sin worktree propio (creada por una sesión previa en modo raíz), adjuntar el worktree a esa rama en vez de crear una nueva: `git worktree add .claude/worktrees/<number> feat/<number>-<kebab>` (sin `-b`).
 3. Cambiar la sesión al worktree con la herramienta `EnterWorktree` del harness (`path: .claude/worktrees/<number>`). Desde acá el cwd de la sesión —y el de cualquier subagente delegado— ya es el worktree.
 4. Setup de dependencias: `pnpm install` seguido de `pnpm run config` (genera `src/app/environments/environment.ts` y `.env`; el hook `postinstall` ya invoca `pnpm run config`, pero se corre explícito para no depender de que dispare en todos los entornos).
 5. Reportar al usuario: número, título, rama y **ruta del worktree**.
@@ -192,7 +192,7 @@ No avanzar a la Fase 3 sin una respuesta "Aprobar".
 
 1. Correr localmente (con `pnpm`, nunca `nx` directo) los **gates de CI** definidos en la sección [Comandos comunes](../../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**). `test:e2e` y `studio-build` son costosos de correr en cada iteración: corré `test:e2e` si el cambio toca flujos E2E y `studio-build` si toca `cms/`; el resto, siempre.
    - **En modo worktree**, anteponer `NX_NO_CLOUD=true NX_DAEMON=false` a todo gate de Nx y reemplazar `pnpm typecheck` por `pnpm exec tsc -p tsconfig.typecheck.json --noEmit` — ver [Modo worktree](#modo-worktree) → "Ajustes transversales" (evita falsos rojos de teardown y resultados stale del daemon).
-   - **Lanzalos concurrentemente**, no uno tras otro: son independientes entre sí y así los corre CI (todos los jobs cuelgan de `setup` y van en runners separados). En serie tardan la **suma**; en paralelo, lo que tarde el más lento. Medido en #1850: 105s → 29s.
+   - **Lanzalos concurrentemente**, no uno tras otro: son independientes entre sí y así los corre CI (todos los jobs cuelgan de `setup` y van en runners separados). En serie tardan la **suma**; en paralelo, lo que tarde el más lento (medido: 105s → 29s).
    - Si alguno falla: reportar cuál, diagnosticar, arreglar, commitear el fix (reglas de Fase 3) y re-correr **solo el que falló** mientras el resto sigue verde; re-correr todo solo si el fix toca superficie compartida.
 2. **Determinar si el diff toca superficie de seguridad.** La lista de disparadores es la sección **"Cuándo correr"** del agente `security-auditor`: `src/api/**` (endpoints, GROQ, mappers), manejo de contenido externo (PortableText/HTML del CMS, `bypassSecurityTrust*`, fetch a servicios externos, `localStorage`), variables de entorno / secrets / config de Sanity o Clarity, y dependencias (`package.json` / `pnpm-lock.yaml`). Un diff que no toca nada de eso —solo documentación, estilos o UI sin datos externos— **no** la amerita; el auditor también puede invocarse a demanda si surge una preocupación puntual.
 3. **Delegar las reviews — en paralelo si corren ambas.** Si el diff toca superficie de seguridad, lanzar al **`security-auditor`** y al **`code-reviewer`** en el **mismo turno** (ambas delegaciones en una única respuesta, igual que los gates del paso 1): sus reviews son independientes y no comparten archivo de salida. Si no la toca, delegar solo al `code-reviewer`. Cada delegación incluye la ruta de salida completa del agente (ver paso 4); en modo worktree, adjuntar además la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales" a cada Task delegada. En ambos casos el `code-reviewer` revisa todos los cambios de la rama vs. `develop` (u `origin/develop` en modo worktree) y recibe **el resultado observado de los gates del paso 1** (qué corriste, con qué resultado, y cuáles omitiste por no aplicar al diff) — sin ese dato los vuelve a correr, que es la parte más cara de la review.

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -21,14 +21,25 @@ Ejemplo: `/issue-workflow https://github.com/cuentoneta/cuentoneta/issues/1234`
 
 ## Fase 0 — Detección de estado
 
-**Propósito:** detectar trabajo previo sobre el issue y reanudar en la fase que corresponda en vez de re-setupear.
+**Propósito:** detectar el entorno de trabajo (worktree o raíz) y el trabajo previo sobre el issue, y reanudar en la fase que corresponda en vez de re-setupear.
 
-Corre siempre, en toda invocación, con el número de issue extraído de la URL. Señales a relevar:
+### Paso 0 — Entorno (worktree o raíz)
+
+Corre siempre, antes de cualquier otra señal:
+
+1. `git worktree list` — ¿ya existe un worktree para `.claude/worktrees/<number>`? Si existe, el entorno es **worktree**: reingresar con `EnterWorktree` (`path: .claude/worktrees/<number>`), sin preguntar. Continuar con "Señales de reanudación" desde ahí.
+2. Si no existe: ¿la invocación actual o una directiva vigente de la sesión ya declaró el entorno? Si sí, usarlo sin preguntar.
+3. Si no hay worktree previo ni declaración: pausar con `AskUserQuestion` — ver [Modo worktree](#modo-worktree) → "Cuándo se activa". La respuesta fija el entorno para el resto de la sesión (Fase 1 en adelante).
+4. Si el entorno resuelto es worktree porque ya existía (paso 1): evaluar además la señal de limpieza `gh pr list --head feat/<number>-<kebab> --state merged` — ver [Modo worktree](#modo-worktree) → "Ciclo de vida".
+
+### Señales de reanudación
+
+Con el entorno ya resuelto (y el cwd ya en el worktree si corresponde), relevar con el número de issue extraído de la URL:
 
 1. `git branch --list 'feat/<number>-*'` — ¿existe la rama?
 2. `workspace/<number>/PLAN.md` — ¿existe el plan? Si existe, contar sus marcadores de paso `[ ]` vs. `[x]`.
 3. `workspace/<number>/CODE_REVIEW.md` y/o `workspace/<number>/SECURITY_REVIEW.md` — ¿existe la review?
-4. Si la rama existe: `git rev-list --count develop..<rama>` — ¿cuántos commits tiene sobre `develop`?
+4. Si la rama existe: `git rev-list --count <base>..<rama>` — ¿cuántos commits tiene sobre la base? `<base>` es `develop` en modo raíz y **`origin/develop`** en modo worktree (ver [Modo worktree](#modo-worktree) → "Ajustes transversales").
 5. Si la rama existe: `gh pr list --head feat/<number>-<kebab> --state open` — ¿hay un PR abierto de esa rama?
 
 | Rama | `PLAN.md`                  | Review | Commits | Interpretación → fase sugerida                                                                                                |

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -140,7 +140,7 @@ En modo raíz, el flujo de Fase 1 queda **igual que hoy**.
 
 **Propósito:** producir un plan de implementación detallado para aprobación.
 
-1. Delegar al agente **`plan-writer`** pasándole la URL del issue, su descripción, el nombre de rama y la ruta de salida completa (`workspace/<number>/PLAN.md`). Si la Fase 0 reanudó acá con un plan ya escrito, saltear la delegación y pasar directo al resumen.
+1. Delegar al agente **`plan-writer`** pasándole la URL del issue, su descripción, el nombre de rama y la ruta de salida completa (`workspace/<number>/PLAN.md`). En modo worktree, adjuntar la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales". Si la Fase 0 reanudó acá con un plan ya escrito, saltear la delegación y pasar directo al resumen.
 2. El plan-writer produce `workspace/<number>/PLAN.md`.
 3. Presentar un resumen breve al usuario (objetivo, enfoque, archivos afectados, decisiones clave).
 
@@ -166,7 +166,7 @@ No avanzar a la Fase 3 sin una respuesta "Aprobar".
 
 1. Ejecutar los pasos de `workspace/<number>/PLAN.md` en orden. Si la Fase 0 reanudó acá, saltear los pasos ya marcados `[x]`.
 2. Un commit atómico por unidad lógica de trabajo. Tras cada commit, marcar `[x]` el checkbox del paso correspondiente en `workspace/<number>/PLAN.md`.
-3. **Scan de impacto en documentación.** Si el cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología de dominio, delegar en el agente **`documentation-writer`** la actualización de `docs/`, `CLAUDE.md` y `.claude/references/`, en el **mismo** commit/PR — lo exige la sección [Scan de impacto en documentación](../../../CLAUDE.md#scan-de-impacto-en-documentación) de `CLAUDE.md`. Si el cambio no toca nada de eso, saltear el paso.
+3. **Scan de impacto en documentación.** Si el cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología de dominio, delegar en el agente **`documentation-writer`** la actualización de `docs/`, `CLAUDE.md` y `.claude/references/` (en modo worktree, adjuntar la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales"), en el **mismo** commit/PR — lo exige la sección [Scan de impacto en documentación](../../../CLAUDE.md#scan-de-impacto-en-documentación) de `CLAUDE.md`. Si el cambio no toca nada de eso, saltear el paso.
 4. **CHANGELOG:** cuentoneta mantiene `CHANGELOG.md` **por release/versión** (no por PR), al cerrar un milestone. **No** se exige una entrada por issue en este flujo; el tracking del cambio vive en el issue + su milestone. (Esto reemplaza el gate de CHANGELOG del starter.)
 
 ### Reglas de commit
@@ -191,10 +191,11 @@ No avanzar a la Fase 3 sin una respuesta "Aprobar".
 **Propósito:** verificar que pasen los gates de CI y correr los agentes de review.
 
 1. Correr localmente (con `pnpm`, nunca `nx` directo) los **gates de CI** definidos en la sección [Comandos comunes](../../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**). `test:e2e` y `studio-build` son costosos de correr en cada iteración: corré `test:e2e` si el cambio toca flujos E2E y `studio-build` si toca `cms/`; el resto, siempre.
+   - **En modo worktree**, anteponer `NX_NO_CLOUD=true NX_DAEMON=false` a todo gate de Nx y reemplazar `pnpm typecheck` por `pnpm exec tsc -p tsconfig.typecheck.json --noEmit` — ver [Modo worktree](#modo-worktree) → "Ajustes transversales" (evita falsos rojos de teardown y resultados stale del daemon).
    - **Lanzalos concurrentemente**, no uno tras otro: son independientes entre sí y así los corre CI (todos los jobs cuelgan de `setup` y van en runners separados). En serie tardan la **suma**; en paralelo, lo que tarde el más lento. Medido en #1850: 105s → 29s.
    - Si alguno falla: reportar cuál, diagnosticar, arreglar, commitear el fix (reglas de Fase 3) y re-correr **solo el que falló** mientras el resto sigue verde; re-correr todo solo si el fix toca superficie compartida.
 2. **Determinar si el diff toca superficie de seguridad.** La lista de disparadores es la sección **"Cuándo correr"** del agente `security-auditor`: `src/api/**` (endpoints, GROQ, mappers), manejo de contenido externo (PortableText/HTML del CMS, `bypassSecurityTrust*`, fetch a servicios externos, `localStorage`), variables de entorno / secrets / config de Sanity o Clarity, y dependencias (`package.json` / `pnpm-lock.yaml`). Un diff que no toca nada de eso —solo documentación, estilos o UI sin datos externos— **no** la amerita; el auditor también puede invocarse a demanda si surge una preocupación puntual.
-3. **Delegar las reviews — en paralelo si corren ambas.** Si el diff toca superficie de seguridad, lanzar al **`security-auditor`** y al **`code-reviewer`** en el **mismo turno** (ambas delegaciones en una única respuesta, igual que los gates del paso 1): sus reviews son independientes y no comparten archivo de salida. Si no la toca, delegar solo al `code-reviewer`. Cada delegación incluye la ruta de salida completa del agente (ver paso 4). En ambos casos el `code-reviewer` revisa todos los cambios de la rama vs. `develop` y recibe **el resultado observado de los gates del paso 1** (qué corriste, con qué resultado, y cuáles omitiste por no aplicar al diff) — sin ese dato los vuelve a correr, que es la parte más cara de la review.
+3. **Delegar las reviews — en paralelo si corren ambas.** Si el diff toca superficie de seguridad, lanzar al **`security-auditor`** y al **`code-reviewer`** en el **mismo turno** (ambas delegaciones en una única respuesta, igual que los gates del paso 1): sus reviews son independientes y no comparten archivo de salida. Si no la toca, delegar solo al `code-reviewer`. Cada delegación incluye la ruta de salida completa del agente (ver paso 4); en modo worktree, adjuntar además la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales" a cada Task delegada. En ambos casos el `code-reviewer` revisa todos los cambios de la rama vs. `develop` (u `origin/develop` en modo worktree) y recibe **el resultado observado de los gates del paso 1** (qué corriste, con qué resultado, y cuáles omitiste por no aplicar al diff) — sin ese dato los vuelve a correr, que es la parte más cara de la review.
 4. Cada agente escribe su propio archivo: el `code-reviewer` en `workspace/<number>/CODE_REVIEW.md` y el `security-auditor` en `workspace/<number>/SECURITY_REVIEW.md`.
 5. Presentar la tabla de hallazgos al usuario (Críticos, Advertencias, Sugerencias), combinando ambos archivos cuando corrió el auditor, e indicando si corrió o por qué no correspondía. Al combinar, cada hallazgo se cita con el número tal como aparece en su documento de origen: los de seguridad llevan el prefijo `S` (p. ej. `S3`) y así no se confunden con los del `code-reviewer` (sin prefijo).
 
@@ -229,6 +230,8 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 ## Fase 6 — Ship
 
 **Propósito:** pushear, crear el PR y actualizar el issue original.
+
+**Modo worktree:** el worktree **no se limpia en esta fase** — se mantiene hasta que el PR mergee, para permitir reanudar la sesión (ver [Modo worktree](#modo-worktree) → "Ciclo de vida"). Push y creación del PR corren igual, con cwd ya resuelto al worktree.
 
 1. `git push -u origin feat/<number>-<kebab>`.
 2. Crear el PR con `gh pr create` (base `develop`, milestone del issue):
@@ -266,6 +269,7 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
    | PR                  | [#<pr>](pr-url)                                                   |
    | Commits             | <N> commits atómicos                                              |
    | Hallazgos abordados | <X> críticos · <Y> advertencias · <Z> sugerencias — <disposición> |
+   | Entorno             | `worktree` (`.claude/worktrees/<number>`) / `raíz`                |
    | CI local            | <Verde / Rojo — ver <motivo>>                                     |
    ```
 
@@ -281,5 +285,6 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 - Nunca abrir el PR antes de que pasen los gates de CI y haya corrido el `code-reviewer`.
 - Nunca abrir el PR sin el keyword de cierre (`Closes #<issue>`) en el cuerpo enlazando el issue de origen.
 - Nunca abrir el PR con un Crítico sin disposición confirmada — definición en la pausa de la Fase 4; verificación en la Fase 6 paso 2.
+- En modo worktree (ver [Modo worktree](#modo-worktree)), el cwd de la sesión y de los subagentes delegados ya está resuelto al worktree tras `EnterWorktree`: la regla anti-`cd` sigue rigiendo igual, y toda comparación de rango git usa `origin/develop` como base, nunca `develop` local.
 - Nunca saltear la fase Plan — aun cambios triviales se benefician de un plan breve.
 - Aplican siempre las reglas de [`.claude/references/coding-agent-policies.md`](../../references/coding-agent-policies.md): sin framings de mantenedor único, sin "salteá el test por ser chico" (salvo cambios solo-doc), sin diferir la review más allá de abrir el PR, y sin comentarios redundantes (Sección 3).

--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -56,7 +56,7 @@ Ramificación tras la respuesta:
 
 **Propósito:** materializar el bump de versión y la entrada de CHANGELOG en commits atómicos.
 
-1. **Bump de versión en lockstep:** actualizar la versión target en **`package.json` raíz Y `cms/package.json`**. El versionado app/Studio va en lockstep (convención del release #1641); omitir `cms/package.json` deja el Studio desincronizado. Commitear (pueden ser uno o dos commits, pero **ambos** archivos deben quedar bumpeados antes del merge).
+1. **Bump de versión en lockstep:** actualizar la versión target en **`package.json` raíz Y `cms/package.json`**. El versionado app/Studio va en lockstep; omitir `cms/package.json` deja el Studio desincronizado. Commitear (pueden ser uno o dos commits, pero **ambos** archivos deben quedar bumpeados antes del merge).
 2. **Entrada de CHANGELOG:** insertar la sección `## Versión <x> (<fecha-de-hoy>)` sobre la anterior, con la prosa y los cambios aprobados en la Fase 1. Commit aparte.
 
 Formato de commit: `[#<issue>] - <qué cambió>` (español). Cada commit deja el repo buildeable.


### PR DESCRIPTION
## Descripción

- **Sección nueva "Modo worktree"** como fuente única: activación con prioridad declaración del usuario > worktree existente (re-entra sin preguntar) > **pregunta `AskUserQuestion`** (header `Entorno`, Worktree recomendada / Raíz, trade-off en las descriptions) — el requisito de que la elección sea una pregunta cuando no se declara; mecánica de creación (fetch → `worktree add` desde `origin/develop` → `EnterWorktree` → `pnpm install` + `pnpm run config`); ajustes transversales (base `origin/develop` para todo rango, gates con `NX_NO_CLOUD=true NX_DAEMON=false`, typecheck vía `tsc` directo, caveat de Node v26, y el texto exacto de la nota de delegación a subagentes); y ciclo de vida (se mantiene hasta el merge, señal de limpieza con pausa `Limpieza` y marca de "Mantener" que evita repreguntar).
- **Fase 0** gana el "Paso 0 — Entorno" (con el conflicto raíz-declarada-vs-worktree-existente avisado y confirmado, nunca resuelto en silencio) y sus señales parametrizan la base del `rev-list` por modo; **Fase 1** bifurca el setup (modo raíz idéntico al flujo previo); Fases 2/3/4/6 y Restricciones son punteros a la sección única — sin doble fuente. Los agentes de `.claude/agents/` no se tocan: la awareness viaja en la delegación.
- Motivado por dos incidentes reales de colisión de working tree con sesiones paralelas; la receta completa venía validada en la práctica (#1916/#1919/#1941 se ejecutaron así) y este mismo PR se produjo con ella, incluida la nota de delegación al `code-reviewer`. Absorbe la mitad "recheck de rama" de #1914 (queda anotado para re-acotarlo).

Closes #1942.
Parte de #1907.

## Plan de pruebas

- [x] `pnpm check:agents` en verde tras cada commit; archivo en 290/500 líneas; los 10 enlaces `#modo-worktree` resuelven al único heading real
- [x] Verificado que el modo raíz queda textualmente idéntico al flujo previo a este PR y que las pausas nuevas (`Entorno`, `Limpieza`) cumplen el mínimo de 2 opciones del contrato de `AskUserQuestion`
- [x] Dogfooding integral: este issue se ejecutó de punta a punta en su propio worktree (`.claude/worktrees/1942`) con la mecánica, receta de gates y nota de delegación que el PR encodea
- [x] Gates locales en verde: `test`, `lint`, `stylelint`, typecheck (tsc directo), `build`, `storybook:build` (`test:e2e` y `studio-build` omitidos: un solo `.md`)
- [x] Review del `code-reviewer`: APROBADO CON COMENTARIOS — 2 advertencias (hueco de prioridad declaración-vs-worktree; fila Commits sin parametrizar) y 2 sugerencias (bullet anti-cd incondicional; repregunta de Limpieza), las 4 Corregidas en la rama


## Fuera de alcance (abordado en este PR)

- **Barrido de referencias a issues en los cuerpos de ambos skills** (pedido del usuario durante la review): los skills describen la conducta vigente sin nombrar su origen — el rationale histórico vive en commits y PRs. Se barrieron las menciones de `issue-workflow/SKILL.md` (incluida una preexistente en la Fase 4) y la preexistente de `release-workflow/SKILL.md` (lockstep de la Fase 2); solo quedan los placeholders de formato `[#1234]`.
