### PR TITLE
[#1853] - Service de LiteraryWork (Slice 1b)

### DIFF
--- a/src/api/modules/literary-work/literary-work.errors.ts
+++ b/src/api/modules/literary-work/literary-work.errors.ts
@@ -1,0 +1,6 @@
+export class LiteraryWorkNotFoundError extends Error {
+	constructor(slug: string) {
+		super(`LiteraryWork with slug "${slug}" not found`);
+		this.name = 'LiteraryWorkNotFoundError';
+	}
+}

--- a/src/api/modules/literary-work/literary-work.service.spec.ts
+++ b/src/api/modules/literary-work/literary-work.service.spec.ts
@@ -1,0 +1,17 @@
+import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
+import { getLiteraryWorkBySlug } from './literary-work.service';
+import { LiteraryWorkNotFoundError } from './literary-work.errors';
+import { InMemoryLiteraryWorkRepository } from './literary-work.repository.mock';
+
+describe('getLiteraryWorkBySlug', () => {
+	const [literaryWork] = onoffLiteraryWorksMock;
+	const repository = new InMemoryLiteraryWorkRepository(onoffLiteraryWorksMock);
+
+	it('devuelve el agregado de dominio para un slug existente', async () => {
+		expect(await getLiteraryWorkBySlug(literaryWork.slug, repository)).toBe(literaryWork);
+	});
+
+	it('lanza LiteraryWorkNotFoundError para un slug desconocido', async () => {
+		await expect(getLiteraryWorkBySlug('no-existe', repository)).rejects.toThrow(LiteraryWorkNotFoundError);
+	});
+});

--- a/src/api/modules/literary-work/literary-work.service.ts
+++ b/src/api/modules/literary-work/literary-work.service.ts
@@ -3,8 +3,7 @@ import { LiteraryWorkNotFoundError } from './literary-work.errors';
 import type { LiteraryWorkRepository } from './literary-work.repository';
 import { SanityLiteraryWorkRepository } from './literary-work.repository.sanity';
 
-// El default permite inyectar el doble en tests sin module mocking. El repository es stateless, así que
-// instanciarlo por llamada no tiene costo de estado compartido.
+// El repository es stateless, así que instanciarlo por llamada (default) no comparte estado.
 export async function getLiteraryWorkBySlug(
 	slug: string,
 	repository: LiteraryWorkRepository = new SanityLiteraryWorkRepository(),

--- a/src/api/modules/literary-work/literary-work.service.ts
+++ b/src/api/modules/literary-work/literary-work.service.ts
@@ -1,0 +1,17 @@
+import type { LiteraryWork } from '@models/literary-work.model';
+import { LiteraryWorkNotFoundError } from './literary-work.errors';
+import type { LiteraryWorkRepository } from './literary-work.repository';
+import { SanityLiteraryWorkRepository } from './literary-work.repository.sanity';
+
+// El default permite inyectar el doble en tests sin module mocking. El repository es stateless, así que
+// instanciarlo por llamada no tiene costo de estado compartido.
+export async function getLiteraryWorkBySlug(
+	slug: string,
+	repository: LiteraryWorkRepository = new SanityLiteraryWorkRepository(),
+): Promise<LiteraryWork> {
+	const literaryWork = await repository.fetchBySlug(slug);
+	if (!literaryWork) {
+		throw new LiteraryWorkNotFoundError(slug);
+	}
+	return literaryWork;
+}


### PR DESCRIPTION
## Descripción

Slice **1b (Service)** de la capa de datos de LiteraryWork, sobre el repository de #2002.

- `getLiteraryWorkBySlug(slug, repository?)`: llama `fetchBySlug` y traduce el `null` del repository en `LiteraryWorkNotFoundError` (que el controller #1930 mapeará a 404). **Sin** parámetro `section` — la lectura de sección `?section=N` se difirió. El default instancia el `SanityLiteraryWorkRepository` (stateless, sin costo por request).
- `LiteraryWorkNotFoundError` — error tipado por operación.
- Spec con el doble `InMemoryLiteraryWorkRepository` (su primer consumidor real): happy path + not-found.

Parte de #1853. Parte de #1481.

## Plan de pruebas
- [x] `typecheck` · `lint` · `test` (módulo literary-work: 12 tests, 10 repository + 2 service) — PASS.
- [x] code-review: **APROBADO**, sin críticos ni advertencias (1 sugerencia opcional aplicada).
- `build`/`storybook`/`stylelint`/`e2e`/`studio-build`: no aplican (backend puro, sin escritura ni GROQ nuevo).