### PR TITLE
[#1996] - Unificar imports hacia el kernel a shortpaths en subproyectos (e2e y cms)

### DIFF
--- a/cms/sanity.cli.ts
+++ b/cms/sanity.cli.ts
@@ -20,14 +20,17 @@ export default defineCliConfig({
 	// tsconfig raíz. Se registra el alias @models hacia el kernel compartido para importar el dominio
 	// por shortpath en vez de rutas relativas ../../src/models. __dirname es cms/ (Sanity carga este
 	// config con su loader CJS), así que resuelve a <repo>/src/models.
-	vite: (config) => ({
-		...config,
-		resolve: {
-			...config.resolve,
-			alias: {
-				...config.resolve?.alias,
-				'@models': path.resolve(__dirname, '../src/models'),
-			},
-		},
-	}),
+	vite: (config) => {
+		const modelsPath = path.resolve(__dirname, '../src/models');
+		const existingAlias = config.resolve?.alias;
+		// resolve.alias admite forma objeto o array (readonly Alias[]): se mergea según la que Sanity
+		// provea para no corromperla — spread de un array dentro de un objeto generaría claves numéricas.
+		const alias = Array.isArray(existingAlias)
+			? [...existingAlias, { find: '@models', replacement: modelsPath }]
+			: { ...existingAlias, '@models': modelsPath };
+		return {
+			...config,
+			resolve: { ...config.resolve, alias },
+		};
+	},
 });

--- a/cms/sanity.cli.ts
+++ b/cms/sanity.cli.ts
@@ -1,4 +1,5 @@
 import { defineCliConfig } from 'sanity/cli';
+import path from 'node:path';
 
 export default defineCliConfig({
 	api: {
@@ -15,4 +16,18 @@ export default defineCliConfig({
 		schema: 'schema.json',
 		generates: '../src/sanity/types.ts',
 	},
+	// cms es un proyecto pnpm standalone: su build bundlea con Vite y no resuelve los `paths` del
+	// tsconfig raíz. Se registra el alias @models hacia el kernel compartido para importar el dominio
+	// por shortpath en vez de rutas relativas ../../src/models. __dirname es cms/ (Sanity carga este
+	// config con su loader CJS), así que resuelve a <repo>/src/models.
+	vite: (config) => ({
+		...config,
+		resolve: {
+			...config.resolve,
+			alias: {
+				...config.resolve?.alias,
+				'@models': path.resolve(__dirname, '../src/models'),
+			},
+		},
+	}),
 });

--- a/cms/schemas/contentCampaign.ts
+++ b/cms/schemas/contentCampaign.ts
@@ -7,7 +7,7 @@ import {
 	ContentCampaignViewport,
 	ContentCampaignViewportKeys,
 	viewportElementSizes,
-} from '../../src/models/content-campaign.model';
+} from '@models/content-campaign.model';
 
 const imageResourcePattern = /^image-([a-f\d]+)-(\d+x\d+)-(\w+)$/;
 

--- a/cms/tsconfig.json
+++ b/cms/tsconfig.json
@@ -4,6 +4,10 @@
 	// here will be ignored.
 	"include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx"],
 	"compilerOptions": {
-		"jsx": "react"
+		"jsx": "react",
+		"baseUrl": ".",
+		"paths": {
+			"@models/*": ["../src/models/*"]
+		}
 	}
 }

--- a/e2e/_utils/seo-invariants.ts
+++ b/e2e/_utils/seo-invariants.ts
@@ -14,8 +14,8 @@
  */
 import type { HTMLElement } from 'node-html-parser';
 
-import { validateJsonLd } from '../../src/testing/json-ld-validation';
-import type { SeoInvariantViolation } from '../../src/testing/seo-invariant-violation';
+import { validateJsonLd } from '@testing/json-ld-validation';
+import type { SeoInvariantViolation } from '@testing/seo-invariant-violation';
 import { parseHtml } from './seo';
 
 export interface IndexableHtmlExpectations {

--- a/e2e/seo/author.spec.ts
+++ b/e2e/seo/author.spec.ts
@@ -15,7 +15,7 @@
 import { test, expect } from '@playwright/test';
 
 import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
-import { assertValidJsonLd } from '../../src/testing/json-ld-validation';
+import { assertValidJsonLd } from '@testing/json-ld-validation';
 import { collectIndexableHtmlViolations } from '../_utils/seo-invariants';
 import { STABLE_SLUGS, SCHEMA_IDS, SITEWIDE_SCHEMA_IDS } from '../_utils/seo-fixtures';
 

--- a/e2e/seo/home.spec.ts
+++ b/e2e/seo/home.spec.ts
@@ -14,8 +14,8 @@
 import { test, expect } from '@playwright/test';
 
 import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
-import { assertValidJsonLd } from '../../src/testing/json-ld-validation';
-import type { SeoInvariantViolation } from '../../src/testing/seo-invariant-violation';
+import { assertValidJsonLd } from '@testing/json-ld-validation';
+import type { SeoInvariantViolation } from '@testing/seo-invariant-violation';
 import {
 	checkNgServerContext,
 	checkTitle,

--- a/e2e/seo/story.spec.ts
+++ b/e2e/seo/story.spec.ts
@@ -15,7 +15,7 @@
 import { test, expect } from '@playwright/test';
 
 import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
-import { assertValidJsonLd } from '../../src/testing/json-ld-validation';
+import { assertValidJsonLd } from '@testing/json-ld-validation';
 import { collectIndexableHtmlViolations } from '../_utils/seo-invariants';
 import { STABLE_SLUGS, SCHEMA_IDS, SITEWIDE_SCHEMA_IDS } from '../_utils/seo-fixtures';
 

--- a/e2e/seo/storylist.spec.ts
+++ b/e2e/seo/storylist.spec.ts
@@ -17,8 +17,8 @@
 import { test, expect } from '@playwright/test';
 
 import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
-import { assertValidJsonLd } from '../../src/testing/json-ld-validation';
-import type { SeoInvariantViolation } from '../../src/testing/seo-invariant-violation';
+import { assertValidJsonLd } from '@testing/json-ld-validation';
+import type { SeoInvariantViolation } from '@testing/seo-invariant-violation';
 import {
 	checkNgServerContext,
 	checkTitle,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,9 @@ const baseURL = process.env['BASE_URL'] || 'http://localhost:4000';
  */
 export default defineConfig({
 	...nxE2EPreset(__filename, { testDir: './e2e' }),
+	// El loader de Playwright transpila los specs por su cuenta y no aplica los `paths` del tsconfig
+	// sin esta opción explícita: la declara para resolver los aliases del repo (p. ej. @testing) en runtime.
+	tsconfig: './tsconfig.json',
 	// e2e/_utils aloja el core puro y su spec de Vitest (no de Playwright); se excluye del testMatch
 	// para que Playwright no intente correrlo (usa los globals de Vitest, no test/expect de Playwright).
 	testIgnore: '**/e2e/_utils/**',


### PR DESCRIPTION
## Descripción

Elimina los imports relativos `../../src/...` hacia el kernel compartido (promovido a top-level en #1992) desde los dos subproyectos que no resolvían los `paths` del tsconfig raíz, migrándolos a shortpaths:

- **e2e:** habilita la resolución de `paths` en el runtime de Playwright (opción top-level `tsconfig: './tsconfig.json'` en `playwright.config.ts`; el loader no los aplica sin esa declaración) y migra los 8 imports cross-boundary de `e2e/**` hacia `src/testing` al alias `@testing`. Los imports internos de e2e (`../_utils/...`) quedan relativos: son superficiales y no hay alias interno de e2e (YAGNI).
- **cms:** registra el alias `@models` en el build del Studio (hook `vite` con `resolve.alias` en `sanity.cli.ts`, blindado ante la forma objeto/array de Vite) y en el editor (`baseUrl`+`paths` en `cms/tsconfig.json`), y migra `cms/schemas/contentCampaign.ts` a `@models/content-campaign.model`. Se registra solo `@models`, el único alias que cms consume hoy (YAGNI); los globs de `typegen` quedan relativos por ser rutas de filesystem.

Con esto, ni `e2e/**` ni `cms/**` importan el kernel por ruta relativa `../../src/...`.

Closes #1996.

## Plan de pruebas

- [x] `typecheck` (tsc) — cubre `playwright.config.ts` + `e2e/**`.
- [x] `lint` — cubre `src` + `e2e`.
- [x] `studio-build` (`pnpm sanity:build`, tras `pnpm -C cms install`) — Vite resuelve `@models` en runtime.
- [x] Smoke `playwright test e2e/seo --list` (46 tests / 5 files) — el loader de Playwright resuelve `@testing` en runtime.
- [ ] `e2e` completo → lo corre CI (depende del build de prod + dataset).
- Review estructural: **aprobada**; la sugerencia de blindar el merge de `resolve.alias` (forma array de Vite) se incorporó a este PR.
