### PR TITLE
[#2073] - Sanear iconMappers: podar entradas sin consumidor y su TODO huérfano

### DIFF
--- a/src/models/icon.model.ts
+++ b/src/models/icon.model.ts
@@ -1,16 +1,4 @@
-import {
-	faSolidAddressBook,
-	faSolidBook,
-	faSolidBookBookmark,
-	faSolidEnvelope,
-	faSolidGlobe,
-	faSolidMedal,
-	faSolidMicrophoneLines,
-	faSolidPeopleGroup,
-	faSolidPlay,
-	faSolidStar,
-	faSolidTrophy,
-} from '@ng-icons/font-awesome/solid';
+import { faSolidAddressBook, faSolidEnvelope, faSolidGlobe, faSolidMedal } from '@ng-icons/font-awesome/solid';
 import {
 	simpleBlogger,
 	simpleDiscord,
@@ -22,47 +10,22 @@ import {
 } from '@ng-icons/simple-icons';
 import { faBrandAmazon, faBrandInstagram, faBrandWikipediaW } from '@ng-icons/font-awesome/brands';
 
-export interface Icon {
-	name: string;
-	provider: string;
-}
-
-// TODO: #535 - Reemplazar estas interfaces por uso directo de íconos cargados de manera dinámica
 export interface IconMapper {
 	name: string;
 	ngIconsName: Record<string, string>;
 }
 
-// TODO: #535 - Reemplazar estas interfaces por uso directo de íconos cargados de manera dinámica
+/**
+ * Traduce el slug de un `resourceType` al ícono de `@ng-icons` que lo representa. Lo consume
+ * `ResourceComponent`, el único lugar del sitio donde se pinta un ícono resuelto por slug.
+ *
+ * El mapa está hardcodeado porque los íconos de `@ng-icons` se importan como símbolos: servirlos desde
+ * el CMS exige resolverlos dinámicamente en tiempo de ejecución, que es la dirección a futuro pero no
+ * está implementada. Hasta entonces, cada entrada tiene que corresponder a un `resourceType` cargado —
+ * una entrada que ningún documento indexa es peso muerto que nadie detecta, porque el componente
+ * simplemente no pinta ícono cuando no encuentra el slug.
+ */
 export const iconMappers: IconMapper[] = [
-	{
-		name: 'curaduria',
-		ngIconsName: { faSolidStar },
-	},
-	{
-		name: 'x-spaces',
-		ngIconsName: { faSolidMicrophoneLines },
-	},
-	{
-		name: 'certamen',
-		ngIconsName: { faSolidTrophy },
-	},
-	{
-		name: 'colaborativa',
-		ngIconsName: { faSolidPeopleGroup },
-	},
-	{
-		name: 'antologia',
-		ngIconsName: { faSolidBookBookmark },
-	},
-	{
-		name: 'tertulia-literaria',
-		ngIconsName: { faSolidBook },
-	},
-	{
-		name: 'video',
-		ngIconsName: { faSolidPlay },
-	},
 	{
 		name: 'wattpad',
 		ngIconsName: { simpleWattpad },
@@ -74,10 +37,6 @@ export const iconMappers: IconMapper[] = [
 	{
 		name: 'recurso-original',
 		ngIconsName: { faSolidMedal },
-	},
-	{
-		name: 'sitio-web',
-		ngIconsName: { faSolidGlobe },
 	},
 	{
 		name: 'web-personal',


### PR DESCRIPTION
Poda de `iconMappers` las entradas que ningún recurso puede alcanzar, elimina la interfaz `Icon` que quedó sin consumidores y resuelve los dos `TODO` que apuntaban a un issue cerrado.

## El relevamiento

La fuente de verdad es el dataset, no el mapa. Se relevó contra **producción**, y se verificó que `development` declara los mismos 15 `resourceType`.

El mapa tenía **22 entradas** (el issue estimaba 19). De ellas, **14 corresponden a un `resourceType` que los recursos efectivamente referencian** y **8 son inalcanzables**:

| Entrada podada | Por qué |
| --- | --- |
| `curaduria`, `certamen`, `colaborativa`, `antologia`, `tertulia-literaria`, `video`, `x-spaces` | Son slugs de **etiqueta**. Los tags existen en Sanity, pero `iconMappers` tiene un solo consumidor —`ResourceComponent`— que lo indexa **solo** por `resource().resourceType.slug`. Nada lo consulta por slug de tag: `TagComponent` tiene por template literalmente `{{ displayLabel() }}`. |
| `sitio-web` | **El slug no existe** en ningún dataset. El `resourceType` real se llama `web-personal`, que sí conserva su entrada. |

## Verificación: ningún ícono visible cambia

No alcanza con que las entradas podadas no correspondan a un `resourceType`; hay que comprobar que las que **quedan** cubren todo lo que el sitio pinta hoy. Sobre los **563 recursos** de producción (los de autor, story y storylist, que renderizan todos vía `ResourceComponent`), los `resourceType` referenciados son exactamente 14:

`amazon` · `biografia-del-autor-en-sitio-web` · `blogspot` · `discord` · `email` · `instagram` · `recurso-original` · `substack` · `wattpad` · `web-personal` · `wikipedia` · `wikisource` · `x` · `youtube`

**Son exactamente las 14 entradas que quedan en el mapa, una a una.** Ninguna de las 8 podadas era alcanzable por ningún recurso, y ninguna de las que quedan sobra: el mapa queda en correspondencia uno a uno con el uso real.

Los "Recursos web sobre el autor" de la página de autor y de `bio-summary-card` quedan intactos.

## La curaduría que se poda no coincide con la de Sanity

Las 7 entradas de tag encodean una curaduría **tag → ícono de `@ng-icons`** distinta de la que estaba cargada en el CMS. Queda registrada acá porque el día que se aborden los íconos dinámicos es material de partida, y de otro modo sobreviviría solo en el diff:

| slug | Sanity (icon picker, purgado en #2068) | `iconMappers` (@ng-icons, podado acá) |
| --- | --- | --- |
| `curaduria` | `fa-reg-star` | `faSolidStar` |
| `x-spaces` | `x` (logo de X) | `faSolidMicrophoneLines` |
| `certamen` | `fa-trophy` | `faSolidTrophy` |
| `colaborativa` | `fa-users` | `faSolidPeopleGroup` |
| `antologia` | `fa-bookmark` | `faSolidBookBookmark` |
| `tertulia-literaria` | `fa-book` | `faSolidBook` |
| `video` | `fa-play-circle` | `faSolidPlay` |

## `Icon` y los `TODO`

`export interface Icon` se elimina: no tenía consumidores desde que el ícono salió del dominio de `Tag` (#2071) y de `ResourceType` (#2069).

Los dos `TODO` citaban **#535, cerrado hace cinco milestones**. Reemplazar el número por el de este issue tendría el mismo defecto apenas mergee, así que se reescribe **sin referencia**: la dirección que enunciaban —resolver los íconos dinámicamente en vez de hardcodearlos— sigue vigente, y ahora queda documentada junto con el motivo por el que todavía no se puede, que es que `@ng-icons` los importa como símbolos.

## Nota

`perfil-de-linkedin` existe como `resourceType` en los dos datasets y no tiene entrada en el mapa, pero **ningún recurso lo referencia** (cero de 563): no es un hueco visible, es un tipo cargado sin uso.

## Gates

`typecheck`, `lint`, `test` (1183 pasan), `build` y `storybook` en verde localmente.

Parte de #2049.

Closes #2073
