### PR TITLE
[#1953] - Persiste el readingTime en el schema de literaryWork (Parte 1: campos + contrato Opción B)

### DIFF
--- a/cms/schemas/literaryWork.ts
+++ b/cms/schemas/literaryWork.ts
@@ -37,6 +37,18 @@ const section = defineArrayMember({
 			type: 'markdown',
 			validation: (Rule) => Rule.required(),
 		}),
+		// Derivado del texto, poblado por el backend (fuera del CMS), no editable. Opcional a propósito:
+		// arranca vacío y lo materializa la primera lectura de la obra (self-healing) — ver
+		// docs/LITERARY_WORK_DESIGN.md §5. Podrá volverse required en un increment futuro, una vez
+		// pobladas todas las obras.
+		defineField({
+			name: 'readingTime',
+			title: 'Tiempo de lectura de la sección (minutos)',
+			description: 'Derivado del texto de la sección; lo computa y persiste el backend, no se edita a mano.',
+			type: 'number',
+			readOnly: true,
+			validation: (Rule) => Rule.integer().min(1),
+		}),
 	],
 	preview: {
 		select: { title: 'chapterTitle' },
@@ -94,6 +106,17 @@ export default defineType({
 			type: 'array',
 			of: [section],
 			validation: (Rule) => Rule.required().min(1),
+		}),
+		// Suma derivada del texto de las secciones, poblada por el backend (fuera del CMS), no editable.
+		// Opcional a propósito (ver la nota de section.readingTime). La "Duración fija"
+		// (readingTimeOverride), si está, la reemplaza aguas abajo — ver docs/LITERARY_WORK_DESIGN.md §5.
+		defineField({
+			name: 'totalReadingTime',
+			title: 'Tiempo de lectura total (minutos)',
+			description: 'Suma derivada del texto de las secciones; lo computa y persiste el backend, no se edita a mano.',
+			type: 'number',
+			readOnly: true,
+			validation: (Rule) => Rule.integer().min(1),
 		}),
 		defineField({
 			name: 'readingTimeOverride',

--- a/docs/LITERARY_WORK_DESIGN.md
+++ b/docs/LITERARY_WORK_DESIGN.md
@@ -280,7 +280,7 @@ El SSR de `/read/:slug` (Slice 1) consume la forma completa; la obtención por s
 
 > **Nota abierta para Slice 1 — slug inexistente / sección fuera de rango:** el comportamiento vigente del módulo `story` ante slug no encontrado es que el service lanza `Error` genérico sin handler `onError` global en `routes.ts` → HTTP **500 sin body estructurado**, no un 404 JSON. Slice 1 debe decidir si `literary-work` introduce un 404 propio (y sienta el precedente) o mantiene paridad con `story` y se difiere el manejo de errores a un issue transversal. La decisión que se tome aplica por igual a ambos casos (slug y sección). Es una decisión **diferida a propósito**, no una omisión de este diseño.
 
-### Consumo desde el frontend — DTO de wire y rehidratación en el provider
+### Consumo desde el frontend — DTO de wire + rehidratación en el provider
 
 **Decisión.** El body de la respuesta **es** la proyección serializada del agregado (no se introduce un shape distinto tipo `LiteraryWorkHttpResponse` — misma repo, sin versionado ni multi-cliente: una tercera forma solo agregaría riesgo de drift). Pero el **tipo** con el que el frontend recibe ese body no es `LiteraryWork`: la serialización pierde exactamente lo que hace dominio al dominio —
 

--- a/docs/LITERARY_WORK_DESIGN.md
+++ b/docs/LITERARY_WORK_DESIGN.md
@@ -24,15 +24,15 @@
 
 Decisiones cerradas en la planificación del epic #1481 — **no se reabren**:
 
-| Decisión              | Detalle                                                                                                                                                                                                                               |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Entidad paralela      | `LiteraryWork` no toca `Story` ni acopla su vocabulario: contrato limpio, **sin supertipo compartido**.                                                                                                                               |
-| Contenido             | Array de **secciones**; el teaser expone la **primera sección**. La navegación multi-sección en UI se difiere (Slice 2).                                                                                                              |
-| Pipeline de contenido | Markdown → HTML **saneado server-side** vía `unified` (`remark-parse → remark-rehype → rehype-sanitize → rehype-stringify`); el cliente solo hace `bypassSecurityTrustHtml` + `[innerHTML]`. Ningún markdown crudo cruza al frontend. |
-| Ruta                  | `/read/:slug`, self-canonical 200 (sin redirect), un documento SSR indexable.                                                                                                                                                         |
-| Repository            | Puerto + adaptador + doble (ver [§6](#6-repository-puerto-adaptador-y-doble)).                                                                                                                                                        |
-| Reading time          | **No se persiste** en el documento fuente; se materializa fuera del CMS (webhook → función → documento derivado, decisión T1b — ver [§8](#8-estrategia-de-materialización)).                                                          |
-| Imágenes              | Assets de Sanity. La URL de `cdn.sanity.io` codifica dimensiones (`assetId-WxH`) → CLS recuperable vía rewrite en un plugin `rehype` (ver [§9](#9-allow-list-de-sanitización)).                                                       |
+| Decisión              | Detalle                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Entidad paralela      | `LiteraryWork` no toca `Story` ni acopla su vocabulario: contrato limpio, **sin supertipo compartido**.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Contenido             | Array de **secciones**; el teaser expone la **primera sección**. La navegación multi-sección en UI se difiere (Slice 2).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| Pipeline de contenido | Markdown → HTML **saneado server-side** vía `unified` (`remark-parse → remark-rehype → rehype-sanitize → rehype-stringify`); el cliente solo hace `bypassSecurityTrustHtml` + `[innerHTML]`. Ningún markdown crudo cruza al frontend.                                                                                                                                                                                                                                                                                                                                                                                   |
+| Ruta                  | `/read/:slug`, self-canonical 200 (sin redirect), un documento SSR indexable.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Repository            | Puerto + adaptador + doble (ver [§6](#6-repository-puerto-adaptador-y-doble)).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Reading time          | **Persistido write-once**: `readingTime` por sección (`section.readingTime`) y `totalReadingTime` en el documento `literaryWork` — el texto de la obra es inmutable una vez creada, no hace falta recalcular en lectura. Poblado por **materialización self-healing** en la primera lectura del backend (Opción B — ver [§5](#5-helper-de-reading-time)), decisión [#1953](https://github.com/cuentoneta/cuentoneta/issues/1953). **Anula la decisión T1b** para el reading time (T1b prohibía persistir lo computado); el webhook de [§8](#8-estrategia-de-materialización) queda exclusivamente para el HTML saneado. |
+| Imágenes              | Assets de Sanity. La URL de `cdn.sanity.io` codifica dimensiones (`assetId-WxH`) → CLS recuperable vía rewrite en un plugin `rehype` (ver [§9](#9-allow-list-de-sanitización)).                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 
 Hallazgos del prototipo (validados, rama `spike/1481-literarywork-schema`):
 
@@ -86,7 +86,7 @@ export interface LiteraryWorkNavigationTeaserWithAuthors extends LiteraryWorkBas
 
 - `StoryTeaser` **vacía** su contenido (`paragraphs: []`); `LiteraryWorkTeaser` expone la **primera sección completa** (`teaserSection`) — decisión del epic: el teaser de una obra es su primera sección.
 - `Story.author` es exactamente uno; `LiteraryWork.authors` es 1..N (el anonimato se expresa con el author "Anónimo", ver [§10](#10-autoría-y-obra-anónima)).
-- `Story.approximateReadingTime` viene persistido del CMS; `LiteraryWork.totalReadingTime` es **derivado** (suma de los `readingTime` de sus secciones, calculado en la factory).
+- `Story.approximateReadingTime` viene persistido del CMS (lo entra el editor); `LiteraryWork.totalReadingTime` es **derivado del texto** (suma de los `readingTime` de sus secciones, ensamblado en la factory) y **materializado write-once** en Sanity — ver [§5](#5-helper-de-reading-time).
 
 **Invariantes del agregado** (validadas en `createLiteraryWork`, la única vía de construcción):
 
@@ -193,14 +193,30 @@ export function countWords(markdown: Markdown): WordCount;
 // mdast-util-to-string sobre el AST de remark-parse → split por whitespace → createWordCount
 ```
 
-El flujo completo por sección: `body (Markdown) → countWords → WordCount → deriveReadingTime → ReadingTime`; el total del agregado: `sumReadingTimes(sections.map(s => s.readingTime))` (derivado en `createLiteraryWork`).
+### Persistencia write-once (decisión #1953 — Opción B)
+
+El texto de una obra es **inmutable una vez creada**, así que el reading time es **write-once**: se computa una sola vez y se **persiste** en Sanity en lugar de recalcularse en cada lectura —
+
+- `readingTime` **por sección**, en `section.readingTime` (campo del object `section` del schema).
+- `totalReadingTime` **en el documento `literaryWork`**.
+
+Ambos campos son **opcionales** en el schema y arrancan vacíos: el poblado no ocurre en el Studio ni por migración, sino por **materialización self-healing en la primera lectura del backend** (Opción B, decisión [#1953](https://github.com/cuentoneta/cuentoneta/issues/1953)). El flujo por sección es el mismo de siempre —
+
+```
+body (Markdown) → countWords → WordCount → deriveReadingTime → ReadingTime
+```
+
+— y el total del agregado sigue siendo `sumReadingTimes(sections.map(s => s.readingTime))`. Lo que cambia frente al transform-on-read puro: cuando el mapper del backend lee una obra a la que le falta `readingTime`/`totalReadingTime`, además de computarlos (con el `countWords` real del dominio, "fuera del CMS") los **persiste de vuelta** en Sanity vía un patch (`@sanity/client` con token de escritura) antes de responder. Las lecturas siguientes de esa obra encuentran el valor ya persistido y lo sirven directo, sin recomputar. Como el texto es inmutable, la regla "falta → computar y persistir" alcanza — no hace falta invalidar por hash ni por `_rev`, y cubre obras nuevas automáticamente sin paso manual en el Studio ni webhook.
+
+> **Estado de implementación:** este increment agrega solo el schema (campos opcionales, arrancan vacíos) y esta doc. El mapper que lee/computa/persiste — y el `?section=N` eficiente que se apoya en él para traer solo el body de la sección pedida más el total ya persistido ([§7](#7-contrato-del-endpoint)) — se implementan en el increment de backend rebaseado sobre el PR [#1929](https://github.com/cuentoneta/cuentoneta/pull/1929) (read-side diferido, aún no en este PR).
 
 ### Override editorial de duración (`readingTimeOverride`)
 
-Para obras cuyo contenido principal es un **recitado o audiovisual** (p. ej. narraciones verbales sin texto fuente), la duración relevante es la del medio, no la del texto. El schema expone el campo opcional **`readingTimeOverride`** (entero `>= 1`, minutos): si está presente, `createLiteraryWork` lo usa como `totalReadingTime` en lugar de la suma de secciones. La interfaz pública no cambia — los consumidores ven un único `totalReadingTime` sin conocer su procedencia.
+Para obras cuyo contenido principal es un **recitado o audiovisual** (p. ej. narraciones verbales sin texto fuente), la duración relevante es la del medio, no la del texto. El schema expone el campo opcional **`readingTimeOverride`** (entero `>= 1`, minutos): si está presente, `createLiteraryWork` lo usa como `totalReadingTime` en lugar del total derivado del texto. La interfaz pública no cambia — los consumidores ven un único `totalReadingTime` sin conocer su procedencia.
 
-- **Compatibilidad con T1b:** el override es un **dato fuente editorial** (input curatorial), no un derivado persistido — la decisión "el source doc no persiste `approximateReadingTime`" prohíbe persistir lo computado, no un input.
-- El `readingTime` **por sección** sigue derivándose del texto (el override es solo del total).
+- **`totalReadingTime` persistido = suma pura del texto.** Lo que se persiste en `literaryWork.totalReadingTime` ([#1953](https://github.com/cuentoneta/cuentoneta/issues/1953)) es siempre `sumReadingTimes` sobre las secciones — nunca el override "bakeado" en el campo. La precedencia `override ?? total` sigue resolviéndose en `createLiteraryWork`, en cada construcción del agregado.
+- **El override no se persiste como derivado.** Sigue siendo un **dato fuente editorial** (input curatorial) que vive únicamente en su propio campo del schema. Distinto del reading time por texto, que #1953 sí persiste (anula T1b para ese derivado): el override nunca estuvo alcanzado por T1b porque no es lo computado, es el input.
+- El `readingTime` **por sección** sigue derivándose del texto (el override es solo del total) y es lo que #1953 persiste en `section.readingTime`.
 
 ### Obras solo-recitado (sin texto fuente)
 
@@ -264,7 +280,7 @@ El SSR de `/read/:slug` (Slice 1) consume la forma completa; la obtención por s
 
 > **Nota abierta para Slice 1 — slug inexistente / sección fuera de rango:** el comportamiento vigente del módulo `story` ante slug no encontrado es que el service lanza `Error` genérico sin handler `onError` global en `routes.ts` → HTTP **500 sin body estructurado**, no un 404 JSON. Slice 1 debe decidir si `literary-work` introduce un 404 propio (y sienta el precedente) o mantiene paridad con `story` y se difiere el manejo de errores a un issue transversal. La decisión que se tome aplica por igual a ambos casos (slug y sección). Es una decisión **diferida a propósito**, no una omisión de este diseño.
 
-### Consumo desde el frontend — DTO de wire + rehidratación en el provider
+### Consumo desde el frontend — DTO de wire y rehidratación en el provider
 
 **Decisión.** El body de la respuesta **es** la proyección serializada del agregado (no se introduce un shape distinto tipo `LiteraryWorkHttpResponse` — misma repo, sin versionado ni multi-cliente: una tercera forma solo agregaría riesgo de drift). Pero el **tipo** con el que el frontend recibe ese body no es `LiteraryWork`: la serialización pierde exactamente lo que hace dominio al dominio —
 
@@ -286,18 +302,20 @@ El contrato del frontend (Slice 1) es entonces:
 
 ## 8. Estrategia de materialización
 
-Decisión T1b del epic; implementación en **Slice 4**. Hasta entonces rige **transform-on-read** (el ACL transforma en cada lectura, Slice 1).
+**Alcance acotado a partir de [#1953](https://github.com/cuentoneta/cuentoneta/issues/1953): esta estrategia (webhook → documento derivado) es exclusiva del HTML saneado** — issue [#1856](https://github.com/cuentoneta/cuentoneta/issues/1856), "Materialización del HTML saneado vía webhook". El reading time (por sección y total) **ya no depende de esta sección**: se persiste write-once en campos propios del documento fuente, poblados por la materialización self-healing del backend descrita en [§5](#5-helper-de-reading-time) — sin webhook, sin documento derivado.
 
-| Elemento     | Diseño                                                                                                                                                                                                                               |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Trigger      | Webhook de Sanity → función serverless ante cambio de documento                                                                                                                                                                      |
-| Persistencia | **Documento derivado separado** del source: `{ HTML por sección, readingTimes, stamp de revisión / hash de contenido de origen }`. Separado para esquivar el loop de `_rev` (patchear derivados no debe re-disparar la regeneración) |
-| Pipeline     | **El mismo código del ACL** (función pura compartida) — una sola implementación de MD→HTML                                                                                                                                           |
-| Fallback     | Si el derivado falta o está stale respecto del hash/rev: el ACL transforma on-the-fly esa vez y dispara la regeneración                                                                                                              |
-| Regen masivo | Tarea/función para re-materializar todo ante cambio de allow-list o de estrategia de imágenes                                                                                                                                        |
-| Source doc   | `literaryWork` **no persiste** `approximateReadingTime` ni HTML — solo markdown                                                                                                                                                      |
+Decisión T1b del epic (para el HTML saneado); implementación en **Slice 4**. Hasta entonces rige **transform-on-read** (el ACL transforma en cada lectura, Slice 1).
 
-**Granularidad por sección y `?section=N`.** El documento derivado persiste los transformados **por sección, indexados por `position`** (HTML + `readingTime` de cada una, más los agregados de la obra: `totalReadingTime`, `sectionCount`). Eso hace que servir `GET /literary-work/:slug?section=N` ([§7](#7-contrato-del-endpoint)) sea una lectura directa de la porción N del derivado — sin recomputar la obra completa — y que la respuesta parcial conserve los metadatos totales sin costo extra. El webhook regenera el derivado por documento; la invalidación de caché de una obra cubre todas sus secciones de una vez (una edición cambia el hash de origen → todas las porciones vuelven a servirse frescas).
+| Elemento     | Diseño                                                                                                                                                                                                                 |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Trigger      | Webhook de Sanity → función serverless ante cambio de documento                                                                                                                                                        |
+| Persistencia | **Documento derivado separado** del source: `{ HTML por sección, stamp de revisión / hash de contenido de origen }`. Separado para esquivar el loop de `_rev` (patchear derivados no debe re-disparar la regeneración) |
+| Pipeline     | **El mismo código del ACL** (función pura compartida) — una sola implementación de MD→HTML                                                                                                                             |
+| Fallback     | Si el derivado falta o está stale respecto del hash/rev: el ACL transforma on-the-fly esa vez y dispara la regeneración                                                                                                |
+| Regen masivo | Tarea/función para re-materializar todo ante cambio de allow-list o de estrategia de imágenes                                                                                                                          |
+| Source doc   | `literaryWork` **no persiste** HTML — solo markdown. El reading time sí se persiste, pero por la vía de [§5](#5-helper-de-reading-time) (#1953), no por esta                                                           |
+
+**Granularidad por sección y `?section=N`.** El documento derivado persiste el HTML transformado **por sección, indexado por `position`**. Eso hace que servir `GET /literary-work/:slug?section=N` ([§7](#7-contrato-del-endpoint)) resuelva el HTML de la porción N sin recomputar la obra completa; los metadatos totales de esa respuesta (`totalReadingTime`, `sectionCount`) salen de los campos persistidos de [§5](#5-helper-de-reading-time), no de este documento derivado. El webhook regenera el derivado por documento; la invalidación de caché de una obra cubre todas sus secciones de una vez (una edición cambia el hash de origen → todas las porciones vuelven a servirse frescas).
 
 ---
 


### PR DESCRIPTION
## Descripción

**Parte 1** de #1953 (persistencia write-once del reading time). Prepara el schema de Sanity y cierra el contrato de diseño (Opción B); la materialización se implementa en un increment posterior rebaseado sobre #1929.

- **Schema** (`cms/schemas/literaryWork.ts`): campos read-only **opcionales** `readingTime` (por sección) + `totalReadingTime` (documento). Los pobla el backend, no el editor; opcionales a propósito porque arrancan vacíos hasta que aterrice el read-side (de ser `required` romperían el guardado en el Studio).
- **Doc** (`docs/LITERARY_WORK_DESIGN.md` §1/§5/§8): especifica la Opción B como contrato — materialización **self-healing** en la primera lectura del backend, computando con el `countWords` real del dominio (fuera del CMS) y persistiendo de vuelta. **Anula la decisión T1b**; acota el webhook de #1856 al HTML saneado.

**Diferido a #1929** (rebaseado tras su merge): el mapper que lee/computa/persiste, el `?section=N` eficiente y el token de escritura `@sanity/client`. Ver la anotación de responsabilidad en #1929.

Refs #1953 (Parte 1 de 2 — el `Closes` va en el PR de la Parte 2, el read-side sobre #1929).
Parte de #1481.

## Plan de pruebas

- [x] `pnpm sanity:build` (studio-build — valida el schema; es el gate del diff)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm stylelint`
- [x] `pnpm check:agents`
- [x] Campos read-only y opcionales (sin `Rule.required()`), descripciones en español que aclaran que los pobla el backend
- [x] Doc: §1/§5/§8 coherentes con §2/§7; anclas del índice intactas; sin tocar `CLAUDE.md` ni `.claude/`
- [x] Code review: APROBADO — 1 sugerencia corregida (encabezado §7 restaurado), 1 diferida a #1929
- N/A `test` / `build` / `storybook:build` / `e2e`: el diff no toca `src/**` ni componentes/stories/specs
