### PR TITLE
[#2008] - Ergonomía de test-data del canon de Onoff: selectores por capacidad + it.each

### DIFF
--- a/src/api/modules/literary-work/literary-work.controller.spec.ts
+++ b/src/api/modules/literary-work/literary-work.controller.spec.ts
@@ -3,10 +3,9 @@ import { createLiteraryWorkController } from './literary-work.controller';
 import { InMemoryLiteraryWorkRepository } from './literary-work.repository.mock';
 
 describe('literaryWorkController', () => {
-	const [literaryWork] = onoffLiteraryWorksMock;
 	const controller = createLiteraryWorkController(new InMemoryLiteraryWorkRepository(onoffLiteraryWorksMock));
 
-	it('devuelve la obra completa con status 200 para un slug existente', async () => {
+	it.each(onoffLiteraryWorksMock)('devuelve la obra completa con status 200 para "$slug"', async (literaryWork) => {
 		const response = await controller.request(`/${literaryWork.slug}`);
 		const body = await response.json();
 

--- a/src/api/modules/literary-work/literary-work.repository.mock.spec.ts
+++ b/src/api/modules/literary-work/literary-work.repository.mock.spec.ts
@@ -2,10 +2,10 @@ import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
 import { InMemoryLiteraryWorkRepository } from './literary-work.repository.mock';
 
 describe('InMemoryLiteraryWorkRepository.fetchBySlug', () => {
-	const [literaryWork] = onoffLiteraryWorksMock;
+	const [firstLiteraryWork] = onoffLiteraryWorksMock;
 	const repository = new InMemoryLiteraryWorkRepository(onoffLiteraryWorksMock);
 
-	it('devuelve el agregado de dominio almacenado para un slug existente', async () => {
+	it.each(onoffLiteraryWorksMock)('devuelve el agregado de dominio almacenado para "$slug"', async (literaryWork) => {
 		expect(await repository.fetchBySlug(literaryWork.slug)).toBe(literaryWork);
 	});
 
@@ -14,6 +14,6 @@ describe('InMemoryLiteraryWorkRepository.fetchBySlug', () => {
 	});
 
 	it('devuelve null cuando no hay obras cargadas', async () => {
-		expect(await new InMemoryLiteraryWorkRepository().fetchBySlug(literaryWork.slug)).toBeNull();
+		expect(await new InMemoryLiteraryWorkRepository().fetchBySlug(firstLiteraryWork.slug)).toBeNull();
 	});
 });

--- a/src/api/modules/literary-work/literary-work.service.spec.ts
+++ b/src/api/modules/literary-work/literary-work.service.spec.ts
@@ -4,10 +4,9 @@ import { LiteraryWorkNotFoundError } from './literary-work.errors';
 import { InMemoryLiteraryWorkRepository } from './literary-work.repository.mock';
 
 describe('getLiteraryWorkBySlug', () => {
-	const [literaryWork] = onoffLiteraryWorksMock;
 	const repository = new InMemoryLiteraryWorkRepository(onoffLiteraryWorksMock);
 
-	it('devuelve el agregado de dominio para un slug existente', async () => {
+	it.each(onoffLiteraryWorksMock)('devuelve el agregado de dominio para "$slug"', async (literaryWork) => {
 		expect(await getLiteraryWorkBySlug(literaryWork.slug, repository)).toBe(literaryWork);
 	});
 

--- a/src/app/pages/read/read-meta-tags.directive.spec.ts
+++ b/src/app/pages/read/read-meta-tags.directive.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 
-import { elOdioLiteraryWorkMock } from '@mocks/onoff/el-odio.mock';
+import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
 import { type LiteraryWork } from '@models/literary-work.model';
 import { AppRoutes } from '../../app.routes';
 import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
@@ -39,30 +39,30 @@ describe('ReadMetaTagsDirective', () => {
 		expect(titleSpy).not.toHaveBeenCalled();
 	});
 
-	it('setea el título con el byline multi-autor cuando la obra resuelve', () => {
-		literaryWorkSignal.set(elOdioLiteraryWorkMock);
+	it.each(onoffLiteraryWorksMock)('setea el título con el byline multi-autor para "$slug"', (literaryWork) => {
+		literaryWorkSignal.set(literaryWork);
 		const titleSpy = spyOn(TestBed.inject(Title), 'setTitle');
 
 		instantiate();
 		TestBed.tick();
 
 		expect(titleSpy).toHaveBeenCalledWith(
-			expect.stringContaining(`${elOdioLiteraryWorkMock.title} - ${elOdioLiteraryWorkMock.authors[0].name}`),
+			expect.stringContaining(`${literaryWork.title} - ${literaryWork.authors[0].name}`),
 		);
 	});
 
-	it('setea la URL canónica de /read desde el slug de la obra', () => {
-		literaryWorkSignal.set(elOdioLiteraryWorkMock);
+	it.each(onoffLiteraryWorksMock)('setea la URL canónica de /read desde el slug de "$slug"', (literaryWork) => {
+		literaryWorkSignal.set(literaryWork);
 		const canonicalSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setCanonicalUrl');
 
 		instantiate();
 		TestBed.tick();
 
-		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(`${AppRoutes.Read}/${elOdioLiteraryWorkMock.slug}`));
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(`${AppRoutes.Read}/${literaryWork.slug}`));
 	});
 
 	it('marca la página como indexable', () => {
-		literaryWorkSignal.set(elOdioLiteraryWorkMock);
+		literaryWorkSignal.set(onoffLiteraryWorksMock[0]);
 		const robotsSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setRobots');
 
 		instantiate();

--- a/src/app/pages/read/read-meta-tags.directive.spec.ts
+++ b/src/app/pages/read/read-meta-tags.directive.spec.ts
@@ -39,7 +39,7 @@ describe('ReadMetaTagsDirective', () => {
 		expect(titleSpy).not.toHaveBeenCalled();
 	});
 
-	it.each(onoffLiteraryWorksMock)('setea el título con el byline multi-autor para "$slug"', (literaryWork) => {
+	it.each(onoffLiteraryWorksMock)('setea el título con el byline para "$slug"', (literaryWork) => {
 		literaryWorkSignal.set(literaryWork);
 		const titleSpy = spyOn(TestBed.inject(Title), 'setTitle');
 

--- a/src/app/pages/read/read-structured-data.directive.spec.ts
+++ b/src/app/pages/read/read-structured-data.directive.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { DOCUMENT } from '@angular/common';
 import { signal } from '@angular/core';
 
-import { elOdioLiteraryWorkMock } from '@mocks/onoff/el-odio.mock';
+import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
 import { type LiteraryWork } from '@models/literary-work.model';
 import { ReadStructuredDataDirective } from './read-structured-data.directive';
 import { READ_HOST } from './read-host';
@@ -39,8 +39,8 @@ describe('ReadStructuredDataDirective', () => {
 		expect(TestBed.inject(DOCUMENT).head.querySelector('script[data-schema-id="article"]')).toBeNull();
 	});
 
-	it('emite el Article y el breadcrumb cuando la obra resuelve', () => {
-		literaryWorkSignal.set(elOdioLiteraryWorkMock);
+	it.each(onoffLiteraryWorksMock)('emite el Article y el breadcrumb cuando resuelve "$slug"', (literaryWork) => {
+		literaryWorkSignal.set(literaryWork);
 
 		instantiate();
 		TestBed.tick();
@@ -55,7 +55,7 @@ describe('ReadStructuredDataDirective', () => {
 	});
 
 	it('remueve ambos bloques JSON-LD al destruirse', () => {
-		literaryWorkSignal.set(elOdioLiteraryWorkMock);
+		literaryWorkSignal.set(onoffLiteraryWorksMock[0]);
 		instantiate();
 		TestBed.tick();
 		const head = TestBed.inject(DOCUMENT).head;

--- a/src/app/pages/read/read.page.spec.ts
+++ b/src/app/pages/read/read.page.spec.ts
@@ -8,7 +8,6 @@ import { throwError, type Observable } from 'rxjs';
 
 // Models
 import type { LiteraryWork } from '@models/literary-work.model';
-import { elOdioLiteraryWorkMock } from '@mocks/onoff/el-odio.mock';
 import { onoffLiteraryWorksMock, onoffLiteraryWorksWithSectionTitles } from '@mocks/onoff-literary-works.mock';
 import { provideLiteraryWorkApiMock, StubLiteraryWorkApi } from '../../providers/literary-work.mock';
 import type { LiteraryWorkApi } from '../../providers/literary-work-api.interface';
@@ -22,9 +21,16 @@ class StubFailingLiteraryWorkApi implements LiteraryWorkApi {
 	}
 }
 
+// Obra representativa del canon para los casos que solo necesitan una obra cualquiera (su slug, o el
+// camino de error): se toma de la colección, no por import directo de un mock específico.
+const [representativeLiteraryWork] = onoffLiteraryWorksMock;
+
+// NOTA (#1471): `ReadPage` es hoy un walking skeleton (#1853); estos tests cubren su render y sus
+// estados mínimos. Al implementar la ReadPage V3 completa en #1471 se expanden y robustecen
+// (variantes de media, sección "Más cuentos", layout V3), reemplazando estos casos transitorios.
 describe('ReadPage', () => {
 	const setup = async (
-		literaryWork: LiteraryWork = elOdioLiteraryWorkMock,
+		literaryWork: LiteraryWork,
 		options: { api?: LiteraryWorkApi; responseInit?: ResponseInit } = {},
 	) => {
 		return await render(ReadPage, {
@@ -49,7 +55,11 @@ describe('ReadPage', () => {
 	);
 
 	it('renderiza el cuerpo saneado de la obra', async () => {
-		await setup(elOdioLiteraryWorkMock);
+		const elOdio = onoffLiteraryWorksMock.find((literaryWork) => literaryWork.slug === 'el-odio');
+		if (elOdio === undefined) {
+			throw new Error('El corpus de Onoff no contiene "el-odio"');
+		}
+		await setup(elOdio);
 
 		expect(await screen.findByText(/No empezó por nada/i)).toBeTruthy();
 	});
@@ -74,7 +84,7 @@ describe('ReadPage', () => {
 
 	it('renderiza el estado not-found y marca la respuesta SSR como 404', async () => {
 		const responseInit: ResponseInit = {};
-		await setup(elOdioLiteraryWorkMock, { api: new StubFailingLiteraryWorkApi(404), responseInit });
+		await setup(representativeLiteraryWork, { api: new StubFailingLiteraryWorkApi(404), responseInit });
 
 		expect(await screen.findByText(/no encontramos esta obra/i)).toBeTruthy();
 		expect(responseInit.status).toBe(404);
@@ -82,7 +92,7 @@ describe('ReadPage', () => {
 
 	it('no marca la respuesta SSR para errores que no son 404', async () => {
 		const responseInit: ResponseInit = {};
-		await setup(elOdioLiteraryWorkMock, { api: new StubFailingLiteraryWorkApi(500), responseInit });
+		await setup(representativeLiteraryWork, { api: new StubFailingLiteraryWorkApi(500), responseInit });
 
 		expect(await screen.findByText(/no encontramos esta obra/i)).toBeTruthy();
 		expect(responseInit.status).toBeUndefined();

--- a/src/app/pages/read/read.page.spec.ts
+++ b/src/app/pages/read/read.page.spec.ts
@@ -9,7 +9,8 @@ import { throwError, type Observable } from 'rxjs';
 // Models
 import type { LiteraryWork } from '@models/literary-work.model';
 import { elOdioLiteraryWorkMock } from '@mocks/onoff/el-odio.mock';
-import { provideLiteraryWorkApiMock } from '../../providers/literary-work.mock';
+import { onoffLiteraryWorksMock, onoffLiteraryWorksWithSectionTitles } from '@mocks/onoff-literary-works.mock';
+import { provideLiteraryWorkApiMock, StubLiteraryWorkApi } from '../../providers/literary-work.mock';
 import type { LiteraryWorkApi } from '../../providers/literary-work-api.interface';
 import ReadPage from './read.page';
 
@@ -22,43 +23,58 @@ class StubFailingLiteraryWorkApi implements LiteraryWorkApi {
 }
 
 describe('ReadPage', () => {
-	const setup = async (api?: LiteraryWorkApi, responseInit?: ResponseInit) => {
+	const setup = async (
+		literaryWork: LiteraryWork = elOdioLiteraryWorkMock,
+		options: { api?: LiteraryWorkApi; responseInit?: ResponseInit } = {},
+	) => {
 		return await render(ReadPage, {
 			providers: [
-				provideLiteraryWorkApiMock(api),
-				...(responseInit ? [{ provide: RESPONSE_INIT, useValue: responseInit }] : []),
+				provideLiteraryWorkApiMock(options.api ?? new StubLiteraryWorkApi(literaryWork)),
+				...(options.responseInit ? [{ provide: RESPONSE_INIT, useValue: options.responseInit }] : []),
 			],
-			inputs: { slug: elOdioLiteraryWorkMock.slug },
+			inputs: { slug: literaryWork.slug },
 		});
 	};
 
-	it('renderiza el H1, el byline y el cuerpo saneado', async () => {
-		await setup();
+	it.each(onoffLiteraryWorksMock)(
+		'renderiza el H1, el byline y la barra de lectura de "$slug"',
+		async (literaryWork) => {
+			await setup(literaryWork);
 
-		expect(await screen.findByRole('heading', { level: 1, name: elOdioLiteraryWorkMock.title })).toBeTruthy();
-		expect(screen.getByText(elOdioLiteraryWorkMock.authors[0].name)).toBeTruthy();
-		expect(screen.getByText(/No empezó por nada/i)).toBeTruthy();
+			expect(await screen.findByRole('heading', { level: 1, name: literaryWork.title })).toBeTruthy();
+			expect(screen.getByText(literaryWork.authors[0].name)).toBeTruthy();
+			expect(screen.getByText(new RegExp(`${literaryWork.totalReadingTime} minutos de lectura`))).toBeTruthy();
+			expect(screen.getByRole('button', { name: /compartir/i })).toBeTruthy();
+		},
+	);
+
+	it('renderiza el cuerpo saneado de la obra', async () => {
+		await setup(elOdioLiteraryWorkMock);
+
+		expect(await screen.findByText(/No empezó por nada/i)).toBeTruthy();
 	});
 
-	it('renderiza la barra de lectura con el tiempo total y el botón Compartir', async () => {
-		await setup();
+	it.each(onoffLiteraryWorksWithSectionTitles)(
+		'renderiza el título de sección de "$slug" con su ancla',
+		async (literaryWork) => {
+			await setup(literaryWork);
 
-		expect(
-			await screen.findByText(new RegExp(`${elOdioLiteraryWorkMock.totalReadingTime} minutos de lectura`)),
-		).toBeTruthy();
-		expect(screen.getByRole('button', { name: /compartir/i })).toBeTruthy();
-	});
+			const titledSection = literaryWork.content.find((section) => section.title !== undefined);
+			const sectionTitle = titledSection?.title;
+			if (sectionTitle === undefined) {
+				throw new Error(
+					`"${literaryWork.slug}" está en onoffLiteraryWorksWithSectionTitles pero no tiene sección con título`,
+				);
+			}
 
-	it('renderiza el título de sección con su ancla', async () => {
-		await setup();
-
-		const heading = await screen.findByRole('heading', { level: 2, name: 'El primer golpe' });
-		expect(heading.getAttribute('id')).toBe('el-primer-golpe');
-	});
+			const heading = await screen.findByRole('heading', { level: 2, name: sectionTitle.value });
+			expect(heading.getAttribute('id')).toBe(sectionTitle.toAnchor());
+		},
+	);
 
 	it('renderiza el estado not-found y marca la respuesta SSR como 404', async () => {
 		const responseInit: ResponseInit = {};
-		await setup(new StubFailingLiteraryWorkApi(404), responseInit);
+		await setup(elOdioLiteraryWorkMock, { api: new StubFailingLiteraryWorkApi(404), responseInit });
 
 		expect(await screen.findByText(/no encontramos esta obra/i)).toBeTruthy();
 		expect(responseInit.status).toBe(404);
@@ -66,7 +82,7 @@ describe('ReadPage', () => {
 
 	it('no marca la respuesta SSR para errores que no son 404', async () => {
 		const responseInit: ResponseInit = {};
-		await setup(new StubFailingLiteraryWorkApi(500), responseInit);
+		await setup(elOdioLiteraryWorkMock, { api: new StubFailingLiteraryWorkApi(500), responseInit });
 
 		expect(await screen.findByText(/no encontramos esta obra/i)).toBeTruthy();
 		expect(responseInit.status).toBeUndefined();

--- a/src/app/pages/read/read.page.spec.ts
+++ b/src/app/pages/read/read.page.spec.ts
@@ -55,13 +55,17 @@ describe('ReadPage', () => {
 	);
 
 	it('renderiza el cuerpo saneado de la obra', async () => {
-		const elOdio = onoffLiteraryWorksMock.find((literaryWork) => literaryWork.slug === 'el-odio');
-		if (elOdio === undefined) {
-			throw new Error('El corpus de Onoff no contiene "el-odio"');
-		}
-		await setup(elOdio);
+		await setup(representativeLiteraryWork);
 
-		expect(await screen.findByText(/No empezó por nada/i)).toBeTruthy();
+		// Una palabra del cuerpo saneado (sin tags) de la propia obra, para verificar que el bodyHtml
+		// se renderiza — derivada de la obra, no un texto clavado de una obra concreta.
+		const bodyText = representativeLiteraryWork.content[0].bodyHtml.replace(/<[^>]+>/g, ' ');
+		const [bodyWord] = bodyText.match(/\p{L}{6,}/gu) ?? [];
+		if (bodyWord === undefined) {
+			throw new Error(`La primera sección de "${representativeLiteraryWork.slug}" no tiene texto de cuerpo`);
+		}
+
+		expect((await screen.findAllByText(new RegExp(bodyWord, 'i'))).length).toBeGreaterThan(0);
 	});
 
 	it.each(onoffLiteraryWorksWithSectionTitles)(

--- a/src/app/pages/read/read.schema.spec.ts
+++ b/src/app/pages/read/read.schema.spec.ts
@@ -1,33 +1,40 @@
-import { elOdioLiteraryWorkMock } from '@mocks/onoff/el-odio.mock';
+import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
 import { buildLiteraryWorkArticleSchema, buildLiteraryWorkBreadcrumb } from './read.schema';
 
 const WEBSITE = 'https://test.cuentoneta.ar';
 
 describe('read.schema', () => {
 	describe('buildLiteraryWorkArticleSchema', () => {
-		const article = buildLiteraryWorkArticleSchema(elOdioLiteraryWorkMock, WEBSITE);
+		it.each(onoffLiteraryWorksMock)('construye un Article con headline y mainEntity de "$slug"', (literaryWork) => {
+			const article = buildLiteraryWorkArticleSchema(literaryWork, WEBSITE);
 
-		it('construye un Article con el título de la obra como headline', () => {
 			expect(article['@type']).toBe('Article');
-			expect(article.headline).toBe(elOdioLiteraryWorkMock.title);
-			expect(article.mainEntityOfPage).toBe(`${WEBSITE}/read/${elOdioLiteraryWorkMock.slug}`);
+			expect(article.headline).toBe(literaryWork.title);
+			expect(article.mainEntityOfPage).toBe(`${WEBSITE}/read/${literaryWork.slug}`);
 		});
 
-		it('emite un Person por autor (multi-autor)', () => {
+		it.each(onoffLiteraryWorksMock)('emite un Person por autor de "$slug" (multi-autor)', (literaryWork) => {
+			const article = buildLiteraryWorkArticleSchema(literaryWork, WEBSITE);
+
 			const authors = Array.isArray(article.author) ? article.author : [article.author];
-			expect(authors).toHaveLength(elOdioLiteraryWorkMock.authors.length);
-			expect(authors[0]).toMatchObject({ '@type': 'Person', name: elOdioLiteraryWorkMock.authors[0].name });
+			expect(authors).toHaveLength(literaryWork.authors.length);
+			expect(authors[0]).toMatchObject({ '@type': 'Person', name: literaryWork.authors[0].name });
 		});
 
-		it('omite dateModified (LiteraryWork no tiene updatedAt)', () => {
-			expect('dateModified' in article).toBe(false);
-		});
+		it.each(onoffLiteraryWorksMock)(
+			'omite dateModified para "$slug" (LiteraryWork no tiene updatedAt)',
+			(literaryWork) => {
+				const article = buildLiteraryWorkArticleSchema(literaryWork, WEBSITE);
+
+				expect('dateModified' in article).toBe(false);
+			},
+		);
 	});
 
 	describe('buildLiteraryWorkBreadcrumb', () => {
-		const breadcrumb = buildLiteraryWorkBreadcrumb(elOdioLiteraryWorkMock, WEBSITE);
+		it.each(onoffLiteraryWorksMock)('construye un BreadcrumbList de 2 niveles para "$slug"', (literaryWork) => {
+			const breadcrumb = buildLiteraryWorkBreadcrumb(literaryWork, WEBSITE);
 
-		it('construye un BreadcrumbList de 2 niveles (Inicio → obra)', () => {
 			expect(breadcrumb['@type']).toBe('BreadcrumbList');
 			expect(breadcrumb.itemListElement).toHaveLength(2);
 		});

--- a/src/app/pages/read/read.schema.spec.ts
+++ b/src/app/pages/read/read.schema.spec.ts
@@ -13,7 +13,7 @@ describe('read.schema', () => {
 			expect(article.mainEntityOfPage).toBe(`${WEBSITE}/read/${literaryWork.slug}`);
 		});
 
-		it.each(onoffLiteraryWorksMock)('emite un Person por autor de "$slug" (multi-autor)', (literaryWork) => {
+		it.each(onoffLiteraryWorksMock)('emite un Person por autor de "$slug"', (literaryWork) => {
 			const article = buildLiteraryWorkArticleSchema(literaryWork, WEBSITE);
 
 			const authors = Array.isArray(article.author) ? article.author : [article.author];

--- a/src/app/providers/literary-work.mock.ts
+++ b/src/app/providers/literary-work.mock.ts
@@ -9,7 +9,7 @@ import { LiteraryWorkApi } from './literary-work-api.interface';
 
 export class StubLiteraryWorkApi implements LiteraryWorkApi {
 	// Seam de construcción: un test puede alimentar la obra del canon que quiere ejercitar,
-	// sin hand-authorear un objeto paralelo. Default el-odio → compatible con los consumidores previos.
+	// sin hand-authorear un objeto paralelo.
 	constructor(private readonly literaryWork: LiteraryWork = elOdioLiteraryWorkMock) {}
 
 	public getBySlug(): Observable<LiteraryWork> {

--- a/src/app/providers/literary-work.mock.ts
+++ b/src/app/providers/literary-work.mock.ts
@@ -8,8 +8,12 @@ import { elOdioLiteraryWorkMock } from '@mocks/onoff/el-odio.mock';
 import { LiteraryWorkApi } from './literary-work-api.interface';
 
 export class StubLiteraryWorkApi implements LiteraryWorkApi {
+	// Seam de construcción: un test puede alimentar la obra del canon que quiere ejercitar,
+	// sin hand-authorear un objeto paralelo. Default el-odio → compatible con los consumidores previos.
+	constructor(private readonly literaryWork: LiteraryWork = elOdioLiteraryWorkMock) {}
+
 	public getBySlug(): Observable<LiteraryWork> {
-		return of(elOdioLiteraryWorkMock);
+		return of(this.literaryWork);
 	}
 }
 

--- a/src/app/providers/literary-work.mock.ts
+++ b/src/app/providers/literary-work.mock.ts
@@ -7,8 +7,6 @@ import type { LiteraryWork } from '@models/literary-work.model';
 import { LiteraryWorkApi } from './literary-work-api.interface';
 
 export class StubLiteraryWorkApi implements LiteraryWorkApi {
-	// El test provee la obra del canon de Onoff a ejercitar; sin default, para no acoplar el doble
-	// a una obra concreta ni hand-authorear un objeto paralelo.
 	constructor(private readonly literaryWork: LiteraryWork) {}
 
 	public getBySlug(): Observable<LiteraryWork> {

--- a/src/app/providers/literary-work.mock.ts
+++ b/src/app/providers/literary-work.mock.ts
@@ -4,19 +4,18 @@ import { Observable, of } from 'rxjs';
 
 // Models
 import type { LiteraryWork } from '@models/literary-work.model';
-import { elOdioLiteraryWorkMock } from '@mocks/onoff/el-odio.mock';
 import { LiteraryWorkApi } from './literary-work-api.interface';
 
 export class StubLiteraryWorkApi implements LiteraryWorkApi {
-	// Seam de construcción: un test puede alimentar la obra del canon que quiere ejercitar,
-	// sin hand-authorear un objeto paralelo.
-	constructor(private readonly literaryWork: LiteraryWork = elOdioLiteraryWorkMock) {}
+	// El test provee la obra del canon de Onoff a ejercitar; sin default, para no acoplar el doble
+	// a una obra concreta ni hand-authorear un objeto paralelo.
+	constructor(private readonly literaryWork: LiteraryWork) {}
 
 	public getBySlug(): Observable<LiteraryWork> {
 		return of(this.literaryWork);
 	}
 }
 
-export function provideLiteraryWorkApiMock(api: LiteraryWorkApi = new StubLiteraryWorkApi()): EnvironmentProviders {
+export function provideLiteraryWorkApiMock(api: LiteraryWorkApi): EnvironmentProviders {
 	return makeEnvironmentProviders([{ provide: LiteraryWorkApi, useValue: api }]);
 }

--- a/src/app/providers/literary-work.provider.spec.ts
+++ b/src/app/providers/literary-work.provider.spec.ts
@@ -2,7 +2,11 @@ import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import type { LiteraryWork } from '@models/literary-work.model';
-import { elOdioLiteraryWorkMock } from '@mocks/onoff/el-odio.mock';
+import {
+	onoffLiteraryWorksMock,
+	onoffLiteraryWorksWithEpigraphs,
+	onoffLiteraryWorksWithSectionTitles,
+} from '@mocks/onoff-literary-works.mock';
 import { environment } from '../environments/environment';
 import { Endpoints } from './endpoints';
 import { HttpLiteraryWorkApi } from './literary-work.provider';
@@ -39,27 +43,45 @@ describe('HttpLiteraryWorkApi', () => {
 		return result;
 	}
 
-	it('rehydrates the wire DTO back into the domain aggregate, frozen and with methods restored', async () => {
-		const dto = toWireDto(elOdioLiteraryWorkMock);
+	it.each(onoffLiteraryWorksMock)('rehidrata "$slug" al agregado de dominio, congelado', async (literaryWork) => {
+		const dto = toWireDto(literaryWork);
 		const rehydrated = await requestBySlug(dto);
 
 		// Round-trip: re-serializar el agregado rehidratado reproduce el DTO de origen.
 		expect(toWireDto(rehydrated)).toEqual(dto);
 		expect(Object.isFrozen(rehydrated)).toBe(true);
-		// toAnchor() no cruza el wire; la rehidratación lo reconstruye vía createSectionTitle.
-		expect(rehydrated.content[0].title?.toAnchor()).toBe(elOdioLiteraryWorkMock.content[0].title?.toAnchor());
-		expect(rehydrated.content[0].epigraphs?.[0].reference).toContain('Onoff');
 	});
 
-	it('derives totalReadingTime from the sections, ignoring the wire value', async () => {
-		const dto = toWireDto(elOdioLiteraryWorkMock);
-		const rehydrated = await requestBySlug({ ...dto, totalReadingTime: dto.totalReadingTime + 999 });
+	it.each(onoffLiteraryWorksMock)(
+		'deriva totalReadingTime de las secciones de "$slug", ignorando el valor del wire',
+		async (literaryWork) => {
+			const dto = toWireDto(literaryWork);
+			const rehydrated = await requestBySlug({ ...dto, totalReadingTime: dto.totalReadingTime + 999 });
 
-		expect(rehydrated.totalReadingTime).toBe(elOdioLiteraryWorkMock.totalReadingTime);
+			expect(rehydrated.totalReadingTime).toBe(literaryWork.totalReadingTime);
+		},
+	);
+
+	it.each(onoffLiteraryWorksWithSectionTitles)(
+		'reconstruye el toAnchor() del título de sección de "$slug"',
+		async (literaryWork) => {
+			const rehydrated = await requestBySlug(toWireDto(literaryWork));
+			// toAnchor() no cruza el wire; la rehidratación lo reconstruye vía createSectionTitle.
+			const index = literaryWork.content.findIndex((section) => section.title !== undefined);
+			expect(rehydrated.content[index].title?.toAnchor()).toBe(literaryWork.content[index].title?.toAnchor());
+		},
+	);
+
+	it.each(onoffLiteraryWorksWithEpigraphs)('preserva el epígrafe de "$slug" en el round-trip', async (literaryWork) => {
+		const rehydrated = await requestBySlug(toWireDto(literaryWork));
+		const index = literaryWork.content.findIndex((section) => (section.epigraphs?.length ?? 0) > 0);
+		expect(rehydrated.content[index].epigraphs?.[0].reference).toBe(
+			literaryWork.content[index].epigraphs?.[0].reference,
+		);
 	});
 
 	it('errors the stream when the DTO violates a domain invariant', async () => {
-		const dto = toWireDto(elOdioLiteraryWorkMock);
+		const dto = toWireDto(onoffLiteraryWorksMock[0]);
 
 		// authors: [] pasa el schema de zod (array vacío es shape válido) pero viola la invariante
 		// de dominio: la factory es la que lanza, no zod.
@@ -67,7 +89,7 @@ describe('HttpLiteraryWorkApi', () => {
 	});
 
 	it('errors the stream when the wire shape violates the DTO schema', async () => {
-		const dto = toWireDto(elOdioLiteraryWorkMock);
+		const dto = toWireDto(onoffLiteraryWorksMock[0]);
 		// readingTime como string en vez de number: zod lo rechaza en la frontera, antes de rehidratar.
 		const malformed = { ...dto, content: [{ ...dto.content[0], readingTime: 'dos' }] };
 

--- a/src/mocks/onoff-literary-works.mock.ts
+++ b/src/mocks/onoff-literary-works.mock.ts
@@ -20,3 +20,14 @@ export const onoffLiteraryWorksMock: LiteraryWork[] = [
 	lasDosAntorchasLiteraryWorkMock,
 	neronLiteraryWorkMock,
 ];
+
+// Selectores por capacidad, derivados por predicado: un spec declara el shape que necesita (obras con
+// título de sección / con epígrafes) en vez de conocer un slug concreto. Se auto-mantienen al crecer el
+// corpus o al enriquecer más obras, sin tocar los specs.
+export const onoffLiteraryWorksWithSectionTitles: LiteraryWork[] = onoffLiteraryWorksMock.filter((literaryWork) =>
+	literaryWork.content.some((section) => section.title !== undefined),
+);
+
+export const onoffLiteraryWorksWithEpigraphs: LiteraryWork[] = onoffLiteraryWorksMock.filter((literaryWork) =>
+	literaryWork.content.some((section) => (section.epigraphs?.length ?? 0) > 0),
+);

--- a/src/mocks/onoff/README.md
+++ b/src/mocks/onoff/README.md
@@ -27,7 +27,7 @@ Mismo elenco, coexistiendo con el corpus `Story`. Diferencias de origen del cont
 - **Cuerpo (`bodyHtml`):** vive como Markdown plano en `<slug>.md` (solo el cuerpo, sin metadata) y se importa con `?raw` de Vite. El mock corre `markdownToSanitizedHtml` (`@utils/markdown-pipeline.utils`) al cargar el módulo para obtener el `SanitizedHtml`; el `.md` es la fuente literal editable.
 - **`readingTime`:** se **deriva** del propio cuerpo (`deriveSectionReadingTime`); `totalReadingTime` lo suma la factory. No se hardcodea.
 - **Metadata** (título, slug, portada, autor, tags, publicación): literales TS en el mock, no en el `.md`.
-- **Secciones:** una por obra (`position: 0`, sin `title` ni `epigraphs`), ya que cada obra es prosa plana.
+- **Secciones:** una por obra (`position: 0`). La mayoría es prosa plana (sin `title` ni `epigraphs`), pero un subconjunto — `el-odio`, `el-palacio-de-las-nueve-fronteras`, `geometria` — lleva `title` (`SectionTitle`) + `epigraphs` para darle sustancia a los selectores por capacidad del canon (`onoffLiteraryWorksWithSectionTitles` / `onoffLiteraryWorksWithEpigraphs` en `onoff-literary-works.mock.ts`).
 
 Archivos:
 

--- a/src/mocks/onoff/el-palacio-de-las-nueve-fronteras.mock.ts
+++ b/src/mocks/onoff/el-palacio-de-las-nueve-fronteras.mock.ts
@@ -1,6 +1,7 @@
 import type { Story } from '@models/story.model';
 import { createLiteraryWork, type LiteraryWork } from '@models/literary-work.model';
-import { createLiteraryWorkSection } from '@models/literary-work-section.model';
+import { createLiteraryWorkEpigraph, createLiteraryWorkSection } from '@models/literary-work-section.model';
+import { createSectionTitle } from '@models/section-title.model';
 import { createMarkdown } from '@models/markdown.model';
 import { deriveSectionReadingTime } from '@models/reading-time.model';
 import { createIsoDateTime } from '@utils/date.utils';
@@ -271,6 +272,13 @@ export const palacioNueveFronterasLiteraryWorkMock: LiteraryWork = createLiterar
 	content: [
 		createLiteraryWorkSection({
 			position: 0,
+			title: createSectionTitle('La primera frontera'),
+			epigraphs: [
+				createLiteraryWorkEpigraph({
+					text: markdownToSanitizedHtml(createMarkdown('*Toda frontera es una puerta que finge ser un muro.*')),
+					reference: markdownToSanitizedHtml(createMarkdown('François Onoff, cuaderno de 1973')),
+				}),
+			],
 			bodyHtml: markdownToSanitizedHtml(palacioNueveFronterasBody),
 			readingTime: deriveSectionReadingTime(palacioNueveFronterasBody),
 		}),

--- a/src/mocks/onoff/geometria.mock.ts
+++ b/src/mocks/onoff/geometria.mock.ts
@@ -1,6 +1,7 @@
 import type { Story } from '@models/story.model';
 import { createLiteraryWork, type LiteraryWork } from '@models/literary-work.model';
-import { createLiteraryWorkSection } from '@models/literary-work-section.model';
+import { createLiteraryWorkEpigraph, createLiteraryWorkSection } from '@models/literary-work-section.model';
+import { createSectionTitle } from '@models/section-title.model';
 import { createMarkdown } from '@models/markdown.model';
 import { deriveSectionReadingTime } from '@models/reading-time.model';
 import { createIsoDateTime } from '@utils/date.utils';
@@ -291,6 +292,15 @@ export const geometriaLiteraryWorkMock: LiteraryWork = createLiteraryWork({
 	content: [
 		createLiteraryWorkSection({
 			position: 0,
+			title: createSectionTitle('El primer teorema'),
+			epigraphs: [
+				createLiteraryWorkEpigraph({
+					text: markdownToSanitizedHtml(
+						createMarkdown('*Entre dos puntos, la recta es la más breve de las mentiras.*'),
+					),
+					reference: markdownToSanitizedHtml(createMarkdown('François Onoff, cuaderno de 1971')),
+				}),
+			],
 			bodyHtml: markdownToSanitizedHtml(geometriaBody),
 			readingTime: deriveSectionReadingTime(geometriaBody),
 		}),


### PR DESCRIPTION
## Descripción

Ergonomía transversal de test-data de `LiteraryWork`: los specs dejan de clavar `elOdioLiteraryWorkMock` y usan selectores por capacidad + `it.each` deterministas sobre el canon de Onoff.

- **Selectores por predicado** en `onoff-literary-works.mock.ts`: `onoffLiteraryWorksWithSectionTitles` / `onoffLiteraryWorksWithEpigraphs` (`.filter(...)`, tipados `LiteraryWork[]`, auto-mantenidos) — un test declara el shape que necesita, no un slug.
- **`it.each`** en los specs de la capa de datos: backend (controller/service/repository.mock) sobre el canon entero; provider (round-trip/`totalReadingTime` sobre todo el canon; `toAnchor()`/epígrafe sobre los grupos); SEO de read (meta-tags/structured-data/schema); y `read.page` (con un seam de construcción en `StubLiteraryWorkApi`). Cada aserción deriva sus valores esperados del propio mock de la iteración.
- **2 obras enriquecidas** (`el-palacio-de-las-nueve-fronteras`, `geometria`) con título de sección + epígrafe → los grupos por capacidad tienen 3 elementos (antes solo `el-odio`). `onoff/README.md` corregido.

Determinista: **sin `Math.random()`** (descartado a propósito — un fallo se vuelve irreproducible); `it.each` cubre las 8 obras y nombra la que falla.

Fuera de alcance: `repository.sanity.spec.ts` y los mocks raw (operan sobre el corpus raw, no el canon de dominio).

Closes #2008.

## Plan de pruebas

- [x] `typecheck` / `lint` verdes.
- [x] `test` (unit): 1025 passed / 3 skipped (+99 casos por el `it.each` sobre las 8 obras).
- [x] `storybook:build` verde (las stories consumen el canon enriquecido).
- [x] Regresión de los teasers (`literary-work-card-teaser`, `home-card-teaser`) verificada verde tras el enriquecimiento.
- [x] Code review aprobado (2 sugerencias cosméticas incorporadas).

Parte de #1481.
