### PR TITLE
[#1853] - Reading time: helpers deriveSectionReadingTime/deriveTotalReadingTime

### DIFF
--- a/docs/LITERARY_WORK_DESIGN.md
+++ b/docs/LITERARY_WORK_DESIGN.md
@@ -186,12 +186,20 @@ export function sumReadingTimes(times: readonly ReadingTime[]): ReadingTime;
 // suma por sección → total del agregado; mínimo 1
 ```
 
-**Contrato para Slice 1** (no implementado — requiere `unified`/`remark-parse`/`mdast-util-to-string`, que no se instalan sin caller real):
+**Implementado** (`reading-time.model.ts`, sobre `unified`/`remark-parse`):
 
 ```typescript
 export function countWords(markdown: Markdown): WordCount;
-// mdast-util-to-string sobre el AST de remark-parse → split por whitespace → createWordCount
+// texto legible del AST de remark-parse → split por whitespace → createWordCount
+
+export function deriveSectionReadingTime(body: Markdown): ReadingTime;
+// deriveReadingTime(countWords(body)) — reading time de una sección desde su cuerpo
+
+export function deriveTotalReadingTime(bodies: readonly Markdown[]): ReadingTime;
+// sumReadingTimes(bodies.map(deriveSectionReadingTime)) — total = suma pura del texto
 ```
+
+`deriveSectionReadingTime`/`deriveTotalReadingTime` son la **fuente única** del algoritmo, para que el backfill batch y la materialización self-healing del backend produzcan el mismo número por sección.
 
 ### Persistencia write-once (decisión #1953 — Opción B)
 

--- a/src/app/models/reading-time.model.spec.ts
+++ b/src/app/models/reading-time.model.spec.ts
@@ -1,4 +1,11 @@
-import { countWords, createReadingTime, deriveReadingTime, sumReadingTimes } from './reading-time.model';
+import {
+	countWords,
+	createReadingTime,
+	deriveReadingTime,
+	deriveSectionReadingTime,
+	deriveTotalReadingTime,
+	sumReadingTimes,
+} from './reading-time.model';
 import { createMarkdown } from './markdown.model';
 import { createWordCount } from './word-count.model';
 
@@ -70,5 +77,30 @@ describe('sumReadingTimes', () => {
 
 	it('returns at least 1 minute for an empty list', () => {
 		expect(sumReadingTimes([])).toBe(1);
+	});
+});
+
+describe('deriveSectionReadingTime', () => {
+	it('composes countWords and deriveReadingTime for a section body', () => {
+		expect(deriveSectionReadingTime(createMarkdown('palabra '.repeat(401).trim()))).toBe(3);
+	});
+
+	it('returns at least 1 minute for a short section', () => {
+		expect(deriveSectionReadingTime(createMarkdown('Una obra corta.'))).toBe(1);
+	});
+});
+
+describe('deriveTotalReadingTime', () => {
+	it('equals the single section time for a one-section work', () => {
+		expect(deriveTotalReadingTime([createMarkdown('palabra '.repeat(401).trim())])).toBe(3);
+	});
+
+	it('sums the per-section reading times of a multi-section work', () => {
+		const body = createMarkdown('palabra '.repeat(401).trim()); // 3 min cada una
+		expect(deriveTotalReadingTime([body, body])).toBe(6);
+	});
+
+	it('returns at least 1 minute for a work whose sections are all very short', () => {
+		expect(deriveTotalReadingTime([createMarkdown('Breve.')])).toBe(1);
 	});
 });

--- a/src/app/models/reading-time.model.ts
+++ b/src/app/models/reading-time.model.ts
@@ -60,3 +60,16 @@ export function countWords(markdown: Markdown): WordCount {
 		.filter((word) => /[\p{L}\p{N}]/u.test(word));
 	return createWordCount(words.length);
 }
+
+// Composición canónica body → palabras → minutos. Fuente única del algoritmo de reading time,
+// pensada para compartirse entre el backfill batch (scripts/) y la materialización self-healing del
+// backend, que la consumirán en slices siguientes: ambos deben producir el mismo número por sección.
+export function deriveSectionReadingTime(body: Markdown): ReadingTime {
+	return deriveReadingTime(countWords(body));
+}
+
+// Total de la obra: suma de los tiempos por sección (mínimo 1). Es la suma pura del texto — un
+// eventual total editorial (obras recitadas) lo aplica la capa que consume estos helpers, no acá.
+export function deriveTotalReadingTime(bodies: readonly Markdown[]): ReadingTime {
+	return sumReadingTimes(bodies.map(deriveSectionReadingTime));
+}


### PR DESCRIPTION
## Descripción

Agrega la **composición canónica** del algoritmo de reading time en `reading-time.model.ts`:

- `deriveSectionReadingTime(body)` = `deriveReadingTime(countWords(body))` — reading time de una sección desde su cuerpo.
- `deriveTotalReadingTime(bodies)` = `sumReadingTimes(bodies.map(deriveSectionReadingTime))` — total = suma pura del texto.

Son la **fuente única** del algoritmo, pensadas para que el backfill batch y la materialización self-healing del backend (que las consumirán en slices siguientes) produzcan el mismo número por sección. Se agregan con su spec.

**Scan de impacto en documentación**: §5 de `docs/LITERARY_WORK_DESIGN.md` documenta ambos helpers y marca `countWords` como implementado (ya lo está en `develop`).

Slice chico extraído de la draft #1929 (capa de datos de LiteraryWork) para achicar su superficie. Independiente del slice de `mediaSources` (#1969). Refs #1853. Parte de #1481.

## Plan de pruebas

- [x] `typecheck` verde.
- [x] Spec de `reading-time.model` verde (18/18, +5 nuevos).
- [x] `lint` sobre los archivos tocados verde.
