### PR TITLE
[#1853] - Guard de _key en la materialización de reading time (preliminar)

### DIFF
--- a/src/models/reading-time-materialization.model.spec.ts
+++ b/src/models/reading-time-materialization.model.spec.ts
@@ -112,6 +112,17 @@ describe('buildReadingTimeMaterialization', () => {
 		expect(Object.keys(materialization.setIfMissing)).toContain('content[_key=="una-clave-arbitraria"].readingTime');
 	});
 
+	it('lanza ante un _key inseguro en vez de interpolar un path de patch envenenado (inyección GROQ)', () => {
+		// El `_key` se interpola en la expresión de selección `content[_key=="…"]` que ejecuta Sanity;
+		// solo se toca cuando la sección está sin materializar (readingTime null → arma el path).
+		const input: ReadingTimeMaterializationInput = {
+			sections: [{ _key: 'section-1"] || true', body: bodyOne, readingTime: null }],
+			totalReadingTime: null,
+		};
+
+		expect(() => buildReadingTimeMaterialization(input)).toThrow('_key de sección inseguro');
+	});
+
 	it('es idempotente: recomputar sobre una obra ya materializada no arma patch (write-once)', () => {
 		const first = buildReadingTimeMaterialization(allMissingInput());
 

--- a/src/models/reading-time-materialization.model.spec.ts
+++ b/src/models/reading-time-materialization.model.spec.ts
@@ -123,6 +123,63 @@ describe('buildReadingTimeMaterialization', () => {
 		expect(() => buildReadingTimeMaterialization(input)).toThrow('_key de sección inseguro');
 	});
 
+	// El `_key` solo se interpola cuando la sección está sin materializar (readingTime null → arma el
+	// path del patch). Se cubren varios vectores de la sintaxis GROQ que el allowlist debe rechazar.
+	for (const unsafeKey of ['section"', 'section]', 'section 1', 'section.1', '*', '']) {
+		it(`lanza ante el _key inseguro ${JSON.stringify(unsafeKey)}`, () => {
+			const input: ReadingTimeMaterializationInput = {
+				sections: [{ _key: unsafeKey, body: bodyOne, readingTime: null }],
+				totalReadingTime: null,
+			};
+
+			expect(() => buildReadingTimeMaterialization(input)).toThrow('_key de sección inseguro');
+		});
+	}
+
+	for (const safeKey of ['section-1', 'A_b-9', 'abcDEF0123']) {
+		it(`acepta el _key alfanumérico válido ${JSON.stringify(safeKey)}`, () => {
+			const input: ReadingTimeMaterializationInput = {
+				sections: [{ _key: safeKey, body: bodyOne, readingTime: null }],
+				totalReadingTime: null,
+			};
+
+			expect(() => buildReadingTimeMaterialization(input)).not.toThrow();
+		});
+	}
+
+	it('no valida el _key cuando la sección ya está materializada (no se arma el path del patch)', () => {
+		const input: ReadingTimeMaterializationInput = {
+			sections: [{ _key: 'section"] || true', body: bodyOne, readingTime: 3 }],
+			totalReadingTime: 3,
+		};
+
+		expect(() => buildReadingTimeMaterialization(input)).not.toThrow();
+	});
+
+	// Fail-fast del reading time persistido: `createReadingTime` lanza ante no-entero < 1, no hay
+	// fallback silencioso (finding S3). Cubre el total y el valor por sección.
+	for (const invalidTotal of [0, -1, 2.5]) {
+		it(`lanza ante un totalReadingTime persistido inválido (${invalidTotal})`, () => {
+			const input: ReadingTimeMaterializationInput = {
+				sections: [{ _key: 'section-1', body: bodyOne, readingTime: 3 }],
+				totalReadingTime: invalidTotal,
+			};
+
+			expect(() => buildReadingTimeMaterialization(input)).toThrow();
+		});
+	}
+
+	for (const invalidSection of [0, -1, 2.5]) {
+		it(`lanza ante un readingTime de sección persistido inválido (${invalidSection})`, () => {
+			const input: ReadingTimeMaterializationInput = {
+				sections: [{ _key: 'section-1', body: bodyOne, readingTime: invalidSection }],
+				totalReadingTime: null,
+			};
+
+			expect(() => buildReadingTimeMaterialization(input)).toThrow();
+		});
+	}
+
 	it('es idempotente: recomputar sobre una obra ya materializada no arma patch (write-once)', () => {
 		const first = buildReadingTimeMaterialization(allMissingInput());
 

--- a/src/models/reading-time-materialization.model.ts
+++ b/src/models/reading-time-materialization.model.ts
@@ -34,9 +34,16 @@ export interface ReadingTimeMaterializationWriter {
 	};
 }
 
-// Asume `_key` generado por Sanity (alfanumérico): el llamador construye el input desde documentos
-// del CMS, no desde entrada de usuario, así que no hace falta escapar comillas en el path.
+// `_key` es identidad de sección generada por Sanity (alfanumérico). Se valida antes de interpolarlo:
+// la expresión de selección la ejecuta el cliente Sanity, así que un `_key` corrupto (bug de migración,
+// doc mal formado) sería inyección GROQ en la ruta de escritura. Ante un `_key` inseguro se lanza para
+// que el consumidor degrade (no escribe) en vez de mandar un patch con un path envenenado.
+const SANITY_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
+
 function sectionReadingTimePath(key: string): string {
+	if (!SANITY_KEY_PATTERN.test(key)) {
+		throw new Error(`_key de sección inseguro para interpolar en el path del patch: "${key}"`);
+	}
 	return `content[_key=="${key}"].readingTime`;
 }
 


### PR DESCRIPTION
## Descripción

Fix de seguridad **preliminar y aislado** al modelo compartido de materialización de reading time (#1986), extraído del slice del repository (PR #2002) para landear independiente y proteger a todos sus consumidores antes de que aterrice el slice grande.

`sectionReadingTimePath` interpola el `_key` de sección en la expresión de selección `content[_key=="…"].readingTime` que el cliente Sanity ejecuta en la **ruta de escritura** del patch. La versión previa (draft #1929) validaba el `_key`; el rewrite de #1986 perdió esa guarda. Un `_key` corrupto (bug de migración, doc mal formado) sería **inyección GROQ** en la escritura.

- Reintroduce el guard `SANITY_KEY_PATTERN = /^[A-Za-z0-9_-]+$/` que **lanza** ante un `_key` inseguro, para que el consumidor degrade (no escribe) en vez de mandar un patch con un path envenenado.
- Es la **fuente única** de materialización, compartida por el repository de LiteraryWork (PR #2002) y el backfill batch (#1959) — el guard protege a ambos.
- Cobertura de valores inválidos ampliada: varios vectores de `_key` inseguro (comilla, corchete, espacio, punto, comodín, vacío), el borde de `_key` alfanuméricos válidos que pasan, el caso de que el guard no corre en secciones ya materializadas (no se arma el path), y el fail-fast de `createReadingTime` ante `totalReadingTime`/`readingTime` de sección persistidos inválidos.

Preliminar: el PR #2002 contiene hoy este mismo guard; cuando este PR mergee, #2002 se rebasa sobre `develop` y dropea su commit del guard.

Parte de #1853. Parte de #1481.

## Plan de pruebas

- [x] `typecheck` — PASS.
- [x] `lint` — PASS.
- [x] `test` (suite completa) — PASS (900 passed / 3 skipped; 28 en el spec del modelo).
