### PR TITLE
[#2042] - Saca la clasificación del título del issue y la deja en labels y jerarquía

### DIFF
--- a/.claude/references/coding-agent-policies.md
+++ b/.claude/references/coding-agent-policies.md
@@ -110,6 +110,28 @@ Prohibido. Si el componente tiene un **estado de carga (skeleton)**, su story de
 
 Prohibido. Nunca incluir `🤖 Generated with [Claude Code]…`, `Co-Authored-By: Claude …` ni `Claude-Session: …` en un mensaje de commit ni en el cuerpo de un PR (`gh pr create --body`/`--body-file`). El trailer **automático** de commits ya está suprimido por `attribution` en `.claude/settings.json`; el vector que queda es que el agente lo **tipee a mano** en el cuerpo del PR —ese setting no lo borra porque no es un trailer del harness—. La descripción de un PR o commit que lo contenga es bloqueante para la review.
 
+### "Le pongo `[Tooling]` al título para que se sepa de qué va"
+
+Prohibido. El título de un issue enuncia **el trabajo**, nada más. La categoría va en **labels** y la pertenencia a una iniciativa en la **jerarquía de sub-issues** del epic (ver la entrada siguiente). Un prefijo no se puede filtrar, no aparece en ninguna vista agregada y no tiene vocabulario cerrado — `[Test]`, `[QA]` y `[Test][E2E]` llegaron a convivir.
+
+Peor: **desplaza al label**. Los once issues de CollectionPage llevaban prefijo `[Frontend]`/`[Backend]` y ninguno tenía label; el prefijo hace sentir el issue clasificado y lo único filtrable nunca se pone.
+
+La prohibición es **por la función, no por la puntuación** — `[SEO] …`, `SEO — …` y `SEO: …` son el mismo mecanismo:
+
+| ❌                                                  | ✅                                                                 |
+| --------------------------------------------------- | ------------------------------------------------------------------ |
+| `[Backend] Controller Hono GET /collection/:slug`   | `Controller Hono GET /collection/:slug` + label `🔌 backend`       |
+| `SEO — opt-out temporal de indexación de /read`     | `Opt-out temporal de indexación de /read` + label `🧭 indexado`    |
+| `[Cloudflare] Crons: migrar a Cron Triggers`        | `Migrar los crons a Cloudflare Cron Triggers` + sub-issue del epic |
+| `[#2036] - Integrar ReadingSuggestions en ReadPage` | `Integrar ReadingSuggestions en ReadPage`                          |
+
+Dos precisiones:
+
+- **El `[#<id>]` es de commits y PRs, no de issues** (ver [`CLAUDE.md`](../../CLAUDE.md#git)). En el título de un issue repite un número que GitHub ya muestra al lado.
+- Cuando el prefijo carga contexto que el resto del título no tiene, **se pliega dentro de la oración**, no se borra: `[Cloudflare] Cutover: preview → e2e → DNS` → `Cutover a Cloudflare: preview → e2e → DNS`. Un título que pierde información no cumple la regla, la incumple de otra forma.
+
+**Si no existe un label adecuado, se propone al usuario y se espera su confirmación** — crear un label es una acción hacia afuera. Nunca inventar un prefijo para tapar el hueco, ni crear el label por cuenta propia.
+
 ### "Listo los hijos del epic en el cuerpo y queda linkeado igual"
 
 Prohibido. Los issues hijos de un epic se crean **como child issues reales** (relación de sub-issue de GitHub), nunca como una tasklist o una lista de menciones `#<id>` en el cuerpo del epic. Una mención crea una referencia cruzada, no una jerarquía: no aparece en el panel de sub-issues, no aporta progreso agregado y se pierde al reordenar el cuerpo.

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -261,6 +261,7 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
    - ✅ `[#1234] - Acota la constante al cuerpo de la función — estaba a nivel de módulo`
    - ❌ `[#1234] - Arregla el hallazgo #2`
 4. Si un hallazgo se **difiere**, proponer el issue al usuario y **esperar su confirmación** antes de crearlo (`gh issue create`); una vez creado, anotar su URL junto al valor **Diferido** en la columna **Estado**. Crear un issue es una acción hacia afuera: la misma política rige en la Fase 6.
+   - **Título sin prefijo de categoría** (`[Tooling]`, `[SEO]`, `[#<id>]`, ni variantes con guion o dos puntos): la categoría va en `--label` y la pertenencia a una iniciativa en la relación de sub-issue. Si ningún label existente encaja, proponer su creación al usuario en vez de codificar la categoría en el título. Ver [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 2.
 5. Tras abordar Críticos y Advertencias, re-correr los gates de CI. Arreglar regresiones.
 6. Las **Sugerencias** son opcionales: presentarlas y dejar que el usuario decida.
 7. Si un hallazgo es específicamente un **gap de cobertura de tests**, el orquestador **puede** delegar en **`test-generator`** el scaffolding de los specs faltantes (en modo worktree, adjuntar la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales"). Es un aid opcional, **no** un gate: los tests igual deben existir y pasar; el agente es solo una vía para producirlos.
@@ -298,6 +299,7 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 4. Escanear la sesión por ítems **fuera de alcance** (fixes/hallazgos/mejoras más allá del issue). Si hay:
    - Actualizar la descripción del issue (`gh issue edit`) con una sección "Fuera de alcance (abordado en este PR)".
    - Preguntar al usuario si quiere crear issues separados para follow-ups. Esperar confirmación antes de crearlos. **Nunca crear issues en repos donde el usuario no es contribuidor.**
+   - Al crearlos, aplican las mismas reglas de la Fase 5 paso 4: **título sin prefijo de categoría**, categoría en `--label`, y sub-issue del epic cuando el follow-up pertenece a una iniciativa.
 5. Presentar el resumen final como **exactamente** esta tabla Item/Valor (renderizar solo después de que push + PR + edición del issue se completaron con artefactos reales):
 
    ```markdown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ Reglas no negociables. Una violación requiere justificación explícita.
 - **Ramas:** `feat/<id_issue>-<descripcion-en-kebab-case>` desde `develop` actualizado (p. ej. `feat/1495-claude-md-and-references`).
 - **Commits:** `[#<id_issue>] - <mensaje>`.
 - **PRs:** título `[#<id_issue>] - <título>`; cuerpo en español con `Closes #<id_issue>`; base `develop`; milestone correspondiente. **Reviews en español.**
+- **Issues:** título **sin prefijo de categoría** — ni `[Tooling]`/`[SEO]`/`[Frontend]`, ni sus variantes con guion o dos puntos, ni el `[#<id_issue>]` (ese es de commits y PRs). El título enuncia el trabajo; la categoría va en **labels** y la pertenencia a una iniciativa en la **jerarquía de sub-issues** del epic. Si falta un label adecuado, se propone al usuario y se espera confirmación → [`coding-agent-policies.md`](.claude/references/coding-agent-policies.md) (Sección 2).
 
 ### Naming
 


### PR DESCRIPTION
## Descripción

- **`.claude/references/coding-agent-policies.md` (Sección 2):** entrada nueva —"Le pongo `[Tooling]` al título para que se sepa de qué va"— vecina de la de sub-issues de epic, que es su contraparte de jerarquía. Enuncia la prohibición **por la función y no por la puntuación** (`[SEO] …`, `SEO — …` y `SEO: …` son el mismo mecanismo), con tabla de ❌/✅ sobre títulos reales del repo, la aclaración de que el `[#<id>]` pertenece a commits y PRs, y la regla de plegar el prefijo dentro de la oración cuando cargaba contexto que el resto del título no tenía.
- **`CLAUDE.md` → Convenciones del repo → Git:** bullet **Issues**, junto a los de ramas, commits y PRs. Ese hueco era por donde se había colado el prefijo: la sección definía los tres títulos de Git y callaba sobre el del issue.
- **`.claude/skills/issue-workflow/SKILL.md`:** los dos puntos donde el flujo crea issues — Fase 5 paso 4 (hallazgo diferido) y Fase 6 paso 4 (follow-ups fuera de alcance) — ahora exigen título sin prefijo, categoría en `--label` y sub-issue del epic cuando corresponde.

Closes #2042.

Parte de #1907.

## Ya ejecutado fuera de este PR

La parte operativa del issue se hizo directamente contra la API de GitHub y no deja diff:

- **6 labels creados** — `🔌 backend`, `🧭 indexado`, `💳 deuda técnica`, `🧱 design system`, `🔐 seguridad`, `🤖 agentes`.
- **37 issues etiquetados**: los issues abiertos sin ningún label pasaron de 18 a 0.
- **53 issues retitulados**: no queda ningún issue abierto con prefijo de categoría.
- **4 sub-issues enganchados** a #1720, que figuraban solo como menciones en el cuerpo.

El nombre `🧭 indexado` no es vocabulario nuevo: es el término que el repo ya usaba como paraguas de SEO/AEO/GEO, con nueve apariciones en código y documentación (`e2e/_utils/seo-invariants.ts`, `scripts/seo-smoke.ts`, `src/testing/seo-invariant-violation.ts`, entre otras).

## Plan de pruebas

- [x] `pnpm check:agents` en verde — valida el frontmatter de los agentes, las anclas a `CLAUDE.md` y las rutas citadas en las referencias, incluidas las tres que agrega este cambio.
- [x] `prettier --check` sobre los tres archivos (estaban limpios en `HEAD`; quedan limpios acá).
- [x] Verificado que no queda ningún issue abierto con prefijo de categoría, en ninguna de sus formas.
