### PR TITLE
[#2000] - Incluye e2e/_utils en tsconfig.spec.json para resolver @testing en Vitest

### DIFF
--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -10,5 +10,14 @@
 		"rootDir": "."
 	},
 	"files": ["src/test-setup.ts"],
-	"include": ["vitest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts", "src/test-utils.ts"]
+	// e2e/_utils entra acá porque su spec corre bajo Vitest: vite-tsconfig-paths solo aplica los
+	// `paths` a los archivos que un proyecto incluye, y sin esto el alias @testing no resuelve ahí.
+	"include": [
+		"vitest.config.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.d.ts",
+		"src/test-utils.ts",
+		"e2e/_utils/**/*.ts"
+	]
 }


### PR DESCRIPTION
## Qué resuelve

El gate `test` quedó **rojo en `develop`** desde el merge del PR #1997 ([run 30378354041](https://github.com/cuentoneta/cuentoneta/actions/runs/30378354041)):

```
FAIL  e2e/_utils/seo-invariants.spec.ts [ e2e/_utils/seo-invariants.spec.ts ]
Error: Failed to resolve import "@testing/json-ld-validation" from "e2e/_utils/seo-invariants.ts". Does the file exist?
  Plugin: vite:import-analysis
```

`e2e/_utils/seo-invariants.ts` tiene **dos consumidores**, y la unificación de imports a shortpaths cubrió solo uno:

- **Playwright** — resuelto por el `tsconfig: './tsconfig.json'` que #1997 agregó a `playwright.config.ts`. ✅
- **Vitest** — `e2e/_utils/**/*.spec.ts` está en el `include` de `vitest.config.ts` desde #1772, y ahí resuelve `vite-tsconfig-paths`. ❌

El plugin aplica los `paths` de un tsconfig **solo a los archivos que ese proyecto incluye**. `tsconfig.json` es solution-style (`"files": []`, `"include": []`, todo por `references`) y `tsconfig.spec.json` incluía únicamente `src/**`, así que ningún proyecto cubría `e2e/**`: para Vite el alias `@testing` no existía.

El gate `typecheck` no lo detectó porque `tsc` toma los `paths` del config extendido, sin el scoping por proyecto del plugin — de ahí que el PR pasara en verde salvo por `test`.

## Cambios

- `tsconfig.spec.json`: se agrega `e2e/_utils/**/*.ts` al `include`, que es el proyecto que representa lo que corre bajo Vitest.

## Verificación

- Antes del cambio, sobre `develop`: `seo-invariants.spec.ts` falla al colectar (1 failed | 115 passed).
- Con el cambio: `CI=true pnpm exec vitest run` → **882 passed, 3 skipped**, suite colectada y coverage generado.
- `pnpm lint` ✅ · `tsc --noEmit` (tsconfig.typecheck.json) ✅ · Prettier ✅

## Relación con #1998

Este PR y #1999 (issue #1998, iframe de Spotify en happy-dom) arreglan **dos causas independientes** del mismo gate rojo. Al correr el CI de un PR sobre el merge con `develop`, #1999 hereda esta rotura: se pone verde recién cuando este PR entre. Conviene mergear este primero.

Closes #2000
