### PR TITLE
[#1914] - issue-workflow Fase 3: verificación barata por commit y recheck de rama activa

### DIFF
--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -189,7 +189,10 @@ No avanzar a la Fase 3 sin una respuesta "Aprobar".
 
 - Formato del mensaje: `[#<issue>] - <qué cambió y por qué>` (en español).
 - Un commit por cambio lógico distinto (p. ej. componente nuevo + spec = un commit; una story es otro commit si es otra preocupación).
-- Cada commit debe dejar el código **buildeable** (los gates de CI pasarían).
+- Cada commit debe dejar el código **buildeable** (los gates de CI pasarían). Para no descubrir un commit roto recién en la Fase 4 con todo acumulado, antes de cada commit que toque código TS/runtime correr una **verificación barata** (un subconjunto rápido, **no** la suite ni el resto de gates —eso sigue siendo la Fase 4—):
+  - **typecheck:** `pnpm typecheck` (en modo worktree, `pnpm exec tsc -p tsconfig.typecheck.json --noEmit` — ver [Modo worktree](#modo-worktree) → "Ajustes transversales").
+  - **specs afectados:** `pnpm exec vitest related --run $(git diff --name-only --cached)` — corre solo los `*.spec.ts` que importan los archivos staged; si `related` no rinde, los specs del módulo tocado.
+  - Los commits **solo-doc / solo-config de tooling** (sin efecto en runtime) saltean esta verificación.
 - Nunca mensajes no descriptivos ("WIP", "fix", "update").
 - Nunca `--amend`; crear commits nuevos tras fallos del hook de pre-commit.
 

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -195,6 +195,7 @@ No avanzar a la Fase 3 sin una respuesta "Aprobar".
   - Los commits **solo-doc / solo-config de tooling** (sin efecto en runtime) saltean esta verificación.
 - Nunca mensajes no descriptivos ("WIP", "fix", "update").
 - Nunca `--amend`; crear commits nuevos tras fallos del hook de pre-commit.
+- **En modo raíz**, antes de cada commit confirmar la rama activa con `git branch --show-current` contra `feat/<number>-<kebab>`; si un subagente con Bash la cambió en el medio, re-checkoutear la rama correcta antes de commitear. En **modo worktree** se omite: `EnterWorktree` fija el cwd/rama del worktree y los subagentes lo heredan (ver [Modo worktree](#modo-worktree)).
 
 ### No hacer en esta fase
 


### PR DESCRIPTION
## Descripción

- La **Fase 3** ("Reglas de commit") corre una **verificación barata antes de cada commit** que toca código TS/runtime — `pnpm typecheck` (o `tsc` directo en modo worktree) + `pnpm exec vitest related --run $(git diff --name-only --cached)` para los specs que importan lo staged. Atrapa un commit roto ahí, en vez de descubrirlo acumulado en la Fase 4. Es un subconjunto rápido para feedback temprano: **no** duplica la suite ni el resto de gates (eso sigue siendo la Fase 4), y los commits solo-doc / solo-config quedan exentos (consistente con la exención de test de `coding-agent-policies.md` Sección 2).
- **Guard de rama acotado a modo raíz:** `git branch --show-current` antes de cada commit, por si un subagente con Bash cambió la rama activa. En modo worktree se **omite**: `EnterWorktree` fija el cwd/rama del worktree y los subagentes lo heredan.

> El issue tenía dos mitades; la del recheck de rama quedó cubierta por el aislamiento por worktree, así que se acotó al modo raíz (el único donde la colisión sigue siendo posible).

Closes #1914.
Parte de #1907.

## Plan de pruebas

- [x] `pnpm check:agents` en verde tras cada commit
- [x] Sin números de issue en la prosa nueva del skill (respeta la regla de coding-agent-policies Sección 3); los únicos `#` son los placeholders `[#1234]` del formato de commit
- [x] `vitest related` verificado como soportado por el binario del repo; el typecheck en worktree remite a "Modo worktree → Ajustes transversales" sin re-explicar
- [x] Gates locales en verde en worktree aislado: `test`, `lint`, `stylelint`, typecheck (tsc directo), `build`, `storybook:build` (`test:e2e` y `studio-build` omitidos: solo Markdown de `.claude/`)
- [x] Review del `code-reviewer` con veredicto APROBADO, sin hallazgos bloqueantes (2 sugerencias de precisión evaluadas y descartadas: la zona gris solo-`.css` ya existe en la política base)
