### PR TITLE
[#1959] - Script batch de backfill de reading time para LiteraryWork

### DIFF
--- a/.claude/references/scripts.md
+++ b/.claude/references/scripts.md
@@ -16,6 +16,7 @@
 
 - `set-environment.ts` — genera environments de Angular (`pnpm config`).
 - `delete-unused-assets.ts` — borra assets huérfanos en Sanity (`pnpm delete-unused-assets`).
+- `backfill-reading-time.ts` — puebla los reading time faltantes de las obras `LiteraryWork` en Sanity (`readingTime` por sección + `totalReadingTime`), recorriendo por cursor y persistiendo idempotentemente con `setIfMissing` (`pnpm backfill-reading-time`). **Dry-run por defecto**; `--apply` (o `BACKFILL_APPLY=true`) persiste. La lógica pura de planificación vive en `scripts/backfill-reading-time.helpers.ts` (con su spec). Precondición de runtime: los campos deben estar desplegados en el schema del dataset objetivo.
 - `remove-all-unpublished-drafts.ts` — limpia drafts no publicados (operacional, no en package.json).
 - `fix-index-file-name.mjs` — postbuild: renombra el index SSR.
 - `vercel-environments.model.ts` — tipos compartidos con `cms/set-environment.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,25 +42,26 @@
 
 Usar **siempre `pnpm`** para instalar y ejecutar scripts. Los scripts envuelven targets de Nx del proyecto `@cuentoneta/app`.
 
-| Comando                                   | Descripción                                                                                                                          |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `pnpm install`                            | Instala dependencias                                                                                                                 |
-| `pnpm dev`                                | Dev server (SSR) en desarrollo                                                                                                       |
-| `pnpm build`                              | Build de producción                                                                                                                  |
-| `pnpm lint`                               | ESLint sobre `src` y `e2e`                                                                                                           |
-| `pnpm check:agents`                       | Valida la integridad de `.claude/` (frontmatter de agentes + anclas y rutas de las referencias) — reproduce el gate `check-agents`   |
-| `pnpm stylelint`                          | Stylelint sobre CSS                                                                                                                  |
-| `pnpm typecheck`                          | Type-check estricto (`tsc --noEmit`)                                                                                                 |
-| `pnpm test`                               | Tests unitarios (Vitest)                                                                                                             |
-| `pnpm test:watch`                         | Tests en watch                                                                                                                       |
-| `pnpm test:e2e`                           | E2E (Playwright)                                                                                                                     |
-| `pnpm seo:smoke`                          | Smoke manual post-deploy de indexado (invariantes SSR sobre `BASE_URL`, muestreando el sitemap)                                      |
-| `pnpm storybook` / `pnpm storybook:build` | Storybook dev / build                                                                                                                |
-| `pnpm sanity:dev`                         | Studio de Sanity (`@cuentoneta/cms`)                                                                                                 |
-| `pnpm sanity:build`                       | Build del Studio (`sanity build`) — reproduce en local el gate de CI `studio-build`                                                  |
-| `pnpm sanity:extract-schema`              | Extrae el schema de Sanity                                                                                                           |
-| `pnpm sanity:run-typegen-generator`       | Genera tipos a partir del schema                                                                                                     |
-| `pnpm exec sanity migration run <slug>`   | Corre una migración de datos (desde `cms/`; dry-run por defecto) → [`sanity-migrations.md`](.claude/references/sanity-migrations.md) |
+| Comando                                   | Descripción                                                                                                                                             |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm install`                            | Instala dependencias                                                                                                                                    |
+| `pnpm dev`                                | Dev server (SSR) en desarrollo                                                                                                                          |
+| `pnpm build`                              | Build de producción                                                                                                                                     |
+| `pnpm lint`                               | ESLint sobre `src` y `e2e`                                                                                                                              |
+| `pnpm check:agents`                       | Valida la integridad de `.claude/` (frontmatter de agentes + anclas y rutas de las referencias) — reproduce el gate `check-agents`                      |
+| `pnpm stylelint`                          | Stylelint sobre CSS                                                                                                                                     |
+| `pnpm typecheck`                          | Type-check estricto (`tsc --noEmit`)                                                                                                                    |
+| `pnpm test`                               | Tests unitarios (Vitest)                                                                                                                                |
+| `pnpm test:watch`                         | Tests en watch                                                                                                                                          |
+| `pnpm test:e2e`                           | E2E (Playwright)                                                                                                                                        |
+| `pnpm seo:smoke`                          | Smoke manual post-deploy de indexado (invariantes SSR sobre `BASE_URL`, muestreando el sitemap)                                                         |
+| `pnpm backfill-reading-time`              | Puebla los reading time faltantes de `LiteraryWork` en Sanity (dry-run por defecto; `--apply` persiste) → [`scripts.md`](.claude/references/scripts.md) |
+| `pnpm storybook` / `pnpm storybook:build` | Storybook dev / build                                                                                                                                   |
+| `pnpm sanity:dev`                         | Studio de Sanity (`@cuentoneta/cms`)                                                                                                                    |
+| `pnpm sanity:build`                       | Build del Studio (`sanity build`) — reproduce en local el gate de CI `studio-build`                                                                     |
+| `pnpm sanity:extract-schema`              | Extrae el schema de Sanity                                                                                                                              |
+| `pnpm sanity:run-typegen-generator`       | Genera tipos a partir del schema                                                                                                                        |
+| `pnpm exec sanity migration run <slug>`   | Corre una migración de datos (desde `cms/`; dry-run por defecto) → [`sanity-migrations.md`](.claude/references/sanity-migrations.md)                    |
 
 **Gates de CI** (deben quedar verdes en cada PR): `test`, `lint`, `stylelint`, `typecheck`, `e2e`, `build`, `storybook`, `studio-build`, `guard-config`, `check-agents`.
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"dev": "nx run @cuentoneta/app:serve:development",
 		"build": "nx run @cuentoneta/app:build:production --skip-nx-cache",
 		"config": "node --import tsx ./scripts/set-environment.ts",
+		"backfill-reading-time": "node --import tsx --env-file=.env ./scripts/backfill-reading-time.ts",
 		"delete-unused-assets": "node --import tsx --env-file=.env ./scripts/delete-unused-assets.ts",
 		"storybook": "nx run @cuentoneta/app:storybook",
 		"storybook:build": "nx run @cuentoneta/app:build-storybook",

--- a/scripts/backfill-reading-time.helpers.spec.ts
+++ b/scripts/backfill-reading-time.helpers.spec.ts
@@ -1,0 +1,85 @@
+import { isEmptyPlan, planBackfill, type RawWorkForBackfill } from './backfill-reading-time.helpers';
+
+const LONG_BODY = 'palabra '.repeat(401).trim(); // 401 palabras → 3 min por sección
+const SHORT_BODY = 'Breve.'; // → 1 min (piso)
+
+function work(content: RawWorkForBackfill['content'], totalReadingTime?: number | null): RawWorkForBackfill {
+	return { _id: 'lw_1', totalReadingTime, content };
+}
+
+describe('planBackfill', () => {
+	it('returns an empty plan when the work is already complete', () => {
+		const plan = planBackfill(
+			work(
+				[
+					{ _key: 'a', body: LONG_BODY, readingTime: 3 },
+					{ _key: 'b', body: LONG_BODY, readingTime: 3 },
+				],
+				6,
+			),
+		);
+		expect(isEmptyPlan(plan)).toBe(true);
+	});
+
+	it('plans every section and the total for a work with nothing persisted', () => {
+		const plan = planBackfill(
+			work([
+				{ _key: 'a', body: LONG_BODY },
+				{ _key: 'b', body: LONG_BODY },
+			]),
+		);
+		expect(plan.sectionReadingTimes).toEqual([
+			{ key: 'a', readingTime: 3 },
+			{ key: 'b', readingTime: 3 },
+		]);
+		expect(plan.totalReadingTime).toBe(6);
+	});
+
+	it('plans only the missing sections, identified by _key', () => {
+		const plan = planBackfill(
+			work(
+				[
+					{ _key: 'a', body: LONG_BODY, readingTime: 3 },
+					{ _key: 'b', body: LONG_BODY },
+				],
+				6,
+			),
+		);
+		expect(plan.sectionReadingTimes).toEqual([{ key: 'b', readingTime: 3 }]);
+		expect(plan.totalReadingTime).toBeUndefined();
+	});
+
+	it('plans the total as the pure text sum when it is missing but every section has its time', () => {
+		const plan = planBackfill(
+			work([
+				{ _key: 'a', body: LONG_BODY, readingTime: 3 },
+				{ _key: 'b', body: SHORT_BODY, readingTime: 1 },
+			]),
+		);
+		expect(plan.sectionReadingTimes).toEqual([]);
+		expect(plan.totalReadingTime).toBe(4); // 3 + 1
+	});
+
+	it('never lets an editorial override leak into the plan (it is not part of the projection)', () => {
+		// `readingTimeOverride` no se proyecta: el total es siempre la suma pura del texto.
+		const plan = planBackfill(work([{ _key: 'a', body: LONG_BODY }]));
+		expect(plan.totalReadingTime).toBe(3);
+	});
+
+	it('is idempotent: a work already patched from a previous run yields an empty plan', () => {
+		const raw = work([
+			{ _key: 'a', body: LONG_BODY },
+			{ _key: 'b', body: SHORT_BODY },
+		]);
+		expect(isEmptyPlan(planBackfill(raw))).toBe(false);
+		// Estado tras aplicar el primer plan: total + readingTime por sección ya presentes.
+		const patched = work(
+			[
+				{ _key: 'a', body: LONG_BODY, readingTime: 3 },
+				{ _key: 'b', body: SHORT_BODY, readingTime: 1 },
+			],
+			4,
+		);
+		expect(isEmptyPlan(planBackfill(patched))).toBe(true);
+	});
+});

--- a/scripts/backfill-reading-time.helpers.spec.ts
+++ b/scripts/backfill-reading-time.helpers.spec.ts
@@ -1,4 +1,9 @@
-import { isEmptyPlan, planBackfill, type RawWorkForBackfill } from './backfill-reading-time.helpers';
+import {
+	isEmptyPlan,
+	planBackfill,
+	sectionReadingTimePath,
+	type RawWorkForBackfill,
+} from './backfill-reading-time.helpers';
 
 const LONG_BODY = 'palabra '.repeat(401).trim(); // 401 palabras → 3 min por sección
 const SHORT_BODY = 'Breve.'; // → 1 min (piso)
@@ -81,5 +86,21 @@ describe('planBackfill', () => {
 			4,
 		);
 		expect(isEmptyPlan(planBackfill(patched))).toBe(true);
+	});
+
+	it('propagates the error of an inconsistent work (empty body) so the orchestrator counts it', () => {
+		// `createMarkdown('')` lanza: un dato editorial inválido debe fallar en la frontera, no
+		// materializar un reading time silenciosamente. El orquestador lo captura por obra.
+		expect(() => planBackfill(work([{ _key: 'a', body: '' }]))).toThrow();
+	});
+});
+
+describe('sectionReadingTimePath', () => {
+	it('builds the keyed patch path for a well-formed _key', () => {
+		expect(sectionReadingTimePath('a1B2c3')).toBe('content[_key=="a1B2c3"].readingTime');
+	});
+
+	it('throws on a _key with unexpected characters (defense in depth)', () => {
+		expect(() => sectionReadingTimePath('x"] || *[0]')).toThrow('formato inesperado');
 	});
 });

--- a/scripts/backfill-reading-time.helpers.ts
+++ b/scripts/backfill-reading-time.helpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Helpers puros del backfill de reading time (sin I/O): dado el shape crudo de una obra (proyección
+ * GROQ), decide qué falta y arma el plan de patch idempotente. Separados del orquestador
+ * `backfill-reading-time.ts` (red/Sanity) para poder testear la decisión sin tocar la red.
+ */
+import { createMarkdown } from '../src/app/models/markdown.model';
+import {
+	deriveSectionReadingTime,
+	deriveTotalReadingTime,
+	type ReadingTime,
+} from '../src/app/models/reading-time.model';
+
+// Shape crudo mínimo (proyección GROQ) de una obra candidata. El script no importa los tipos
+// generados de `cms/`: proyecta solo lo necesario para computar el plan.
+export interface RawWorkForBackfill {
+	readonly _id: string;
+	readonly totalReadingTime?: number | null;
+	readonly content: readonly RawSectionForBackfill[];
+}
+
+export interface RawSectionForBackfill {
+	readonly _key: string;
+	readonly body: string;
+	readonly readingTime?: number | null;
+}
+
+// El readingTime de una sección que lo tenía ausente, identificada por su `_key` (no por índice del
+// array: el patch selecciona por `_key` para ser estable ante reordenamientos).
+export interface SectionReadingTimePatch {
+	readonly key: string;
+	readonly readingTime: ReadingTime;
+}
+
+// Plan de patch idempotente de una obra: solo lo que falta. Vacío ⇒ nada que hacer.
+export interface BackfillPlan {
+	readonly sectionReadingTimes: readonly SectionReadingTimePatch[];
+	readonly totalReadingTime?: ReadingTime;
+}
+
+export function planBackfill(work: RawWorkForBackfill): BackfillPlan {
+	const sectionReadingTimes = work.content
+		.filter((section) => isMissing(section.readingTime))
+		.map((section) => ({ key: section._key, readingTime: deriveSectionReadingTime(createMarkdown(section.body)) }));
+
+	// El total persistido es la suma pura del texto: `readingTimeOverride` no interviene — ni se
+	// proyecta ni se toca; su precedencia vive en la factory de dominio.
+	const totalReadingTime = isMissing(work.totalReadingTime)
+		? deriveTotalReadingTime(work.content.map((section) => createMarkdown(section.body)))
+		: undefined;
+
+	return { sectionReadingTimes, totalReadingTime };
+}
+
+export function isEmptyPlan(plan: BackfillPlan): boolean {
+	return plan.sectionReadingTimes.length === 0 && plan.totalReadingTime === undefined;
+}
+
+// "Falta" = ausente (null/undefined), la misma semántica que `setIfMissing` en el patch: un valor
+// ya presente no se recomputa ni se pisa.
+function isMissing(value: number | null | undefined): boolean {
+	return value === null || value === undefined;
+}

--- a/scripts/backfill-reading-time.helpers.ts
+++ b/scripts/backfill-reading-time.helpers.ts
@@ -55,6 +55,18 @@ export function isEmptyPlan(plan: BackfillPlan): boolean {
 	return plan.sectionReadingTimes.length === 0 && plan.totalReadingTime === undefined;
 }
 
+// El `_key` de Sanity es autogenerado y alfanumérico. Validarlo antes de interpolarlo en el selector
+// del patch (`content[_key=="…"]`) es defensa en profundidad: un `_key` con formato inesperado no
+// llega a alterar el path. Lanza para que el orquestador lo cuente como error de esa obra sin escribir.
+const SECTION_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export function sectionReadingTimePath(key: string): string {
+	if (!SECTION_KEY_PATTERN.test(key)) {
+		throw new Error(`_key de sección con formato inesperado: "${key}"`);
+	}
+	return `content[_key=="${key}"].readingTime`;
+}
+
 // "Falta" = ausente (null/undefined), la misma semántica que `setIfMissing` en el patch: un valor
 // ya presente no se recomputa ni se pisa.
 function isMissing(value: number | null | undefined): boolean {

--- a/scripts/backfill-reading-time.ts
+++ b/scripts/backfill-reading-time.ts
@@ -1,0 +1,123 @@
+/**
+ * Backfill de reading time para LiteraryWork. Recorre progresivamente (cursor por `_id`) las obras
+ * publicadas a las que les falta el `readingTime` de alguna sección o el `totalReadingTime`, computa
+ * los valores con el `countWords` real del dominio y los persiste de forma idempotente (`setIfMissing`).
+ * Es el complemento proactivo/batch del self-healing on-read (que llega en un increment aparte).
+ *
+ * Uso:
+ *   pnpm backfill-reading-time            # dry-run: reporta qué llenaría, sin escribir
+ *   pnpm backfill-reading-time --apply    # persiste (o BACKFILL_APPLY=true, para cron no-interactivo)
+ *
+ * El dataset objetivo lo fija SANITY_STUDIO_DATASET (el cliente compartido lo levanta del entorno) y
+ * se loguea al arrancar. Requiere un token de escritura por entorno (SANITY_STUDIO_TOKEN); nunca
+ * hardcodear. Precondición de runtime: los campos deben estar desplegados en el schema del dataset
+ * objetivo (ver .claude/references/scripts.md).
+ */
+/* eslint-disable no-console */
+import { client } from '../src/api/_helpers/sanity-connector';
+import { isEmptyPlan, planBackfill, type BackfillPlan, type RawWorkForBackfill } from './backfill-reading-time.helpers';
+
+const APPLY = process.argv.includes('--apply') || process.env.BACKFILL_APPLY === 'true';
+const PAGE_SIZE = parsePageSize(process.env.BACKFILL_PAGE_SIZE);
+
+// Candidatas: obras publicadas (no drafts) con `_id` mayor al cursor a las que falta el total o
+// alguna sección sin `readingTime`. `order(_id)` + `_id > $lastId` da un recorrido estable ante
+// escrituras concurrentes (a diferencia del slice por offset).
+const candidatePageQuery = `
+*[_type == 'literaryWork' && !(_id in path('drafts.**')) && _id > $lastId
+  && (!defined(totalReadingTime) || count(content[!defined(readingTime)]) > 0)]
+  | order(_id) [0...$pageSize] {
+    _id, totalReadingTime, 'content': content[]{ _key, body, readingTime }
+  }`;
+
+interface Totals {
+	scanned: number;
+	filled: number;
+	sections: number;
+	totals: number;
+	errors: number;
+}
+
+function parsePageSize(raw: string | undefined): number {
+	const parsed = Number(raw);
+	return Number.isInteger(parsed) && parsed > 0 ? parsed : 50;
+}
+
+function fetchCandidatePage(lastId: string): Promise<RawWorkForBackfill[]> {
+	return client.fetch<RawWorkForBackfill[]>(candidatePageQuery, { lastId, pageSize: PAGE_SIZE });
+}
+
+function buildSetValues(plan: BackfillPlan): Record<string, number> {
+	const values: Record<string, number> = {};
+	if (plan.totalReadingTime !== undefined) {
+		values.totalReadingTime = plan.totalReadingTime;
+	}
+	for (const section of plan.sectionReadingTimes) {
+		values[`content[_key=="${section.key}"].readingTime`] = section.readingTime;
+	}
+	return values;
+}
+
+async function processWork(work: RawWorkForBackfill, totals: Totals): Promise<void> {
+	const plan = planBackfill(work);
+	if (isEmptyPlan(plan)) {
+		return;
+	}
+	totals.filled += 1;
+	totals.sections += plan.sectionReadingTimes.length;
+	totals.totals += plan.totalReadingTime === undefined ? 0 : 1;
+	if (APPLY) {
+		await client.patch(work._id).setIfMissing(buildSetValues(plan)).commit({ visibility: 'async' });
+	}
+}
+
+async function processPage(page: readonly RawWorkForBackfill[], totals: Totals): Promise<string> {
+	let lastId = '';
+	for (const work of page) {
+		totals.scanned += 1;
+		lastId = work._id;
+		try {
+			await processWork(work, totals);
+		} catch (error) {
+			totals.errors += 1;
+			console.error(`Error en la obra ${work._id}:`, new Error('backfill de reading time falló', { cause: error }));
+		}
+	}
+	return lastId;
+}
+
+async function run(): Promise<Totals> {
+	const totals: Totals = { scanned: 0, filled: 0, sections: 0, totals: 0, errors: 0 };
+	let lastId = '';
+	for (;;) {
+		const page = await fetchCandidatePage(lastId);
+		if (page.length === 0) {
+			break;
+		}
+		lastId = await processPage(page, totals);
+	}
+	return totals;
+}
+
+async function main(): Promise<void> {
+	const dataset = client.config().dataset ?? 'desconocido';
+	console.log(
+		`Backfill de reading time — dataset "${dataset}" — ${APPLY ? 'APPLY (escribe)' : 'DRY-RUN (no escribe)'}`,
+	);
+	const totals = await run();
+	console.log(
+		`Listo. Escaneadas: ${totals.scanned} · A completar: ${totals.filled} ` +
+			`(secciones: ${totals.sections}, totales: ${totals.totals}) · Errores: ${totals.errors}`,
+	);
+	if (!APPLY && totals.filled > 0) {
+		console.log('Dry-run: nada se escribió. Corré con --apply para persistir.');
+	}
+	if (totals.errors > 0) {
+		process.exitCode = 1;
+	}
+}
+
+main().catch((error) => {
+	console.error('Backfill falló:', error);
+	process.exitCode = 1;
+});

--- a/scripts/backfill-reading-time.ts
+++ b/scripts/backfill-reading-time.ts
@@ -23,8 +23,8 @@ import {
 	type RawWorkForBackfill,
 } from './backfill-reading-time.helpers';
 
-const APPLY = process.argv.includes('--apply') || process.env.BACKFILL_APPLY === 'true';
-const PAGE_SIZE = parsePageSize(process.env.BACKFILL_PAGE_SIZE);
+const APPLY = process.argv.includes('--apply') || process.env['BACKFILL_APPLY'] === 'true';
+const PAGE_SIZE = parsePageSize(process.env['BACKFILL_PAGE_SIZE']);
 
 // Candidatas: obras publicadas (no drafts) con `_id` mayor al cursor a las que falta el total o
 // alguna sección sin `readingTime`. `order(_id)` + `_id > $lastId` da un recorrido estable ante
@@ -38,9 +38,9 @@ const candidatePageQuery = `
 
 interface Totals {
 	scanned: number;
-	filled: number;
-	sections: number;
-	totals: number;
+	worksFilled: number;
+	sectionsFilled: number;
+	totalsFilled: number;
 	errors: number;
 }
 
@@ -69,9 +69,9 @@ async function processWork(work: RawWorkForBackfill, totals: Totals): Promise<vo
 	if (isEmptyPlan(plan)) {
 		return;
 	}
-	totals.filled += 1;
-	totals.sections += plan.sectionReadingTimes.length;
-	totals.totals += plan.totalReadingTime === undefined ? 0 : 1;
+	totals.worksFilled += 1;
+	totals.sectionsFilled += plan.sectionReadingTimes.length;
+	totals.totalsFilled += plan.totalReadingTime === undefined ? 0 : 1;
 	if (APPLY) {
 		await client.patch(work._id).setIfMissing(buildSetValues(plan)).commit({ visibility: 'async' });
 	}
@@ -93,7 +93,7 @@ async function processPage(page: readonly RawWorkForBackfill[], totals: Totals):
 }
 
 async function run(): Promise<Totals> {
-	const totals: Totals = { scanned: 0, filled: 0, sections: 0, totals: 0, errors: 0 };
+	const totals: Totals = { scanned: 0, worksFilled: 0, sectionsFilled: 0, totalsFilled: 0, errors: 0 };
 	let lastId = '';
 	for (;;) {
 		const page = await fetchCandidatePage(lastId);
@@ -112,10 +112,10 @@ async function main(): Promise<void> {
 	);
 	const totals = await run();
 	console.log(
-		`Listo. Escaneadas: ${totals.scanned} · A completar: ${totals.filled} ` +
-			`(secciones: ${totals.sections}, totales: ${totals.totals}) · Errores: ${totals.errors}`,
+		`Listo. Escaneadas: ${totals.scanned} · A completar: ${totals.worksFilled} ` +
+			`(secciones: ${totals.sectionsFilled}, totales: ${totals.totalsFilled}) · Errores: ${totals.errors}`,
 	);
-	if (!APPLY && totals.filled > 0) {
+	if (!APPLY && totals.worksFilled > 0) {
 		console.log('Dry-run: nada se escribió. Corré con --apply para persistir.');
 	}
 	if (totals.errors > 0) {

--- a/scripts/backfill-reading-time.ts
+++ b/scripts/backfill-reading-time.ts
@@ -15,7 +15,13 @@
  */
 /* eslint-disable no-console */
 import { client } from '../src/api/_helpers/sanity-connector';
-import { isEmptyPlan, planBackfill, type BackfillPlan, type RawWorkForBackfill } from './backfill-reading-time.helpers';
+import {
+	isEmptyPlan,
+	planBackfill,
+	sectionReadingTimePath,
+	type BackfillPlan,
+	type RawWorkForBackfill,
+} from './backfill-reading-time.helpers';
 
 const APPLY = process.argv.includes('--apply') || process.env.BACKFILL_APPLY === 'true';
 const PAGE_SIZE = parsePageSize(process.env.BACKFILL_PAGE_SIZE);
@@ -53,7 +59,7 @@ function buildSetValues(plan: BackfillPlan): Record<string, number> {
 		values.totalReadingTime = plan.totalReadingTime;
 	}
 	for (const section of plan.sectionReadingTimes) {
-		values[`content[_key=="${section.key}"].readingTime`] = section.readingTime;
+		values[sectionReadingTimePath(section.key)] = section.readingTime;
 	}
 	return values;
 }

--- a/src/app/models/reading-time.model.spec.ts
+++ b/src/app/models/reading-time.model.spec.ts
@@ -1,4 +1,11 @@
-import { countWords, createReadingTime, deriveReadingTime, sumReadingTimes } from './reading-time.model';
+import {
+	countWords,
+	createReadingTime,
+	deriveReadingTime,
+	deriveSectionReadingTime,
+	deriveTotalReadingTime,
+	sumReadingTimes,
+} from './reading-time.model';
 import { createMarkdown } from './markdown.model';
 import { createWordCount } from './word-count.model';
 
@@ -70,5 +77,30 @@ describe('sumReadingTimes', () => {
 
 	it('returns at least 1 minute for an empty list', () => {
 		expect(sumReadingTimes([])).toBe(1);
+	});
+});
+
+describe('deriveSectionReadingTime', () => {
+	it('composes countWords and deriveReadingTime for a section body', () => {
+		expect(deriveSectionReadingTime(createMarkdown('palabra '.repeat(401).trim()))).toBe(3);
+	});
+
+	it('returns at least 1 minute for a short section', () => {
+		expect(deriveSectionReadingTime(createMarkdown('Una obra corta.'))).toBe(1);
+	});
+});
+
+describe('deriveTotalReadingTime', () => {
+	it('equals the single section time for a one-section work', () => {
+		expect(deriveTotalReadingTime([createMarkdown('palabra '.repeat(401).trim())])).toBe(3);
+	});
+
+	it('sums the per-section reading times of a multi-section work', () => {
+		const body = createMarkdown('palabra '.repeat(401).trim()); // 3 min cada una
+		expect(deriveTotalReadingTime([body, body])).toBe(6);
+	});
+
+	it('returns at least 1 minute for a work whose sections are all very short', () => {
+		expect(deriveTotalReadingTime([createMarkdown('Breve.')])).toBe(1);
 	});
 });

--- a/src/app/models/reading-time.model.ts
+++ b/src/app/models/reading-time.model.ts
@@ -60,3 +60,16 @@ export function countWords(markdown: Markdown): WordCount {
 		.filter((word) => /[\p{L}\p{N}]/u.test(word));
 	return createWordCount(words.length);
 }
+
+// Composición canónica body → palabras → minutos. Fuente única del algoritmo de reading time,
+// compartida por el backfill batch (scripts/) y el self-healing on-read del backend: ambos deben
+// producir el mismo número para una misma sección.
+export function deriveSectionReadingTime(body: Markdown): ReadingTime {
+	return deriveReadingTime(countWords(body));
+}
+
+// Total de la obra: suma de los tiempos por sección (mínimo 1). Es la suma pura del texto; el
+// readingTimeOverride editorial no interviene acá — su precedencia vive en la factory de dominio.
+export function deriveTotalReadingTime(bodies: readonly Markdown[]): ReadingTime {
+	return sumReadingTimes(bodies.map(deriveSectionReadingTime));
+}


### PR DESCRIPTION
## Descripción

Script batch (a demanda + apto para cron) que recorre progresivamente los `literaryWork` en Sanity sin reading times persistidos, los computa con el `countWords` real del dominio y los persiste idempotentemente (`setIfMissing`). Es el complemento **proactivo/batch** del self-healing on-read de #1953 Parte 2 (reactivo).

- **Helpers de cómputo compartidos** en `src/app/models/reading-time.model.ts` (`deriveSectionReadingTime` / `deriveTotalReadingTime`) — fuente única del algoritmo, reusable por el read-side de #1953 Parte 2 (no reimplementar).
- **Helper puro** de planificación (`scripts/backfill-reading-time.helpers.ts`, testeado): arma el patch idempotente por obra desde el shape crudo y valida el `_key` antes de interpolarlo en el path del patch.
- **Orquestador** (`scripts/backfill-reading-time.ts`): scan GROQ paginado por cursor sobre `_id`, dry-run por defecto + `--apply`, patch `setIfMissing`, exit codes cron-friendly.
- npm script `pnpm backfill-reading-time` + doc en `scripts.md` y `CLAUDE.md`.

**Precondición de runtime:** `--apply` solo es útil una vez que el schema de #1957 (campos `readingTime`/`totalReadingTime`) esté **desplegado** en el dataset objetivo. Requiere token de escritura por entorno (`SANITY_STUDIO_TOKEN`), nunca hardcodeado; dry-run por defecto.

**Cron:** el script se diseña cron-friendly pero el schedule **no** se cablea (decisión: valor marginal frente al self-healing on-read; queda como follow-up opcional).

Closes #1959.
Parte de #1481.

## Plan de pruebas

- [x] `pnpm test` (specs de los helpers de cómputo + de planificación: composición/suma/piso, idempotencia, `readingTimeOverride` intacto, propagación ante body vacío, validación del `_key`)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm stylelint`
- [x] `pnpm check:agents`
- [x] Code review: **APROBADO** (3 sugerencias corregidas) · Security audit: **SEGURO** (S1 — validación del `_key` — corregido; sin secrets hardcodeados)
- N/A `e2e` / `storybook:build` / `studio-build`: el diff no toca flujos E2E, componentes/stories ni `cms/`
- La corrida real del backfill (dry-run o `--apply`) la ejecuta el usuario, fuera del PR
