### PR TITLE
Analytics de Nx off + ignore de la major de @types/node en Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,13 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # La major de @types/node tiene que seguir a la de engines.node (^22).
+      # Dependabot no lee engines y trata @types/node como un paquete más, así
+      # que hay que bloquear la major a mano y subirla al migrar de runtime.
+      - dependency-name: '@types/node'
+        update-types:
+          - version-update:semver-major
     commit-message:
       prefix: 'chore(deps)'
 
@@ -46,5 +53,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: '@types/node'
+        update-types:
+          - version-update:semver-major
     commit-message:
       prefix: 'chore(deps-cms)'

--- a/nx.json
+++ b/nx.json
@@ -132,5 +132,6 @@
 				"targetName": "eslint:lint"
 			}
 		}
-	]
+	],
+	"analytics": false
 }


### PR DESCRIPTION
## Descripción

Dos ajustes de tooling, separados del PR de `/read` (#2009) por no tener relación con esa feature (se hicieron en su rama y se movieron acá):

- **`nx.json`** — `analytics: false`: desactiva la telemetría de Nx.
- **`.github/dependabot.yml`** — ignora el bump de **major** de `@types/node` (raíz y `cms/`). Dependabot no lee `engines.node`, así que la major de `@types/node` debe seguir a mano la de `engines.node` (`^22`) y subirse recién al migrar de runtime.

Config-only, sin cambios de runtime (exento de tests).

## Plan de pruebas

- [x] Sin impacto en runtime; los gates de CI corren igual.
