### PR TITLE
[#2061] - Resolver los paths del tsconfig con la opción nativa de Vite

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,5 @@
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default {
 	stories: ['../src/app/**/*.stories.mdx', '../src/app/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -12,11 +11,14 @@ export default {
 	},
 	docs: {},
 	staticDirs: [{ from: '../src/assets', to: '/assets' }],
-	// Vite no resuelve los `paths` del tsconfig por sí solo: el plugin mapea @models, @utils,
-	// @components, @mocks, @test-utils (mismo patrón que vitest.config.ts). El plugin de Analog
-	// que compila Angular ya lo aporta el framework @storybook/angular-vite.
+	// Resolución nativa de los `paths` del tsconfig (@models, @mocks, @components, …), en lugar de
+	// `vite-tsconfig-paths`: el plugin descubre proyectos recorriendo el árbol, y bajo
+	// `.claude/worktrees/` hay copias enteras del repo. Basta con que el tsconfig de una de ellas no
+	// le parsee para que aborte y deje de resolver alias en TODO el catálogo — sin más síntoma que
+	// stories que no cargan. El plugin de Analog que compila Angular lo aporta el framework
+	// @storybook/angular-vite.
 	viteFinal: async (config) => {
-		config.plugins = [...(config.plugins ?? []), tsconfigPaths()];
+		config.resolve = { ...config.resolve, tsconfigPaths: true };
 		return config;
 	},
 };

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
 		"typescript": "6.0.3",
 		"typescript-eslint": "8.65.0",
 		"vite": "^8.0.0",
-		"vite-tsconfig-paths": "^6.1.1",
 		"vitest": "^4.1.10",
 		"webpack": "5.109.1"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,9 +353,6 @@ importers:
       vite:
         specifier: ^8.0.0
         version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.102.0)(stylus@0.64.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.102.0)(stylus@0.64.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@26.1.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.102.0)(stylus@0.64.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
@@ -5824,6 +5821,7 @@ packages:
     resolution:
       { integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q== }
     engines: { node: '>=12.0.0' }
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-spawn@7.0.6:
     resolution:
@@ -6946,10 +6944,6 @@ packages:
   globjoin@0.1.4:
     resolution:
       { integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg== }
-
-  globrex@0.1.2:
-    resolution:
-      { integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg== }
 
   gopd@1.2.0:
     resolution:
@@ -10602,18 +10596,6 @@ packages:
     resolution:
       { integrity: sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg== }
 
-  tsconfck@3.1.6:
-    resolution:
-      { integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w== }
-    engines: { node: ^18 || >=20 }
-    deprecated: unmaintained
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths-webpack-plugin@4.2.0:
     resolution:
       { integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA== }
@@ -10851,12 +10833,6 @@ packages:
   vfile@6.0.3:
     resolution:
       { integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q== }
-
-  vite-tsconfig-paths@6.1.1:
-    resolution:
-      { integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg== }
-    peerDependencies:
-      vite: '>=7.3.2 <8'
 
   vite@7.3.6:
     resolution:
@@ -17865,8 +17841,6 @@ snapshots:
 
   globjoin@0.1.4: {}
 
-  globrex@0.1.2: {}
-
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -21351,10 +21325,6 @@ snapshots:
       '@ts-morph/common': 0.22.0
       code-block-writer: 12.0.0
 
-  tsconfck@3.1.6(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
-
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
@@ -21548,16 +21518,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.102.0)(stylus@0.64.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
-    dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.102.0)(stylus@0.64.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.99.0)(stylus@0.64.0)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,16 @@
 /// <reference types="vitest" />
 import angular from '@analogjs/vite-plugin-angular';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 // Configuración de Vitest para Angular zoneless (Nx 23 + builder vite/esbuild).
 // El plugin de Analog compila componentes/plantillas Angular en modo JIT durante los tests.
 export default defineConfig({
-	plugins: [angular(), tsconfigPaths()],
+	// Resolución nativa de los `paths` del tsconfig, en lugar de `vite-tsconfig-paths`: el plugin
+	// descubre proyectos recorriendo el árbol, y bajo `.claude/worktrees/` hay copias enteras del
+	// repo. Basta con que el tsconfig de una de ellas no le parsee para que aborte y deje de resolver
+	// alias en toda la corrida.
+	plugins: [angular()],
+	resolve: { tsconfigPaths: true },
 	test: {
 		globals: true,
 		environment: 'happy-dom',


### PR DESCRIPTION
Reemplaza `vite-tsconfig-paths` por la resolución nativa de Vite en Storybook y en Vitest, y elimina la dependencia.

## La causa de fondo

El plugin **descubre proyectos recorriendo el árbol de directorios**. Bajo `.claude/worktrees/` conviven copias enteras del repo, y basta con que el tsconfig de una de ellas no le parsee para que aborte y deje de resolver alias **en todo el catálogo**: ninguna story que importara `@mocks`, `@models` o `@components` cargaba en el dev server, sin más síntoma que un error de resolución por import.

Eso explica por qué el fallo aparecía y desaparecía sin patrón: dependía de qué otros checkouts hubiera en disco en ese momento, no del código.

Vite 8 resuelve los `paths` de forma nativa, sin descubrimiento por árbol, así que la configuración deja de depender del contenido del disco. Se alinea también `vitest.config.ts`, que traía el mismo plugin sin acotar y por lo tanto el mismo modo de falla — y de paso desaparece el warning de deprecación que emitía en cada corrida. La dependencia queda sin consumidores y se quita.

## Qué se verificó

**Que resuelve.** Con el dev server levantado, el módulo de una story que importa `@mocks` se sirve con el import ya reescrito:

```
import { onoffAudioRecordingsMock } from "/src/mocks/onoff-media.mock.ts";
```

**Que un alias nuevo también resuelve** — la pregunta que importa para que esto no vuelva a morder. Se agregó un `@alias-nuevo/*` al `tsconfig.json` raíz, se importó desde una story y desde un spec, y resolvió en las dos superficies sin tocar nada más: `.storybook/tsconfig.json` hace `extends` del raíz, así que hereda los `paths` automáticamente. La caché de Storybook, ya poblada de corridas anteriores, no interfirió. El experimento quedó revertido.

**Que la build estática sigue igual.** `storybook:build` en verde, como lo estuvo siempre — ahí estaba el problema.

## Lo que este PR NO cierra

El issue proponía además **una verificación automatizada del dev server**, la única superficie que ningún gate cubre: `storybook:build` compila el catálogo estático y resuelve bien, y por eso pasó en verde todo el tiempo que el catálogo estuvo inusable en desarrollo.

Se decidió no incorporarla. La casilla correspondiente del issue queda sin tildar y la ceguera sigue abierta: si algo vuelve a romper la resolución del dev server, ningún gate lo detectará.

## Reemplaza el workaround de #2038

#2038 había destrabado esto declarando los alias a mano en `viteFinal`, derivados del tsconfig raíz. Al mergear este PR, ese hunk queda obsoleto y se retira de #2048.

Closes #2061
