### PR TITLE
[#1953] - Corrige el mecanismo de poblado que el schema aún daba por vigente

### DIFF
--- a/cms/schemas/literaryWork.ts
+++ b/cms/schemas/literaryWork.ts
@@ -37,14 +37,15 @@ const section = defineArrayMember({
 			type: 'markdown',
 			validation: (Rule) => Rule.required(),
 		}),
-		// Derivado del texto, poblado por el backend (fuera del CMS), no editable. Opcional a propósito:
-		// arranca vacío y lo materializa la primera lectura de la obra (self-healing) — ver
+		// Derivado del texto, poblado por el script de backfill (`pnpm backfill:reading-time`, fuera del
+		// CMS), no editable. Opcional a propósito: arranca vacío y sigue vacío hasta que corra el
+		// backfill — mientras tanto la lectura deriva un fallback puro, sin persistir. Ver
 		// docs/LITERARY_WORK_DESIGN.md §5. Podrá volverse required en un increment futuro, una vez
 		// pobladas todas las obras.
 		defineField({
 			name: 'readingTime',
 			title: 'Tiempo de lectura de la sección (minutos)',
-			description: 'Derivado del texto de la sección; lo computa y persiste el backend, no se edita a mano.',
+			description: 'Derivado del texto de la sección; lo computa y persiste el backfill, no se edita a mano.',
 			type: 'number',
 			readOnly: true,
 			validation: (Rule) => Rule.integer().min(1),
@@ -115,13 +116,13 @@ export default defineType({
 			type: 'markdown',
 		}),
 		// Total de la obra, en minutos. Editable y opcional a propósito: en obras de texto lo completa
-		// el backend con la suma de las secciones, sin pisar un valor ya cargado; en
+		// el backfill con la suma de las secciones, sin pisar un valor ya cargado; en
 		// recitados/audiovisuales el editor setea a mano la duración del medio.
 		defineField({
 			name: 'totalReadingTime',
 			title: 'Tiempo de lectura total (minutos)',
 			description:
-				'Total de la obra. En obras de texto lo completa el backend con la suma de las secciones; en recitados o audiovisuales, seteá a mano la duración del medio.',
+				'Total de la obra. En obras de texto lo completa el backfill con la suma de las secciones; en recitados o audiovisuales, seteá a mano la duración del medio.',
 			type: 'number',
 			validation: (Rule) => Rule.integer().min(1),
 		}),


### PR DESCRIPTION
Cabo suelto de #1953 (ya cerrado): el schema de `literaryWork` seguía describiendo la **materialización self-healing en la primera lectura** como el mecanismo que puebla los campos de reading time. Esa vía quedó **superseded** por el script de backfill de #1959, y así está documentado en `docs/LITERARY_WORK_DESIGN.md` §5. Los gemelos de este comentario en `src/models/reading-time.model.ts` y `src/mocks/onoff/README.md` ya se corrigieron en #1959; este quedó afuera del scan por vivir en `cms/`.

## Cambios

- `readingTime` (por sección): el comentario nombra al backfill como vía de poblado y explica qué pasa mientras el campo está vacío (la lectura deriva un fallback puro, sin persistir), que es el motivo real de que el campo sea opcional.
- `totalReadingTime`: mismo reemplazo en el comentario y en la `description`.

Las `description` no son comentarios: son el texto que se lee en el Studio. Decir "lo completa el backend" hace esperar que el valor aparezca solo tras publicar, cuando en realidad depende de una corrida del backfill.

## Verificación

El backfill ya se corrió sobre `production` con los campos vacíos en las 2 obras publicadas, y quedaron persistidos: `fobal-del-grande` (1 sección, total 5) y `el-taco-de-ebano` (4 secciones — 16/25/50/24 —, total 115). Los totales cierran con la suma de las secciones.

Solo cambian comentarios y una `description`: sin impacto en el shape de los documentos ni en el typegen.

Ref #1953
