### PR TITLE
[#1792] - Crear path aliases @schemas y @queries para el backend (src/api)

### DIFF
--- a/src/api/modules/author/author.controller.ts
+++ b/src/api/modules/author/author.controller.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 
 // Esquemas de zod
-import { slugSchema } from '../../schemas/common.schemas';
+import { slugSchema } from '@schemas/common.schemas';
 
 // Funciones de service
 import { getAllAuthors, getAuthorBySlug } from './author.service';

--- a/src/api/modules/author/author.repository.ts
+++ b/src/api/modules/author/author.repository.ts
@@ -2,7 +2,7 @@
 import { client } from '../../_helpers/sanity-connector';
 
 // Queries
-import { authorBySlugQuery, authorsQuery } from '../../_queries/author.query';
+import { authorBySlugQuery, authorsQuery } from '@queries/author.query';
 
 export async function fetchAuthorBySlug(slug: string) {
 	return client.fetch(authorBySlugQuery, { slug });

--- a/src/api/modules/content/content.repository.ts
+++ b/src/api/modules/content/content.repository.ts
@@ -7,7 +7,7 @@ import {
 	landingPageListQuery,
 	latestLandingPageReferencesQuery,
 	rotatingContentQuery,
-} from '../../_queries/content.query';
+} from '@queries/content.query';
 import {
 	LandingPageContentQueryResult,
 	LandingPageListQueryResult,

--- a/src/api/modules/contributor/contributor.repository.ts
+++ b/src/api/modules/contributor/contributor.repository.ts
@@ -1,6 +1,6 @@
 // Sanity
 import { client } from '../../_helpers/sanity-connector';
-import { allContributorsQuery } from '../../_queries/contributor.query';
+import { allContributorsQuery } from '@queries/contributor.query';
 
 // Interfaces
 import { Contributor, CONTRIBUTOR_AREA_LABELS } from '@models/contributor.model';

--- a/src/api/modules/sitemap/sitemap.repository.ts
+++ b/src/api/modules/sitemap/sitemap.repository.ts
@@ -2,7 +2,7 @@
 import { client } from '../../_helpers/sanity-connector';
 
 // Queries
-import { sitemapSlugsQuery } from '../../_queries/sitemap.query';
+import { sitemapSlugsQuery } from '@queries/sitemap.query';
 
 // Interfaces
 interface SlugEntry {

--- a/src/api/modules/story/story.controller.ts
+++ b/src/api/modules/story/story.controller.ts
@@ -4,7 +4,7 @@ import { zValidator } from '@hono/zod-validator';
 
 // Esquemas de zod
 import { mostReadStorySchema, storyControllerSchema } from './story.schema';
-import { slugSchema } from '../../schemas/common.schemas';
+import { slugSchema } from '@schemas/common.schemas';
 
 import { StoriesByAuthorSlugArgs } from '../../interfaces/queryArgs';
 import {

--- a/src/api/modules/story/story.repository.ts
+++ b/src/api/modules/story/story.repository.ts
@@ -8,7 +8,7 @@ import {
 	storyBySlugQuery,
 	storyNavigationTeasersByAuthorSlugQuery,
 	allStoriesQuery,
-} from '../../_queries/story.query';
+} from '@queries/story.query';
 
 export async function fetchStoryBySlug(slug: string) {
 	return client.fetch(storyBySlugQuery, { slug });

--- a/src/api/modules/story/story.schema.ts
+++ b/src/api/modules/story/story.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { basePaginationSchema } from '../../schemas/common.schemas';
+import { basePaginationSchema } from '@schemas/common.schemas';
 
 export const mostReadStorySchema = basePaginationSchema.extend({
 	limit: basePaginationSchema.shape.limit.default(6),

--- a/src/api/modules/storylist/storylist.controller.ts
+++ b/src/api/modules/storylist/storylist.controller.ts
@@ -4,7 +4,7 @@ import { zValidator } from '@hono/zod-validator';
 
 // Esquemas de zod
 import { paginationSchema, storylistQuerySchema } from './storylist.schema';
-import { slugSchema } from '../../schemas/common.schemas';
+import { slugSchema } from '@schemas/common.schemas';
 
 // Funciones de service
 import {

--- a/src/api/modules/storylist/storylist.repository.ts
+++ b/src/api/modules/storylist/storylist.repository.ts
@@ -10,7 +10,7 @@ import {
 	storylistStoriesNavigationTeasersQuery,
 	storylistQuery,
 	storylistTeasersQuery,
-} from '../../_queries/storylist.query';
+} from '@queries/storylist.query';
 
 // Utilidades
 import { mapMediaSources, mapMediaSourcesTeasers } from '../../_utils/media-sources.functions';

--- a/src/api/modules/storylist/storylist.schema.ts
+++ b/src/api/modules/storylist/storylist.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { basePaginationSchema } from '../../schemas/common.schemas';
+import { basePaginationSchema } from '@schemas/common.schemas';
 
 export const paginationSchema = basePaginationSchema.extend({
 	limit: basePaginationSchema.shape.limit.default(100),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
 			"@components/*": ["./src/app/components/*"],
 			"@mocks/*": ["./src/app/mocks/*"],
 			"@models/*": ["./src/app/models/*"],
+			"@queries/*": ["./src/api/_queries/*"],
+			"@schemas/*": ["./src/api/schemas/*"],
 			"@utils/*": ["./src/app/utils/*"],
 			"@test-utils": ["./src/test-utils.ts"]
 		},


### PR DESCRIPTION
## Descripción

- Agrega los path aliases `@schemas/*` y `@queries/*` a `tsconfig.json` para el backend.
- Migra imports relativos `../../schemas/` y `../../_queries/` a los nuevos aliases en 11 archivos de `src/api/modules/`.

Closes #1792.

## Plan de pruebas

- [x] `pnpm lint` — verde.
- [x] `pnpm typecheck` — sin errores nuevos (fallos pre-existentes en dependencias sin tipos).
- [x] `pnpm test` — sin regresiones (fallos pre-existentes de happy-dom).
- [x] `pnpm build` — sin errores nuevos (fallo pre-existente de `schema-dts`).
- [x] Grep confirma 0 imports relativos residuales a `../../schemas/` o `../../_queries/`.