### PR TITLE
[HF] - Back-merge a develop: no-indexar staging (2.8.8)

### DIFF
--- a/.claude/references/scripts.md
+++ b/.claude/references/scripts.md
@@ -14,7 +14,7 @@
 
 ## Scripts en la raíz (vivos)
 
-- `set-environment.ts` — genera environments de Angular (`pnpm config`).
+- `set-environment.ts` — genera environments de Angular (`pnpm config`). Emite `environment.indexable` (postura de indexado SEO): `true` solo en producción, o forzado con `SEO_INDEXABLE=true` para una build no productiva con URLs locales (lo usa el job de e2e para validar el HTML indexable del crawler contra el server SSR local).
 - `delete-unused-assets.ts` — borra assets huérfanos en Sanity (`pnpm delete-unused-assets`).
 - `remove-all-unpublished-drafts.ts` — limpia drafts no publicados (operacional, no en package.json).
 - `fix-index-file-name.mjs` — postbuild: renombra el index SSR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,14 @@ jobs:
           restore-keys: |
             nx-cache-e2e-
 
+      # Regenera environment.ts con la postura indexable de producción (SEO_INDEXABLE=true) pero sin
+      # tocar las URLs: el entorno sigue siendo `development` (apiUrl/website locales, contra el server
+      # SSR en localhost), lo que permite que los specs de SEO afirmen el HTML indexable del crawler.
+      - name: Generate e2e environment (postura indexable, URLs locales)
+        run: pnpm run config
+        env:
+          SEO_INDEXABLE: 'true'
+
       # El webServer de Playwright levanta el build SSR de producción (fidelidad con el crawler), así
       # que hay que compilarlo acá. Los e2e corren contra `staging` (espejo de producción, aislado del
       # `development` compartido que los devs mutan) para reducir la fragilidad por curación de contenido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ La lista de características futuras a implementar puede hallarse en la sección
 
 Los hitos futuros de desarrollo, en los cuales se detallan las funcionalidades a desarrollar y los cambios a implementar, pueden encontrarse en las secciones [milestones](https://github.com/cuentoneta/cuentoneta/milestones) y [projects](https://github.com/cuentoneta/cuentoneta/projects) del repositorio de Github del proyecto.
 
+## Versión 2.8.8 (2026-07-26)
+
+La versión 2.8.8 es un **hotfix de SEO**: `staging.cuentoneta.ar` y las previews estaban siendo indexados por Google porque compartían el build de producción y no había ninguna señal de no-indexado gateada por entorno ([#1962](https://github.com/cuentoneta/cuentoneta/pull/1962)).
+
+Se agregan dos capas complementarias que solo actúan fuera de producción (producción sigue indexable):
+
+- **Server:** un middleware de Hono emite `X-Robots-Tag: noindex, nofollow` en toda respuesta —HTML (SSR o CSR degradado), `sitemap.xml`, estáticos y OG images—.
+- **Frontend:** `HeadMetadataDirective.setRobots()` fuerza `noindex, nofollow` en builds no indexables, alineando el `<meta name="robots">` con el header y blindando páginas futuras.
+
+Se desacopla la indexabilidad del string `environment` mediante `environment.indexable` (con override `SEO_INDEXABLE`), de modo que los tests e2e de SEO sigan validando la postura de producción con URLs locales.
+
 ## Versión 2.8.7 (2026-07-22)
 
 La versión 2.8.7 es un release de **mantenimiento de tooling y deuda técnica**, centrado en el epic de **saneamiento de la configuración de Claude Code** (#1843). Se corrige la deriva acumulada en el corpus de configuración: los cinco sitios que transcribían los gates de CI omitían `e2e` y/o `studio-build` (#1844), el catálogo de referencias se declaraba completo con 13 de 15 archivos (#1845), ocho punteros apuntaban a secciones de `CLAUDE.md` inexistentes (#1846), y varias referencias y agentes describían rutas, archivos y deuda técnica ya eliminados (#1847). Se saldan además cuatro ejemplos del corpus que violaban sus propias reglas (#1848), las contradicciones semánticas entre referencias y dos agentes huérfanos que ningún flujo invocaba (#1849), y tres ejemplos de `angular-components.md` que inyectaban un `StoryService` inexistente (#1872). Se documenta como restricción dura que los hijos de un epic se crean como sub-issues reales (#1860), se repara la ausencia de `documentation-writer` en el registro de agentes (#1874), y se evalúa cómo acelerar la ejecución de los flujos sin perder calidad (#1850). Un conjunto de correcciones de endurecimiento cierra el epic: el gate `check-agents` pasa a validar también las rutas citadas en las referencias (#1888), se deduplican los gates en el `code-reviewer` (#1886), se prohíbe `git add -A` como política (#1887) y se corrige la taxonomía de dobles de test `Stub*`/`Fake*`/`InMemory*` (#1889).

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -83,6 +83,12 @@ const generateApiUrl = (environment: TEnvironmentType): string => {
 };
 
 const apiUrl = generateApiUrl(environment);
+
+// Postura de indexado SEO de la build: solo producción indexa; staging/preview/development van
+// noindex. SEO_INDEXABLE=true la fuerza en una build no productiva sin tocar las URLs (lo usa el
+// job de e2e para validar el HTML del crawler contra el server SSR local).
+const indexable = environment === 'production' || process.env['SEO_INDEXABLE'] === 'true';
+
 // Accede a las variables de entorno y genera un string
 // correspondiente al objeto environment que utilizará Angular
 
@@ -91,6 +97,7 @@ const exportedEnvironment = {
 	website: `${apiUrl ?? 'https://cuentoneta.ar/'}`,
 	apiUrl: `${apiUrl}`,
 	clarityProjectId: '',
+	indexable,
 };
 
 // Chequea si existe la variable de entorno para analytics de Microsoft Clarity

--- a/src/api/_middleware/noindex.middleware.spec.ts
+++ b/src/api/_middleware/noindex.middleware.spec.ts
@@ -1,0 +1,42 @@
+import { Hono } from 'hono';
+import { environment } from '../_helpers/environment';
+import { noindexNonProduction } from './noindex.middleware';
+
+describe('noindexNonProduction', () => {
+	const originalProduction = environment.production;
+
+	afterEach(() => {
+		environment.production = originalProduction;
+	});
+
+	function appUnderTest(): Hono {
+		const app = new Hono();
+		app.use('*', noindexNonProduction);
+		app.get('/', (c) => c.text('ok'));
+		return app;
+	}
+
+	it('should set X-Robots-Tag: noindex on responses in non-production environments', async () => {
+		environment.production = false;
+
+		const response = await appUnderTest().request('/');
+
+		expect(response.headers.get('X-Robots-Tag')).toBe('noindex, nofollow');
+	});
+
+	it('should not set X-Robots-Tag in production so the site stays indexable', async () => {
+		environment.production = true;
+
+		const response = await appUnderTest().request('/');
+
+		expect(response.headers.get('X-Robots-Tag')).toBeNull();
+	});
+
+	it('should preserve the downstream response body', async () => {
+		environment.production = false;
+
+		const response = await appUnderTest().request('/');
+
+		expect(await response.text()).toBe('ok');
+	});
+});

--- a/src/api/_middleware/noindex.middleware.ts
+++ b/src/api/_middleware/noindex.middleware.ts
@@ -1,0 +1,14 @@
+import { createMiddleware } from 'hono/factory';
+import { environment } from '../_helpers/environment';
+
+/**
+ * Emite `X-Robots-Tag: noindex, nofollow` en despliegues no productivos (staging, previews) para
+ * sacarlos del índice. `noindex` des-indexa lo ya indexado; un `Disallow` solo frena el crawl.
+ * En producción no agrega el header y el sitio sigue indexable.
+ */
+export const noindexNonProduction = createMiddleware(async (c, next) => {
+	await next();
+	if (!environment.production) {
+		c.header('X-Robots-Tag', 'noindex, nofollow');
+	}
+});

--- a/src/app/directives/head-metadata.directive.spec.ts
+++ b/src/app/directives/head-metadata.directive.spec.ts
@@ -209,6 +209,16 @@ describe('HeadMetadataDirective', () => {
 	});
 
 	describe('setRobots', () => {
+		const originalIndexable = environment.indexable;
+
+		beforeEach(() => {
+			environment.indexable = true;
+		});
+
+		afterEach(() => {
+			environment.indexable = originalIndexable;
+		});
+
 		it('should expand "index, follow" into indexable robots with preview directives', () => {
 			const metaSpy = spyOn(metaService, 'updateTag');
 
@@ -273,6 +283,26 @@ describe('HeadMetadataDirective', () => {
 				name: 'robots',
 				content: 'none',
 			});
+		});
+
+		describe('in non-indexable builds', () => {
+			beforeEach(() => {
+				environment.indexable = false;
+			});
+
+			it.each(['index, follow', 'all', 'index, nofollow', 'noindex, follow', 'none'] as const)(
+				'should force "noindex, nofollow" even when the page requests "%s"',
+				(requested) => {
+					const metaSpy = spyOn(metaService, 'updateTag');
+
+					directive.setRobots(requested);
+
+					expect(metaSpy).toHaveBeenCalledWith({
+						name: 'robots',
+						content: 'noindex, nofollow',
+					});
+				},
+			);
 		});
 	});
 

--- a/src/app/directives/head-metadata.directive.ts
+++ b/src/app/directives/head-metadata.directive.ts
@@ -158,6 +158,12 @@ export class HeadMetadataDirective {
 	public setRobots(
 		content: 'index, follow' | 'noindex, nofollow' | 'index, nofollow' | 'noindex, follow' | 'all' | 'none',
 	) {
+		// Builds no indexables (staging/previews) van noindex sin importar el argumento: alinea el <meta>
+		// con el header X-Robots-Tag del server y blinda esos entornos frente a páginas futuras.
+		if (!environment.indexable) {
+			this.metaTagService.updateTag({ name: 'robots', content: 'noindex, nofollow' });
+			return;
+		}
 		const value = content === 'index, follow' || content === 'all' ? this.indexableRobots : content;
 		this.metaTagService.updateTag({
 			name: 'robots',

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,11 +9,12 @@ import { secureHeaders } from 'hono/secure-headers';
 import apiRoutes from './api/routes';
 import sitemapController from './api/modules/sitemap/sitemap.controller';
 import { getAllowedHosts } from './api/_helpers/environment';
+import { noindexNonProduction } from './api/_middleware/noindex.middleware';
 
 /**
  * Inicializa Hono y exporta la instancia de la aplicación
  */
-export const app = new Hono({ strict: false }).use(requestId()).use(secureHeaders());
+export const app = new Hono({ strict: false }).use(requestId()).use(secureHeaders()).use('*', noindexNonProduction);
 // Vercel termina TLS y siempre agrega headers `x-forwarded-*` (incluido `x-forwarded-for`).
 // Sin declararlos confiables, el hardening SSR de Angular degrada cada request a client-side
 // rendering (sirve `index.csr.html` sin contenido ni meta), dejando las páginas Server sin SSR


### PR DESCRIPTION
## Contexto

Back-merge del hotfix de SEO liberado en `master` como **2.8.8** ([#1962](https://github.com/cuentoneta/cuentoneta/pull/1962), tag `2.8.8` ya publicado). `develop` no tenía el fix; sin este back-merge, el próximo release `develop → master` (2.9.0) pisaría producción **sin** el noindex y reintroduciría el bug.

## Qué trae

- **El fix completo** (idéntico al mergeado a `master`):
  - `src/api/_middleware/noindex.middleware.ts` (+ spec) y `src/server.ts` — Capa 1: `X-Robots-Tag: noindex, nofollow` en toda respuesta fuera de producción.
  - `src/app/directives/head-metadata.directive.ts` (+ spec) — Capa 2: `setRobots()` fuerza `noindex` en builds no indexables.
  - `scripts/set-environment.ts` — `environment.indexable` (con override `SEO_INDEXABLE`).
  - `.github/workflows/ci.yml` — el job de e2e regenera el environment con `SEO_INDEXABLE=true`.
  - `.claude/references/scripts.md` — documenta el flag.
- **Entrada de CHANGELOG 2.8.8**, idéntica a la de `master`, para mantener ambos changelogs alineados y evitar conflicto en el futuro release `develop → master`.

## Qué NO trae

- **No** se bumpea `package.json` / `cms/package.json` a 2.8.8: `develop` mantiene su versión (2.8.7) y el número lo maneja el flujo de release de `develop` (milestone 2.9.0), según lo acordado.

## Verificación

- `pnpm typecheck` ✅ · `pnpm lint` ✅ (sobre `develop` + el fix).
- El código es el mismo ya validado en CI y en producción vía #1962.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfW2yzYRp9QKkDYisXE2DQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfW2yzYRp9QKkDYisXE2DQ)_