### PR TITLE
[#1760] - cms/: sin infraestructura de tests (Vitest) para lógica runtime del Studio

### DIFF
--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -338,6 +338,14 @@ El kernel compartido de paths (`@models/*`, `@utils/*` — ver [Aliases de paths
 
 Si falta declararlo en alguno de los tres, el síntoma es puntual a esa herramienta: el editor marca error pero el build pasa, o el build falla pero el editor no se queja, o los tests fallan al resolver el import mientras el resto compila bien.
 
+#### Las dependencias del kernel también hay que aliasarlas
+
+Si el archivo del kernel que consume el Studio importa un paquete (`date-fns`, por ejemplo), ese bare import se resuelve **desde el archivo que lo importa** — o sea desde `src/**`, fuera de `cms/`. En CI eso falla: el job del Studio hace checkout propio e instala **solo** `cms/`, así que `<repo>/node_modules` no existe y Rollup corta el build con `Failed to resolve import`.
+
+Por eso cada paquete que el kernel importe tiene que estar declarado como dependencia de `cms/package.json` **y** aliasado a `cms/node_modules/<paquete>` en `sanity.cli.ts` y `vitest.config.ts`.
+
+**Este es el modo de falla más traicionero de todo el cruce de límites, porque no se reproduce en local por ningún medio:** cualquier checkout del repo tiene un `node_modules` en la raíz, y la resolución sube hasta encontrarlo. Un worktree bajo `.claude/worktrees/` es todavía peor, porque sube hasta el `node_modules` del checkout principal aunque se esconda el propio. La única señal es el gate `studio-build` en CI.
+
 ---
 
 ## Storybook

--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -22,6 +22,8 @@ Archivos clave:
 - **`src/test-setup.ts`** — inicializa el `TestBed` zoneless (Angular 22 corre zoneless por defecto cuando `zone.js` no está presente; no se llama a `provideZonelessChangeDetection()`). El `ErrorHandler` **relanza** cualquier error no manejado para que falle el test. Instala el stub global de `IntersectionObserver`.
 - **`src/test-utils.ts`** — los wrappers obligatorios (ver abajo).
 
+> Esta es la config de **la app** (`@cuentoneta/app`). El Studio de Sanity (`cms/`) tiene su propia config de Vitest, independiente — ver [Segunda config de Vitest: el Studio (`cms/`)](#segunda-config-de-vitest-el-studio-cms).
+
 ---
 
 ## Regla dura: nada de `vi.*` directo
@@ -276,6 +278,68 @@ Reglas del patrón:
 
 ---
 
+## Segunda config de Vitest: el Studio (`cms/`)
+
+`cms/` (el Studio de Sanity) tiene su **propia config de Vitest** (`cms/vitest.config.ts`), independiente de la de la app. Se corre con `pnpm sanity:test` desde la raíz (o `pnpm -C cms test`), y es el paso `Test Sanity Studio` del gate `studio-build` — ver [Comandos comunes](../../CLAUDE.md#comandos-comunes).
+
+### Qué cubre y qué no
+
+Cubre **lógica Node pura del Studio**: resolvers de Desk Structure, utils que corren dentro del proceso del Studio (p. ej. `cms/utils/landing-page.ts`). No hay nada de Angular, ni Angular Testing Library, ni `happy-dom` — el Studio no renderiza componentes Angular ni corre en un DOM simulado con esa configuración.
+
+### Por qué es una config aparte
+
+`cms/` es un **proyecto pnpm standalone**, con su propio árbol de `node_modules` y su propio `package.json`. La config raíz de Vitest carga `@analogjs/vite-plugin-angular`, que no tiene nada que resolver ahí. Un `include` adicional en el `vitest.config.ts` de la raíz correría por fuera del entorno de `cms/` y arrastraría ese plugin sin necesidad.
+
+### Convenciones propias (no las de `@test-utils`)
+
+- Los specs de `cms/` **importan `describe`/`it`/`expect` de `vitest` explícitamente** (`cms/vitest.config.ts` no declara `globals`), a diferencia de los specs de la app.
+- **No usan `@test-utils`.** Esos wrappers viven en el árbol de `node_modules` de la app; arrastrarlos a `cms/` acoplaría dos proyectos pnpm por casos que se resuelven con diez líneas.
+- Los dobles se escriben **a mano**, siguiendo la misma taxonomía por comportamiento del resto del repo — `Stub*`/`Fake*`/`Spy*`, **nunca** `Mock*` (ver [Naming](../../CLAUDE.md#naming)). El ejemplo vigente es `SpyGroqClient` en `cms/utils/landing-page.spec.ts`: registra la query y los params con los que se lo invocó, sin depender de `vi.fn()`.
+- `cms/` **no** está cubierto por ESLint (el script `lint` de la raíz corre sobre `./src ./e2e ./resources`) ni por `tsconfig.typecheck.json`. Sin esas dos redes, los specs de `cms/` se mantienen deliberadamente simples: sin abstracciones de test propias, dobles chicos y anotados a mano.
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { buildWeekSlug } from '@utils/week-slug.utils';
+import { ACTIVE_LANDING_ID_QUERY, resolveActiveLandingId } from './landing-page';
+
+class SpyGroqClient {
+	query: string | null = null;
+	params: Record<string, unknown> | null = null;
+
+	constructor(private readonly result: unknown) {}
+
+	fetch<T>(query: string, params?: Record<string, unknown>): Promise<T> {
+		this.query = query;
+		this.params = params ?? null;
+		return this.result instanceof Error ? Promise.reject(this.result) : Promise.resolve(this.result as T);
+	}
+}
+
+describe('resolveActiveLandingId', () => {
+	it('queries the active landing with the ISO week of the given date', async () => {
+		const client = new SpyGroqClient('landing-page-current');
+
+		await resolveActiveLandingId(client, new Date(2025, 10, 14));
+
+		expect(client.query).toBe(ACTIVE_LANDING_ID_QUERY);
+	});
+});
+```
+
+### El kernel (`@models`/`@utils`) también es consumible desde `cms/`
+
+El kernel compartido de paths (`@models/*`, `@utils/*` — ver [Aliases de paths](../../CLAUDE.md#resumen-del-proyecto)) no es exclusivo de `src/`: el Studio también lo consume (p. ej. `cms/utils/landing-page.ts` importa `buildWeekSlug` de `@utils/week-slug.utils`). Como `cms/` es un proyecto pnpm standalone con su propio tooling, el alias hay que declararlo en **tres** lugares independientes, cada uno con su propio resolutor:
+
+| Lugar                  | Quién lo lee                        | Por qué no alcanza con uno solo                                                      |
+| ---------------------- | ----------------------------------- | ------------------------------------------------------------------------------------ |
+| `cms/sanity.cli.ts`    | El bundler del Studio (Vite/Rollup) | Es lo que hace que `sanity dev`/`sanity build` resuelvan el alias                    |
+| `cms/vitest.config.ts` | Vitest                              | Vitest **no** lee `sanity.cli.ts`; hay que repetir el `alias` ahí                    |
+| `cms/tsconfig.json`    | El editor / IntelliSense            | Solo aporta autocompletado y chequeo en el editor, no afecta al build ni a los tests |
+
+Si falta declararlo en alguno de los tres, el síntoma es puntual a esa herramienta: el editor marca error pero el build pasa, o el build falla pero el editor no se queja, o los tests fallan al resolver el import mientras el resto compila bien.
+
+---
+
 ## Storybook
 
 Todo componente nuevo en **`src/app/components/`** lleva su `*.stories.ts` (documentación viva + catálogo visual). Los componentes de página (`src/app/pages/`) están exentos.
@@ -370,3 +434,4 @@ Si el componente **renderiza su propio skeleton** según un input (p. ej. cuando
 - **Service/repository de backend** → spec funcional; si necesita aislar el repository, module mocking con el bloque `eslint-disable` + nota #1503.
 - **Mocks/timers** → siempre desde `@test-utils`; `clearAllMocks()` en `beforeEach`.
 - **Componente que usa `IntersectionObserver`** → `installIntersectionObserverStub()` en `beforeEach`; simular overflow con `markOutsideViewport` / `markInsideViewport`.
+- **Lógica Node pura de `cms/`** → spec propio con Vitest standalone (`pnpm sanity:test`); dobles escritos a mano (`Spy*`/`Stub*`/`Fake*`), sin `@test-utils`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,12 @@ jobs:
         working-directory: cms
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      # Los tests del Studio corren en este job y no en `test`: cms tiene su propio árbol de
+      # node_modules y su propia config de Vitest, y este job es el único que lo instala.
+      - name: Test Sanity Studio
+        working-directory: cms
+        run: pnpm test
+
       # `sanity build` (bundler Vite/Rollup) es el gate autoritativo del Studio: un
       # `tsc --noEmit` sobre cms/ no sirve (ruido de moduleResolution sobre node_modules,
       # sin relación con errores reales de bundling). `--ignore-scripts` en el install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@
 | **Estilos**            | Tailwind v4 + Stylelint                                           |
 | **Componentes**        | Storybook 10                                                      |
 
-**Aliases de paths** (ver `tsconfig.json`): kernel compartido a top-level `@models/*`, `@utils/*`, `@sanity-types`, `@mocks/*` (viven en `src/models`/`src/utils`/`src/sanity`/`src/mocks`, consumidos por app **y** api); frontend `@components/*`, `@app-utils/*` (utils de `src/app/utils` acoplados a `environment`, no kernel); backend `@queries/*`, `@schemas/*`; test `@test-utils`, `@testing/*`.
+**Aliases de paths** (ver `tsconfig.json`): kernel compartido a top-level `@models/*`, `@utils/*`, `@sanity-types`, `@mocks/*` (viven en `src/models`/`src/utils`/`src/sanity`/`src/mocks`, consumidos por app, api **y** el Studio de Sanity — `cms/` los resuelve con sus propios alias, declarados en `cms/sanity.cli.ts`, `cms/vitest.config.ts` y `cms/tsconfig.json`); frontend `@components/*`, `@app-utils/*` (utils de `src/app/utils` acoplados a `environment`, no kernel); backend `@queries/*`, `@schemas/*`; test `@test-utils`, `@testing/*`.
 
 **Prefijo de selectores:** componentes `cuentoneta-` (kebab-case, elemento); directivas `cuentoneta` (camelCase, atributo).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ Usar **siempre `pnpm`** para instalar y ejecutar scripts. Los scripts envuelven 
 | `pnpm seo:smoke`                          | Smoke manual post-deploy de indexado (invariantes SSR sobre `BASE_URL`, muestreando el sitemap)                                                        |
 | `pnpm storybook` / `pnpm storybook:build` | Storybook dev / build                                                                                                                                  |
 | `pnpm sanity:dev`                         | Studio de Sanity (`@cuentoneta/cms`)                                                                                                                   |
-| `pnpm sanity:build`                       | Build del Studio (`sanity build`) — reproduce en local el gate de CI `studio-build`                                                                    |
+| `pnpm sanity:build`                       | Build del Studio (`sanity build`) — reproduce en local el build del gate de CI `studio-build`                                                          |
+| `pnpm sanity:test`                        | Tests del Studio (Vitest standalone en `cms/`) — reproduce en local el paso de test del gate `studio-build`                                            |
 | `pnpm sanity:extract-schema`              | Extrae el schema de Sanity                                                                                                                             |
 | `pnpm sanity:run-typegen-generator`       | Genera tipos a partir del schema                                                                                                                       |
 | `pnpm exec sanity migration run <slug>`   | Corre una migración de datos (desde `cms/`; dry-run por defecto) → [`sanity-migrations.md`](.claude/references/sanity-migrations.md)                   |
@@ -69,7 +70,7 @@ Usar **siempre `pnpm`** para instalar y ejecutar scripts. Los scripts envuelven 
 
 > El gate `typecheck` (`pnpm typecheck` → `tsc --noEmit` estricto) cubre el **TS puro** de la app (`src/**`, incluidos `*.spec.ts` y `*.stories.ts`) y `scripts/`. **No** valida plantillas Angular (eso lo hacen `build`/`storybook` vía `ngtsc`) ni el proyecto `cms/`.
 >
-> El build del Studio de Sanity (`cms/`) lo cubre el gate **`studio-build`** (`pnpm -C cms exec sanity build`, el bundler Vite/Rollup real del Studio), no `typecheck` ni `build`. Corre en un job aparte con install propio de `cms/` (proyecto pnpm standalone). Cierra el punto ciego por el que un bump roto de una dependencia del Studio podía llegar a `develop` sin señal de CI.
+> El gate **`studio-build`** cubre `cms/` con un job aparte, con install propio (proyecto pnpm standalone), en dos pasos secuenciales: primero **tests** (`pnpm -C cms test`, Vitest standalone — ver [`testing.md`](.claude/references/testing.md)) y después el **build** real del Studio (`pnpm -C cms exec sanity build`, el bundler Vite/Rollup). No es `typecheck` ni `build` de la app. Cierra el punto ciego por el que un bump roto de una dependencia del Studio, o una regresión en su lógica Node, podía llegar a `develop` sin señal de CI.
 
 ---
 

--- a/cms/components/LandingPageListPane.tsx
+++ b/cms/components/LandingPageListPane.tsx
@@ -7,7 +7,7 @@ import { CodeBlockIcon } from '@sanity/icons/CodeBlock';
 
 import { buildWeekSlug } from '@utils/week-slug.utils';
 
-import { ACTIVE_LANDING_ID_QUERY, API_VERSION, LANDING_LIST_QUERY, type LandingPageRow } from '../utils/landing-page';
+import { API_VERSION, LANDING_LIST_QUERY, type LandingPageRow, resolveActiveLandingId } from '../utils/landing-page';
 
 function toMessage(cause: unknown): string {
 	return cause instanceof Error ? cause.message : 'Error desconocido';
@@ -24,10 +24,10 @@ export function LandingPageListPane() {
 		try {
 			const [list, active] = await Promise.all([
 				client.fetch<LandingPageRow[]>(LANDING_LIST_QUERY),
-				client.fetch<string | null>(ACTIVE_LANDING_ID_QUERY, { slug: buildWeekSlug(new Date()) }),
+				resolveActiveLandingId(client),
 			]);
 			setRows(list);
-			setActiveId(active ?? null);
+			setActiveId(active);
 			setError(null);
 		} catch (cause) {
 			setError(toMessage(cause));

--- a/cms/components/LandingPageListPane.tsx
+++ b/cms/components/LandingPageListPane.tsx
@@ -5,13 +5,9 @@ import { Badge, Box, Button, Card, Flex, Spinner, Stack, Text } from '@sanity/ui
 import { AddIcon } from '@sanity/icons/Add';
 import { CodeBlockIcon } from '@sanity/icons/CodeBlock';
 
-import {
-	ACTIVE_LANDING_ID_QUERY,
-	API_VERSION,
-	LANDING_LIST_QUERY,
-	activeWeekSlug,
-	type LandingPageRow,
-} from '../utils/landing-page';
+import { buildWeekSlug } from '@utils/week-slug.utils';
+
+import { ACTIVE_LANDING_ID_QUERY, API_VERSION, LANDING_LIST_QUERY, type LandingPageRow } from '../utils/landing-page';
 
 function toMessage(cause: unknown): string {
 	return cause instanceof Error ? cause.message : 'Error desconocido';
@@ -28,7 +24,7 @@ export function LandingPageListPane() {
 		try {
 			const [list, active] = await Promise.all([
 				client.fetch<LandingPageRow[]>(LANDING_LIST_QUERY),
-				client.fetch<string | null>(ACTIVE_LANDING_ID_QUERY, { slug: activeWeekSlug() }),
+				client.fetch<string | null>(ACTIVE_LANDING_ID_QUERY, { slug: buildWeekSlug(new Date()) }),
 			]);
 			setRows(list);
 			setActiveId(active ?? null);
@@ -65,7 +61,7 @@ export function LandingPageListPane() {
 
 	// Referencia para clasificar filas: el config de la activa (máximo config <= semana actual). Toda fila con
 	// config mayor es una semana futura. Sin activa, se cae a la semana actual como referencia.
-	const activeConfig = rows.find((row) => row._id === activeId)?.config ?? activeWeekSlug();
+	const activeConfig = rows.find((row) => row._id === activeId)?.config ?? buildWeekSlug(new Date());
 
 	return (
 		<Stack space={0}>

--- a/cms/package.json
+++ b/cms/package.json
@@ -14,6 +14,7 @@
 		"start": "sanity start",
 		"build": "sanity build",
 		"dev": "sanity dev",
+		"test": "vitest run",
 		"config": "node --import tsx ./set-environment.ts"
 	},
 	"keywords": [
@@ -41,7 +42,8 @@
 	},
 	"devDependencies": {
 		"@types/node": "^24.13.3",
-		"tsx": "^4.23.1"
+		"tsx": "^4.23.1",
+		"vitest": "^4.1.10"
 	},
 	"pnpm": {
 		"overrides": {

--- a/cms/pnpm-lock.yaml
+++ b/cms/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
   '@acemir/cssom@0.9.31':
@@ -2770,6 +2773,10 @@ packages:
       { integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ== }
     engines: { node: '>=18' }
 
+  '@standard-schema/spec@1.1.0':
+    resolution:
+      { integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w== }
+
   '@tanstack/react-table@8.21.3':
     resolution:
       { integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww== }
@@ -2814,9 +2821,17 @@ packages:
     resolution:
       { integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng== }
 
+  '@types/chai@5.2.3':
+    resolution:
+      { integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA== }
+
   '@types/codemirror@5.60.17':
     resolution:
       { integrity: sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw== }
+
+  '@types/deep-eql@4.0.2':
+    resolution:
+      { integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw== }
 
   '@types/estree@1.0.8':
     resolution:
@@ -2967,6 +2982,42 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.10':
+    resolution:
+      { integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA== }
+
+  '@vitest/mocker@4.1.10':
+    resolution:
+      { integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow== }
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution:
+      { integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q== }
+
+  '@vitest/runner@4.1.10':
+    resolution:
+      { integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg== }
+
+  '@vitest/snapshot@4.1.10':
+    resolution:
+      { integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw== }
+
+  '@vitest/spy@4.1.10':
+    resolution:
+      { integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw== }
+
+  '@vitest/utils@4.1.10':
+    resolution:
+      { integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA== }
+
   '@xstate/react@6.1.0':
     resolution:
       { integrity: sha512-ep9F0jGTI63B/jE8GHdMpUqtuz7yRebNaKv8EMUaiSi29NOglywc2X2YSOV/ygbIK+LtmgZ0q9anoEA2iBSEOw== }
@@ -3076,6 +3127,11 @@ packages:
   arrify@3.0.0:
     resolution:
       { integrity: sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw== }
+    engines: { node: '>=12' }
+
+  assertion-error@2.0.1:
+    resolution:
+      { integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA== }
     engines: { node: '>=12' }
 
   async@3.2.6:
@@ -3332,6 +3388,11 @@ packages:
       { integrity: sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA== }
     peerDependencies:
       react: '>=17.0.0'
+
+  chai@6.2.2:
+    resolution:
+      { integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg== }
+    engines: { node: '>=18' }
 
   chalk@5.6.2:
     resolution:
@@ -3784,6 +3845,10 @@ packages:
       { integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA== }
     engines: { node: '>=4.0' }
 
+  estree-walker@3.0.3:
+    resolution:
+      { integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g== }
+
   esutils@2.0.3:
     resolution:
       { integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g== }
@@ -3824,6 +3889,11 @@ packages:
   exif-component@1.0.1:
     resolution:
       { integrity: sha512-FXnmK9yJYTa3V3G7DE9BRjUJ0pwXMICAxfbsAuKPTuSlFzMZhQbcvvwx0I8ofNJHxz3tfjze+whxcGpfklAWOQ== }
+
+  expect-type@1.4.0:
+    resolution:
+      { integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA== }
+    engines: { node: '>=12.0.0' }
 
   fast-deep-equal@3.1.3:
     resolution:
@@ -4685,6 +4755,10 @@ packages:
   lru-cache@5.1.1:
     resolution:
       { integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w== }
+
+  magic-string@0.30.21:
+    resolution:
+      { integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ== }
 
   make-dir@2.1.0:
     resolution:
@@ -5617,6 +5691,10 @@ packages:
       { integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A== }
     engines: { node: '>=8' }
 
+  siginfo@2.0.0:
+    resolution:
+      { integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g== }
+
   signal-exit@4.1.0:
     resolution:
       { integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw== }
@@ -5693,6 +5771,14 @@ packages:
   sprintf-js@1.0.3:
     resolution:
       { integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g== }
+
+  stackback@0.0.2:
+    resolution:
+      { integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw== }
+
+  std-env@4.2.0:
+    resolution:
+      { integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw== }
 
   stdin-discarder@0.3.2:
     resolution:
@@ -5836,10 +5922,24 @@ packages:
     resolution:
       { integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw== }
 
+  tinybench@2.9.0:
+    resolution:
+      { integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg== }
+
+  tinyexec@1.3.0:
+    resolution:
+      { integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ== }
+    engines: { node: '>=18' }
+
   tinyglobby@0.2.17:
     resolution:
       { integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g== }
     engines: { node: '>=12.0.0' }
+
+  tinyrainbow@3.1.1:
+    resolution:
+      { integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw== }
+    engines: { node: '>=14.0.0' }
 
   tldts-core@6.1.86:
     resolution:
@@ -6231,6 +6331,48 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution:
+      { integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw== }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution:
       { integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w== }
@@ -6295,6 +6437,12 @@ packages:
     resolution:
       { integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg== }
     engines: { node: ^20.17.0 || >=22.9.0 }
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution:
+      { integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w== }
+    engines: { node: '>=8' }
     hasBin: true
 
   widest-line@3.1.0:
@@ -9483,6 +9631,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/table-core': 8.21.3
@@ -9525,9 +9675,16 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/codemirror@5.60.17':
     dependencies:
       '@types/tern': 0.23.9
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -9652,6 +9809,47 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.1.5)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0))
       babel-plugin-react-compiler: 1.0.0
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   '@xstate/react@6.1.0(@types/react@19.1.8)(react@19.2.8)(xstate@5.32.2)':
     dependencies:
       react: 19.2.8
@@ -9716,6 +9914,8 @@ snapshots:
   arrify@2.0.1: {}
 
   arrify@3.0.0: {}
+
+  assertion-error@2.0.1: {}
 
   async@3.2.6: {}
 
@@ -9908,6 +10108,8 @@ snapshots:
   ce-la-react@0.3.2(react@19.2.8):
     dependencies:
       react: 19.2.8
+
+  chai@6.2.2: {}
 
   chalk@5.6.2: {}
 
@@ -10267,6 +10469,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   event-source-polyfill@1.0.31: {}
@@ -10303,6 +10509,8 @@ snapshots:
       yoctocolors: 2.2.0
 
   exif-component@1.0.1: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -10976,6 +11184,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-dir@2.1.0:
     dependencies:
@@ -11861,6 +12073,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-wcswidth@1.1.2: {}
@@ -11905,6 +12119,10 @@ snapshots:
   speakingurl@14.0.1: {}
 
   sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   stdin-discarder@0.3.2: {}
 
@@ -12061,10 +12279,16 @@ snapshots:
     dependencies:
       readable-stream: 3.6.2
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   tldts-core@6.1.86: {}
 
@@ -12337,6 +12561,34 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
+  vitest@4.1.10(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+      jsdom: 29.1.1(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - msw
+
   void-elements@3.1.0: {}
 
   w3c-keyname@2.2.8: {}
@@ -12379,6 +12631,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@3.1.0:
     dependencies:

--- a/cms/project.json
+++ b/cms/project.json
@@ -28,6 +28,13 @@
 				"cwd": "cms"
 			}
 		},
+		"test": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "pnpm test",
+				"cwd": "cms"
+			}
+		},
 		"deploy": {
 			"executor": "nx:run-commands",
 			"dependsOn": ["build"],

--- a/cms/project.json
+++ b/cms/project.json
@@ -30,6 +30,7 @@
 		},
 		"test": {
 			"executor": "nx:run-commands",
+			"inputs": ["default", "{workspaceRoot}/src/models/**/*", "{workspaceRoot}/src/utils/**/*"],
 			"options": {
 				"command": "pnpm test",
 				"cwd": "cms"

--- a/cms/sanity.cli.ts
+++ b/cms/sanity.cli.ts
@@ -24,6 +24,11 @@ export default defineCliConfig({
 		const kernelAliases = {
 			'@models': path.resolve(__dirname, '../src/models'),
 			'@utils': path.resolve(__dirname, '../src/utils'),
+			// Todo bare import que haga el kernel se resuelve desde el archivo que lo importa, o sea desde
+			// <repo>/src/**, que está fuera de cms/. En CI ese directorio no tiene node_modules —el job del
+			// Studio instala solo cms/—, así que sin este alias Rollup no encuentra el paquete y el build
+			// falla. Localmente no se nota: la resolución sube hasta el node_modules de la raíz.
+			'date-fns': path.resolve(__dirname, 'node_modules/date-fns'),
 		};
 		const existingAlias = config.resolve?.alias;
 		// resolve.alias admite forma objeto o array (readonly Alias[]): se mergea según la que Sanity

--- a/cms/sanity.cli.ts
+++ b/cms/sanity.cli.ts
@@ -17,17 +17,20 @@ export default defineCliConfig({
 		generates: '../src/sanity/types.ts',
 	},
 	// cms es un proyecto pnpm standalone: su build bundlea con Vite y no resuelve los `paths` del
-	// tsconfig raíz. Se registra el alias @models hacia el kernel compartido para importar el dominio
-	// por shortpath en vez de rutas relativas ../../src/models. __dirname es cms/ (Sanity carga este
-	// config con su loader CJS), así que resuelve a <repo>/src/models.
+	// tsconfig raíz. Se registran los alias del kernel compartido para importarlo por shortpath en vez
+	// de rutas relativas ../../src/*. __dirname es cms/ (Sanity carga este config con su loader CJS),
+	// así que resuelven a <repo>/src/*.
 	vite: (config) => {
-		const modelsPath = path.resolve(__dirname, '../src/models');
+		const kernelAliases = {
+			'@models': path.resolve(__dirname, '../src/models'),
+			'@utils': path.resolve(__dirname, '../src/utils'),
+		};
 		const existingAlias = config.resolve?.alias;
 		// resolve.alias admite forma objeto o array (readonly Alias[]): se mergea según la que Sanity
 		// provea para no corromperla — spread de un array dentro de un objeto generaría claves numéricas.
 		const alias = Array.isArray(existingAlias)
-			? [...existingAlias, { find: '@models', replacement: modelsPath }]
-			: { ...existingAlias, '@models': modelsPath };
+			? [...existingAlias, ...Object.entries(kernelAliases).map(([find, replacement]) => ({ find, replacement }))]
+			: { ...existingAlias, ...kernelAliases };
 		return {
 			...config,
 			resolve: { ...config.resolve, alias },

--- a/cms/tsconfig.json
+++ b/cms/tsconfig.json
@@ -7,7 +7,8 @@
 		"jsx": "react",
 		"baseUrl": ".",
 		"paths": {
-			"@models/*": ["../src/models/*"]
+			"@models/*": ["../src/models/*"],
+			"@utils/*": ["../src/utils/*"]
 		}
 	}
 }

--- a/cms/utils/landing-page.spec.ts
+++ b/cms/utils/landing-page.spec.ts
@@ -25,9 +25,16 @@ describe('resolveActiveLandingId', () => {
 		await resolveActiveLandingId(client, new Date(2025, 10, 14));
 
 		expect(client.query).toBe(ACTIVE_LANDING_ID_QUERY);
-		// El esperado se deriva de la implementación única del kernel, no de un literal: si el alias
-		// @utils deja de resolver o la fórmula cambia, el fallo aparece acá y no recién en el Studio.
-		expect(client.params).toEqual({ slug: buildWeekSlug(new Date(2025, 10, 14)) });
+		expect(client.params).toEqual({ slug: '2025-46' });
+	});
+
+	it('falls back to the current date when none is given', async () => {
+		// El único call site de producción (el ítem de Desk Structure) invoca sin fecha.
+		const client = new SpyGroqClient('landing-page-current');
+
+		await resolveActiveLandingId(client);
+
+		expect(client.params).toEqual({ slug: buildWeekSlug(new Date()) });
 	});
 
 	it('returns the id resolved by the client', async () => {

--- a/cms/utils/landing-page.spec.ts
+++ b/cms/utils/landing-page.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { buildWeekSlug } from '@utils/week-slug.utils';
+
+import { ACTIVE_LANDING_ID_QUERY, resolveActiveLandingId } from './landing-page';
+
+// Doble escrito a mano en vez de vi.fn(): los wrappers de @test-utils viven en el árbol de la app y
+// arrastrarlos acá sería acoplar dos proyectos pnpm por un caso que se resuelve con diez líneas.
+class SpyGroqClient {
+	query: string | null = null;
+	params: Record<string, unknown> | null = null;
+
+	constructor(private readonly result: unknown) {}
+
+	fetch<T>(query: string, params?: Record<string, unknown>): Promise<T> {
+		this.query = query;
+		this.params = params ?? null;
+		return this.result instanceof Error ? Promise.reject(this.result) : Promise.resolve(this.result as T);
+	}
+}
+
+describe('resolveActiveLandingId', () => {
+	it('queries the active landing with the ISO week of the given date', async () => {
+		const client = new SpyGroqClient('landing-page-current');
+
+		await resolveActiveLandingId(client, new Date(2025, 10, 14));
+
+		expect(client.query).toBe(ACTIVE_LANDING_ID_QUERY);
+		// El esperado se deriva de la implementación única del kernel, no de un literal: si el alias
+		// @utils deja de resolver o la fórmula cambia, el fallo aparece acá y no recién en el Studio.
+		expect(client.params).toEqual({ slug: buildWeekSlug(new Date(2025, 10, 14)) });
+	});
+
+	it('returns the id resolved by the client', async () => {
+		const client = new SpyGroqClient('landing-page-current');
+
+		await expect(resolveActiveLandingId(client, new Date(2025, 10, 14))).resolves.toBe('landing-page-current');
+	});
+
+	it('normalizes a missing result to null', async () => {
+		const client = new SpyGroqClient(undefined);
+
+		await expect(resolveActiveLandingId(client, new Date(2025, 10, 14))).resolves.toBeNull();
+	});
+
+	it('propagates a rejection from the client', async () => {
+		// La propagación es contrato: quien la captura es el ítem de Desk Structure que la invoca.
+		const client = new SpyGroqClient(new Error('GROQ no disponible'));
+
+		await expect(resolveActiveLandingId(client, new Date(2025, 10, 14))).rejects.toThrow('GROQ no disponible');
+	});
+});

--- a/cms/utils/landing-page.ts
+++ b/cms/utils/landing-page.ts
@@ -1,16 +1,10 @@
-import { getISOWeek, getISOWeekYear } from 'date-fns';
+import { buildWeekSlug } from '@utils/week-slug.utils';
 
 export const API_VERSION = '2024-01-01';
 
 export interface LandingPageRow {
 	_id: string;
 	config: string;
-}
-
-// Espejo de buildWeekSlug (src/api/modules/content/content.service.ts): formato YYYY-WW con numeración
-// ISO-8601 (lunes = día 1; la semana 1 es la que contiene el primer jueves del año).
-export function activeWeekSlug(date: Date = new Date()): string {
-	return `${getISOWeekYear(date)}-${getISOWeek(date).toString().padStart(2, '0')}`;
 }
 
 // Espejo de latestLandingPageReferencesQuery (src/api/_queries/content.query.ts): la landing activa es la
@@ -27,6 +21,6 @@ type GroqClient = {
 };
 
 export async function resolveActiveLandingId(client: GroqClient, date: Date = new Date()): Promise<string | null> {
-	const id = await client.fetch<string | null>(ACTIVE_LANDING_ID_QUERY, { slug: activeWeekSlug(date) });
+	const id = await client.fetch<string | null>(ACTIVE_LANDING_ID_QUERY, { slug: buildWeekSlug(date) });
 	return id ?? null;
 }

--- a/cms/utils/validations.spec.ts
+++ b/cms/utils/validations.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateHistoricalDate } from './validations';
+
+describe('validateHistoricalDate', () => {
+	it('accepts an empty value: the field is optional', () => {
+		expect(validateHistoricalDate()).toBe(true);
+		expect(validateHistoricalDate('')).toBe(true);
+	});
+
+	it('accepts a well-formed date', () => {
+		expect(validateHistoricalDate('1936-07-17')).toBe(true);
+	});
+
+	it('accepts a BC date, written with a leading minus', () => {
+		expect(validateHistoricalDate('-0044-03-15')).toBe(true);
+	});
+
+	it('rejects a value that is not YYYY-MM-DD', () => {
+		expect(validateHistoricalDate('17/07/1936')).toContain('Formato inválido');
+		expect(validateHistoricalDate('1936-7-17')).toContain('Formato inválido');
+		expect(validateHistoricalDate('1936-07')).toContain('Formato inválido');
+	});
+
+	it('rejects year 0: historical numbering goes from 1 BC to 1 AD', () => {
+		expect(validateHistoricalDate('0000-01-01')).toContain('No existe el año 0');
+		expect(validateHistoricalDate('-0000-01-01')).toContain('No existe el año 0');
+	});
+
+	it('rejects years outside the admitted range', () => {
+		expect(validateHistoricalDate('-3001-01-01')).toContain('fuera de rango');
+		expect(validateHistoricalDate('2101-01-01')).toContain('fuera de rango');
+	});
+
+	it('accepts the boundaries of the admitted range', () => {
+		expect(validateHistoricalDate('-3000-01-01')).toBe(true);
+		expect(validateHistoricalDate('2100-01-01')).toBe(true);
+	});
+
+	it('rejects a well-formed value that is not a real calendar date', () => {
+		expect(validateHistoricalDate('1936-02-31')).toContain('Fecha calendario inválida');
+		expect(validateHistoricalDate('1936-13-01')).toContain('Fecha calendario inválida');
+	});
+
+	it('resolves leap years against the year given, not the current one', () => {
+		expect(validateHistoricalDate('2024-02-29')).toBe(true);
+		expect(validateHistoricalDate('2023-02-29')).toContain('Fecha calendario inválida');
+	});
+});

--- a/cms/vitest.config.ts
+++ b/cms/vitest.config.ts
@@ -1,0 +1,16 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+// Config propia del Studio, separada de la raíz: cms es un proyecto pnpm standalone con su propio
+// árbol de node_modules, y la config raíz carga el plugin de Angular, que no tiene nada que aportar
+// acá. Cubre lógica Node pura (sin DOM, sin testing library): lo que corre en el Studio y no en la app.
+export default defineConfig({
+	test: {
+		include: ['**/*.spec.ts'],
+		// El bundler del Studio lee los alias de sanity.cli.ts, que Vitest no carga: hay que repetirlos acá.
+		alias: {
+			'@models': path.resolve(__dirname, '../src/models'),
+			'@utils': path.resolve(__dirname, '../src/utils'),
+		},
+	},
+});

--- a/cms/vitest.config.ts
+++ b/cms/vitest.config.ts
@@ -7,10 +7,12 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
 	test: {
 		include: ['**/*.spec.ts'],
-		// El bundler del Studio lee los alias de sanity.cli.ts, que Vitest no carga: hay que repetirlos acá.
+		// El bundler del Studio lee los alias de sanity.cli.ts, que Vitest no carga: hay que repetirlos acá,
+		// incluido el de date-fns — los bare imports del kernel se resuelven desde <repo>/src/**, fuera de cms/.
 		alias: {
 			'@models': path.resolve(__dirname, '../src/models'),
 			'@utils': path.resolve(__dirname, '../src/utils'),
+			'date-fns': path.resolve(__dirname, 'node_modules/date-fns'),
 		},
 	},
 });

--- a/docs/CONTENT_UPDATE_STRATEGIES.md
+++ b/docs/CONTENT_UPDATE_STRATEGIES.md
@@ -130,6 +130,8 @@ El año va primero para que el **orden lexicográfico del slug coincida con el o
 
 ### Ubicación en el Código
 
+- **Utilidad de dominio compartida (kernel)**: `src/utils/week-slug.utils.ts` - `buildWeekSlug(date)`, implementación **única** del slug semanal `YYYY-WW` (ISO-8601, ver [Nomenclatura de Slugs](#nomenclatura-de-slugs)). La consumen tanto `content.service.ts` como, desde el Studio de Sanity, `cms/utils/landing-page.ts` (resolución de la landing activa en Desk Structure) — evita mantener dos implementaciones de la misma fórmula en dos proyectos pnpm distintos.
+
 - **Consultas GROQ**: `src/api/_queries/content.query.ts`
   - `landingPageContentQuery` - Obtiene contenido de una semana específica
   - `landingPageListQuery` - Lista landing pages existentes
@@ -144,7 +146,7 @@ El año va primero para que el **orden lexicográfico del slug coincida con el o
 - **Servicio de lógica de negocio**: `src/api/modules/content/content.service.ts`
   - `addNextWeeksLandingPageContent(weeksInTheFuture = 4)` - Función principal
 
-- **Tests unitarios**: `src/api/modules/content/content.service.spec.ts`
+- **Tests unitarios**: `src/utils/week-slug.utils.spec.ts` (casos borde del slug ISO-8601), `src/api/modules/content/content.service.spec.ts` y, del lado del Studio, `cms/utils/landing-page.spec.ts` (Vitest standalone de `cms/` — ver [`testing.md`](../.claude/references/testing.md))
 
 ### Proceso de Generación
 
@@ -259,8 +261,16 @@ src/api/modules/content/
 src/api/_queries/
 └── content.query.ts           # Consultas GROQ
 
+src/utils/
+├── week-slug.utils.ts         # buildWeekSlug(date) — implementación única del slug YYYY-WW (kernel compartido, alias @utils)
+└── week-slug.utils.spec.ts    # Tests unitarios (casos borde ISO-8601)
+
 src/sanity/
 └── types.ts                   # Tipos generados por Sanity (kernel compartido, alias @sanity-types)
+
+cms/utils/
+├── landing-page.ts            # Resolución de la landing activa para Desk Structure; consume buildWeekSlug()
+└── landing-page.spec.ts       # Tests unitarios (Vitest standalone de cms/)
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"seo:smoke": "node --import tsx ./scripts/seo-smoke.ts",
 		"sanity:dev": "nx run @cuentoneta/cms:dev",
 		"sanity:build": "nx run @cuentoneta/cms:build --skip-nx-cache",
+		"sanity:test": "nx run @cuentoneta/cms:test --skip-nx-cache",
 		"sanity:extract-schema": "nx run @cuentoneta/cms:extract-schema",
 		"sanity:run-typegen-generator": "nx run @cuentoneta/cms:typegen",
 		"prepare": "husky"

--- a/src/api/modules/content/content.service.spec.ts
+++ b/src/api/modules/content/content.service.spec.ts
@@ -34,7 +34,7 @@ describe('ContentService', () => {
 	});
 
 	describe('addNextWeeksLandingPageContent', () => {
-		const currentDate = new Date('2025-11-14');
+		const currentDate = new Date(2025, 10, 14);
 		const currentSlug = buildWeekSlug(currentDate);
 
 		const mockLandingPage = {

--- a/src/api/modules/content/content.service.spec.ts
+++ b/src/api/modules/content/content.service.spec.ts
@@ -1,4 +1,5 @@
-import { addWeeks, getISOWeek, getISOWeekYear } from 'date-fns';
+import { addWeeks } from 'date-fns';
+import { buildWeekSlug } from '@utils/week-slug.utils';
 import {
 	clearAllMocks,
 	runOnlyPendingTimers,
@@ -34,8 +35,7 @@ describe('ContentService', () => {
 
 	describe('addNextWeeksLandingPageContent', () => {
 		const currentDate = new Date('2025-11-14');
-		const buildSlug = (date: Date) => `${getISOWeekYear(date)}-${getISOWeek(date).toString().padStart(2, '0')}`;
-		const currentSlug = buildSlug(currentDate);
+		const currentSlug = buildWeekSlug(currentDate);
 
 		const mockLandingPage = {
 			_id: 'landing-page-current',
@@ -125,7 +125,7 @@ describe('ContentService', () => {
 			]);
 			// La semana que la home leerá de lunes a sábado (lunes 29/jun → 2026-27) está entre las generadas.
 			const generatedSlugs = (contentRepository.fetchLandingPagesList as Mock).mock.calls[0][0];
-			expect(generatedSlugs).toContain(buildSlug(new Date(2026, 5, 29)));
+			expect(generatedSlugs).toContain(buildWeekSlug(new Date(2026, 5, 29)));
 		});
 
 		it('should clone the base returned by the repository verbatim, without leaking its _id', async () => {
@@ -156,7 +156,7 @@ describe('ContentService', () => {
 			const weeksInTheFuture = 4;
 			const futureWeeks = Array.from({ length: weeksInTheFuture }, (_, index) => ({
 				_id: `landing-page-${index}`,
-				config: buildSlug(addWeeks(currentDate, index + 1)),
+				config: buildWeekSlug(addWeeks(currentDate, index + 1)),
 			}));
 
 			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue(futureWeeks);
@@ -192,7 +192,7 @@ describe('ContentService', () => {
 			const weeksInTheFuture = 4;
 			const existingWeek = Array.from({ length: 2 }, (_, index) => ({
 				_id: `landing-page-${index}`,
-				config: buildSlug(addWeeks(currentDate, index + 1)),
+				config: buildWeekSlug(addWeeks(currentDate, index + 1)),
 			}));
 
 			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue(existingWeek);

--- a/src/api/modules/content/content.service.ts
+++ b/src/api/modules/content/content.service.ts
@@ -11,15 +11,9 @@ import {
 import { LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
 
 // Utils
-import { addWeeks, getISOWeek, getISOWeekYear } from 'date-fns';
+import { addWeeks } from 'date-fns';
 import slugify from 'slugify';
-
-// Formato YYYY-WW con numeración ISO-8601 (lunes = día 1; la semana 1 es la que contiene el primer
-// jueves del año). El orden lexicográfico sigue coincidiendo con el cronológico: getISOWeekYear
-// etiqueta la semana con su año ISO, no con el calendario, así que el cruce dic/ene no rompe el orden.
-function buildWeekSlug(date: Date): string {
-	return `${getISOWeekYear(date)}-${getISOWeek(date).toString().padStart(2, '0')}`;
-}
+import { buildWeekSlug } from '@utils/week-slug.utils';
 
 export async function getLandingPageContent(): Promise<LandingPageContent> {
 	return fetchAndMapLandingPageContent(buildWeekSlug(new Date()));

--- a/src/utils/week-slug.utils.spec.ts
+++ b/src/utils/week-slug.utils.spec.ts
@@ -1,0 +1,34 @@
+import { buildWeekSlug } from './week-slug.utils';
+
+// Las fechas se construyen con el constructor local (año, mesIndex, día) y no con string ISO/UTC:
+// date-fns opera en hora local, así que un `new Date('2024-12-30T00:00:00Z')` cae en otro día —y en
+// otra semana— según la zona horaria del runner.
+describe('buildWeekSlug', () => {
+	it('formats the date as YYYY-WW', () => {
+		expect(buildWeekSlug(new Date(2025, 10, 14))).toBe('2025-46');
+	});
+
+	it('labels the week with its ISO week-year, not the calendar year', () => {
+		// 2024-12-30 es lunes: abre la semana ISO 01 de 2025 aunque el año calendario todavía sea 2024.
+		expect(buildWeekSlug(new Date(2024, 11, 30))).toBe('2025-01');
+	});
+
+	it('uses ISO-8601 week numbering (Monday-start), not the locale default', () => {
+		// 2023-01-01 es domingo: en ISO cierra la semana 52 de 2022; con la convención de domingo = día 1
+		// sería la semana 1 de 2023.
+		expect(buildWeekSlug(new Date(2023, 0, 1))).toBe('2022-52');
+	});
+
+	it('supports years with 53 ISO weeks', () => {
+		expect(buildWeekSlug(new Date(2020, 11, 31))).toBe('2020-53');
+	});
+
+	it('pads the week number to two digits', () => {
+		expect(buildWeekSlug(new Date(2026, 0, 1))).toBe('2026-01');
+	});
+
+	it('keeps lexicographic order aligned with chronological order across the Dec/Jan boundary', () => {
+		// Invariante del que dependen las queries GROQ que comparan configs con `<=`.
+		expect(buildWeekSlug(new Date(2025, 11, 22)) < buildWeekSlug(new Date(2026, 0, 5))).toBe(true);
+	});
+});

--- a/src/utils/week-slug.utils.ts
+++ b/src/utils/week-slug.utils.ts
@@ -1,0 +1,8 @@
+import { getISOWeek, getISOWeekYear } from 'date-fns';
+
+// Formato YYYY-WW con numeración ISO-8601 (lunes = día 1; la semana 1 es la que contiene el primer
+// jueves del año). El orden lexicográfico sigue coincidiendo con el cronológico: getISOWeekYear
+// etiqueta la semana con su año ISO, no con el calendario, así que el cruce dic/ene no rompe el orden.
+export function buildWeekSlug(date: Date): string {
+	return `${getISOWeekYear(date)}-${getISOWeek(date).toString().padStart(2, '0')}`;
+}


### PR DESCRIPTION
## Descripción

- **Unifica la fórmula del slug semanal ISO-8601**, que estaba triplicada: privada en `content.service.ts`, reimplementada inline en su propio spec (o sea, el spec no ejercitaba la implementación real) y espejada como `activeWeekSlug` en el Studio. Ahora vive una sola vez en `src/utils/week-slug.utils.ts`, con cobertura propia de casos borde, y la consumen el backend y `cms/` vía el alias `@utils` (mismo mecanismo que ya existía para `@models`). La divergencia silenciosa entre las dos copias pasa a ser estructuralmente imposible, en vez de algo que un test tuviera que vigilar.
- **Suma Vitest standalone a `cms/`**, con config propia y minimalista (entorno Node, sin el stack Angular de la raíz) y dobles escritos a mano. Cubre las dos piezas de lógica runtime del Studio que no tenían tests: `resolveActiveLandingId` (qué landing abre el Desk Structure) y `validateHistoricalDate` (fechas históricas con años a.C., sin año 0 y con rango admitido). El Studio pasa de 0 a 14 tests.
- **Corre esos tests en CI dentro del job `studio-build` existente**, que ya hace checkout e install propios de `cms/`. Deliberadamente sin job nuevo: uno aparte sumaría un 11.º required status check y obligaría a tocar branch protection, sin aportar señal.

De paso, el pane de la lista de landings dejó de repetir inline la query y el cálculo de slug de `resolveActiveLandingId`: el camino que corre en el Studio ahora es el mismo que quedó cubierto por tests.

Closes #1760.

## Plan de pruebas

- [x] `test` — verde (incluye los 6 casos borde ISO de `week-slug.utils.spec.ts`)
- [x] `lint` — verde
- [x] `stylelint` — verde
- [x] `typecheck` — verde
- [x] `build` — verde
- [x] `storybook` — verde
- [x] `studio-build` — verde (es el único gate que prueba que el alias `@utils` resuelve en el bundler real del Studio)
- [x] `check-agents` — verde
- [x] `pnpm sanity:test` — verde, 14 tests; verificado también tras un install equivalente al de CI (`pnpm -C cms install --frozen-lockfile --ignore-scripts`)
- [x] Verificado que el lockfile de `cms/` regenerado pasa `--frozen-lockfile`, que es como instala el job
- [x] Verificado empíricamente que tocar `src/utils/**` invalida la caché de Nx del target `test` de `cms/` (antes hubiera servido un PASS cacheado)
- [x] Verificado que el job resuelve `date-fns` sin `<repo>/node_modules`: se simuló el entorno de CI ocultando la instalación de la raíz y ambos pasos del job pasan igual
- [ ] `e2e` — omitido en local: el diff no cambia comportamiento observable de la app (la fórmula del slug es idéntica y solo cambió de módulo); corre igual en el PR
