### PR TITLE
[#1920] - Deduplicar la regla anti-cd de los agentes en coding-agent-policies.md

### DIFF
--- a/.claude/agents/architecture-advisor.md
+++ b/.claude/agents/architecture-advisor.md
@@ -9,14 +9,7 @@ Sos el asesor de arquitectura de este proyecto Angular/Nx (La Cuentoneta).
 
 ## CRÍTICO: reglas de comandos Bash
 
-**Nunca prefijes ningún comando Bash con `cd`**. El directorio de trabajo ya es la raíz del proyecto. Usar `cd <path> && ...` cambia la firma del comando y obliga al usuario a aprobar manualmente cada comando.
-
-- ✅ `git log --oneline -10`
-- ✅ `pnpm ls <nombre-paquete>`
-- ❌ `cd /path/to/project && git log --oneline -10`
-- ❌ `cd /path/to/project && pnpm ls <nombre-paquete>`
-
-Esto aplica a TODOS los comandos: git, pnpm y cualquier otra CLI.
+**Nunca prefijes un comando Bash con `cd`** — el working directory ya está resuelto. Regla completa y ejemplos: [`coding-agent-policies.md`](../references/coding-agent-policies.md) Sección 8.
 
 ## Cuándo intervenir
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -9,14 +9,7 @@ Sos un revisor de código senior del proyecto **La Cuentoneta** (Angular 22 stan
 
 ## CRÍTICO: reglas de comandos Bash
 
-**NUNCA prefijes ningún comando Bash con `cd`.** El working directory ya es la raíz del proyecto. Usar `cd <path> && ...` cambia la firma del comando y obliga al usuario a aprobar manualmente cada ejecución.
-
-- ✅ `git diff develop...HEAD`
-- ✅ `pnpm lint`
-- ❌ `cd /ruta/al/proyecto && git diff develop...HEAD`
-- ❌ `cd /ruta/al/proyecto && pnpm lint`
-
-Aplica a TODOS los comandos: git, pnpm y cualquier otra CLI. Usá **siempre `pnpm`** (nunca `npm`/`yarn`: están bloqueados por `only-allow`).
+**Nunca prefijes un comando Bash con `cd`** — el working directory ya está resuelto. Usá siempre `pnpm` para scripts del repo. Regla completa y ejemplos: [`coding-agent-policies.md`](../references/coding-agent-policies.md) Sección 8.
 
 ## Cuándo ejecutarse
 

--- a/.claude/agents/domain-model-advisor.md
+++ b/.claude/agents/domain-model-advisor.md
@@ -11,16 +11,9 @@ Sos el asesor de modelo de dominio de **La Cuentoneta** (Angular 22 zoneless, pn
 >
 > **Contexto de madurez:** cuentoneta es hoy **"DDD-lite"** — capas `controller → service → repository` con un ACL de mappers sólido, pero sin clases de agregado, value objects, specification ni domain events como código. La implementación profunda de esos patrones es **roadmap** (`docs/DDD_IMPROVEMENTS.md`, issue **#1503**), no el estado actual. Distinguí siempre entre lo **vigente** (qué exigir hoy) y lo **objetivo** (qué recomendar como dirección).
 
-## CRÍTICO: reglas para comandos Bash
+## CRÍTICO: reglas de comandos Bash
 
-**NUNCA prefijes ningún comando Bash con `cd`**. El working directory **ya es** la raíz del proyecto. Usar `cd <ruta> && ...` cambia la firma del comando y obliga al usuario a aprobar manualmente cada ejecución.
-
-- ✅ `git diff develop...HEAD`
-- ✅ `pnpm test`
-- ❌ `cd /ruta/al/proyecto && git diff develop...HEAD`
-- ❌ `cd /ruta/al/proyecto && pnpm test`
-
-Aplica a **todos** los comandos: git, pnpm y cualquier otro CLI. Nota: el repo usa **pnpm** (no npm/yarn, bloqueados por `only-allow`) y la rama base es **`develop`**.
+**Nunca prefijes un comando Bash con `cd`** — el working directory ya está resuelto. Usá siempre `pnpm`; la rama base es `develop`. Regla completa y ejemplos: [`coding-agent-policies.md`](../references/coding-agent-policies.md) Sección 8.
 
 ## Cuándo correr
 

--- a/.claude/agents/migration-planner.md
+++ b/.claude/agents/migration-planner.md
@@ -7,18 +7,9 @@ model: sonnet
 
 Sos un especialista en planificación de migraciones para **La Cuentoneta** (Angular 22 zoneless + Nx 23.1 single-project, pnpm).
 
-## CRÍTICO: reglas para comandos Bash
+## CRÍTICO: reglas de comandos Bash
 
-**NUNCA prefijes un comando Bash con `cd`**. El directorio de trabajo YA es la raíz del proyecto. Usar `cd <path> && ...` cambia la firma del comando y obliga al usuario a aprobar manualmente cada llamada.
-
-- ✅ `pnpm list <package-name>`
-- ✅ `git log --oneline -10`
-- ✅ `pnpm outdated`
-- ❌ `cd /path/to/project && pnpm list <package-name>`
-- ❌ `cd /path/to/project && git log --oneline -10`
-- ❌ `cd /path/to/project && pnpm outdated`
-
-Esto aplica a TODOS los comandos: git, pnpm y cualquier otro CLI. Este repo usa **pnpm** (10.x); `npm`/`yarn` están bloqueados (`only-allow`). No uses `npm run` ni `npm install` jamás.
+**Nunca prefijes un comando Bash con `cd`** — el working directory ya está resuelto. Usá siempre `pnpm`, jamás `npm run`/`npm install`. Regla completa y ejemplos: [`coding-agent-policies.md`](../references/coding-agent-policies.md) Sección 8.
 
 ## Cuándo ejecutarse
 

--- a/.claude/agents/plan-writer.md
+++ b/.claude/agents/plan-writer.md
@@ -9,14 +9,7 @@ Sos un arquitecto de software para La Cuentoneta (Angular 22 zoneless, Nx 23.1 s
 
 ## CRÍTICO: reglas de comandos Bash
 
-**Nunca prefijes un comando Bash con `cd`**. El working directory ya es la raíz del proyecto. Usar `cd <ruta> && ...` cambia la firma del comando y obliga al usuario a aprobar manualmente cada comando.
-
-- ✅ `git log --oneline -10`
-- ✅ `pnpm ls <package-name>`
-- ❌ `cd /ruta/al/proyecto && git log --oneline -10`
-- ❌ `cd /ruta/al/proyecto && pnpm ls <package-name>`
-
-Aplica a TODOS los comandos: git, pnpm y cualquier otro CLI.
+**Nunca prefijes un comando Bash con `cd`** — el working directory ya está resuelto. Regla completa y ejemplos: [`coding-agent-policies.md`](../references/coding-agent-policies.md) Sección 8.
 
 ## Cuándo se ejecuta
 

--- a/.claude/agents/refactoring-specialist.md
+++ b/.claude/agents/refactoring-specialist.md
@@ -7,16 +7,9 @@ model: sonnet
 
 Sos un especialista en refactoring para **La Cuentoneta** (Angular 22 zoneless + OnPush, Nx, pnpm, Hono plano + Sanity ACL, estado signals-first sin NgRx, Vitest + `@test-utils`).
 
-## CRÍTICO: reglas de Bash
+## CRÍTICO: reglas de comandos Bash
 
-**NUNCA prefijes un comando de Bash con `cd`**. El working directory ya es la raíz del proyecto. Usar `cd <ruta> && ...` cambia la firma del comando y obliga al usuario a aprobar cada comando manualmente.
-
-- ✅ `git diff develop...HEAD`
-- ✅ `pnpm test`
-- ❌ `cd /ruta/al/proyecto && git diff develop...HEAD`
-- ❌ `cd /ruta/al/proyecto && pnpm test`
-
-Esto aplica a TODOS los comandos: git, pnpm y cualquier otra CLI.
+**Nunca prefijes un comando Bash con `cd`** — el working directory ya está resuelto. Regla completa y ejemplos: [`coding-agent-policies.md`](../references/coding-agent-policies.md) Sección 8.
 
 ## Cuándo intervenir
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -11,14 +11,7 @@ Sos un auditor de seguridad para este proyecto Angular/Nx con un **backend Hono 
 
 ## CRÍTICO: reglas de comandos Bash
 
-**NUNCA prefijes ningún comando Bash con `cd`**. El working directory **ya es** la raíz del proyecto. Usar `cd <path> && ...` cambia la firma del comando y obliga a aprobar manualmente cada ejecución.
-
-- ✅ `git diff develop...HEAD`
-- ✅ `pnpm test`
-- ❌ `cd /path/to/project && git diff develop...HEAD`
-- ❌ `cd /path/to/project && pnpm test`
-
-Esto aplica a TODOS los comandos: git, pnpm y cualquier otra CLI.
+**Nunca prefijes un comando Bash con `cd`** — el working directory ya está resuelto. Regla completa y ejemplos: [`coding-agent-policies.md`](../references/coding-agent-policies.md) Sección 8.
 
 ## Cuándo correr
 

--- a/.claude/agents/test-generator.md
+++ b/.claude/agents/test-generator.md
@@ -9,13 +9,7 @@ Sos un especialista en generación de tests para **La Cuentoneta** (Angular 22 z
 
 ## CRÍTICO: reglas de comandos Bash
 
-**Nunca** prefijes un comando Bash con `cd`. El working directory ya es la raíz del proyecto. Usar `cd <path> && ...` cambia la firma del comando y obliga al usuario a aprobar cada llamada a mano.
-
-- ✅ `pnpm test`
-- ✅ `git diff develop...HEAD`
-- ❌ `cd /path/to/project && pnpm test`
-
-Esto aplica a **todos** los comandos: git, pnpm y cualquier otra CLI. Usá siempre **`pnpm`** (nunca `npm`/`yarn`: están bloqueados por `only-allow`).
+**Nunca prefijes un comando Bash con `cd`** — el working directory ya está resuelto. Usá siempre `pnpm`. Regla completa y ejemplos: [`coding-agent-policies.md`](../references/coding-agent-policies.md) Sección 8.
 
 ## Cuándo correr
 

--- a/.claude/references/coding-agent-policies.md
+++ b/.claude/references/coding-agent-policies.md
@@ -211,6 +211,19 @@ Independientemente de lo anterior, todo PR debe dejar verdes los gates de CI def
 
 Proponé cambios vía issue en `cuentoneta/cuentoneta`. Las enmiendas requieren aprobación explícita del usuario antes de mergear al documento. Cada PR que modifique este archivo debe actualizar la fecha de "Última actualización" del pie de página.
 
+## Sección 8 — Disciplina de comandos Bash: nunca prefijar con `cd`
+
+Regla operativa para todo agente con acceso a Bash en este repo: **nunca prefijar un comando con `cd`**. El working directory ya está resuelto al invocar al agente — la raíz del repo, o la del worktree de la sesión. Prefijar con `cd <ruta> && ...` cambia la firma del comando frente al sistema de permisos del harness y obliga a aprobar manualmente cada ejecución.
+
+- ✅ `git diff origin/develop...HEAD`
+- ✅ `pnpm lint`
+- ❌ `cd /ruta/al/proyecto && git diff origin/develop...HEAD`
+- ❌ `cd /ruta/al/proyecto && pnpm lint`
+
+Aplica a TODOS los CLIs: git, pnpm, gh y cualquier otro. Usar **siempre `pnpm`** para scripts del repo — `npm`/`yarn` están bloqueados por `only-allow`.
+
+Las definiciones de agentes (`.claude/agents/*.md`) enuncian la regla en una línea y remiten acá — no duplican los ejemplos, para que esta sección sea la única fuente.
+
 ---
 
-_Última actualización: 2026-07-21. Versión inicial en #1495 (CLAUDE.md + archivos de referencia); Sección 3 (Disciplina de comentarios) agregada en #1499 y ampliada en #1542 (visibilidad de API y reemplazos canónicos); regla de story intercambiable para estados de carga agregada en #1581; regla de child issues reales en epics agregada en #1843; "Gates de CI" convertida a remisión a CLAUDE.md en #1844; punteros a secciones de CLAUDE.md corregidos a headings reales en #1846; prohibición de `git add -A` agregada tras un incidente en el flujo de #1882._
+_Última actualización: 2026-07-24. Versión inicial en #1495 (CLAUDE.md + archivos de referencia); Sección 3 (Disciplina de comentarios) agregada en #1499 y ampliada en #1542 (visibilidad de API y reemplazos canónicos); regla de story intercambiable para estados de carga agregada en #1581; regla de child issues reales en epics agregada en #1843; "Gates de CI" convertida a remisión a CLAUDE.md en #1844; punteros a secciones de CLAUDE.md corregidos a headings reales en #1846; prohibición de `git add -A` agregada tras un incidente en el flujo de #1882; Sección 8 (regla anti-`cd`) consolidada desde las tres copias divergentes de los agentes en #1920._

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -281,7 +281,7 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 ## Restricciones (todas las fases)
 
 - Usar `pnpm <script>` para ejecutar tareas; no construir variantes de `nx` directas a mano.
-- Nunca prefijar comandos git con `cd` — el working dir ya está resuelto (raíz del repo, o del worktree según el entorno).
+- Nunca prefijar comandos git con `cd` — el working dir ya está resuelto (raíz del repo, o del worktree según el entorno); regla completa en [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 8.
 - Nunca abrir el PR antes de que pasen los gates de CI y haya corrido el `code-reviewer`.
 - Nunca abrir el PR sin el keyword de cierre (`Closes #<issue>`) en el cuerpo enlazando el issue de origen.
 - Nunca abrir el PR con un Crítico sin disposición confirmada — definición en la pausa de la Fase 4; verificación en la Fase 6 paso 2.

--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -137,7 +137,7 @@ Ramificación tras la respuesta:
 ## Restricciones (todas las fases)
 
 - Usar `pnpm <script>`; no construir variantes de `nx` a mano.
-- Nunca prefijar comandos git con `cd` — el working dir ya está en la raíz.
+- Nunca prefijar comandos git con `cd` — el working dir ya está resuelto; regla completa en [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 8.
 - Nunca correr migraciones de Sanity automáticamente: mutan producción, son paso manual del usuario.
 - Nunca mergear `develop → master` desde el skill: ese es el gatillo del release y lo hace el usuario.
 - Nunca abrir el PR sin `Closes #<issue>` en el cuerpo, ni antes de que pasen los gates de CI y la verificación.


### PR DESCRIPTION
## Descripción

- Consolida la regla "nunca prefijar un comando Bash con `cd`" en una **Sección 8 nueva** de `coding-agent-policies.md` (fuente única), sin renumerar las secciones existentes (Sección 2/3 están citadas por número en CLAUDE.md y skills) y actualizando el pie de página con fecha y entrada, como exige el propio documento. La sección contempla además el cwd de worktrees y la regla pnpm/only-allow.
- Reemplaza las copias divergentes de la regla en **los 8 agentes con Bash** por una remisión de una línea a la Sección 8. El issue listaba 3 agentes; al implementarlo aparecieron **otros 5** con sus propias copias divergentes (hasta el título de la sección variaba) — se incluyeron todos. Cada remisión conserva la regla operativa en una línea (crítico para `security-auditor`, que no carga el archivo de políticas en su Paso 0) más los matices propios de algunos (pnpm/npm en migration-planner, rama base en domain-model-advisor).
- Las menciones sueltas de la regla en ambos skills (`issue-workflow`, `release-workflow`) también remiten ahora a la Sección 8: la regla queda con una única fuente en todo `.claude/`.

Closes #1920.
Parte de #1907.

## Plan de pruebas

- [x] `pnpm check:agents` en verde tras cada commit (frontmatter, anclas y rutas citadas — incluidos los enlaces relativos `../references/` y `../../references/` nuevos)
- [x] Grep de cierre: cero menciones de la regla anti-`cd` sin remisión a la Sección 8 en `.claude/agents` y `.claude/skills`
- [x] Verificado que ningún agente con Bash perdió la regla operativa y que `documentation-writer` (sin Bash) correctamente no la tiene; ninguna sección existente (1–7) fue renumerada
- [x] Review del `code-reviewer` (pasada local pre-PR) con veredicto APROBADO, sin hallazgos bloqueantes; sus dos sugerencias (menciones en los skills) quedaron incorporadas en esta rama
- [x] Gates restantes cubiertos por los required checks de CI del PR — el diff es solo Markdown de `.claude/`
