### PR TITLE
[#2056] - Hace que el ejemplo de etiquetado nombre labels que existen

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -186,7 +186,7 @@ Cuando un problema se marca como **Diferido**, hay que **proponer** un issue de 
 
 1. Referenciar el número de la review original (p. ej. "Detectado como #7 durante la review del PR `#<pr>`").
 2. Incluir contexto suficiente para actuar de forma independiente (archivo, línea, descripción del problema y la corrección recomendada).
-3. Estar etiquetado apropiadamente (p. ej. `tech-debt`, `enhancement` o el label de dominio correspondiente).
+3. Estar etiquetado con labels que **existan** en el repo — `gh label list` los enumera, y pasar uno inexistente a `gh issue create --label` falla con un 422. Para un hallazgo diferido suelen aplicar `💳 deuda técnica` o `🏎️ mejora`, más el de dominio que corresponda (`🔌 backend`, `🅰️ angular`, `🧭 indexado`, …). Si ninguno encaja, proponer el label nuevo al usuario en vez de inventarlo — misma política que [`coding-agent-policies.md`](../references/coding-agent-policies.md) Sección 2.
 4. Estar vinculado al PR e issue actuales para trazabilidad.
 
 Una vez que el usuario confirma y el issue existe, anotar su URL en el reporte junto al ítem diferido.


### PR DESCRIPTION
## Descripción

- `.claude/agents/code-reviewer.md` citaba `tech-debt` y `enhancement` como ejemplos de etiquetado para un hallazgo diferido. **Ninguno existe** en el repo: los equivalentes reales son `💳 deuda técnica` y `🏎️ mejora`. Un agente que siguiera la instrucción al pie de la letra le pasaba a `gh issue create --label` un valor inexistente, que devuelve 422.
- La corrección no se limita a reemplazar los dos nombres: la instrucción ahora **remite a `gh label list`** y menciona la posibilidad de proponer un label nuevo cuando ninguno encaja, alineado con la política de la Sección 2 de `coding-agent-policies.md`. Un ejemplo con nombres hardcodeados vuelve a envejecer — la taxonomía creció en seis labels el 2026-08-01.

Closes #2056.

Parte de #1907.

## Barrido del resto de `.claude/**`

El issue pedía verificar que no hubiera más citas a labels inexistentes antes de cerrarlo. Relevé todas las menciones a labels en `.claude/**/*.md` (excluyendo `worktrees/`) y contrasté contra `gh label list`: **la de `code-reviewer.md:189` era la única incorrecta**. La otra cita concreta —el label `release` que `release-workflow/SKILL.md` usa como gate del Action `prepare-release-pr`— existe y es correcta. El resto de las coincidencias con "label" son de Testing Library (`getByLabelText`) o del input `label` del componente Tag, sin relación.

## Plan de pruebas

- [x] `pnpm check:agents` — verde (valida el frontmatter del agente y la ruta nueva que cita la instrucción).
- [x] `prettier --check` sobre el archivo — verde.
- [x] Los cinco labels citados en el texto nuevo verificados contra `gh label list`: `💳 deuda técnica`, `🏎️ mejora`, `🔌 backend`, `🅰️ angular`, `🧭 indexado`.
- [ ] `test`, `lint`, `build`, `storybook`, `e2e`, `studio-build` — omitidos localmente: el diff toca un solo `.md` de `.claude/`, que ninguno lee como input. Corren igual en CI.
