### PR TITLE
[#1853] - Schema de LiteraryWork: totalReadingTime editable, sin readingTimeOverride

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -892,6 +892,13 @@
 								},
 								"optional": false
 							},
+							"readingTime": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "number"
+								},
+								"optional": true
+							},
 							"_type": {
 								"type": "objectAttribute",
 								"value": {
@@ -915,7 +922,7 @@
 				},
 				"optional": false
 			},
-			"readingTimeOverride": {
+			"totalReadingTime": {
 				"type": "objectAttribute",
 				"value": {
 					"type": "number"

--- a/cms/schemas/literaryWork.ts
+++ b/cms/schemas/literaryWork.ts
@@ -107,22 +107,14 @@ export default defineType({
 			of: [section],
 			validation: (Rule) => Rule.required().min(1),
 		}),
-		// Suma derivada del texto de las secciones, poblada por el backend (fuera del CMS), no editable.
-		// Opcional a propósito (ver la nota de section.readingTime). La "Duración fija"
-		// (readingTimeOverride), si está, la reemplaza aguas abajo — ver docs/LITERARY_WORK_DESIGN.md §5.
+		// Total de la obra, en minutos. Editable y opcional a propósito: en obras de texto lo completa
+		// el backend con la suma de las secciones, sin pisar un valor ya cargado; en
+		// recitados/audiovisuales el editor setea a mano la duración del medio.
 		defineField({
 			name: 'totalReadingTime',
 			title: 'Tiempo de lectura total (minutos)',
-			description: 'Suma derivada del texto de las secciones; lo computa y persiste el backend, no se edita a mano.',
-			type: 'number',
-			readOnly: true,
-			validation: (Rule) => Rule.integer().min(1),
-		}),
-		defineField({
-			name: 'readingTimeOverride',
-			title: 'Duración fija (minutos)',
 			description:
-				'Opcional. Para obras cuyo contenido principal es un recitado o audiovisual: fija la duración total mostrada, en lugar de derivarla del texto de las secciones.',
+				'Total de la obra. En obras de texto lo completa el backend con la suma de las secciones; en recitados o audiovisuales, seteá a mano la duración del medio.',
 			type: 'number',
 			validation: (Rule) => Rule.integer().min(1),
 		}),


### PR DESCRIPTION
## Descripción

Primera PR de la cadena reconstruida de #1853, **acotada a `/cms`**: unifica el tiempo de lectura total de la obra en un único campo de documento.

- **`cms/schemas/literaryWork.ts`**: `totalReadingTime` pasa a ser **editable y opcional** (se le quita `readOnly`). En obras de texto lo completará el backend con la suma de las secciones sin pisar un valor ya cargado; en recitados o audiovisuales el editor setea a mano la duración del medio. Se **elimina** el campo `readingTimeOverride`, redundante con este esquema.
- **`cms/schema.json`**: regenerado para reflejar el rename a `totalReadingTime` y el campo `section.readingTime`, que había quedado desincronizado respecto del schema TS desde su alta.

**Sin migración de datos**: no hay documentos cargados que requieran migrar todavía.

### Fuera de alcance (llegan en PRs posteriores de la cadena)

- La capa de datos (repository, mapper ACL, service) y el backend que **lee/materializa** estos campos.
- La actualización de `docs/LITERARY_WORK_DESIGN.md` §5, que acompaña al cambio de comportamiento del backend.

Refs #1853. Parte de #1481.

## Plan de pruebas

- [x] `pnpm sanity:build` (gate `studio-build`) verde.
