### PR TITLE
[#1998] - Deshabilita la navegación de frames hijos de happy-dom en los tests

### DIFF
--- a/src/testing/test-environment.spec.ts
+++ b/src/testing/test-environment.spec.ts
@@ -1,0 +1,12 @@
+import type { DetachedWindowAPI } from 'happy-dom';
+
+const happyDOM = (window as unknown as { happyDOM: DetachedWindowAPI }).happyDOM;
+
+describe('entorno de test (happy-dom)', () => {
+	// Con la navegación de frames hijos habilitada, cada <iframe> montado por un spec dispara un fetch
+	// real y su aborto al desmontar tumba la corrida entera. Afirmar el flag —y no el comportamiento
+	// observable— es deliberado: comprobarlo montando un iframe dependería de la red que se busca evitar.
+	it('no navega los frames hijos', () => {
+		expect(happyDOM.settings.navigation.disableChildFrameNavigation).toBe(true);
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,16 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: 'happy-dom',
+		// Por defecto happy-dom navega los frames hijos: cada <iframe> montado dispara un fetch real
+		// (p. ej. el embed de Spotify), que al desmontar el frame se aborta y emite un unhandled error
+		// que tumba la corrida. Los tests no deben depender de red externa.
+		environmentOptions: {
+			happyDOM: {
+				settings: {
+					navigation: { disableChildFrameNavigation: true },
+				},
+			},
+		},
 		setupFiles: ['src/test-setup.ts'],
 		include: ['src/**/*.{test,spec}.ts', 'scripts/**/*.{test,spec}.ts', 'e2e/_utils/**/*.{test,spec}.ts'],
 		// @sanity y los bundles fesm de Angular se inlinan para que Vite los transforme.


### PR DESCRIPTION
## Qué resuelve

El gate `test` caía de forma intermitente con exit code 1 **sin que ninguna aserción fallara**. La corrida moría por unhandled errors ([run 30376139624](https://github.com/cuentoneta/cuentoneta/actions/runs/30376139624/job/90334423460)):

```
DOMException [AbortError]: The operation was aborted.
    at AsyncTaskManager.abortAll (happy-dom/lib/async-task-manager/AsyncTaskManager.js:292:30)
    at HTMLIFrameElement.#unloadPage (happy-dom/lib/nodes/html-iframe-element/HTMLIFrameElement.js:363:33)

DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL
"https://open.spotify.com/embed/episode/5XmGKzNdtU1Ca8xXZVTf2Q": The operation was aborted.
```

`SpotifyPodcastEpisodeWidget` monta un `<iframe>` real apuntando a `open.spotify.com`, y happy-dom —con su configuración por defecto— **navega los frames hijos**: dispara un `fetch()` saliente por cada iframe montado. Al desmontar, destruye el frame y aborta ese fetch, que emite `AbortError` + `NetworkError` fuera del ciclo de vida del test. Vitest los cuenta como unhandled errors.

Los conteos calzaban exacto: 5 `AbortError` + 5 `NetworkError` = los 5 `it()` de `spotify-podcast-episode-widget.spec.ts`.

La intermitencia dependía de si Spotify respondía antes del teardown. De fondo, el problema real es que la suite unitaria dependía de una red externa que no controlamos.

## Cambios

- `vitest.config.ts`: se agrega `environmentOptions.happyDOM.settings.navigation.disableChildFrameNavigation`. En happy-dom 20 el flag histórico `disableIframePageLoading` está deprecado en favor de este (ver `IBrowserSettings.d.ts`).
- `src/testing/test-environment.spec.ts`: test de regresión que afirma el flag. Es deliberado que afirme la configuración y no el comportamiento observable — comprobarlo montando un iframe dependería de la misma red que se busca evitar, reintroduciendo la intermitencia.

Es config global del entorno de test, así que cubre también los otros specs que montan el embed (`media-selectors`, `literary-work-card-teaser`, `literary-work-home-card-teaser`). Ninguna aserción existente necesitaba que el iframe cargara: solo verifican presencia del elemento y la forma de su `src`.

## Verificación

- `pnpm exec vitest run` → **883 passed, 3 skipped, 0 unhandled errors**. La corrida local baja de ~55s (CI, con las esperas de red) a ~12s.
- Regresión comprobada en ambos sentidos: con `disableChildFrameNavigation: false` el nuevo test falla de forma determinística; con la config puesta, pasa.
- `pnpm lint` ✅ · `tsc --noEmit` (tsconfig.typecheck.json) ✅ · Prettier ✅

## Relación con #2000

Mientras se preparaba este fix, el merge del PR #1997 dejó el gate `test` roto en `develop` por una causa **independiente** (Vitest no resuelve `@testing/*` desde `e2e/_utils`). Como el CI de un PR corre sobre el merge con la base, este PR heredaba esa rotura y no podía dar verde.

Por eso queda **apilado sobre `feat/2000-vitest-alias-testing-e2e`** (PR #2001), que arregla esa otra causa. Orden de merge: primero #2001, después este — GitHub reapunta la base a `develop` automáticamente al mergear el primero.

Closes #1998
