### PR TITLE
[#1963] - Endurece el manejo de tipos multimedia: type guards, dispatch único y descarte con rastro

### DIFF
--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -71,6 +71,7 @@ Un spec o una story que importa una obra concreta queda atado a ella: sus aserci
 | Una obra con o sin nota editorial         | `onoffLiteraryWorksWith(out)EditorialNote` / `onoffRawLiteraryWorksWith(out)EditorialNote`            |
 | Un texto con atribución (epígrafe o nota) | `onoffLiteraryWorkEpigraphsMock`; en stories, `corpusAttributedTexts` + `attributedTextSelectArgType` |
 | Una story o colección crudas              | `onoffRawStoriesMock`, `onoffRawCollectionsMock`, `onoffRawNavCollectionsMock`                        |
+| Una story o teaser crudos con multimedia  | `onoffRawStoriesWithMediaSources` / `onoffRawTeasersWithMediaSources`                                 |
 
 Corolario: **las aserciones se derivan del fixture**, no de prosa clavada. Si el caso necesita una palabra del texto, extraela del propio mock (`bodyHtml.replace(/<[^>]+>/g, ' ')` y tomá una palabra) en vez de escribirla a mano — así sigue pasando cuando el canon cambie. Si falta un selector para el shape que necesitás, **agregalo al agregador** (derivado por predicado, no una lista en paralelo) en vez de importar la obra.
 

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -516,11 +516,13 @@ interface MarkDef {
 
 **Propósito:** Encapsular diferentes tipos de contenido multimedia.
 
+`Media` es el tipo **ancho**: el de las colecciones y el que devuelve el ACL, con `data?: unknown` porque el supertipo no correlaciona el tag con la forma de su carga. `MediaTypes` es el **angosto**, la unión discriminada que consumen los widgets, donde cada tag ya fija su `data`. Se pasa de uno al otro con los type guards de abajo, nunca con una aserción.
+
 ```typescript
 interface Media {
 	title: string;
 	description: TextBlockContent[];
-	type: MediaTypeKey; // 'audioRecording' | 'spaceRecording' | 'youTubeVideo'
+	type: MediaTypeKey; // 'audioRecording' | 'spaceRecording' | 'youTubeVideo' | 'spotifyPodcastEpisode'
 	data?: unknown;
 }
 
@@ -529,17 +531,29 @@ interface AudioRecording extends Media {
 }
 
 interface SpaceRecording extends Media {
-	data: Tweet & { duration: string };
+	data: {
+		url: string | null; // null en la proyección de teaser, que no resuelve audioUrl
+		duration: string;
+		hostName: string;
+		hostAvatar?: string;
+		date: string;
+	};
 }
 
 interface YouTubeVideo extends Media {
 	data: { videoId: string };
 }
+
+interface SpotifyPodcastEpisode extends Media {
+	data: { url: string };
+}
+
+type MediaTypes = AudioRecording | SpaceRecording | YouTubeVideo | SpotifyPodcastEpisode;
 ```
 
-**Patrón:** Polimorfismo mediante discriminador (`type`).
+**Patrón:** Polimorfismo mediante discriminador (`type`). Los type guards (`isAudioRecording`, `isSpaceRecording`, `isYouTubeVideo`, `isSpotifyPodcastEpisode`) discriminan **solo por el tag** y no por la forma de `data`: `AudioRecording` y `SpotifyPodcastEpisode` son estructuralmente idénticos (`{ url }`), así que inspeccionar `data` no alcanza para distinguirlos. `narrowMedia(media: Media): MediaTypes` los encadena y lanza si el `type` no corresponde a ningún tag que el dominio modele.
 
-**Uso:** Asociar audio, tweets de espacios de X, y videos a historias.
+**Uso:** Asociar audio, espacios de X, episodios de podcast de Spotify y videos de YouTube a una obra o colección.
 
 ---
 

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -2,7 +2,7 @@
 import { client } from '../_helpers/sanity-connector';
 
 // Funciones
-import { mapMediaSources, mapMediaSourcesTeasers } from './media-sources.functions';
+import { mapMediaSources } from './media-sources.functions';
 import { mapImagery } from './storylist-imagery.functions';
 
 // Tipos de Sanity
@@ -193,7 +193,7 @@ function mapStorylistTeasers(result: StorylistTeasersQueryResult): StorylistTeas
 			tags: mapTags(item.tags),
 			stories: [],
 			tabs: [],
-			media: mapMediaSourcesTeasers(mediaSources),
+			media: mapMediaSources(mediaSources),
 			imagery: mapImagery({ featuredImage, storyCoverImages }),
 		};
 	});
@@ -241,7 +241,7 @@ export function mapStoryTeaser(result: StoryTeasersQueryResult): StoryTeaser[] {
 		stories.push({
 			...properties,
 			coverImage: urlFor(coverImage),
-			media: mapMediaSourcesTeasers(mediaSources),
+			media: mapMediaSources(mediaSources),
 			resources: mapResources(resources),
 			paragraphs: mapBlockContentToTextParagraphs(body) as [TextBlockContent, TextBlockContent, TextBlockContent],
 			tags: [],
@@ -260,7 +260,7 @@ export function mapStoryNavigationTeaser(result: NonNullable<StoriesByAuthorSlug
 		stories.push({
 			...properties,
 			coverImage: urlFor(coverImage),
-			media: mapMediaSourcesTeasers(mediaSources),
+			media: mapMediaSources(mediaSources),
 			resources: mapResources(resources),
 			paragraphs: [],
 			tags: [],
@@ -283,7 +283,7 @@ export function mapStoryNavigationTeaserWithAuthor(
 			...properties,
 			author: mapAuthorTeaser(item.author),
 			coverImage: urlFor(coverImage),
-			media: mapMediaSourcesTeasers(mediaSources),
+			media: mapMediaSources(mediaSources),
 			resources: mapResources(resources),
 			paragraphs: [],
 			tags: [],

--- a/src/api/_utils/media-sources.functions.spec.ts
+++ b/src/api/_utils/media-sources.functions.spec.ts
@@ -1,0 +1,81 @@
+import { mapMediaSources, mapMediaSourcesTeasers } from './media-sources.functions';
+import { onoffRawStoriesWithMediaSources, onoffRawTeasersWithMediaSources } from '@mocks/onoff-raw-stories.mock';
+import type { AudioRecording, SpaceRecording, SpotifyPodcastEpisode, YouTubeVideo } from '@models/media.model';
+
+const [rawStory] = onoffRawStoriesWithMediaSources;
+const [rawTeaser] = onoffRawTeasersWithMediaSources;
+
+function rawSourceOfType<T extends (typeof rawStory.mediaSources)[number]['_type']>(type: T) {
+	const source = rawStory.mediaSources.find((mediaSource) => mediaSource._type === type);
+	if (source === undefined) {
+		throw new Error(`El fixture no trae un mediaSource de tipo "${type}"`);
+	}
+	return source as Extract<(typeof rawStory.mediaSources)[number], { _type: T }>;
+}
+
+describe('mapMediaSources', () => {
+	it('mapea el audio recording con su url', () => {
+		const [audioRecording] = mapMediaSources(rawStory.mediaSources).filter(
+			(media) => media.type === 'audioRecording',
+		) as AudioRecording[];
+		const source = rawSourceOfType('audioRecording');
+
+		expect(audioRecording.title).toBe(source.title);
+		expect(audioRecording.data.url).toBe(source.url);
+	});
+
+	it('mapea el space recording resolviendo audioUrl y su metadata', () => {
+		const [spaceRecording] = mapMediaSources(rawStory.mediaSources).filter(
+			(media) => media.type === 'spaceRecording',
+		) as SpaceRecording[];
+
+		expect(spaceRecording.data.url).toBe('https://cdn.example.org/onoff/geometria-space.ogg');
+		expect(spaceRecording.data.duration).toBe('48:12');
+		expect(spaceRecording.data.hostName).toBe('Biblioteca del Méridien');
+	});
+
+	it('mapea el episodio de podcast y el video con su dato propio', () => {
+		const mapped = mapMediaSources(rawStory.mediaSources);
+		const [podcast] = mapped.filter((media) => media.type === 'spotifyPodcastEpisode') as SpotifyPodcastEpisode[];
+		const [video] = mapped.filter((media) => media.type === 'youTubeVideo') as YouTubeVideo[];
+
+		expect(podcast.data.url).toContain('open.spotify.com');
+		expect(video.data.videoId).toBe('geometriaVideoId');
+	});
+
+	// El fixture lleva un pdfLink: un `_type` que el schema admite y el dominio no modela.
+	it('descarta el tipo que el dominio no modela', () => {
+		const mapped = mapMediaSources(rawStory.mediaSources);
+
+		expect(rawSourceOfType('pdfLink')).toBeTruthy();
+		expect(mapped.map((media) => media.type)).toEqual([
+			'audioRecording',
+			'spaceRecording',
+			'spotifyPodcastEpisode',
+			'youTubeVideo',
+		]);
+	});
+});
+
+describe('mapMediaSourcesTeasers', () => {
+	it('mapea los mismos tipos que la proyección completa', () => {
+		const mapped = mapMediaSourcesTeasers(rawTeaser.mediaSources);
+
+		expect(mapped.map((media) => media.type)).toEqual([
+			'audioRecording',
+			'spaceRecording',
+			'spotifyPodcastEpisode',
+			'youTubeVideo',
+		]);
+	});
+
+	// Caracterización del comportamiento vigente: la proyección de teaser no resuelve audioUrl y hoy
+	// el mapeo responde vaciando `data`, en vez de transportar la metadata que sí proyecta.
+	it('produce un space recording sin data', () => {
+		const [spaceRecording] = mapMediaSourcesTeasers(rawTeaser.mediaSources).filter(
+			(media) => media.type === 'spaceRecording',
+		);
+
+		expect(spaceRecording.data).toEqual({});
+	});
+});

--- a/src/api/_utils/media-sources.functions.spec.ts
+++ b/src/api/_utils/media-sources.functions.spec.ts
@@ -1,7 +1,7 @@
 import { spyOn } from '@test-utils';
 import { mapMediaSources } from './media-sources.functions';
 import { onoffRawStoriesWithMediaSources, onoffRawTeasersWithMediaSources } from '@mocks/onoff-raw-stories.mock';
-import type { AudioRecording, SpaceRecording, SpotifyPodcastEpisode, YouTubeVideo } from '@models/media.model';
+import { isAudioRecording, isSpaceRecording, isSpotifyPodcastEpisode, isYouTubeVideo } from '@models/media.model';
 
 const [rawStory] = onoffRawStoriesWithMediaSources;
 const [rawTeaser] = onoffRawTeasersWithMediaSources;
@@ -16,9 +16,7 @@ function rawSourceOfType<T extends (typeof rawStory.mediaSources)[number]['_type
 
 describe('mapMediaSources', () => {
 	it('mapea el audio recording con su url', () => {
-		const [audioRecording] = mapMediaSources(rawStory.mediaSources).filter(
-			(media) => media.type === 'audioRecording',
-		) as AudioRecording[];
+		const [audioRecording] = mapMediaSources(rawStory.mediaSources).filter(isAudioRecording);
 		const source = rawSourceOfType('audioRecording');
 
 		expect(audioRecording.title).toBe(source.title);
@@ -26,22 +24,21 @@ describe('mapMediaSources', () => {
 	});
 
 	it('mapea el space recording resolviendo audioUrl y su metadata', () => {
-		const [spaceRecording] = mapMediaSources(rawStory.mediaSources).filter(
-			(media) => media.type === 'spaceRecording',
-		) as SpaceRecording[];
+		const [spaceRecording] = mapMediaSources(rawStory.mediaSources).filter(isSpaceRecording);
+		const source = rawSourceOfType('spaceRecording');
 
-		expect(spaceRecording.data.url).toBe('https://cdn.example.org/onoff/geometria-space.ogg');
-		expect(spaceRecording.data.duration).toBe('48:12');
-		expect(spaceRecording.data.hostName).toBe('Biblioteca del Méridien');
+		expect(spaceRecording.data.url).toBe(source.audioUrl);
+		expect(spaceRecording.data.duration).toBe(source.duration);
+		expect(spaceRecording.data.hostName).toBe(source.hostName);
 	});
 
 	it('mapea el episodio de podcast y el video con su dato propio', () => {
 		const mapped = mapMediaSources(rawStory.mediaSources);
-		const [podcast] = mapped.filter((media) => media.type === 'spotifyPodcastEpisode') as SpotifyPodcastEpisode[];
-		const [video] = mapped.filter((media) => media.type === 'youTubeVideo') as YouTubeVideo[];
+		const [podcast] = mapped.filter(isSpotifyPodcastEpisode);
+		const [video] = mapped.filter(isYouTubeVideo);
 
-		expect(podcast.data.url).toContain('open.spotify.com');
-		expect(video.data.videoId).toBe('geometriaVideoId');
+		expect(podcast.data.url).toBe(rawSourceOfType('spotifyPodcastEpisode').url);
+		expect(video.data.videoId).toBe(rawSourceOfType('youTubeVideo').videoId);
 	});
 
 	// El fixture lleva un pdfLink: un `_type` que el schema admite y el dominio no modela.
@@ -73,13 +70,12 @@ describe('mapMediaSources sobre la proyección de teaser', () => {
 	// La proyección de teaser no resuelve audioUrl, pero sí trae el resto de la metadata: el space
 	// recording del teaser es una SpaceRecording válida con la url en null, no un objeto vacío.
 	it('produce un space recording con su metadata y la url en null', () => {
-		const [spaceRecording] = mapMediaSources(rawTeaser.mediaSources).filter(
-			(media) => media.type === 'spaceRecording',
-		) as SpaceRecording[];
+		const [spaceRecording] = mapMediaSources(rawTeaser.mediaSources).filter(isSpaceRecording);
+		const source = rawSourceOfType('spaceRecording');
 
 		expect(spaceRecording.data.url).toBeNull();
-		expect(spaceRecording.data.duration).toBe('48:12');
-		expect(spaceRecording.data.hostName).toBe('Biblioteca del Méridien');
+		expect(spaceRecording.data.duration).toBe(source.duration);
+		expect(spaceRecording.data.hostName).toBe(source.hostName);
 	});
 });
 

--- a/src/api/_utils/media-sources.functions.spec.ts
+++ b/src/api/_utils/media-sources.functions.spec.ts
@@ -1,4 +1,5 @@
-import { mapMediaSources, mapMediaSourcesTeasers } from './media-sources.functions';
+import { spyOn } from '@test-utils';
+import { mapMediaSources } from './media-sources.functions';
 import { onoffRawStoriesWithMediaSources, onoffRawTeasersWithMediaSources } from '@mocks/onoff-raw-stories.mock';
 import type { AudioRecording, SpaceRecording, SpotifyPodcastEpisode, YouTubeVideo } from '@models/media.model';
 
@@ -57,9 +58,9 @@ describe('mapMediaSources', () => {
 	});
 });
 
-describe('mapMediaSourcesTeasers', () => {
+describe('mapMediaSources sobre la proyección de teaser', () => {
 	it('mapea los mismos tipos que la proyección completa', () => {
-		const mapped = mapMediaSourcesTeasers(rawTeaser.mediaSources);
+		const mapped = mapMediaSources(rawTeaser.mediaSources);
 
 		expect(mapped.map((media) => media.type)).toEqual([
 			'audioRecording',
@@ -69,13 +70,27 @@ describe('mapMediaSourcesTeasers', () => {
 		]);
 	});
 
-	// Caracterización del comportamiento vigente: la proyección de teaser no resuelve audioUrl y hoy
-	// el mapeo responde vaciando `data`, en vez de transportar la metadata que sí proyecta.
-	it('produce un space recording sin data', () => {
-		const [spaceRecording] = mapMediaSourcesTeasers(rawTeaser.mediaSources).filter(
+	// La proyección de teaser no resuelve audioUrl, pero sí trae el resto de la metadata: el space
+	// recording del teaser es una SpaceRecording válida con la url en null, no un objeto vacío.
+	it('produce un space recording con su metadata y la url en null', () => {
+		const [spaceRecording] = mapMediaSources(rawTeaser.mediaSources).filter(
 			(media) => media.type === 'spaceRecording',
-		);
+		) as SpaceRecording[];
 
-		expect(spaceRecording.data).toEqual({});
+		expect(spaceRecording.data.url).toBeNull();
+		expect(spaceRecording.data.duration).toBe('48:12');
+		expect(spaceRecording.data.hostName).toBe('Biblioteca del Méridien');
+	});
+});
+
+describe('descarte de un tipo sin modelo de dominio', () => {
+	it('deja rastro en el log en vez de descartarlo en silencio', () => {
+		const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
+
+		mapMediaSources(rawStory.mediaSources);
+
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining('pdfLink'), {
+			_key: rawSourceOfType('pdfLink')._key,
+		});
 	});
 });

--- a/src/api/_utils/media-sources.functions.ts
+++ b/src/api/_utils/media-sources.functions.ts
@@ -4,75 +4,71 @@ import { LiteraryWorkBySlugQueryResult, StoryBySlugQueryResult, StorylistQueryRe
 // Modelos
 import {
 	AudioRecording,
-	AudioRecordingSchemaObject,
 	Media,
+	MediaTypeKey,
 	SpaceRecording,
-	SpotifyPodcasteEpisodeSchemaObject,
 	SpotifyPodcastEpisode,
 	YouTubeVideo,
-	YoutubeVideoSchemaObject,
 } from '@models/media.model';
 import { mapBlockContentToTextParagraphs, urlFor } from './functions';
 
-// mapMediaSources se invoca con la proyección de mediaSources tanto de story como de
-// storylist. Hoy son estructuralmente idénticas; aceptar ambas explícitamente documenta
-// el acoplamiento. SpaceRecordingSource se extrae de la de story: si una futura corrida de
-// typegen diverge la de storylist, getSpaceRecordingData deja de compilar (no es silencioso).
+// El mapeo se invoca con la proyección de mediaSources de story, storylist, obra y teaser. Hoy son
+// estructuralmente idénticas salvo por `audioUrl`, que solo resuelven las tres primeras; aceptarlas
+// todas explícitamente documenta el acoplamiento. Los shapes por tipo se derivan del generado por
+// typegen: si una futura corrida diverge, el mapeo deja de compilar en vez de fallar en silencio.
 type StoryMediaSources = NonNullable<StoryBySlugQueryResult>['mediaSources'];
 type StorylistMediaSources = NonNullable<StorylistQueryResult>['mediaSources'];
 type LiteraryWorkMediaSources = NonNullable<LiteraryWorkBySlugQueryResult>['mediaSources'];
-type SpaceRecordingSource = Extract<StoryMediaSources[number], { _type: 'spaceRecording' }>;
+type MediaResourcesTeasersSubquery = NonNullable<StorylistQueryResult>['stories'][0]['mediaSources'];
+
+type MediaSource = (
+	StoryMediaSources | StorylistMediaSources | LiteraryWorkMediaSources | MediaResourcesTeasersSubquery
+)[number];
+
+type AudioRecordingSource = Extract<StoryMediaSources[number], { _type: 'audioRecording' }>;
+type SpaceRecordingSource = Extract<MediaSource, { _type: 'spaceRecording' }>;
+type SpotifyPodcastEpisodeSource = Extract<StoryMediaSources[number], { _type: 'spotifyPodcastEpisode' }>;
+type YouTubeVideoSource = Extract<StoryMediaSources[number], { _type: 'youTubeVideo' }>;
+
 export function mapMediaSources(
-	mediaSources: StoryMediaSources | StorylistMediaSources | LiteraryWorkMediaSources,
+	mediaSources: StoryMediaSources | StorylistMediaSources | LiteraryWorkMediaSources | MediaResourcesTeasersSubquery,
 ): Media[] {
 	if (!mediaSources) return [];
 
 	const media: Media[] = [];
 	for (const mediaSource of mediaSources) {
-		if (mediaSource._type === 'audioRecording') {
-			media.push(getAudioRecordingData(mediaSource as AudioRecordingSchemaObject));
-		}
-		if (mediaSource._type === 'spaceRecording') {
-			media.push(getSpaceRecordingData(mediaSource));
-		}
-		if (mediaSource._type === 'spotifyPodcastEpisode') {
-			media.push(getSpotifyPodcastEpisodeData(mediaSource as SpotifyPodcasteEpisodeSchemaObject));
-		}
-		if (mediaSource._type === 'youTubeVideo') {
-			media.push(getYoutubeVideoData(mediaSource as YoutubeVideoSchemaObject));
+		const mapped = mapMediaSource(mediaSource);
+		if (mapped) {
+			media.push(mapped);
 		}
 	}
 	return media;
 }
 
-type MediaResourcesTeasersSubquery = NonNullable<StorylistQueryResult>['stories'][0]['mediaSources'];
-export function mapMediaSourcesTeasers(mediaSources: MediaResourcesTeasersSubquery): Media[] {
-	if (!mediaSources) return [];
-
-	const media: Media[] = [];
-	for (const mediaSource of mediaSources) {
-		if (mediaSource._type === 'audioRecording') {
-			media.push(getAudioRecordingData(mediaSource as AudioRecordingSchemaObject));
-		}
-		if (mediaSource._type === 'spaceRecording') {
-			media.push({
-				title: mediaSource.title,
-				type: 'spaceRecording',
-				description: mapBlockContentToTextParagraphs(mediaSource.description),
-				data: {},
+function mapMediaSource(mediaSource: MediaSource): Media | undefined {
+	switch (mediaSource._type) {
+		case 'audioRecording':
+			return getAudioRecordingData(mediaSource);
+		case 'spaceRecording':
+			return getSpaceRecordingData(mediaSource);
+		case 'spotifyPodcastEpisode':
+			return getSpotifyPodcastEpisodeData(mediaSource);
+		case 'youTubeVideo':
+			return getYoutubeVideoData(mediaSource);
+		default: {
+			// El schema admite tipos que el dominio no modela (hoy, pdfLink): se descartan en vez de
+			// tirar la respuesta entera, porque son contenido que un editor cargó legítimamente. La
+			// anotación cubre el otro caso: si se suma un MediaTypeKey sin su rama, deja de compilar.
+			const unmappedType: Exclude<typeof mediaSource._type, MediaTypeKey> = mediaSource._type;
+			console.warn(`mediaSource descartado: el tipo "${unmappedType}" no tiene modelo de dominio`, {
+				_key: mediaSource._key,
 			});
-		}
-		if (mediaSource._type === 'spotifyPodcastEpisode') {
-			media.push(getSpotifyPodcastEpisodeData(mediaSource as SpotifyPodcasteEpisodeSchemaObject));
-		}
-		if (mediaSource._type === 'youTubeVideo') {
-			media.push(getYoutubeVideoData(mediaSource as YoutubeVideoSchemaObject));
+			return undefined;
 		}
 	}
-	return media;
 }
 
-function getAudioRecordingData(mediaSource: AudioRecordingSchemaObject): AudioRecording {
+function getAudioRecordingData(mediaSource: AudioRecordingSource): AudioRecording {
 	return {
 		title: mediaSource.title,
 		type: mediaSource._type,
@@ -89,9 +85,9 @@ function getSpaceRecordingData(mediaSource: SpaceRecordingSource): SpaceRecordin
 		type: mediaSource._type,
 		description: mapBlockContentToTextParagraphs(mediaSource.description),
 		data: {
-			// Se pasa null tal cual (en vez de '') para que el widget pueda mostrar un
-			// placeholder visible en historias aún no migradas, en vez de un reproductor roto.
-			url: mediaSource.audioUrl,
+			// La proyección de teaser no resuelve audioUrl; el resto sí. Se pasa null tal cual (en vez
+			// de '') para que el widget muestre un placeholder visible en vez de un reproductor roto.
+			url: 'audioUrl' in mediaSource ? mediaSource.audioUrl : null,
 			duration: mediaSource.duration,
 			hostName: mediaSource.hostName,
 			hostAvatar: mediaSource.hostAvatar ? urlFor(mediaSource.hostAvatar) : undefined,
@@ -100,7 +96,7 @@ function getSpaceRecordingData(mediaSource: SpaceRecordingSource): SpaceRecordin
 	};
 }
 
-function getYoutubeVideoData(mediaSource: YoutubeVideoSchemaObject): YouTubeVideo {
+function getYoutubeVideoData(mediaSource: YouTubeVideoSource): YouTubeVideo {
 	return {
 		title: mediaSource.title,
 		type: mediaSource._type,
@@ -111,7 +107,7 @@ function getYoutubeVideoData(mediaSource: YoutubeVideoSchemaObject): YouTubeVide
 	};
 }
 
-function getSpotifyPodcastEpisodeData(mediaSource: SpotifyPodcasteEpisodeSchemaObject): SpotifyPodcastEpisode {
+function getSpotifyPodcastEpisodeData(mediaSource: SpotifyPodcastEpisodeSource): SpotifyPodcastEpisode {
 	return {
 		title: mediaSource.title,
 		type: mediaSource._type,

--- a/src/api/modules/story/story.service.ts
+++ b/src/api/modules/story/story.service.ts
@@ -27,7 +27,7 @@ import { fetchClarityData } from '../../_helpers/clarity-connector';
 import { updateRotatingContentMostRead } from '../content/content.repository';
 
 // Funciones de mapeo
-import { mapMediaSourcesTeasers } from '../../_utils/media-sources.functions';
+import { mapMediaSources } from '../../_utils/media-sources.functions';
 
 // Funciones de repository
 import {
@@ -117,7 +117,7 @@ export async function getStories(limit: number = 100, offset: number = 0): Promi
 			...fields,
 			author: mapAuthorTeaser(author),
 			coverImage: urlFor(coverImage),
-			media: mapMediaSourcesTeasers(mediaSources),
+			media: mapMediaSources(mediaSources),
 			paragraphs: mapBlockContentToTextParagraphs(body),
 			resources: [],
 			tags: [],

--- a/src/api/modules/storylist/storylist.repository.ts
+++ b/src/api/modules/storylist/storylist.repository.ts
@@ -13,7 +13,7 @@ import {
 } from '@queries/storylist.query';
 
 // Utilidades
-import { mapMediaSources, mapMediaSourcesTeasers } from '../../_utils/media-sources.functions';
+import { mapMediaSources } from '../../_utils/media-sources.functions';
 import {
 	mapAuthorTeaser,
 	mapBlockContentToTextParagraphs,
@@ -35,7 +35,7 @@ export async function fetchAllStorylistTeasers(): Promise<StorylistTeaser[]> {
 			tags: mapTags(item.tags),
 			stories: [],
 			tabs: [],
-			media: mapMediaSourcesTeasers(mediaSources),
+			media: mapMediaSources(mediaSources),
 			imagery: mapImagery({ featuredImage, storyCoverImages }),
 		};
 	});
@@ -56,7 +56,7 @@ export async function fetchStorylistBySlug(slug: string): Promise<Storylist> {
 				...story,
 				author: mapAuthorTeaser({ ...story.author }),
 				coverImage: urlFor(coverImage),
-				media: mapMediaSourcesTeasers(story.mediaSources),
+				media: mapMediaSources(story.mediaSources),
 				paragraphs: mapBlockContentToTextParagraphs(story.body),
 				resources: [],
 				tags: [],

--- a/src/app/components/media-resource/media-resource.component.spec.ts
+++ b/src/app/components/media-resource/media-resource.component.spec.ts
@@ -1,20 +1,18 @@
 import { render, screen } from '@testing-library/angular';
 import { MediaResourceComponent } from './media-resource.component';
-import { AudioRecording, Media, SpaceRecording, YouTubeVideo } from '@models/media.model';
+import type { Media } from '@models/media.model';
 import { AudioRecordingWidgetComponent } from '../audio-recording-widget/audio-recording-widget.component';
 import { SpaceRecordingWidgetComponent } from '../space-recording-widget/space-recording-widget.component';
 import { YoutubeVideoWidgetComponent } from '../youtube-video-widget/youtube-video-widget.component';
+import { SpotifyPodcastEpisodeWidget } from '@components/spotify-audio-widget/spotify-podcast-episode-widget';
 
 // Mocks
 import { youtubeVideoMock } from '@mocks/youtube-video.mock';
 import { audioRecordingMock } from '@mocks/audio-recording.mock';
 import { spaceRecordingMock } from '@mocks/space-recording.mock';
+import { spotifyPodcastEpisodeMock } from '@mocks/spotify-podcast-episode.mock';
 
-const mockMediaResources: Media[] = [
-	audioRecordingMock as AudioRecording,
-	spaceRecordingMock as SpaceRecording,
-	youtubeVideoMock as YouTubeVideo,
-];
+const mockMediaResources: Media[] = [audioRecordingMock, spaceRecordingMock, youtubeVideoMock];
 
 describe('MediaResourceComponent', () => {
 	test('should render MediaResourceComponent', async () => {
@@ -67,6 +65,15 @@ describe('MediaResourceComponent', () => {
 		});
 
 		expect(screen.getByText('Video alusivo a la narración de "El espejo del tiempo".')).toBeInTheDocument();
+	});
+
+	test('should render a SpotifyPodcastEpisodeWidget for podcast episodes', async () => {
+		await render(MediaResourceComponent, {
+			componentInputs: { mediaResources: [spotifyPodcastEpisodeMock] },
+			imports: [SpotifyPodcastEpisodeWidget],
+		});
+
+		expect(screen.getByText(/Historias narradas para ser escuchadas/)).toBeTruthy();
 	});
 
 	test('should throw an error for unsupported media types', async () => {

--- a/src/app/components/media-resource/media-resource.component.spec.ts
+++ b/src/app/components/media-resource/media-resource.component.spec.ts
@@ -73,7 +73,9 @@ describe('MediaResourceComponent', () => {
 			imports: [SpotifyPodcastEpisodeWidget],
 		});
 
-		expect(screen.getByText(/Historias narradas para ser escuchadas/)).toBeTruthy();
+		// Por el embed y no por la descripción: esa la pinta el mismo parser en los cuatro widgets, así
+		// que la aserción pasaría igual si el registry resolviera el widget equivocado.
+		expect(screen.getByTestId('spotify-embed')).toBeTruthy();
 	});
 
 	test('should throw an error for unsupported media types', async () => {

--- a/src/app/components/media-resource/media-resource.component.ts
+++ b/src/app/components/media-resource/media-resource.component.ts
@@ -1,6 +1,6 @@
 import { Component, input, Type } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Media, MediaTypeKey, MediaTypes } from '@models/media.model';
+import { narrowMedia, type Media, type MediaTypeKey, type MediaTypes } from '@models/media.model';
 import { SpaceRecordingWidgetComponent } from '../space-recording-widget/space-recording-widget.component';
 import { AudioRecordingWidgetComponent } from '../audio-recording-widget/audio-recording-widget.component';
 import { YoutubeVideoWidgetComponent } from '../youtube-video-widget/youtube-video-widget.component';
@@ -34,20 +34,11 @@ export class MediaResourceComponent {
 		transform: (media: Media[]) => media.map((m) => this.mediaTypesAdapter(m)),
 	});
 
-	/**
-	 * Adaptador utilizado para mappear los distintos tipos de media que
-	 * pueden existir en la plataforma a su tipo específico.
-	 * @param media
-	 * @private
-	 */
 	private mediaTypesAdapter(media: Media): {
 		component: Type<MediaTypeWidgetComponents>;
 		inputs: { media: MediaTypes };
 	} {
-		const component = MEDIA_WIDGET_MAP[media.type];
-		if (!component) {
-			throw new Error(`El tipo ${media.type} no está soportado.`);
-		}
-		return { component, inputs: { media: media as MediaTypes } };
+		const narrowed = narrowMedia(media);
+		return { component: MEDIA_WIDGET_MAP[narrowed.type], inputs: { media: narrowed } };
 	}
 }

--- a/src/app/components/media-resource/media-resource.component.ts
+++ b/src/app/components/media-resource/media-resource.component.ts
@@ -1,6 +1,6 @@
 import { Component, input, Type } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { narrowMedia, type Media, type MediaTypeKey, type MediaTypes } from '@models/media.model';
+import type { Media, MediaTypeKey } from '@models/media.model';
 import { SpaceRecordingWidgetComponent } from '../space-recording-widget/space-recording-widget.component';
 import { AudioRecordingWidgetComponent } from '../audio-recording-widget/audio-recording-widget.component';
 import { YoutubeVideoWidgetComponent } from '../youtube-video-widget/youtube-video-widget.component';
@@ -11,13 +11,6 @@ type MediaTypeWidgetComponents =
 	| SpaceRecordingWidgetComponent
 	| YoutubeVideoWidgetComponent
 	| SpotifyPodcastEpisodeWidget;
-
-const MEDIA_WIDGET_MAP: Record<MediaTypeKey, Type<MediaTypeWidgetComponents>> = {
-	audioRecording: AudioRecordingWidgetComponent,
-	spotifyPodcastEpisode: SpotifyPodcastEpisodeWidget,
-	spaceRecording: SpaceRecordingWidgetComponent,
-	youTubeVideo: YoutubeVideoWidgetComponent,
-};
 
 @Component({
 	selector: 'cuentoneta-media-resource',
@@ -30,15 +23,25 @@ const MEDIA_WIDGET_MAP: Record<MediaTypeKey, Type<MediaTypeWidgetComponents>> = 
 	},
 })
 export class MediaResourceComponent {
+	private readonly mediaWidgetMap: Record<MediaTypeKey, Type<MediaTypeWidgetComponents>> = {
+		audioRecording: AudioRecordingWidgetComponent,
+		spotifyPodcastEpisode: SpotifyPodcastEpisodeWidget,
+		spaceRecording: SpaceRecordingWidgetComponent,
+		youTubeVideo: YoutubeVideoWidgetComponent,
+	};
+
 	public readonly mediaResources = input.required({
 		transform: (media: Media[]) => media.map((m) => this.mediaTypesAdapter(m)),
 	});
 
 	private mediaTypesAdapter(media: Media): {
 		component: Type<MediaTypeWidgetComponents>;
-		inputs: { media: MediaTypes };
+		inputs: { media: Media };
 	} {
-		const narrowed = narrowMedia(media);
-		return { component: MEDIA_WIDGET_MAP[narrowed.type], inputs: { media: narrowed } };
+		const component = this.mediaWidgetMap[media.type];
+		if (!component) {
+			throw new Error(`El tipo ${media.type} no está soportado.`);
+		}
+		return { component, inputs: { media } };
 	}
 }

--- a/src/mocks/onoff-raw-stories.mock.ts
+++ b/src/mocks/onoff-raw-stories.mock.ts
@@ -29,7 +29,10 @@ function withoutAudioUrl(
 		if (mediaSource._type !== 'spaceRecording') {
 			return mediaSource;
 		}
-		const { audioUrl: _audioUrl, ...withoutResolvedUrl } = mediaSource;
+		const withoutResolvedUrl: Omit<typeof mediaSource, 'audioUrl'> & { audioUrl?: string | null } = {
+			...mediaSource,
+		};
+		delete withoutResolvedUrl.audioUrl;
 		return withoutResolvedUrl;
 	});
 }

--- a/src/mocks/onoff-raw-stories.mock.ts
+++ b/src/mocks/onoff-raw-stories.mock.ts
@@ -20,6 +20,20 @@ export const onoffRawStoriesMock: NonNullable<StoryBySlugQueryResult>[] = [
 	neronRawStory,
 ];
 
+// La proyección de teaser no resuelve `audioUrl` (solo lo hace la de la obra completa): si el
+// derivador lo copiara, el fixture sería más rico que la query real y taparía esa diferencia.
+function withoutAudioUrl(
+	mediaSources: NonNullable<StoryBySlugQueryResult>['mediaSources'],
+): StoriesByAuthorSlugQueryResult[0]['mediaSources'] {
+	return mediaSources.map((mediaSource) => {
+		if (mediaSource._type !== 'spaceRecording') {
+			return mediaSource;
+		}
+		const { audioUrl: _audioUrl, ...withoutResolvedUrl } = mediaSource;
+		return withoutResolvedUrl;
+	});
+}
+
 function toRawTeaser(raw: NonNullable<StoryBySlugQueryResult>): StoriesByAuthorSlugQueryResult[0] {
 	return {
 		_id: raw._id,
@@ -30,7 +44,7 @@ function toRawTeaser(raw: NonNullable<StoryBySlugQueryResult>): StoriesByAuthorS
 		originalPublication: raw.originalPublication,
 		approximateReadingTime: raw.approximateReadingTime,
 		coverImage: raw.coverImage,
-		mediaSources: raw.mediaSources,
+		mediaSources: withoutAudioUrl(raw.mediaSources),
 		resources: raw.resources,
 	};
 }
@@ -48,7 +62,7 @@ function toRawNavTeaser(
 		approximateReadingTime: raw.approximateReadingTime,
 		coverImage: raw.coverImage,
 		resources: [],
-		mediaSources: raw.mediaSources,
+		mediaSources: withoutAudioUrl(raw.mediaSources),
 		author: rawOnoffAuthorTeaser,
 	};
 }
@@ -83,3 +97,13 @@ export const onoffRawNavTeasersMock: NonNullable<RotatingContentQueryResult>['mo
 	toRawNavTeaser(lasDosAntorchasRawStory),
 	toRawNavTeaser(neronRawStory),
 ];
+
+// Selectores por capacidad: un spec declara que necesita una story cruda con multimedia en vez de
+// conocer qué obra la tiene. Derivados por predicado, así que enriquecer otra obra los actualiza solo.
+export const onoffRawStoriesWithMediaSources: NonNullable<StoryBySlugQueryResult>[] = onoffRawStoriesMock.filter(
+	(rawStory) => rawStory.mediaSources.length > 0,
+);
+
+export const onoffRawTeasersWithMediaSources: StoriesByAuthorSlugQueryResult = onoffRawTeasersMock.filter(
+	(rawTeaser) => rawTeaser.mediaSources.length > 0,
+);

--- a/src/mocks/onoff-story-teasers.mock.ts
+++ b/src/mocks/onoff-story-teasers.mock.ts
@@ -1,4 +1,5 @@
 import type { Story, StoryTeaserWithAuthor } from '@models/story.model';
+import { isSpaceRecording } from '@models/media.model';
 import { authorTeaserMock } from './author.mock';
 import { elOdioStoryMock } from './onoff/el-odio.mock';
 import { elTratadoDeLosPlaceresStoryMock } from './onoff/el-tratado-de-los-placeres.mock';
@@ -8,6 +9,14 @@ import { lasEscalerasStoryMock } from './onoff/las-escaleras.mock';
 import { losPeldanosStoryMock } from './onoff/los-peldanos.mock';
 import { neronStoryMock } from './onoff/neron.mock';
 import { palacioNueveFronterasStoryMock } from './onoff/el-palacio-de-las-nueve-fronteras.mock';
+
+// El ACL de teaser no resuelve la url del space recording (su proyección no trae audioUrl), así que el
+// teaser derivado tampoco puede traerla: con la url resuelta, el mock prometería más que el mapeo real.
+function toTeaserMedia(media: Story['media']): Story['media'] {
+	return media.map((mediaResource) =>
+		isSpaceRecording(mediaResource) ? { ...mediaResource, data: { ...mediaResource.data, url: null } } : mediaResource,
+	);
+}
 
 // Deriva el teaser desde la story completa: toma los campos de la vista de teaser, trunca el cuerpo a los
 // primeros 3 párrafos (igual que el ACL con body[0...3]) y reemplaza el autor por su variante AuthorTeaser.
@@ -22,7 +31,7 @@ function toTeaser(story: Story): StoryTeaserWithAuthor {
 		resources: story.resources,
 		tags: story.tags,
 		paragraphs: story.paragraphs.slice(0, 3),
-		media: story.media,
+		media: toTeaserMedia(story.media),
 		originalPublication: story.originalPublication,
 		author: authorTeaserMock,
 	};

--- a/src/mocks/onoff/geometria.mock.ts
+++ b/src/mocks/onoff/geometria.mock.ts
@@ -10,6 +10,19 @@ import { markdownToSanitizedHtml } from '@utils/markdown-pipeline.utils';
 import geometriaMdBody from './geometria.md?raw';
 import geometriaEditorialNoteMd from './geometria.editorial-note.md?raw';
 import { geometriaEpigraphReference, geometriaEpigraphText, geometriaSectionTitle } from './geometria.epigraph';
+import type { TextBlockContent } from '@models/block-content.model';
+
+function mediaDescription(text: string): TextBlockContent[] {
+	return [
+		{
+			_type: 'block',
+			_key: `${text.length}-media-description`,
+			style: 'normal',
+			markDefs: [],
+			children: [{ _type: 'span', _key: `${text.length}-media-span`, text, marks: [] }],
+		},
+	];
+}
 import { authorMock } from '../author.mock';
 import { cuentoTagMock, dramaPsicologicoTagMock, filosoficoTagMock } from '../onoff-tags.mock';
 
@@ -23,7 +36,38 @@ export const geometriaStoryMock: Story = {
 	coverImage: 'assets/img/mocks/stories/geometria.png',
 	tags: [cuentoTagMock, dramaPsicologicoTagMock, filosoficoTagMock],
 	resources: [],
-	media: [],
+	// Espeja los mediaSources del fixture raw homónimo, sin el pdfLink que el ACL descarta.
+	media: [
+		{
+			title: 'Lectura de "Geometría" por su autor',
+			type: 'audioRecording',
+			description: mediaDescription('Grabación casera, 1974.'),
+			data: { url: 'https://cdn.example.org/onoff/geometria.ogg' },
+		},
+		{
+			title: 'Conversación sobre el insomnio y la medida del tiempo',
+			type: 'spaceRecording',
+			description: mediaDescription('Espacio grabado con lectores de Onoff.'),
+			data: {
+				url: 'https://cdn.example.org/onoff/geometria-space.ogg',
+				duration: '48:12',
+				hostName: 'Biblioteca del Méridien',
+				date: '1974-06-12',
+			},
+		},
+		{
+			title: 'Episodio dedicado a "Geometría"',
+			type: 'spotifyPodcastEpisode',
+			description: mediaDescription('Análisis de la obra en formato podcast.'),
+			data: { url: 'https://open.spotify.com/embed/episode/geometria' },
+		},
+		{
+			title: 'Video ensayo sobre las coordenadas del desvelo',
+			type: 'youTubeVideo',
+			description: mediaDescription('Ensayo audiovisual sobre la obra.'),
+			data: { videoId: 'geometriaVideoId' },
+		},
+	],
 	epigraphs: [],
 	author: authorMock,
 	publishedAt: '1974-01-01T00:00:00Z',

--- a/src/mocks/onoff/geometria.mock.ts
+++ b/src/mocks/onoff/geometria.mock.ts
@@ -12,14 +12,14 @@ import geometriaEditorialNoteMd from './geometria.editorial-note.md?raw';
 import { geometriaEpigraphReference, geometriaEpigraphText, geometriaSectionTitle } from './geometria.epigraph';
 import type { TextBlockContent } from '@models/block-content.model';
 
-function mediaDescription(text: string): TextBlockContent[] {
+function mediaDescription(key: string, text: string): TextBlockContent[] {
 	return [
 		{
 			_type: 'block',
-			_key: `${text.length}-media-description`,
+			_key: `${key}-description`,
 			style: 'normal',
 			markDefs: [],
-			children: [{ _type: 'span', _key: `${text.length}-media-span`, text, marks: [] }],
+			children: [{ _type: 'span', _key: `${key}-span`, text, marks: [] }],
 		},
 	];
 }
@@ -41,13 +41,13 @@ export const geometriaStoryMock: Story = {
 		{
 			title: 'Lectura de "Geometría" por su autor',
 			type: 'audioRecording',
-			description: mediaDescription('Grabación casera, 1974.'),
+			description: mediaDescription('geometria-audio', 'Grabación casera, 1974.'),
 			data: { url: 'https://cdn.example.org/onoff/geometria.ogg' },
 		},
 		{
 			title: 'Conversación sobre el insomnio y la medida del tiempo',
 			type: 'spaceRecording',
-			description: mediaDescription('Espacio grabado con lectores de Onoff.'),
+			description: mediaDescription('geometria-space', 'Espacio grabado con lectores de Onoff.'),
 			data: {
 				url: 'https://cdn.example.org/onoff/geometria-space.ogg',
 				duration: '48:12',
@@ -58,13 +58,13 @@ export const geometriaStoryMock: Story = {
 		{
 			title: 'Episodio dedicado a "Geometría"',
 			type: 'spotifyPodcastEpisode',
-			description: mediaDescription('Análisis de la obra en formato podcast.'),
+			description: mediaDescription('geometria-spotify', 'Análisis de la obra en formato podcast.'),
 			data: { url: 'https://open.spotify.com/embed/episode/geometria' },
 		},
 		{
 			title: 'Video ensayo sobre las coordenadas del desvelo',
 			type: 'youTubeVideo',
-			description: mediaDescription('Ensayo audiovisual sobre la obra.'),
+			description: mediaDescription('geometria-youtube', 'Ensayo audiovisual sobre la obra.'),
 			data: { videoId: 'geometriaVideoId' },
 		},
 	],

--- a/src/mocks/onoff/geometria.raw.mock.ts
+++ b/src/mocks/onoff/geometria.raw.mock.ts
@@ -1,5 +1,17 @@
-import type { StoryBySlugQueryResult } from '@sanity-types';
+import type { BlockContent, StoryBySlugQueryResult } from '@sanity-types';
 import { rawOnoffAuthor } from '../onoff-raw-author.mock';
+
+function rawMediaDescription(text: string): BlockContent {
+	return [
+		{
+			_type: 'block',
+			_key: `${text.length}-media-description`,
+			style: 'normal',
+			markDefs: [],
+			children: [{ _type: 'span', _key: `${text.length}-media-span`, text, marks: [] }],
+		},
+	];
+}
 
 export const geometriaRawStory: NonNullable<StoryBySlugQueryResult> = {
 	_id: 'onoff-story-geometria',
@@ -253,7 +265,49 @@ export const geometriaRawStory: NonNullable<StoryBySlugQueryResult> = {
 		_type: 'image',
 		asset: { _type: 'reference', _ref: 'image-9e1eab984fbe94e19101c7aa4fc2e99a88f71736-236x328-png' },
 	},
-	mediaSources: [],
+	// Única obra del corpus con multimedia: cubre los cuatro tipos que el dominio modela más un
+	// pdfLink, que el schema admite y el ACL descarta — el caso real de tipo no mapeado.
+	mediaSources: [
+		{
+			_key: 'geometria-audio',
+			_type: 'audioRecording',
+			title: 'Lectura de "Geometría" por su autor',
+			description: rawMediaDescription('Grabación casera, 1974.'),
+			url: 'https://cdn.example.org/onoff/geometria.ogg',
+		},
+		{
+			_key: 'geometria-space',
+			_type: 'spaceRecording',
+			title: 'Conversación sobre el insomnio y la medida del tiempo',
+			description: rawMediaDescription('Espacio grabado con lectores de Onoff.'),
+			audioFile: { _type: 'file', asset: { _type: 'reference', _ref: 'file-geometria-space-ogg' } },
+			hostName: 'Biblioteca del Méridien',
+			date: '1974-06-12',
+			duration: '48:12',
+			audioUrl: 'https://cdn.example.org/onoff/geometria-space.ogg',
+		},
+		{
+			_key: 'geometria-spotify',
+			_type: 'spotifyPodcastEpisode',
+			title: 'Episodio dedicado a "Geometría"',
+			description: rawMediaDescription('Análisis de la obra en formato podcast.'),
+			url: 'https://open.spotify.com/embed/episode/geometria',
+		},
+		{
+			_key: 'geometria-youtube',
+			_type: 'youTubeVideo',
+			title: 'Video ensayo sobre las coordenadas del desvelo',
+			description: rawMediaDescription('Ensayo audiovisual sobre la obra.'),
+			videoId: 'geometriaVideoId',
+		},
+		{
+			_key: 'geometria-pdf',
+			_type: 'pdfLink',
+			title: 'Facsímil de la primera edición',
+			description: rawMediaDescription('Escaneo de la edición de 1974.'),
+			url: 'https://cdn.example.org/onoff/geometria.pdf',
+		},
+	],
 	resources: [],
 	tags: [],
 	author: rawOnoffAuthor,

--- a/src/mocks/onoff/geometria.raw.mock.ts
+++ b/src/mocks/onoff/geometria.raw.mock.ts
@@ -1,14 +1,14 @@
 import type { BlockContent, StoryBySlugQueryResult } from '@sanity-types';
 import { rawOnoffAuthor } from '../onoff-raw-author.mock';
 
-function rawMediaDescription(text: string): BlockContent {
+function rawMediaDescription(key: string, text: string): BlockContent {
 	return [
 		{
 			_type: 'block',
-			_key: `${text.length}-media-description`,
+			_key: `${key}-description`,
 			style: 'normal',
 			markDefs: [],
-			children: [{ _type: 'span', _key: `${text.length}-media-span`, text, marks: [] }],
+			children: [{ _type: 'span', _key: `${key}-span`, text, marks: [] }],
 		},
 	];
 }
@@ -272,14 +272,14 @@ export const geometriaRawStory: NonNullable<StoryBySlugQueryResult> = {
 			_key: 'geometria-audio',
 			_type: 'audioRecording',
 			title: 'Lectura de "Geometría" por su autor',
-			description: rawMediaDescription('Grabación casera, 1974.'),
+			description: rawMediaDescription('geometria-audio', 'Grabación casera, 1974.'),
 			url: 'https://cdn.example.org/onoff/geometria.ogg',
 		},
 		{
 			_key: 'geometria-space',
 			_type: 'spaceRecording',
 			title: 'Conversación sobre el insomnio y la medida del tiempo',
-			description: rawMediaDescription('Espacio grabado con lectores de Onoff.'),
+			description: rawMediaDescription('geometria-space', 'Espacio grabado con lectores de Onoff.'),
 			audioFile: { _type: 'file', asset: { _type: 'reference', _ref: 'file-geometria-space-ogg' } },
 			hostName: 'Biblioteca del Méridien',
 			date: '1974-06-12',
@@ -290,21 +290,21 @@ export const geometriaRawStory: NonNullable<StoryBySlugQueryResult> = {
 			_key: 'geometria-spotify',
 			_type: 'spotifyPodcastEpisode',
 			title: 'Episodio dedicado a "Geometría"',
-			description: rawMediaDescription('Análisis de la obra en formato podcast.'),
+			description: rawMediaDescription('geometria-spotify', 'Análisis de la obra en formato podcast.'),
 			url: 'https://open.spotify.com/embed/episode/geometria',
 		},
 		{
 			_key: 'geometria-youtube',
 			_type: 'youTubeVideo',
 			title: 'Video ensayo sobre las coordenadas del desvelo',
-			description: rawMediaDescription('Ensayo audiovisual sobre la obra.'),
+			description: rawMediaDescription('geometria-youtube', 'Ensayo audiovisual sobre la obra.'),
 			videoId: 'geometriaVideoId',
 		},
 		{
 			_key: 'geometria-pdf',
 			_type: 'pdfLink',
 			title: 'Facsímil de la primera edición',
-			description: rawMediaDescription('Escaneo de la edición de 1974.'),
+			description: rawMediaDescription('geometria-pdf', 'Escaneo de la edición de 1974.'),
 			url: 'https://cdn.example.org/onoff/geometria.pdf',
 		},
 	],

--- a/src/models/media.model.spec.ts
+++ b/src/models/media.model.spec.ts
@@ -1,0 +1,47 @@
+import {
+	isAudioRecording,
+	isSpaceRecording,
+	isSpotifyPodcastEpisode,
+	isYouTubeVideo,
+	narrowMedia,
+	type Media,
+} from './media.model';
+import { audioRecordingMock } from '@mocks/audio-recording.mock';
+import { spaceRecordingMock } from '@mocks/space-recording.mock';
+import { spotifyPodcastEpisodeMock } from '@mocks/spotify-podcast-episode.mock';
+import { youtubeVideoMock } from '@mocks/youtube-video.mock';
+
+const guards = [
+	{ name: 'isAudioRecording', guard: isAudioRecording, own: audioRecordingMock },
+	{ name: 'isSpaceRecording', guard: isSpaceRecording, own: spaceRecordingMock },
+	{ name: 'isYouTubeVideo', guard: isYouTubeVideo, own: youtubeVideoMock },
+	{ name: 'isSpotifyPodcastEpisode', guard: isSpotifyPodcastEpisode, own: spotifyPodcastEpisodeMock },
+];
+
+const everyMedia: Media[] = guards.map((entry) => entry.own);
+
+describe('type guards de Media', () => {
+	it.each(guards)('$name reconoce su propio tipo', ({ guard, own }) => {
+		expect(guard(own)).toBe(true);
+	});
+
+	it.each(guards)('$name rechaza los demás tipos', ({ guard, own }) => {
+		const others = everyMedia.filter((media) => media !== own);
+
+		expect(others.map((media) => guard(media))).toEqual([false, false, false]);
+	});
+});
+
+describe('narrowMedia', () => {
+	it.each(everyMedia)('devuelve el mismo valor de "$type", ya angostado', (media) => {
+		expect(narrowMedia(media)).toBe(media);
+	});
+
+	// El dominio solo modela los tipos que tienen widget: un tag fuera de MediaTypeKey significa que el
+	// ACL del backend quedó desalineado con el modelo, y eso debe romper acá y no pintar un hueco.
+	it('lanza ante un tipo que el dominio no modela', () => {
+		const unsupported = { ...audioRecordingMock, type: 'pdfLink' } as unknown as Media;
+
+		expect(() => narrowMedia(unsupported)).toThrow('El tipo pdfLink no está soportado.');
+	});
+});

--- a/src/models/media.model.spec.ts
+++ b/src/models/media.model.spec.ts
@@ -1,11 +1,4 @@
-import {
-	isAudioRecording,
-	isSpaceRecording,
-	isSpotifyPodcastEpisode,
-	isYouTubeVideo,
-	narrowMedia,
-	type Media,
-} from './media.model';
+import { isAudioRecording, isSpaceRecording, isSpotifyPodcastEpisode, isYouTubeVideo, type Media } from './media.model';
 import { audioRecordingMock } from '@mocks/audio-recording.mock';
 import { spaceRecordingMock } from '@mocks/space-recording.mock';
 import { spotifyPodcastEpisodeMock } from '@mocks/spotify-podcast-episode.mock';
@@ -29,19 +22,5 @@ describe('type guards de Media', () => {
 		const others = everyMedia.filter((media) => media !== own);
 
 		expect(others.map((media) => guard(media))).toEqual([false, false, false]);
-	});
-});
-
-describe('narrowMedia', () => {
-	it.each(everyMedia)('devuelve el mismo valor de "$type", ya angostado', (media) => {
-		expect(narrowMedia(media)).toBe(media);
-	});
-
-	// El dominio solo modela los tipos que tienen widget: un tag fuera de MediaTypeKey significa que el
-	// ACL del backend quedó desalineado con el modelo, y eso debe romper acá y no pintar un hueco.
-	it('lanza ante un tipo que el dominio no modela', () => {
-		const unsupported = { ...audioRecordingMock, type: 'pdfLink' } as unknown as Media;
-
-		expect(() => narrowMedia(unsupported)).toThrow('El tipo pdfLink no está soportado.');
 	});
 });

--- a/src/models/media.model.ts
+++ b/src/models/media.model.ts
@@ -1,5 +1,4 @@
 import { TextBlockContent } from '@models/block-content.model';
-import type { BlockContent } from '@sanity-types';
 
 /**
  * Modelos del contenido multimedia vinculado a una obra o a una colección.
@@ -74,27 +73,4 @@ export function narrowMedia(media: Media): MediaTypes {
 		return media;
 	}
 	throw new Error(`El tipo ${media.type} no está soportado.`);
-}
-
-/**
- * Interfaces utilizadas por backend para definir los tipos de contenido multimedia
- */
-export interface MediaSchemaObject {
-	_key: string;
-	_type: MediaTypeKey;
-	title: string;
-	icon: string;
-	description: BlockContent;
-}
-
-export interface AudioRecordingSchemaObject extends MediaSchemaObject {
-	url: string;
-}
-
-export interface SpotifyPodcasteEpisodeSchemaObject extends MediaSchemaObject {
-	url: string;
-}
-
-export interface YoutubeVideoSchemaObject extends MediaSchemaObject {
-	videoId: string;
 }

--- a/src/models/media.model.ts
+++ b/src/models/media.model.ts
@@ -2,14 +2,12 @@ import { TextBlockContent } from '@models/block-content.model';
 import type { BlockContent } from '@sanity-types';
 
 /**
- * Modelos relacionados a los distintos tipos de contenido multimedia que se
- * pueden encontrar vinculados a una Story o Storylist.
+ * Modelos del contenido multimedia vinculado a una obra o a una colección.
  *
- * La interfaz base Media define los atributos comunes a todos los tipos de
- * contenido multimedia y debe ser usada para definir el tipo de la propiedad media en DTOs.
- *
- * El tipo MediaTypes define la unión de tipos de contenido multimedia que se pueden
- * encontrar vinculados a una instancia definida de Story o Storylist.
+ * `Media` es el tipo **ancho**: el de las colecciones y el que devuelve el ACL, con `data?: unknown`
+ * porque el supertipo no correlaciona el tag con la forma de su carga. `MediaTypes` es el **angosto**,
+ * la unión discriminada que consumen los widgets, donde cada tag ya fija su `data`. Se pasa de uno al
+ * otro con los guards de abajo, nunca con una aserción.
  */
 export interface Media {
 	title: string;
@@ -42,6 +40,41 @@ export interface SpotifyPodcastEpisode extends Media {
 
 export type MediaTypes = AudioRecording | SpaceRecording | YouTubeVideo | SpotifyPodcastEpisode;
 export type MediaTypeKey = 'spaceRecording' | 'audioRecording' | 'youTubeVideo' | 'spotifyPodcastEpisode';
+
+// Los guards discriminan por el tag y no por la forma de `data`: AudioRecording y
+// SpotifyPodcastEpisode son estructuralmente idénticos ({ url }), así que inspeccionar `data` no
+// puede distinguirlos. Alcanza porque el único productor de Media es el mapper del propio dominio.
+export function isAudioRecording(media: Media): media is AudioRecording {
+	return media.type === 'audioRecording';
+}
+
+export function isSpaceRecording(media: Media): media is SpaceRecording {
+	return media.type === 'spaceRecording';
+}
+
+export function isYouTubeVideo(media: Media): media is YouTubeVideo {
+	return media.type === 'youTubeVideo';
+}
+
+export function isSpotifyPodcastEpisode(media: Media): media is SpotifyPodcastEpisode {
+	return media.type === 'spotifyPodcastEpisode';
+}
+
+export function narrowMedia(media: Media): MediaTypes {
+	if (isAudioRecording(media)) {
+		return media;
+	}
+	if (isSpaceRecording(media)) {
+		return media;
+	}
+	if (isYouTubeVideo(media)) {
+		return media;
+	}
+	if (isSpotifyPodcastEpisode(media)) {
+		return media;
+	}
+	throw new Error(`El tipo ${media.type} no está soportado.`);
+}
 
 /**
  * Interfaces utilizadas por backend para definir los tipos de contenido multimedia

--- a/src/models/media.model.ts
+++ b/src/models/media.model.ts
@@ -58,19 +58,3 @@ export function isYouTubeVideo(media: Media): media is YouTubeVideo {
 export function isSpotifyPodcastEpisode(media: Media): media is SpotifyPodcastEpisode {
 	return media.type === 'spotifyPodcastEpisode';
 }
-
-export function narrowMedia(media: Media): MediaTypes {
-	if (isAudioRecording(media)) {
-		return media;
-	}
-	if (isSpaceRecording(media)) {
-		return media;
-	}
-	if (isYouTubeVideo(media)) {
-		return media;
-	}
-	if (isSpotifyPodcastEpisode(media)) {
-		return media;
-	}
-	throw new Error(`El tipo ${media.type} no está soportado.`);
-}


### PR DESCRIPTION
## Descripción

- **Type guards** (`isAudioRecording`, `isSpaceRecording`, `isYouTubeVideo`, `isSpotifyPodcastEpisode`) en `src/models/media.model.ts`, con spec propio. Discriminan **solo por el tag**, porque `AudioRecording` y `SpotifyPodcastEpisode` son estructuralmente idénticos (`{ url }`) y solo el discriminante los separa. Sus consumidores son los filtros del spec del ACL y el derivador de teasers del corpus, donde el narrowing evita un cast. El comentario del modelo fija además la distinción que el tipo no captura: `Media` es el tipo **ancho** de colección y ACL, `MediaTypes` el **angosto** de consumo.
- **El cast del adapter desaparece sin reemplazo.** El `media as MediaTypes` de `MediaResourceComponent` existía solo para satisfacer la anotación `inputs: { media: MediaTypes }`; al tipar ese input como `Media`, se cae junto con ella. El adapter resuelve el widget por el tag y lanza si no lo encuentra, como antes.
- **Un solo dispatch en el ACL**: `mapMediaSourcesTeasers` desaparece y queda `mapMediaSources`, con un `switch` que narrowea el raw. Los shapes por tipo se derivan del generado por typegen (`Extract<…, { _type }>`), como ya hacía el de `spaceRecording`: eso elimina los cuatro `as` del backend **y** las cuatro interfaces `*SchemaObject` hand-authored que describían en el modelo de dominio un shape que no le pertenece.
- **El `_type` sin modelo de dominio deja rastro**: `console.warn` con su tipo y su `_key`. El backend sigue descartando y no lanza, porque es contenido que un editor cargó y no debe tirar la respuesta entera; el frontend sí lanza, porque ahí significa que el ACL quedó desalineado con el modelo.
- **El canon estrena multimedia**: Geometría lleva ahora los cuatro tipos mapeables más un `pdfLink`, con selectores por capacidad (`onoffRawStoriesWithMediaSources`, `onoffRawTeasersWithMediaSources`) y el spec del ACL que hasta ahora no existía.

**Dos hallazgos de la exploración que el issue no anticipaba y este PR resuelve:**

1. **El "tipo desconocido" no era hipotético.** La unión que genera typegen tiene **cinco** miembros y el dominio modela cuatro: todo `pdfLink` cargado en Sanity se venía descartando sin dejar rastro. Por eso el guard de exhaustividad **no puede ser `never`** — `pdfLink` es un miembro legítimo que el dominio no mapea —, y se afirma contra `Exclude<typeof mediaSource._type, MediaTypeKey>`, que rompe si mañana se suma un `MediaTypeKey` sin su rama.
2. **La rama de teaser producía un objeto que mentía sobre su tipo.** Construía `{ type: 'spaceRecording', data: {} }`, que type-checkea como `SpaceRecording` sin tener `duration`, `hostName` ni `date`. Resultó que la proyección de teaser **sí** trae esos campos —lo único que no resuelve es `audioUrl`—, así que ahora construye una `SpaceRecording` válida con `url: null`, el mismo caso que el widget ya sabe mostrar. Reparado eso, los cuerpos de las dos funciones eran idénticos, y de ahí que colapsen en una.

Closes #1963.

Parte de #1481.

## Plan de pruebas

- [x] `test` — spec nuevo de los guards; spec nuevo del ACL de media (los cuatro tipos, el descarte del `pdfLink` con su warn, y el teaser con `url: null`); el spec del adapter suma el caso de `spotifyPodcastEpisode`, que no estaba cubierto
- [x] `typecheck` (`tsc -p tsconfig.typecheck.json --noEmit`)
- [x] `lint`
- [x] `build`
- [x] `storybook`
- [x] `stylelint`
- [x] `check-agents`
- [ ] `studio-build` — omitido: el diff no toca `cms/`
- [ ] `e2e` — no observado en local: en worktree falla siempre por `robots-indexable` (el middleware `noindexNonProduction` con `environment.production` falso). **Verificar en CI**
- [x] Review local del `code-reviewer` y del `security-auditor` antes de abrir el PR

## Notas de review

- **Auditoría de seguridad: SEGURO.** El `console.warn` no expone nada del editor (`_type` es un enum del schema y `_key` un id interno; `title` y `description`, que sí son texto libre, no se loguean). El widget de space recording ya contempla `url: null` con property binding, así que el cambio del teaser no lo rompe.
- **Fidelidad de los fixtures de teaser**: los derivadores dejaron de copiar campos que la proyección de teaser no resuelve — `audioUrl` del lado raw, y la `url` ya resuelta del lado dominio. Un mock más rico que su query tapa justamente la diferencia que hay que testear.
- **Hallazgo heredado, fuera de este diff**: `spotify-podcast-episode-widget.ts` no valida el host antes de `bypassSecurityTrustResourceUrl`. Lo registró la auditoría como informativo; no se toca acá.
- **Cambio de alcance durante la review.** Este PR llegó a introducir una función `narrowMedia` que encadenaba los cuatro guards para cruzar de `Media` a `MediaTypes`. Se eliminó: devolvía el mismo objeto y, como los guards discriminan por el tag y no por la forma de `data`, daba **exactamente la misma garantía que el cast** que venía a reemplazar. Además no estaba chequeada por exhaustividad —a diferencia del `Record<MediaTypeKey, …>` del mapa de widgets—, así que sumar un tipo de media habría compilado y explotado en runtime. El cast se resolvió por la vía más simple: dejar de anotar un tipo que nadie verifica aguas abajo, porque `ngComponentOutlet` recibe los inputs con el tipo borrado.
- **Deuda de modelo detectada acá, con issue propio**: el teaser recibe el mismo `Media` que la página aunque su proyección trae menos y sus consumidores leen solo `.type`. Por eso los mocks tienen que **fingir la pérdida de información** (`withoutAudioUrl`, `toTeaserMedia`). Se aborda en #2029, que separa las dos vistas en el dominio; acá quedan las dos emulaciones, que son fieles al ACL vigente.

