### PR TITLE
[#1853] - Quita readingTimeOverride del dominio (alinea con el schema)

### DIFF
--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -107,9 +107,9 @@ export function createLiteraryWork(options: CreateLiteraryWorkOptions): Literary
 		throw new Error(`LiteraryWork inválida: sin autores (slug "${options.slug}")`);
 	}
 	return Object.freeze({
-		...rest,
+		...options,
 		slug: createSlug(options.slug),
-		totalReadingTime: readingTimeOverride ?? sumReadingTimes(options.content.map((s) => s.readingTime)),
+		totalReadingTime: sumReadingTimes(options.content.map((s) => s.readingTime)),
 		sectionCount: options.content.length,
 	});
 }
@@ -295,7 +295,7 @@ En cuentoneta, **`LiteraryWork`** es la raíz de agregado con invariantes **hech
 - Debe tener **al menos una sección** de contenido.
 - Debe tener **al menos un autor** (`authors.length >= 1`); la obra anónima referencia al author real "Anónimo" (`isAnonymous`, ver [Policies](#policies-como-funciones-puras)).
 - Las posiciones de sección son contiguas en el agregado completo (`content[i].position === i`).
-- `totalReadingTime`/`sectionCount` se derivan en la factory (salvo `readingTimeOverride` editorial, para obras recitadas/audiovisuales).
+- `totalReadingTime`/`sectionCount` se derivan en la factory (suma de los `readingTime` de las secciones y `content.length`).
 
 ```typescript
 // literary-work.model.ts — invariantes en tiempo de construcción (implementado, #1852)
@@ -310,9 +310,9 @@ export function createLiteraryWork(options: CreateLiteraryWorkOptions): Literary
 		throw new Error(`LiteraryWork inválida: sin autores (slug "${options.slug}")`);
 	}
 	return Object.freeze({
-		...rest,
+		...options,
 		slug: createSlug(options.slug),
-		totalReadingTime: readingTimeOverride ?? sumReadingTimes(options.content.map((s) => s.readingTime)),
+		totalReadingTime: sumReadingTimes(options.content.map((s) => s.readingTime)),
 		sectionCount: options.content.length,
 	});
 }

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -264,7 +264,7 @@ interface LiteraryWorkEpigraph {
 
 - El slug debe ser único (garantizado por Sanity) y con formato válido (validado por el value object `Slug`)
 - La obra debe tener al menos una sección de contenido
-- `totalReadingTime` es la suma de los `readingTime` de sus secciones (derivado en la factory) — salvo `readingTimeOverride` editorial, que lo reemplaza (obras recitadas/audiovisuales, ver [`LITERARY_WORK_DESIGN.md`](LITERARY_WORK_DESIGN.md) §5)
+- `totalReadingTime` es la suma de los `readingTime` de sus secciones (derivado en la factory); a nivel schema es un campo editable/persistido que el backend materializa (ver [`LITERARY_WORK_DESIGN.md`](LITERARY_WORK_DESIGN.md) §5)
 - `sectionCount` es el número real de secciones (derivado en la factory; en proyecciones parciales lo provee el mapper)
 - Las posiciones de sección son contiguas desde 0 en el agregado completo (`content[i].position === i`); las proyecciones parciales conservan el `position` de origen
 - `authors` exige al menos un autor (1..N) — la **obra anónima** referencia explícitamente al author "Anónimo" (slug `anonimo`, valor bien conocido del dominio; policy `isAnonymous` compara por slug, nunca por `_id`)

--- a/docs/LITERARY_WORK_DESIGN.md
+++ b/docs/LITERARY_WORK_DESIGN.md
@@ -95,7 +95,7 @@ export interface LiteraryWorkNavigationTeaserWithAuthors extends LiteraryWorkBas
 | `slug` con formato válido e inmutable        | VO `Slug` (`createSlug` lanza ante formato inválido); unicidad garantizada por Sanity                                                                                                                                                    |
 | `title` no vacío                             | `createLiteraryWork` lanza                                                                                                                                                                                                               |
 | Al menos una sección de contenido            | `createLiteraryWork` lanza si `content.length === 0`                                                                                                                                                                                     |
-| `totalReadingTime` = suma de secciones       | Derivado en la factory — salvo **`readingTimeOverride`** editorial, que lo reemplaza (obras recitadas/audiovisuales, ver [§5](#5-helper-de-reading-time))                                                                                |
+| `totalReadingTime` = suma de secciones       | Derivado en la factory (suma de los `readingTime` de las secciones); persistido/editable a nivel schema y materializado por el backend (ver [§5](#5-helper-de-reading-time))                                                             |
 | `sectionCount` = número real de secciones    | Derivado en la factory (`content.length`); en las vistas parciales/teaser lo provee el mapper (GROQ `count()`) y puede ser mayor que las secciones transportadas                                                                         |
 | Posiciones contiguas en el agregado completo | `createLiteraryWork` lanza si `content[i].position !== i` — el agregado completo siempre transporta las secciones `0..sectionCount-1` en orden; las proyecciones parciales (construidas por el mapper) conservan el `position` de origen |
 | `authors` con al menos un autor              | `createLiteraryWork` lanza si `authors.length === 0`; la obra anónima referencia al author "Anónimo" ([§10](#10-autoría-y-obra-anónima))                                                                                                 |
@@ -210,13 +210,11 @@ body (Markdown) → countWords → WordCount → deriveReadingTime → ReadingTi
 
 > **Estado de implementación:** este increment agrega solo el schema (campos opcionales, arrancan vacíos) y esta doc. El mapper que lee/computa/persiste — y el `?section=N` eficiente que se apoya en él para traer solo el body de la sección pedida más el total ya persistido ([§7](#7-contrato-del-endpoint)) — se implementan en el increment de backend rebaseado sobre el PR [#1929](https://github.com/cuentoneta/cuentoneta/pull/1929) (read-side diferido, aún no en este PR).
 
-### Override editorial de duración (`readingTimeOverride`)
+### Duración de obras recitadas/audiovisuales
 
-Para obras cuyo contenido principal es un **recitado o audiovisual** (p. ej. narraciones verbales sin texto fuente), la duración relevante es la del medio, no la del texto. El schema expone el campo opcional **`readingTimeOverride`** (entero `>= 1`, minutos): si está presente, `createLiteraryWork` lo usa como `totalReadingTime` en lugar del total derivado del texto. La interfaz pública no cambia — los consumidores ven un único `totalReadingTime` sin conocer su procedencia.
+Para obras cuyo contenido principal es un **recitado o audiovisual** (p. ej. narraciones verbales sin texto fuente), la duración relevante es la del medio, no la del texto. No hay un campo aparte para esto: `literaryWork.totalReadingTime` es **editable** en el schema, así que el editor lo carga a mano con la duración del medio y la materialización del backend lo **respeta** (`setIfMissing` no pisa un valor ya cargado). En obras de texto ese mismo campo lo completa el backend con `sumReadingTimes` sobre las secciones.
 
-- **`totalReadingTime` persistido = suma pura del texto.** Lo que se persiste en `literaryWork.totalReadingTime` ([#1953](https://github.com/cuentoneta/cuentoneta/issues/1953)) es siempre `sumReadingTimes` sobre las secciones — nunca el override "bakeado" en el campo. La precedencia `override ?? total` sigue resolviéndose en `createLiteraryWork`, en cada construcción del agregado.
-- **El override no se persiste como derivado.** Sigue siendo un **dato fuente editorial** (input curatorial) que vive únicamente en su propio campo del schema. Distinto del reading time por texto, que #1953 sí persiste (anula T1b para ese derivado): el override nunca estuvo alcanzado por T1b porque no es lo computado, es el input.
-- El `readingTime` **por sección** sigue derivándose del texto (el override es solo del total) y es lo que #1953 persiste en `section.readingTime`.
+`createLiteraryWork` deriva `totalReadingTime` de las secciones en cada construcción del agregado; el valor persistido/editorial vive en el campo del schema y lo sirve el mapper del backend. El `readingTime` **por sección** siempre se deriva del texto y es lo que [#1953](https://github.com/cuentoneta/cuentoneta/issues/1953) persiste en `section.readingTime`.
 
 ### Obras solo-recitado (sin texto fuente)
 
@@ -224,7 +222,7 @@ La invariante `content >= 1` **se mantiene**: una obra cuyo contenido es únicam
 
 1. Una **sección editorial mínima** (presentación/contexto curatorial del recitado) — le da a `/read/:slug` el cuerpo SSR indexable que la estrategia SEO del epic exige, y mantiene válidos `teaserSection`, `sectionCount` y `?section=N`.
 2. El medio en **`mediaSources`** (el schema ya soporta `youTubeVideo`/`audioRecording`/etc.).
-3. **`readingTimeOverride`** con la duración real del medio.
+3. **`totalReadingTime`** (editable) cargado a mano con la duración real del medio.
 
 Permitir `content: []` se evaluó y descartó: degeneraría `totalReadingTime` (mínimo 1 falso), `teaserSection` (pasaría a opcional en cascada), la semántica de `?section=N` y la premisa "un documento SSR indexable" del epic. Una `MediaSection` como tipo de sección (unión `TextSection | MediaSection`) queda como extensión futura si surge necesidad curatorial concreta — reabre pipeline, reading time y render, y no se justifica hoy.
 

--- a/src/app/models/literary-work.model.spec.ts
+++ b/src/app/models/literary-work.model.spec.ts
@@ -50,15 +50,6 @@ describe('createLiteraryWork', () => {
 		expect(work.sectionCount).toBe(3);
 	});
 
-	it('uses readingTimeOverride as totalReadingTime when present (recited/audiovisual works)', () => {
-		const work = createLiteraryWork(
-			buildOptions({ content: [buildSection(0, 1)], readingTimeOverride: createReadingTime(40) }),
-		);
-
-		expect(work.totalReadingTime).toBe(40);
-		expect('readingTimeOverride' in work).toBe(false);
-	});
-
 	it('throws when section positions do not match their array index', () => {
 		expect(() => createLiteraryWork(buildOptions({ content: [buildSection(1, 2)] }))).toThrow(
 			'LiteraryWork inválida: posiciones de sección no contiguas (slug "la-obra", índice 0 con position 1)',

--- a/src/app/models/literary-work.model.ts
+++ b/src/app/models/literary-work.model.ts
@@ -70,9 +70,6 @@ interface CreateLiteraryWorkOptions {
 	tags: readonly Tag[];
 	originalPublication: string;
 	publishedAt: IsoDateTime;
-	// Duración editorial fija (obras recitadas/audiovisuales): reemplaza a la suma de
-	// secciones como totalReadingTime — ver LITERARY_WORK_DESIGN.md §5.
-	readingTimeOverride?: ReadingTime;
 }
 
 export function createLiteraryWork(options: CreateLiteraryWorkOptions): LiteraryWork {
@@ -97,11 +94,10 @@ export function createLiteraryWork(options: CreateLiteraryWorkOptions): Literary
 			);
 		}
 	});
-	const { readingTimeOverride, ...rest } = options;
 	return Object.freeze({
-		...rest,
+		...options,
 		slug: createSlug(options.slug),
-		totalReadingTime: readingTimeOverride ?? sumReadingTimes(options.content.map((section) => section.readingTime)),
+		totalReadingTime: sumReadingTimes(options.content.map((section) => section.readingTime)),
 		sectionCount: options.content.length,
 	});
 }


### PR DESCRIPTION
## Descripción

Alinea el **dominio** con el schema de Sanity, que ya eliminó `readingTimeOverride` en #1964 (mergeado). Fix acotado.

- **`literary-work.model.ts`**: `createLiteraryWork` deja de aceptar la opción `readingTimeOverride`; `totalReadingTime` se computa **siempre** como `sumReadingTimes` sobre las secciones. Se elimina el destructuring del override (spread directo de `options`).
- **`literary-work.model.spec.ts`**: se quita el test del override; el resto de las invariantes intacto.
- **Duración de obras recitadas/audiovisuales**: ya no hay un campo aparte — la duración editorial vive en el campo `totalReadingTime` **editable** del schema (lo respeta la materialización `setIfMissing` del backend), no en un override del dominio.

**Scan de impacto en documentación** (regla dura de `CLAUDE.md`): actualiza `docs/LITERARY_WORK_DESIGN.md` (§5 y la tabla de invariantes), `docs/DOMAIN_MODEL.md` y `.claude/references/domain-model.md`, eliminando el override editorial y sus ejemplos de código.

Refs #1853. Parte de #1481.

## Plan de pruebas

- [x] `typecheck` verde.
- [x] Spec de `literary-work.model` verde (12/12).
- [x] `lint` sobre modelo + spec verde.
- [x] `check:agents` verde (se editó una referencia).
- [x] Sin rastros de `readingTimeOverride` en `src/`, `docs/`, `.claude/references/`.
