### PR TITLE
[#1915] - Subagentes de issue-workflow: model inherit para plan-writer y code-reviewer

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Revisa cambios de código de La Cuentoneta (Angular 22 zoneless + Hono/Sanity) buscando calidad, arquitectura y adherencia a CLAUDE.md y a las referencias. Usar proactivamente cuando una implementación está completa, cuando se hicieron varios commits en una rama de feature, o cuando el usuario dice "listo", "terminado" o "lista para revisar".
 tools: Read, Grep, Glob, Bash, Write
-model: sonnet
+model: inherit
 ---
 
 Sos un revisor de código senior del proyecto **La Cuentoneta** (Angular 22 standalone zoneless + OnPush sobre Nx 23.1 single-project, con backend Hono plano + Sanity). Las reviews van **siempre en español**; el código y los identificadores van en inglés.

--- a/.claude/agents/plan-writer.md
+++ b/.claude/agents/plan-writer.md
@@ -2,7 +2,7 @@
 name: plan-writer
 description: Arquitecto de software que diseña planes de implementación para La Cuentoneta. Usar al entrar en modo plan o en la Fase 2 del skill issue-workflow, para explorar el código, definir un enfoque y producir un plan escrito en workspace/<number>/PLAN.md para aprobación del usuario.
 tools: Read, Grep, Glob, Bash, Write
-model: sonnet
+model: inherit
 ---
 
 Sos un arquitecto de software para La Cuentoneta (Angular 22 zoneless, Nx 23.1 single-project, pnpm, Hono plano + Sanity ACL, Vitest, estado signals-first sin NgRx).


### PR DESCRIPTION
## Descripción

- `plan-writer` y `code-reviewer` pasan de `model: sonnet` a **`model: inherit`**: las dos etapas de mayor apalancamiento intelectual del flujo (plan y review) escalan con el modelo de la sesión principal en vez de quedar clavadas en Sonnet.
- `security-auditor` y `documentation-writer` conservan `model: sonnet` deliberadamente — su checklist estructurado hace la mayor parte del trabajo y el costo pesa más que la profundidad.
- Se eligió el valor explícito `inherit` (reconocido por el harness de subagentes) sobre eliminar la línea `model:`: auditable a simple vista y simétrico con los agentes que declaran `sonnet`. El gate `check-agents` no valida el campo `model` — verificado leyendo su validador.

Closes #1915.
Parte de #1907.

## Plan de pruebas

- [x] `pnpm check:agents` en verde (frontmatter YAML válido en ambos agentes)
- [x] Diff verificado: exactamente 2 archivos / 2 líneas, sin arrastres del formatter; los otros 7 agentes intactos
- [x] Grep sobre `CLAUDE.md`, `docs/`, `.claude/references/` y `.claude/skills/`: ninguna afirmación desactualizada sobre qué modelo usan los subagentes
- [x] Gates locales en verde en worktree aislado: `test`, `lint`, `stylelint`, typecheck (tsc directo), `build`, `storybook:build` (`test:e2e` y `studio-build` omitidos: dos líneas de frontmatter)
- [x] Review del `code-reviewer` con veredicto APROBADO, sin hallazgos — ejecutada, de hecho, por el propio agente ya heredando el modelo de la sesión desde este worktree
