### PR TITLE
[#1955] - Regla: no referenciar en los .md de agentes issues ya abordados/cerrados

### DIFF
--- a/.claude/references/coding-agent-policies.md
+++ b/.claude/references/coding-agent-policies.md
@@ -84,7 +84,7 @@ Prohibido para artefactos intencionalmente autorados aunque estén gitignoreados
 
 Prohibido. **Stagear siempre rutas explícitas**: `git add <path> <path>`, nunca `git add -A`, `git add .` ni `git commit -a`.
 
-El working tree de este repo acumula artefactos no versionados que no son basura: `workspace/` (planes y notas de review), salidas bajo `tools/`, worktrees en `.claude/worktrees/`, archivos generados como `src/app/environments/environment.ts`. Un `-A` los barre sin que nadie los mire, y el commit se pushea antes de que se note. Ya pasó en el PR #1576.
+El working tree de este repo acumula artefactos no versionados que no son basura: `workspace/` (planes y notas de review), salidas bajo `tools/`, worktrees en `.claude/worktrees/`, archivos generados como `src/app/environments/environment.ts`. Un `-A` los barre sin que nadie los mire, y el commit se pushea antes de que se note.
 
 El argumento de que "el `.gitignore` los cubre" no alcanza: la lista de ignorados cambia, un artefacto nuevo puede no estar contemplado todavía, y el momento de descubrirlo no es después del push. Listar las rutas obliga a mirar qué entra, que es justamente el control que se busca.
 
@@ -133,7 +133,7 @@ Los comentarios explican el **porqué no obvio**, nunca el **qué**. Si el códi
 **No comentar** (es ruido y se desincroniza; review-blocking si solo agrega ruido):
 
 - **Restatear una convención ya documentada.** ❌ `// doble de test, nunca Mock*` · ❌ `// el token no lleva providedIn/factory`. La convención vive en `clean-architecture.md`; repetirla en cada archivo es ruido.
-- **Rationale histórico / de cambio inline.** ❌ `// Rediseñado en #1499: la versión previa usaba .toPromise()…` · ❌ `// sin consumidores al momento del cambio`. Eso va al commit/PR.
+- **Rationale histórico / de cambio inline.** ❌ `// Rediseñado: la versión previa usaba .toPromise()…` · ❌ `// sin consumidores al momento del cambio`. Eso va al commit/PR.
 - **Navegación / estructura obvia.** ❌ `// la implementación HTTP vive en x.provider.ts` · ❌ `// API providers (patrón provideX)`. Los imports y los nombres de archivo ya lo muestran.
 - **Parafrasear la línea siguiente.** ❌ `// inyecta el HttpClient` encima de `inject(HttpClient)`.
 - **Justificar una visibilidad que la convención ya fija.** ❌ `// public porque es la API imperativa` sobre un `input()`/`output()`/signal expuesta. Si el miembro **es** la API pública, su visibilidad ya la dicta `angular-components.md`; el modificador es autoexplicativo.
@@ -147,6 +147,20 @@ Los comentarios explican el **porqué no obvio**, nunca el **qué**. Si el códi
 **Antes de escribir un comentario, preguntarse:** ¿esto ya lo dice el código, un nombre, un tipo o una referencia? ¿es contexto de cambio que debería ir al PR? Si la respuesta a cualquiera es "sí", no se escribe.
 
 Los comentarios de sección de estilo `// Core` / `// Models` que ya existen en el repo se respetan donde están, pero **no se agregan nuevos** salvo que aporten navegación real en un archivo grande.
+
+### Menciones a issues en la documentación de agentes (`.claude/references/**`, `.claude/agents/**`, `.claude/skills/**`)
+
+El mismo principio rige la prosa de estos documentos: **describen la conducta vigente, no su historia**. La procedencia y la trazabilidad de cambio viven en el historial de git y en los PRs — nunca inline. En concreto, **no citar un issue** para:
+
+- Documentar trabajo **ya implementado** o un issue ya **cerrado** (❌ "el value object `Slug` (implementado, `#<issue>`)", ❌ "el gate se agregó en `#<issue>`"). La documentación de lo ya hecho no lleva número: se enuncia el estado, no el issue que lo produjo.
+- Sellar procedencia de una regla o convención (❌ "regla agregada en `#<issue>`", ❌ "el fallo costó dos agentes caídos (`#<issue>`)").
+
+**Excepción acotada — trabajo futuro a manera de TODO, con issue abierto.** Un doc de reference/agent/skill **sí** puede citar un issue cuando el número es _load-bearing_ para una instrucción vigente y el issue está **OPEN**:
+
+1. **Puntero de gobernanza:** una prohibición provisional cuyo número es la condición de expiración — "dirección no adoptada; **no generar** X **hasta que el issue cambie de estado**" (p. ej. NgRx Signal Store, OpenAPIHono, o DDD-en-código para clases de repositorio/DI). Sin el número, un "todavía no" se leería como "nunca".
+2. **Justificación de supresión de lint/TS enlazada:** el issue que `CLAUDE.md` (Restricciones duras) exige junto a un `eslint-disable`/`@ts-ignore`, incluso en los ejemplos que enseñan ese patrón.
+
+`CLAUDE.md` y `docs/` quedan fuera de esta regla (llevan su propia decisión).
 
 ---
 
@@ -226,4 +240,4 @@ Las definiciones de agentes (`.claude/agents/*.md`) enuncian la regla en una lí
 
 ---
 
-_Última actualización: 2026-07-24. Versión inicial en #1495 (CLAUDE.md + archivos de referencia); Sección 3 (Disciplina de comentarios) agregada en #1499 y ampliada en #1542 (visibilidad de API y reemplazos canónicos); regla de story intercambiable para estados de carga agregada en #1581; regla de child issues reales en epics agregada en #1843; "Gates de CI" convertida a remisión a CLAUDE.md en #1844; punteros a secciones de CLAUDE.md corregidos a headings reales en #1846; prohibición de `git add -A` agregada tras un incidente en el flujo de #1882; Sección 8 (regla anti-`cd`) consolidada desde las tres copias divergentes de los agentes en #1920._
+_Última actualización: 2026-07-25. Este documento evoluciona por enmiendas (ver Sección 7); su historial detallado —qué se agregó, cuándo y por qué— vive en el log de git y en los PRs. Cambios mayores: versión inicial (CLAUDE.md + archivos de referencia); Sección 3 (Disciplina de comentarios) y sus ampliaciones sobre visibilidad de API y reemplazos canónicos; regla de story intercambiable para estados de carga; regla de child issues reales en epics; "Gates de CI" convertida a remisión a CLAUDE.md; prohibición de `git add -A`; Sección 8 (regla anti-`cd`) consolidada desde las copias de los agentes; y la política de menciones a issues en la documentación de agentes (Sección 3)._


### PR DESCRIPTION
## Descripción

- Amplía `coding-agent-policies.md` Sección 3 con la política de menciones a issues en la documentación de agentes: la prosa de `.claude/references/**`, `.claude/agents/**` y `.claude/skills/**` describe la conducta vigente, no su historia — la procedencia y la trazabilidad viven en el log de git y en los PRs. No se cita un issue para documentar trabajo ya implementado ni un issue cerrado.
- **Excepción acotada:** un doc de agente sí puede citar un issue **abierto** cuando el número es load-bearing como (1) puntero de gobernanza (prohibición provisional "no generar X hasta que el issue cambie de estado") o (2) justificación de supresión de lint/TS enlazada exigida por `CLAUDE.md`. `CLAUDE.md` y `docs/` quedan fuera de la regla.
- **Dogfooding:** aplica la regla al propio documento — de-numera su pie de página (el changelog pasa a descriptivo, el historial vive en git) y limpia sus ejemplos internos. Los ejemplos ❌ de la regla usan placeholders `#<issue>`, no números reales.

> **Nota de alcance:** este PR es la mitad **preventiva** (la regla). El **borrado** de las referencias ya existentes en el resto de los docs se difiere a #1948 (cada una se elimina cuando el trabajo de su issue termine); su inventario completo vive en el cuerpo de #1948. Este PR fue rescopeado desde el barrido original: los commits de barrido se revirtieron y quedó solo la regla + su dogfooding.

Closes #1955.
Parte de #1907.

## Plan de pruebas

- [x] `pnpm check:agents` en verde (frontmatter, anclas y rutas citadas)
- [x] `coding-agent-policies.md` cumple su propia regla: cero menciones a issues reales (solo placeholders `#<issue>` en los ejemplos)
- [x] El diff toca **solo** `coding-agent-policies.md`; el barrido de los demás docs quedó revertido y diferido a #1948
- [x] Cambio solo-documentación, exento de tests (Sección 2); gates de app/cms cubiertos por los required checks de CI
