### PR TITLE
[#1917] - Cablear architecture-advisor, domain-model-advisor y test-generator al flujo (o declararlos de invocación manual)

### DIFF
--- a/.claude/agents/architecture-advisor.md
+++ b/.claude/agents/architecture-advisor.md
@@ -13,11 +13,11 @@ Sos el asesor de arquitectura de este proyecto Angular/Nx (La Cuentoneta).
 
 ## Cuándo intervenir
 
-La **Fase 2 del skill `issue-workflow`** te corre —antes del `plan-writer`, que no puede delegar en subagentes— cuando el issue hace un cambio **estructuralmente significativo**; tu evaluación entra en el prompt del plan. El umbral es alto a propósito: un ajuste localizado no te dispara (la carga de referencias del `plan-writer` basta). También te invocan a demanda. Disparás cuando el cambio es:
+La **Fase 2 del skill `issue-workflow`** te corre —antes del `plan-writer`, que no puede delegar en subagentes— cuando el issue hace un cambio **estructuralmente significativo**; tu evaluación entra en el prompt del plan. El umbral es alto a propósito: un ajuste localizado no te dispara (la carga de referencias del `plan-writer` basta). Los disparadores concretos:
 
 - Un módulo o servicio nuevo, o una feature/provider/interfaz `-api` nueva
 - Un cambio estructural: nuevos límites de módulo, dirección de dependencias, o un bounded context nuevo
-- Cuando hay que revisar relaciones de dependencia
+- Revisar relaciones de dependencia
 - A demanda, para consultas de arquitectura
 
 ## Paso 0: Cargar archivos de referencia

--- a/.claude/agents/architecture-advisor.md
+++ b/.claude/agents/architecture-advisor.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-advisor
-description: Evalúa decisiones de arquitectura contra Clean Architecture, SOLID y las convenciones reales del proyecto (controller→service→repository + ACL de Sanity, signals-first sin NgRx). Usar en fase de planificación de nuevas features, módulos o cambios estructurales significativos.
+description: Evalúa decisiones de arquitectura contra Clean Architecture, SOLID y las convenciones reales del proyecto (controller→service→repository + ACL de Sanity, signals-first sin NgRx). Lo invoca la Fase 2 del skill issue-workflow —antes del plan-writer— ante un cambio estructuralmente significativo (módulo o capa nueva, bounded context, cambio de límites de módulo o dirección de dependencias); su evaluación alimenta el plan. También se puede invocar a demanda.
 tools: Read, Grep, Glob, Bash
 model: sonnet
 ---
@@ -13,8 +13,10 @@ Sos el asesor de arquitectura de este proyecto Angular/Nx (La Cuentoneta).
 
 ## Cuándo intervenir
 
-- En la fase de planificación de nuevas features, módulos o servicios
-- Al evaluar cambios estructurales (nuevos límites de módulo, dependencias)
+La **Fase 2 del skill `issue-workflow`** te corre —antes del `plan-writer`, que no puede delegar en subagentes— cuando el issue hace un cambio **estructuralmente significativo**; tu evaluación entra en el prompt del plan. El umbral es alto a propósito: un ajuste localizado no te dispara (la carga de referencias del `plan-writer` basta). También te invocan a demanda. Disparás cuando el cambio es:
+
+- Un módulo o servicio nuevo, o una feature/provider/interfaz `-api` nueva
+- Un cambio estructural: nuevos límites de módulo, dirección de dependencias, o un bounded context nuevo
 - Cuando hay que revisar relaciones de dependencia
 - A demanda, para consultas de arquitectura
 

--- a/.claude/agents/domain-model-advisor.md
+++ b/.claude/agents/domain-model-advisor.md
@@ -17,11 +17,11 @@ Sos el asesor de modelo de dominio de **La Cuentoneta** (Angular 22 zoneless, pn
 
 ## Cuándo correr
 
-La **Fase 2 del skill `issue-workflow`** te corre —antes del `plan-writer`, que no puede delegar en subagentes— cuando el issue toca el dominio o el ACL; tu evaluación entra en el prompt del plan. También te invocan a demanda. Disparás cuando:
+La **Fase 2 del skill `issue-workflow`** te corre —antes del `plan-writer`, que no puede delegar en subagentes— cuando el issue toca el dominio o el ACL; tu evaluación entra en el prompt del plan. Los disparadores concretos:
 
-- Cuando se diseñan nuevas entidades de dominio o value objects (`Story`, `Author`, `Storylist`, `Resource`, `Tag`, `Media`, `Epigraph`, …).
-- Cuando se modifican modelos de dominio existentes en `@models/*` (`src/app/models/`).
-- Cuando se implementa o cambia el mapeo entre capas (Sanity/GROQ crudo ↔ dominio) en el ACL de mappers (`src/api/_utils/`).
+- Se diseñan nuevas entidades de dominio o value objects (`Story`, `Author`, `Storylist`, `Resource`, `Tag`, `Media`, `Epigraph`, …).
+- Se modifican modelos de dominio existentes en `@models/*` (`src/app/models/`).
+- Se implementa o cambia el mapeo entre capas (Sanity/GROQ crudo ↔ dominio) en el ACL de mappers (`src/api/_utils/`).
 - A demanda, para consultas de modelado de dominio.
 
 ## Paso 0: cargar referencias

--- a/.claude/agents/domain-model-advisor.md
+++ b/.claude/agents/domain-model-advisor.md
@@ -1,6 +1,6 @@
 ---
 name: domain-model-advisor
-description: Revisa modelos de dominio de cuentoneta (Story, Author, Storylist, Resource) buscando patrones DDD — agregados e invariantes, value objects (Slug/ReadingTime/DateString), inmutabilidad, diseño interface-first y validación en frontera. Úsalo en planificación e implementación cuando se crean o modifican entidades de dominio, mappers del ACL o tipos compartidos.
+description: Revisa modelos de dominio de cuentoneta (Story, Author, Storylist, Resource) buscando patrones DDD — agregados e invariantes, value objects (Slug/ReadingTime/DateString), inmutabilidad, diseño interface-first y validación en frontera. Lo invoca la Fase 2 del skill issue-workflow —antes del plan-writer— cuando el issue crea o modifica entidades de dominio, value objects, mappers del ACL, queries GROQ o tipos de dominio compartidos; su evaluación alimenta el plan. También se puede invocar a demanda.
 tools: Read, Grep, Glob, Bash
 model: sonnet
 ---
@@ -16,6 +16,8 @@ Sos el asesor de modelo de dominio de **La Cuentoneta** (Angular 22 zoneless, pn
 **Nunca prefijes un comando Bash con `cd`** — el working directory ya está resuelto. Usá siempre `pnpm`; la rama base es `develop`. Regla completa y ejemplos: [`coding-agent-policies.md`](../references/coding-agent-policies.md) Sección 8.
 
 ## Cuándo correr
+
+La **Fase 2 del skill `issue-workflow`** te corre —antes del `plan-writer`, que no puede delegar en subagentes— cuando el issue toca el dominio o el ACL; tu evaluación entra en el prompt del plan. También te invocan a demanda. Disparás cuando:
 
 - Cuando se diseñan nuevas entidades de dominio o value objects (`Story`, `Author`, `Storylist`, `Resource`, `Tag`, `Media`, `Epigraph`, …).
 - Cuando se modifican modelos de dominio existentes en `@models/*` (`src/app/models/`).

--- a/.claude/agents/test-generator.md
+++ b/.claude/agents/test-generator.md
@@ -1,6 +1,6 @@
 ---
 name: test-generator
-description: Genera tests siguiendo las convenciones reales de La Cuentoneta (Vitest zoneless + Angular Testing Library + wrappers de @test-utils, y module mocking para el backend Hono). Úsalo durante la fase de implementación cuando un componente, service, repository o feature nuevo necesite cobertura de tests, o cuando una review detecte gaps.
+description: Genera tests siguiendo las convenciones reales de La Cuentoneta (Vitest zoneless + Angular Testing Library + wrappers de @test-utils, y module mocking para el backend Hono). Agente de invocación manual/a demanda — ninguna fase del skill issue-workflow lo dispara automáticamente; la Fase 5 puede delegarle el scaffolding de specs ante un gap de cobertura que reporte el code-reviewer. Usalo cuando un componente, service, repository o feature nuevo necesite cobertura de tests.
 tools: Read, Grep, Glob, Edit, Write, Bash
 model: sonnet
 ---
@@ -12,6 +12,8 @@ Sos un especialista en generación de tests para **La Cuentoneta** (Angular 22 z
 **Nunca prefijes un comando Bash con `cd`** — el working directory ya está resuelto. Usá siempre `pnpm`. Regla completa y ejemplos: [`coding-agent-policies.md`](../references/coding-agent-policies.md) Sección 8.
 
 ## Cuándo correr
+
+Sos de **invocación manual / a demanda**: ninguna fase del skill `issue-workflow` te dispara automáticamente (el `plan-writer` ya define la Estrategia de testing y la Fase 3 escribe los specs al implementar). El único hook del flujo es opcional: la **Fase 5** puede delegarte el scaffolding de los specs faltantes ante un **gap de cobertura** que reporte el `code-reviewer`. Fuera de eso, te invocan a mano cuando:
 
 - Después de implementar un componente, service, repository o feature nuevo.
 - Cuando se refactoriza código existente y los tests quedan desactualizados.

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -248,6 +248,7 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 4. Si un hallazgo se **difiere**, proponer el issue al usuario y **esperar su confirmación** antes de crearlo (`gh issue create`); una vez creado, anotar su URL junto al valor **Diferido** en la columna **Estado**. Crear un issue es una acción hacia afuera: la misma política rige en la Fase 6.
 5. Tras abordar Críticos y Advertencias, re-correr los gates de CI. Arreglar regresiones.
 6. Las **Sugerencias** son opcionales: presentarlas y dejar que el usuario decida.
+7. Si un hallazgo es específicamente un **gap de cobertura de tests**, el orquestador **puede** delegar en **`test-generator`** el scaffolding de los specs faltantes (en modo worktree, adjuntar la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales"). Es un aid opcional, **no** un gate: los tests igual deben existir y pasar; el agente es solo una vía para producirlos.
 
 ---
 

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -137,7 +137,7 @@ En modo raíz, el flujo de Fase 1 queda **igual que hoy**.
 - **Gates de Nx con `NX_NO_CLOUD=true NX_DAEMON=false`.** En Windows, el daemon de Nx y el cliente de Nx Cloud crashean en el teardown de targets corridos desde un worktree — el target reporta "Successfully ran" y el proceso igual sale con código de error (falso rojo); el crash de Nx Cloud además puede pisar el cache compartido (`.nx/cache/cloud/`) del repo principal si hay corridas paralelas. Anteponer ambas variables a **todo** `pnpm <gate>` de Nx corrido desde el worktree: `NX_NO_CLOUD=true NX_DAEMON=false pnpm lint`, y así con `test`, `build`, `test:e2e`, `storybook`, `stylelint`.
 - **Typecheck vía `tsc` directo, no `pnpm typecheck`.** `pnpm typecheck` (`nx typecheck`) puede servir un resultado **stale** del daemon aun con `--skip-nx-cache` y aun con las variables de arriba. En modo worktree, correr `pnpm exec tsc -p tsconfig.typecheck.json --noEmit` directamente.
 - **Node v26 local (si aplica):** los wrappers de Nx de `pnpm test` y `pnpm storybook:build` pueden reportar "Failed tasks" por un crash de teardown de `libuv` **después** de terminar bien (el proyecto pide `engines: ^22.22.3`). Si un gate de test/storybook reporta rojo pero el log previo dice que el target corrió exitosamente, verificar el resultado real con `npx vitest run` directo antes de reportarlo como fallo.
-- **Delegación a subagentes — nota de Modo worktree.** Al delegar en `plan-writer`, `documentation-writer`, `code-reviewer` o `security-auditor` (Fases 2, 3 y 4), agregar a la instrucción de la delegación:
+- **Delegación a subagentes — nota de Modo worktree.** Al delegar en `plan-writer`, `domain-model-advisor`, `architecture-advisor`, `documentation-writer`, `code-reviewer`, `security-auditor` o `test-generator` (Fases 2, 3, 4 y 5), agregar a la instrucción de la delegación:
 
   > "Esta sesión corre en el worktree `.claude/worktrees/<number>` (cwd ya resuelto — no hace falta `cd`). Tu base de diff es `origin/develop`, no `develop` local. Los archivos generados/gitignoreados del setup (`src/app/environments/environment.ts`, `.env`) sí existen tras `pnpm install` + `pnpm run config` aunque no estén versionados — antes de reportar una ruta como faltante, verificá con `git check-ignore <ruta>`."
 
@@ -156,9 +156,13 @@ En modo raíz, el flujo de Fase 1 queda **igual que hoy**.
 
 **Propósito:** producir un plan de implementación detallado para aprobación.
 
-1. Delegar al agente **`plan-writer`** pasándole la URL del issue, su descripción (el **body** recolectado en la Fase 0 → "Datos del issue"), el nombre de rama y la ruta de salida completa (`workspace/<number>/PLAN.md`). En modo worktree, adjuntar la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales". Si la Fase 0 reanudó acá con un plan ya escrito, saltear la delegación y pasar directo al resumen.
-2. El plan-writer produce `workspace/<number>/PLAN.md`.
-3. Presentar un resumen breve al usuario (objetivo, enfoque, archivos afectados, decisiones clave).
+1. **Determinar si el issue amerita asesoría previa de dominio o de arquitectura** (mismo patrón que el paso 2 de la Fase 4 con el `security-auditor`, pero _antes_ de planificar). A partir del alcance del issue (el body de la Fase 0 + una exploración inicial):
+   - **`domain-model-advisor`** si el issue crea o modifica entidades de dominio o value objects (`@models/*`, `src/app/models/`), mappers del ACL (`src/api/_utils/`), queries GROQ (`src/api/_queries/`) o tipos de dominio compartidos.
+   - **`architecture-advisor`** solo ante un cambio **estructuralmente significativo**: módulo nuevo bajo `src/api/modules/<dominio>/`, feature/provider/interfaz `-api` nuevo en el frontend, bounded context nuevo, o cambio de límites de módulo / dirección de dependencias. Un ajuste localizado —UI, copy, estilos, un campo puntual— **no** lo amerita: el `plan-writer` ya carga las mismas referencias según el diff y su pasada basta.
+2. **Delegar en paralelo los advisors que matcheen** (ambas delegaciones en el mismo turno si aplican los dos; son independientes y devuelven su evaluación como **texto**, no como archivo — no tienen `Write`). En modo worktree, adjuntar la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales". Capturar su salida.
+3. Delegar al agente **`plan-writer`** pasándole la URL del issue, su descripción (el **body** recolectado en la Fase 0 → "Datos del issue"), el nombre de rama, la ruta de salida completa (`workspace/<number>/PLAN.md`) y **la evaluación de los advisors que corrieron en el paso 2**. Los advisors los corre el orquestador —no el `plan-writer`, que no puede delegar en subagentes— y su aporte entra en el prompt del plan. En modo worktree, adjuntar la nota de delegación. Si la Fase 0 reanudó acá con un plan ya escrito, saltear los pasos 1-3 (los advisors ya corrieron y su aporte vive en el plan) y pasar directo al resumen.
+4. El plan-writer produce `workspace/<number>/PLAN.md`.
+5. Presentar un resumen breve al usuario (objetivo, enfoque, archivos afectados, decisiones clave).
 
 **⏸ PAUSA — decisión vía `AskUserQuestion`.**
 
@@ -170,7 +174,7 @@ Ramificación tras la respuesta:
 
 - **Aprobar** → avanzar a la Fase 3.
 - **Dar feedback** → pedir el texto del feedback al usuario y tratarlo igual que Other.
-- **Other** (feedback) → reenviar el texto recibido **a la misma Task del `plan-writer`** delegada en el paso 1 — conserva toda la exploración en contexto — para que revise `workspace/<number>/PLAN.md` en función del feedback y reescriba el plan en el mismo archivo. Nunca editar `PLAN.md` a mano desde el orquestador ni relanzar un `plan-writer` de cero mientras la Task siga disponible. Repetir la pausa tras cada revisión, iterando hasta un "Aprobar". Si la Task original ya no está disponible (p. ej. reanudación vía Fase 0 en una sesión nueva), delegar en un `plan-writer` nuevo pasándole el `PLAN.md` existente más el feedback — revisa sobre lo escrito, no re-explora de cero.
+- **Other** (feedback) → reenviar el texto recibido **a la misma Task del `plan-writer`** delegada en el paso 3 — conserva toda la exploración en contexto — para que revise `workspace/<number>/PLAN.md` en función del feedback y reescriba el plan en el mismo archivo. Los advisors del paso 2 **no** se re-corren: su aporte ya está incorporado al plan. Nunca editar `PLAN.md` a mano desde el orquestador ni relanzar un `plan-writer` de cero mientras la Task siga disponible. Repetir la pausa tras cada revisión, iterando hasta un "Aprobar". Si la Task original ya no está disponible (p. ej. reanudación vía Fase 0 en una sesión nueva), delegar en un `plan-writer` nuevo pasándole el `PLAN.md` existente más el feedback — revisa sobre lo escrito, no re-explora de cero.
 
 No avanzar a la Fase 3 sin una respuesta "Aprobar".
 


### PR DESCRIPTION
## Descripción

Tres agentes del catálogo estaban en limbo (ninguna fase los invocaba). Se decidió **por agente**, sin forzar los tres al flujo:

- **`domain-model-advisor` → cableado en la Fase 2** (disparador acotado: el issue crea/modifica entidades, value objects, mappers del ACL, queries GROQ o tipos de dominio). Segunda opinión DDD especialista antes de planificar.
- **`architecture-advisor` → cableado en la Fase 2 con umbral alto** (solo cambios estructuralmente significativos: módulo/capa/bounded context/dirección de dependencias nuevos). Un ajuste localizado no lo dispara — la carga de referencias del `plan-writer` ya basta, así el carve-out evita ceremonia.
- **`test-generator` → invocación manual/a demanda.** Su disparador propuesto ("estrategia de tests vaga") era inoperable: el `plan-writer` siempre produce una Estrategia de testing. Se declara manual y se le da un hook concreto y opcional en la Fase 5 (scaffolding de specs ante un gap de cobertura del `code-reviewer`) — aid, no gate. La `description` deja de sugerir una fase automática que no lo invoca (el bug que el issue pedía corregir).

Detalle de diseño: el orquestador corre los advisors **antes** del `plan-writer` y le pasa su evaluación en el prompt, porque `plan-writer` no tiene la herramienta `Task` (no puede delegar en subagentes). Los advisors no tienen `Write`: devuelven texto, sin artefacto en `workspace/`. En reanudación y en el loop de feedback no se re-corren.

Closes #1917.
Parte de #1907.

## Plan de pruebas

- [x] `pnpm check:agents` en verde tras cada commit (las 3 `description:` reescritas sin `: ` sin comillas — el gotcha de frontmatter)
- [x] Confirmado que `plan-writer.md` no tiene `Task` en sus tools (fundamento del diseño); los advisors tampoco tienen `Write`
- [x] Sin procedencia nueva en la prosa; las menciones pre-existentes (#1530/#1531/#1503, gobernanza/supresión de lint) no se tocaron
- [x] Gates locales en verde en worktree aislado: `test`, `lint`, `stylelint`, typecheck (tsc directo), `build`, `storybook:build` (`test:e2e` y `studio-build` omitidos: solo Markdown de `.claude/`)
- [x] Review del `code-reviewer`: APROBADO CON COMENTARIOS — 0 críticos/advertencias, 2 sugerencias de prosa (concordancia/repetición en los bullets) corregidas en la rama
