### PR TITLE
[#2069] - Eliminar el ícono de resourceType del wire y del schema

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -3175,51 +3175,6 @@
 					"type": "string"
 				},
 				"optional": false
-			},
-			"icon": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "iconPicker"
-				},
-				"optional": false
-			}
-		}
-	},
-	{
-		"name": "iconPicker",
-		"type": "type",
-		"value": {
-			"type": "object",
-			"attributes": {
-				"_type": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string",
-						"value": "iconPicker"
-					}
-				},
-				"provider": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string"
-					},
-					"optional": true
-				},
-				"name": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string"
-					},
-					"optional": true
-				},
-				"svg": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string"
-					},
-					"optional": true
-				}
 			}
 		}
 	},
@@ -3327,6 +3282,43 @@
 					"type": "string"
 				},
 				"optional": true
+			}
+		}
+	},
+	{
+		"name": "iconPicker",
+		"type": "type",
+		"value": {
+			"type": "object",
+			"attributes": {
+				"_type": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string",
+						"value": "iconPicker"
+					}
+				},
+				"provider": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string"
+					},
+					"optional": true
+				},
+				"name": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string"
+					},
+					"optional": true
+				},
+				"svg": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string"
+					},
+					"optional": true
+				}
 			}
 		}
 	},

--- a/cms/schemas/resourceType.ts
+++ b/cms/schemas/resourceType.ts
@@ -1,5 +1,4 @@
 import { LinkIcon } from '@sanity/icons/Link';
-import { preview } from 'sanity-plugin-icon-picker';
 import { defineField, defineType } from 'sanity';
 
 export const resource = defineType({
@@ -9,13 +8,6 @@ export const resource = defineType({
 	preview: {
 		select: {
 			title: 'resourceType.title',
-			icon: 'resourceType.icon',
-		},
-		prepare(selection) {
-			return {
-				title: selection.title,
-				media: preview(selection.icon),
-			};
 		},
 	},
 	fields: [
@@ -49,17 +41,7 @@ export const resourceType = defineType({
 	preview: {
 		select: {
 			title: 'title',
-			shortDescription: 'shortDescription',
-			provider: 'icon.provider',
-			name: 'icon.name',
-			options: 'icon.options',
-		},
-		prepare({ title, shortDescription, provider, name, options }) {
-			return {
-				title: title,
-				subtitle: shortDescription,
-				media: preview({ provider, name, options }),
-			};
+			subtitle: 'shortDescription',
 		},
 	},
 	fields: [
@@ -83,16 +65,6 @@ export const resourceType = defineType({
 			name: 'shortDescription',
 			title: 'Descripción breve',
 			type: 'string',
-			validation: (Rule) => Rule.required(),
-		}),
-		defineField({
-			name: 'icon',
-			title: 'Icono',
-			type: 'iconPicker',
-			options: {
-				providers: ['fa', 'si'],
-				storeSvg: true,
-			},
 			validation: (Rule) => Rule.required(),
 		}),
 	],

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -572,9 +572,10 @@ interface ResourceType {
 	slug: string; // Identificador único del tipo
 	title: string; // Nombre del tipo (ej: "Wikipedia")
 	shortDescription: string; // Descripción corta
-	icon: Icon; // Ícono de representación
 }
 ```
+
+> El ícono que acompaña a un recurso en la interfaz lo resuelve el frontend a partir del `slug` del tipo, contra el mapa local de `@models/icon.model`. No viaja desde el CMS.
 
 **Ejemplos de tipos:**
 
@@ -607,6 +608,8 @@ interface Tag {
 ### Icon (Ícono)
 
 **Propósito:** Referenciar iconos desde diferentes proveedores.
+
+> Ninguna entidad del dominio lo declara ya: ni `Tag` ni `ResourceType` llevan ícono. Los íconos que la interfaz muestra los resuelve el frontend por `slug`, y viven en `@models/icon.model`.
 
 ```typescript
 interface Icon {

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -609,7 +609,7 @@ interface Tag {
 
 **Propósito:** Referenciar iconos desde diferentes proveedores.
 
-> Ninguna entidad del dominio lo declara ya: ni `Tag` ni `ResourceType` llevan ícono. Los íconos que la interfaz muestra los resuelve el frontend por `slug`, y viven en `@models/icon.model`.
+> Ninguna entidad del dominio lo declara ya: ni `Tag` ni `ResourceType` llevan ícono. Otras superficies sí muestran íconos, cada una por su cuenta —`StorylistTab.icon` viaja desde el CMS, y el pie de página y los botones de compartir los nombran literalmente en el código—, pero ninguna usa este tipo.
 
 ```typescript
 interface Icon {

--- a/src/api/_queries/author.query.ts
+++ b/src/api/_queries/author.query.ts
@@ -21,8 +21,7 @@ export const authorBySlugQuery = defineQuery(`
         resourceType->{
         	'slug': slug.current,
         	title,
-        	shortDescription,
-            icon
+        	shortDescription
         }
     }, []),
     'tags': coalesce(tags[] -> {

--- a/src/api/_queries/literary-work.query.ts
+++ b/src/api/_queries/literary-work.query.ts
@@ -38,8 +38,7 @@ export const literaryWorkBySlugQuery = defineQuery(`
         resourceType->{
             'slug': slug.current,
             title,
-            shortDescription,
-            icon
+            shortDescription
         }
     }, []),
     'authors': coalesce(authors[]-> {
@@ -59,8 +58,7 @@ export const literaryWorkBySlugQuery = defineQuery(`
             resourceType->{
                 'slug': slug.current,
                 title,
-                shortDescription,
-                icon
+                shortDescription
             }
         }, []),
         'tags': []
@@ -108,8 +106,7 @@ export const literaryWorkSectionBySlugQuery = defineQuery(`
         resourceType->{
             'slug': slug.current,
             title,
-            shortDescription,
-            icon
+            shortDescription
         }
     }, []),
     'authors': coalesce(authors[]-> {
@@ -129,8 +126,7 @@ export const literaryWorkSectionBySlugQuery = defineQuery(`
             resourceType->{
                 'slug': slug.current,
                 title,
-                shortDescription,
-                icon
+                shortDescription
             }
         }, []),
         'tags': []

--- a/src/api/_queries/story.query.ts
+++ b/src/api/_queries/story.query.ts
@@ -18,8 +18,7 @@ export const storiesByAuthorSlugQuery = defineQuery(`
         resourceType->{
             'slug': slug.current,
             title,
-            shortDescription,
-            icon
+            shortDescription
         }
     }, []),
 }|order(title asc)`);
@@ -69,8 +68,7 @@ export const storyBySlugQuery = defineQuery(`
         resourceType->{
             'slug': slug.current,
             title,
-            shortDescription,
-            icon
+            shortDescription
         }
     }, []),
     'tags': coalesce(tags[] -> {
@@ -95,8 +93,7 @@ export const storyBySlugQuery = defineQuery(`
             resourceType->{
                 'slug': slug.current,
                 title,
-                shortDescription,
-                icon
+                shortDescription
             }
         }, []),
         'tags': []

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -96,7 +96,6 @@ describe('mapResources (ACL)', () => {
 			slug: rawResource.resourceType.slug,
 			title: rawResource.resourceType.title,
 			shortDescription: rawResource.resourceType.shortDescription,
-			icon: { provider: 'fa', name: 'fa-wikipedia-w' },
 		});
 	});
 
@@ -104,19 +103,7 @@ describe('mapResources (ACL)', () => {
 		const [resource] = mapResources(rawOnoffAuthor.resources);
 
 		expect(Object.keys(resource).sort()).toEqual(['resourceType', 'title', 'url']);
-		expect(Object.keys(resource.resourceType).sort()).toEqual(['icon', 'shortDescription', 'slug', 'title']);
-	});
-
-	it('normalizes a missing icon provider/name to empty strings', () => {
-		const [rawResource] = rawOnoffAuthor.resources;
-		const withoutIcon = {
-			...rawResource,
-			resourceType: { ...rawResource.resourceType, icon: { _type: 'iconPicker' as const } },
-		};
-
-		const [resource] = mapResources([withoutIcon]);
-
-		expect(resource.resourceType.icon).toEqual({ provider: '', name: '' });
+		expect(Object.keys(resource.resourceType).sort()).toEqual(['shortDescription', 'slug', 'title']);
 	});
 
 	it('returns an empty array for an empty, null or undefined input', () => {

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -160,10 +160,6 @@ export function mapResources(resources: ResourcesSubQuery): Resource[] {
 				slug: resource.resourceType.slug,
 				title: resource.resourceType.title,
 				shortDescription: resource.resourceType.shortDescription,
-				icon: {
-					provider: resource.resourceType.icon.provider ?? '',
-					name: resource.resourceType.icon.name ?? '',
-				},
 			},
 		})) ?? []
 	);

--- a/src/app/components/resource/resource.component.spec.ts
+++ b/src/app/components/resource/resource.component.spec.ts
@@ -1,6 +1,13 @@
 import { render, screen } from '@testing-library/angular';
+import { faSolidMedal } from '@ng-icons/font-awesome/solid';
 import { ResourceComponent } from './resource.component';
 import { resourceMock } from '@mocks/resource.mock';
+
+// Los íconos de @ng-icons son el SVG completo como string; el `path` es lo que los distingue entre sí.
+function pathOf(icon: string): string {
+	const [, path] = /d="([^"]+)"/.exec(icon) ?? [];
+	return path;
+}
 
 describe('ResourceComponent', () => {
 	const regexTitle = new RegExp(resourceMock.title, 'i');
@@ -32,5 +39,16 @@ describe('ResourceComponent', () => {
 		const linkResourceElement = screen.getByRole('link');
 
 		expect(linkResourceElement).toHaveAttribute('href', url);
+	});
+
+	// El slug `recurso-original` mapea a `faSolidMedal` en iconMappers. Que el SVG del DOM sea exactamente
+	// ese ícono es lo que prueba de qué lado sale, e impide reconectar el componente a un campo del CMS.
+	// Se consulta con `hidden: true` porque el ícono es decorativo (`aria-hidden`).
+	it('should resolve the icon from the resource type slug, not from the icon shipped by the CMS', async () => {
+		await setup();
+
+		const renderedIcon = screen.getByRole('img', { hidden: true });
+
+		expect(renderedIcon.innerHTML).toContain(pathOf(faSolidMedal));
 	});
 });

--- a/src/mocks/author.mock.ts
+++ b/src/mocks/author.mock.ts
@@ -19,10 +19,6 @@ export const authorMock: AuthorProfile = {
 				slug: 'wikipedia',
 				title: 'Wikipedia',
 				shortDescription: 'Enlace a artículo de Wikipedia',
-				icon: {
-					provider: 'fa',
-					name: 'fa-wikipedia-w',
-				},
 			},
 		},
 	],

--- a/src/mocks/onoff-raw-author.mock.ts
+++ b/src/mocks/onoff-raw-author.mock.ts
@@ -118,7 +118,6 @@ export const rawOnoffAuthor: NonNullable<StoryBySlugQueryResult>['author'] = {
 				slug: 'wikipedia',
 				title: 'Wikipedia',
 				shortDescription: 'Enlace a artículo de Wikipedia',
-				icon: { _type: 'iconPicker', provider: 'fa', name: 'fa-wikipedia-w' },
 			},
 		},
 	],

--- a/src/mocks/resource.mock.ts
+++ b/src/mocks/resource.mock.ts
@@ -7,9 +7,5 @@ export const resourceMock: Resource = {
 		slug: 'recurso-original',
 		title: 'Recurso Original',
 		shortDescription: 'Recurso original de este contenido',
-		icon: {
-			provider: 'fa',
-			name: 'fa-medal',
-		},
 	},
 };

--- a/src/mocks/story.mock.ts
+++ b/src/mocks/story.mock.ts
@@ -17,10 +17,6 @@ export const storyMock: Story = {
 				slug: 'recurso-original',
 				title: 'Recurso Original',
 				shortDescription: 'Recurso original de este contenido',
-				icon: {
-					provider: 'fa',
-					name: 'fa-medal',
-				},
 			},
 		},
 	],
@@ -340,10 +336,6 @@ export const storyTeaserWithAuthorMock: StoryTeaserWithAuthor = {
 				slug: 'recurso-original',
 				title: 'Recurso Original',
 				shortDescription: 'Recurso original de este contenido',
-				icon: {
-					provider: 'fa',
-					name: 'fa-medal',
-				},
 			},
 		},
 	],
@@ -455,10 +447,6 @@ export const storyTeaserMock: StoryTeaser = {
 				slug: 'recurso-original',
 				title: 'Recurso Original',
 				shortDescription: 'Recurso original de este contenido',
-				icon: {
-					provider: 'fa',
-					name: 'fa-medal',
-				},
 			},
 		},
 	],
@@ -580,10 +568,6 @@ export const storyNavigationTeaserMock: StoryNavigationTeaser = {
 				slug: 'recurso-original',
 				title: 'Recurso Original',
 				shortDescription: 'Recurso original de este contenido',
-				icon: {
-					provider: 'fa',
-					name: 'fa-medal',
-				},
 			},
 		},
 	],

--- a/src/models/resource.model.ts
+++ b/src/models/resource.model.ts
@@ -8,5 +8,4 @@ export interface ResourceType {
 	slug: string;
 	title: string;
 	shortDescription: string;
-	icon: Record<string, string>;
 }

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -551,14 +551,6 @@ export type ResourceType = {
 	title: string;
 	slug: Slug;
 	shortDescription: string;
-	icon: IconPicker;
-};
-
-export type IconPicker = {
-	_type: 'iconPicker';
-	provider?: string;
-	name?: string;
-	svg?: string;
 };
 
 export type Contributor = {
@@ -575,6 +567,13 @@ export type Contributor = {
 		url?: string;
 	};
 	notes?: string;
+};
+
+export type IconPicker = {
+	_type: 'iconPicker';
+	provider?: string;
+	name?: string;
+	svg?: string;
 };
 
 export type ComputedText = string;
@@ -709,8 +708,8 @@ export type AllSanitySchemaTypes =
 	| LandingPage
 	| Resource
 	| ResourceType
-	| IconPicker
 	| Contributor
+	| IconPicker
 	| ComputedText
 	| ComputedString
 	| ComputedBoolean
@@ -725,7 +724,7 @@ export type AllSanitySchemaTypes =
 
 // Source: ../src/api/_queries/author.query.ts
 // Variable: authorBySlugQuery
-// Query: *[_type == 'author' && slug.current == $slug && !(_id in path('drafts.**'))][0]{    _id,    'slug': slug.current,    'createdAt': _createdAt,    'updatedAt': _updatedAt,    name,    image,    nationality->,    biography,    bornOn,		bornOnYear,    diedOn,		diedOnYear,    'resources': coalesce(resources[]{        title,        url,        resourceType->{        	'slug': slug.current,        	title,        	shortDescription,            icon        }    }, []),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, [])}
+// Query: *[_type == 'author' && slug.current == $slug && !(_id in path('drafts.**'))][0]{    _id,    'slug': slug.current,    'createdAt': _createdAt,    'updatedAt': _updatedAt,    name,    image,    nationality->,    biography,    bornOn,		bornOnYear,    diedOn,		diedOnYear,    'resources': coalesce(resources[]{        title,        url,        resourceType->{        	'slug': slug.current,        	title,        	shortDescription        }    }, []),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, [])}
 export type AuthorBySlugQueryResult = {
 	_id: string;
 	slug: string;
@@ -767,7 +766,6 @@ export type AuthorBySlugQueryResult = {
 					slug: string;
 					title: string;
 					shortDescription: string;
-					icon: IconPicker;
 				};
 		  }>
 		| Array<never>;
@@ -1187,7 +1185,7 @@ export type AllContributorsQueryResult = Array<{
 
 // Source: ../src/api/_queries/literary-work.query.ts
 // Variable: literaryWorkBySlugQuery
-// Query: *[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    coverImage,    editorialNote,    'badLanguage': coalesce(badLanguage, false),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    totalReadingTime,    'sectionCount': count(content),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, []),    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription,            icon        }    }, []),    'authors': coalesce(authors[]-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                shortDescription,                icon            }        }, []),        'tags': []    }, []),    'content': coalesce(content[]{        _key,        title,        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),        body,        readingTime    }, [])}[0]
+// Query: *[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    coverImage,    editorialNote,    'badLanguage': coalesce(badLanguage, false),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    totalReadingTime,    'sectionCount': count(content),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, []),    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription        }    }, []),    'authors': coalesce(authors[]-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                shortDescription            }        }, []),        'tags': []    }, []),    'content': coalesce(content[]{        _key,        title,        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),        body,        readingTime    }, [])}[0]
 export type LiteraryWorkBySlugQueryResult = {
 	_id: string;
 	slug: string;
@@ -1264,7 +1262,6 @@ export type LiteraryWorkBySlugQueryResult = {
 					slug: string;
 					title: string;
 					shortDescription: string;
-					icon: IconPicker;
 				};
 		  }>
 		| Array<never>;
@@ -1307,7 +1304,6 @@ export type LiteraryWorkBySlugQueryResult = {
 						slug: string;
 						title: string;
 						shortDescription: string;
-						icon: IconPicker;
 					};
 			  }>
 			| Array<never>;
@@ -1329,7 +1325,7 @@ export type LiteraryWorkBySlugQueryResult = {
 
 // Source: ../src/api/_queries/literary-work.query.ts
 // Variable: literaryWorkSectionBySlugQuery
-// Query: *[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    coverImage,    editorialNote,    'badLanguage': coalesce(badLanguage, false),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    totalReadingTime,    'sectionCount': count(content),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, []),    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription,            icon        }    }, []),    'authors': coalesce(authors[]-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                shortDescription,                icon            }        }, []),        'tags': []    }, []),    'section': content[$section...$sectionEnd]{        _key,        title,        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),        body,        readingTime    }}[0]
+// Query: *[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    coverImage,    editorialNote,    'badLanguage': coalesce(badLanguage, false),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    totalReadingTime,    'sectionCount': count(content),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, []),    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription        }    }, []),    'authors': coalesce(authors[]-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                shortDescription            }        }, []),        'tags': []    }, []),    'section': content[$section...$sectionEnd]{        _key,        title,        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),        body,        readingTime    }}[0]
 export type LiteraryWorkSectionBySlugQueryResult = {
 	_id: string;
 	slug: string;
@@ -1406,7 +1402,6 @@ export type LiteraryWorkSectionBySlugQueryResult = {
 					slug: string;
 					title: string;
 					shortDescription: string;
-					icon: IconPicker;
 				};
 		  }>
 		| Array<never>;
@@ -1449,7 +1444,6 @@ export type LiteraryWorkSectionBySlugQueryResult = {
 						slug: string;
 						title: string;
 						shortDescription: string;
-						icon: IconPicker;
 					};
 			  }>
 			| Array<never>;
@@ -1503,7 +1497,7 @@ export type SitemapSlugsQueryResult = {
 
 // Source: ../src/api/_queries/story.query.ts
 // Variable: storiesByAuthorSlugQuery
-// Query: *[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))][$start...$end]{    _id,    'slug': slug.current,    title,    'badLanguage': coalesce(badLanguage, false),    'body': coalesce(body[0...3], []),    'originalPublication': coalesce(originalPublication, ''),    approximateReadingTime,    coverImage,    'mediaSources': coalesce(mediaSources[], []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription,            icon        }    }, []),}|order(title asc)
+// Query: *[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))][$start...$end]{    _id,    'slug': slug.current,    title,    'badLanguage': coalesce(badLanguage, false),    'body': coalesce(body[0...3], []),    'originalPublication': coalesce(originalPublication, ''),    approximateReadingTime,    coverImage,    'mediaSources': coalesce(mediaSources[], []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription        }    }, []),}|order(title asc)
 export type StoriesByAuthorSlugQueryResult = Array<{
 	_id: string;
 	slug: string;
@@ -1599,7 +1593,6 @@ export type StoriesByAuthorSlugQueryResult = Array<{
 					slug: string;
 					title: string;
 					shortDescription: string;
-					icon: IconPicker;
 				};
 		  }>
 		| Array<never>;
@@ -1671,7 +1664,7 @@ export type StoryNavigationTeasersByAuthorSlugQueryResult = Array<{
 
 // Source: ../src/api/_queries/story.query.ts
 // Variable: storyBySlugQuery
-// Query: *[_type == 'story' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,     'badLanguage': coalesce(badLanguage, false),    'epigraphs': coalesce(epigraphs[]{        text,        'reference': coalesce(reference[], [])    }, []),    'body': coalesce(body, []),    'review': coalesce(review, []),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    'updatedAt': _updatedAt,    approximateReadingTime,    coverImage,    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription,            icon        }    }, []),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, []),    'author': author-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                shortDescription,                icon            }        }, []),        'tags': []    }}[0]
+// Query: *[_type == 'story' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,     'badLanguage': coalesce(badLanguage, false),    'epigraphs': coalesce(epigraphs[]{        text,        'reference': coalesce(reference[], [])    }, []),    'body': coalesce(body, []),    'review': coalesce(review, []),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    'updatedAt': _updatedAt,    approximateReadingTime,    coverImage,    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription        }    }, []),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, []),    'author': author-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                shortDescription            }        }, []),        'tags': []    }}[0]
 export type StoryBySlugQueryResult = {
 	_id: string;
 	slug: string;
@@ -1777,7 +1770,6 @@ export type StoryBySlugQueryResult = {
 					slug: string;
 					title: string;
 					shortDescription: string;
-					icon: IconPicker;
 				};
 		  }>
 		| Array<never>;
@@ -1827,7 +1819,6 @@ export type StoryBySlugQueryResult = {
 						slug: string;
 						title: string;
 						shortDescription: string;
-						icon: IconPicker;
 					};
 			  }>
 			| Array<never>;
@@ -2460,20 +2451,20 @@ export type StorylistQueryResult = {
 import '@sanity/client';
 declare module '@sanity/client' {
 	interface SanityQueries {
-		"\n*[_type == 'author' && slug.current == $slug && !(_id in path('drafts.**'))][0]\n{\n    _id,\n    'slug': slug.current,\n    'createdAt': _createdAt,\n    'updatedAt': _updatedAt,\n    name,\n    image,\n    nationality->,\n    biography,\n    bornOn,\n\t\tbornOnYear,\n    diedOn,\n\t\tdiedOnYear,\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n        \t'slug': slug.current,\n        \ttitle,\n        \tshortDescription,\n            icon\n        }\n    }, []),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, [])\n}": AuthorBySlugQueryResult;
+		"\n*[_type == 'author' && slug.current == $slug && !(_id in path('drafts.**'))][0]\n{\n    _id,\n    'slug': slug.current,\n    'createdAt': _createdAt,\n    'updatedAt': _updatedAt,\n    name,\n    image,\n    nationality->,\n    biography,\n    bornOn,\n\t\tbornOnYear,\n    diedOn,\n\t\tdiedOnYear,\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n        \t'slug': slug.current,\n        \ttitle,\n        \tshortDescription\n        }\n    }, []),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, [])\n}": AuthorBySlugQueryResult;
 		"\n*[_type == 'author' && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    name,\n    image,\n    nationality->,\n    'biography': [],\n    bornOn,\n \t\tbornOnYear,\n    diedOn,\n    diedOnYear,\n    'resources': []\n}|order(name asc)": AuthorsQueryResult;
 		"\n*[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{\n    _id,\n    name,\n    'mostRead': coalesce(mostRead[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        badLanguage,\n        'body': [],\n        originalPublication,\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            'biography': [],\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[])\n}": RotatingContentQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current in $slugs]{\n\t\t_id,\n\t\t'slug': slug.current,\n\t\tconfig,\n}": LandingPageListQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{\n    _id,\n    _type,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[],[]),\n    'campaigns': coalesce(campaigns[],[]),\n    'latestReads': coalesce(latestReads,[]),\n} | order(config desc, _createdAt desc)[0]\n": LatestLandingPageReferencesQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{\n    _id,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[]->{\n        _id,\n        title,\n        'slug': slug.current,\n        description,\n        featuredImage,\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            shortDescription\n        }, []),\n        'storyCoverImages': coalesce(stories[]->coverImage, []),\n        'count': coalesce(count(stories), 0),\n\t\t\t\tconfig,\n\t\t\t\t'tabs': [],\n\t      'mediaSources': coalesce(mediaSources[], []),\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'image': contents.xs.image\n            },\n            'md': {\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'latestReads': coalesce(latestReads[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        badLanguage,\n        'body': [],\n        originalPublication,\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> { \n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            'biography': [],\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[]),\n}": LandingPageContentQueryResult;
 		"\n*[_type == 'contributor' && !(_id in path('drafts.**'))]\n{\n\tname,\n\t'slug': slug.current,\n\tarea,\n\tlink {\n\t\thandle,\n\t\turl\n\t},\n\tnotes\n}|order(name asc)\n": AllContributorsQueryResult;
-		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription,\n            icon\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                shortDescription,\n                icon\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'content': coalesce(content[]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }, [])\n}[0]": LiteraryWorkBySlugQueryResult;
-		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription,\n            icon\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                shortDescription,\n                icon\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'section': content[$section...$sectionEnd]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }\n}[0]": LiteraryWorkSectionBySlugQueryResult;
+		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                shortDescription\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'content': coalesce(content[]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }, [])\n}[0]": LiteraryWorkBySlugQueryResult;
+		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                shortDescription\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'section': content[$section...$sectionEnd]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }\n}[0]": LiteraryWorkSectionBySlugQueryResult;
 		"\n*[_type == 'literaryWork' && !(_id in path('drafts.**')) && _id > $cursor\n  && (!defined(totalReadingTime) || count(content[!defined(readingTime)]) > 0)]\n| order(_id asc) [0...$pageSize] {\n    _id,\n    'slug': slug.current,\n    totalReadingTime,\n    'content': coalesce(content[]{ _key, body, readingTime }, [])\n}": ReadingTimeBackfillCandidatesQueryResult;
 		'{\n\t"stories": *[_type == "story" && !(_id in path(\'drafts.**\'))]{ "slug": slug.current, "lastmod": _updatedAt },\n\t"authors": *[_type == "author" && !(_id in path(\'drafts.**\'))]{ "slug": slug.current, "lastmod": _updatedAt },\n\t"storylists": *[_type == "storylist" && !(_id in path(\'drafts.**\'))]{ "slug": slug.current, "lastmod": _updatedAt }\n}': SitemapSlugsQueryResult;
-		"\n*[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))][$start...$end]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'badLanguage': coalesce(badLanguage, false),\n    'body': coalesce(body[0...3], []),\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription,\n            icon\n        }\n    }, []),\n}|order(title asc)": StoriesByAuthorSlugQueryResult;
+		"\n*[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))][$start...$end]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'badLanguage': coalesce(badLanguage, false),\n    'body': coalesce(body[0...3], []),\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription\n        }\n    }, []),\n}|order(title asc)": StoriesByAuthorSlugQueryResult;
 		"\n*[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'badLanguage': coalesce(badLanguage, false),\n    'body': [],\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': [],\n}|order(title asc)[$start...$end]": StoryNavigationTeasersByAuthorSlugQueryResult;
-		"\n*[_type == 'story' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title, \n    'badLanguage': coalesce(badLanguage, false),\n    'epigraphs': coalesce(epigraphs[]{\n        text,\n        'reference': coalesce(reference[], [])\n    }, []),\n    'body': coalesce(body, []),\n    'review': coalesce(review, []),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    'updatedAt': _updatedAt,\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription,\n            icon\n        }\n    }, []),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'author': author-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                shortDescription,\n                icon\n            }\n        }, []),\n        'tags': []\n    }\n}[0]": StoryBySlugQueryResult;
+		"\n*[_type == 'story' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title, \n    'badLanguage': coalesce(badLanguage, false),\n    'epigraphs': coalesce(epigraphs[]{\n        text,\n        'reference': coalesce(reference[], [])\n    }, []),\n    'body': coalesce(body, []),\n    'review': coalesce(review, []),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    'updatedAt': _updatedAt,\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription\n        }\n    }, []),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'author': author-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                shortDescription\n            }\n        }, []),\n        'tags': []\n    }\n}[0]": StoryBySlugQueryResult;
 		"\n*[_type == 'story' && slug.current in $slugs && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'badLanguage': coalesce(badLanguage, false),\n    'epigraphs': [],\n    'body': [],\n    'review': [],\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': [],\n    'author': author-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        'biography': [],\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': []\n    }\n}": StoriesBySlugsQueryResult;
 		"\n*[_type == 'story' && !(_id in path('drafts.**'))]\n[$start...$end]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'badLanguage': coalesce(badLanguage, false),\n    'body': [],\n    'review': [],\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': [],\n    'author': author-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        'biography': [],\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': []\n    }\n}|order(title asc)": AllStoriesQueryResult;
 		"\n*[_type == 'storylist' && !(_id in path('drafts.**'))]{\n    _id,\n    'slug': slug.current,\n    title,\n    description,\n    featuredImage,\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'storyCoverImages': coalesce(stories[]->coverImage, []),\n    'count': coalesce(count(stories), 0),\n    config,\n    'tabs': [],\n\t\t'mediaSources': coalesce(mediaSources[], []),\n    }\n": StorylistTeasersQueryResult;


### PR DESCRIPTION
## Descripción

- Elimina `resourceType.icon` (`iconPicker`, obligatorio) del schema de Sanity y de sus **dos** previews —el del documento y el del objeto `resource` embebido—, de las **8 proyecciones GROQ** bajo `resourceType->`, del mapper `mapResources` y de la interfaz `ResourceType`.
- El frontend nunca lo leyó: `ResourceComponent` resuelve el ícono que pinta desde `resourceType.slug`, contra el mapa local de `iconMappers`. La prueba más clara está en el propio corpus — `resourceMock` declara `fa-medal` y el DOM renderiza `faSolidMedal`, la entrada que el slug mapea. **Los dos valores difieren**, así que el ícono que ve el lector delata de qué lado sale.
- El primer commit **ancla ese comportamiento con un test** antes de tocar nada: compara el SVG renderizado contra la constante del ícono. Sobrevive al cambio y es lo que impide reconectar el componente a un campo del CMS que ya no existe.

Los dos previews **pierden su miniatura**: es la pérdida asumida al decidir retirar el ícono del CMS por completo, la misma que #2071 asumió para las etiquetas. Al sacar `media`, ambos `prepare()` quedaban como identidades, así que se eliminan y el `select` mapea directo.

La propiedad queda huérfana en los documentos del dataset; su purga va agrupada en #2068, cuyo alcance se amplió para incluirla.

Closes #2069.

Parte de #2049.

> Con este PR, `sanity-plugin-icon-picker` queda **sin ningún campo que lo consuma**: solo sobreviven su registro en `cms/sanity.config.ts` y la dependencia en `cms/package.json`. Eso desbloquea #2072, que lo da de baja — y explica por qué el tipo `iconPicker` sigue apareciendo en `cms/schema.json` pese a que ningún schema lo usa.

## Plan de pruebas

- [x] `typecheck` — verde. Es el mecanismo de detección: tras regenerar los tipos señaló los 7 literales del corpus a podar.
- [x] `test` — verde, incluido el test de anclaje nuevo.
- [x] `lint` — verde.
- [x] `build` — verde.
- [x] `storybook` — verde.
- [x] `studio-build` — verde. El diff toca `cms/`.
- [x] `stylelint` — verde.
- [x] **El test de anclaje tiene filo, verificado con una mutación**: al cambiar el mapeo del slug en `iconMappers`, el test falla. Sin esa comprobación, una aserción sobre un SVG podría estar pasando por casualidad.
- [x] Verificado que las 8 eliminaciones son exactamente las de `resourceType->{…}` y que **no queda ninguna `icon` en todo `src/api/_queries/`** — ni bajo `resourceType->` ni bajo `tags[] ->`, que limpió #2071.
- [x] **Verificación estructural de `cms/schema.json`**, no lectura del diff a ojo: 41 tipos sin altas ni bajas, `resourceType` sin `icon` y con `shortDescription` intacto, `tag` sin `icon`, tipo `iconPicker` presente (correcto hasta #2072).
- [x] Code review local y auditoría de seguridad corridas antes de abrir el PR. Sin hallazgos críticos; la auditoría da **SEGURO**.
- [ ] `e2e` — se omitió en local: la suite no asierta sobre íconos de recursos, y el ícono que el sitio muestra no cambia. Queda cubierto por el gate de CI.
