### PR TITLE
[#1853] - LiteraryWork.mediaSources: readonly Media[] (supertipo)

### DIFF
--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -67,7 +67,7 @@ interface LiteraryWorkBase {
 	readonly totalReadingTime: ReadingTime;
 	readonly sectionCount: number;
 	readonly tags: readonly Tag[];
-	readonly mediaSources: readonly MediaTypes[]; // en la base: también lo exponen los teasers de listado
+	readonly mediaSources: readonly Media[]; // en la base: también lo exponen los teasers de listado
 }
 
 export interface LiteraryWork extends LiteraryWorkBase {

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -243,7 +243,7 @@ interface LiteraryWork {
 
 	// Recursos Multimedia
 	resources: Resource[]; // Enlaces a recursos externos
-	mediaSources: MediaTypes[]; // Contenido multimedia asociado
+	mediaSources: Media[]; // Contenido multimedia asociado
 }
 
 interface LiteraryWorkSection {
@@ -282,7 +282,7 @@ Borrador en Sanity → Publicación → Accesible para lectura en /read/:slug
 - `LiteraryWorkNavigationTeaser` - Vista mínima para navegación
 - `LiteraryWorkNavigationTeaserWithAuthors` - Vista mínima con autores resumidos
 
-`mediaSources: MediaTypes[]` **todas** las vistas (incluidas las de teaser/navegación) lo exponen; las tarjetas de listado lo consumen para mostrar los recursos multimedia de la obra.
+`mediaSources: Media[]` **todas** las vistas (incluidas las de teaser/navegación) lo exponen; las tarjetas de listado lo consumen para mostrar los recursos multimedia de la obra.
 
 ---
 

--- a/docs/LITERARY_WORK_DESIGN.md
+++ b/docs/LITERARY_WORK_DESIGN.md
@@ -56,7 +56,7 @@ interface LiteraryWorkBase {
 	readonly totalReadingTime: ReadingTime;
 	readonly sectionCount: number; // total de secciones de la obra (>= 1)
 	readonly tags: readonly Tag[];
-	readonly mediaSources: readonly MediaTypes[]; // en la base: todas las vistas (incl. teaser/navegación) lo exponen
+	readonly mediaSources: readonly Media[]; // en la base: todas las vistas (incl. teaser/navegación) lo exponen
 }
 
 export interface LiteraryWork extends LiteraryWorkBase {

--- a/src/app/models/literary-work.model.ts
+++ b/src/app/models/literary-work.model.ts
@@ -1,6 +1,6 @@
 import type { Author, AuthorTeaser } from './author.model';
 import type { LiteraryWorkSection } from './literary-work-section.model';
-import type { MediaTypes } from './media.model';
+import type { Media } from './media.model';
 import type { Resource } from './resource.model';
 import type { Tag } from './tag.model';
 import type { IsoDateTime } from '@utils/date.utils';
@@ -19,7 +19,7 @@ interface LiteraryWorkBase {
 	readonly tags: readonly Tag[];
 	// Las tarjetas de listado (vistas de teaser/navegación) muestran los recursos multimedia
 	// de la obra; por eso el campo vive en la base y no solo en el agregado completo.
-	readonly mediaSources: readonly MediaTypes[];
+	readonly mediaSources: readonly Media[];
 }
 
 export interface LiteraryWork extends LiteraryWorkBase {
@@ -64,7 +64,7 @@ interface CreateLiteraryWorkOptions {
 	authors: readonly Author[];
 	coverImage: string;
 	content: readonly LiteraryWorkSection[];
-	mediaSources: readonly MediaTypes[];
+	mediaSources: readonly Media[];
 	resources: readonly Resource[];
 	badLanguage?: boolean;
 	tags: readonly Tag[];


### PR DESCRIPTION
## Descripción

Corrige el tipo de `mediaSources` en `LiteraryWork`: de `readonly MediaTypes[]` a **`readonly Media[]`** (el supertipo), en `LiteraryWorkBase` y en la opción de `createLiteraryWork`.

- #1938 lo aterrizó como `MediaTypes[]`; con `Media[]` el `mapMediaSources` compartido (que devuelve `Media[]`) encaja directo en los mappers, **sin casts**.
- `MediaTypes` se conserva para el adapter de `media-resource` (discriminar `Media` → subtipo).

**Scan de impacto en documentación**: alinea `docs/DOMAIN_MODEL.md`, `docs/LITERARY_WORK_DESIGN.md` y `.claude/references/domain-model.md` al tipo `Media[]`.

Slice chico extraído de la draft #1929 (capa de datos de LiteraryWork) para achicar su superficie. Refs #1853. Parte de #1481.

## Plan de pruebas

- [x] `typecheck` verde.
- [x] Spec de `literary-work.model` verde.
- [x] `check:agents` verde.
