### PR TITLE
[#2102] - Solapar la corrida de CI con la review vía PR draft y acotar los gates locales del skill issue-workflow

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -34,7 +34,8 @@ Antes de revisar, leé **todas** las referencias del catálogo para tener el con
 4. **Verificar los gates de CI** — Los que deben quedar verdes en cada PR son los definidos en la sección [Comandos comunes](../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**).
 
 - **Corré solo los que aplican al diff.** `e2e` y `studio-build` son costosos: `e2e` solo si el cambio toca flujos E2E, `studio-build` solo si toca `cms/`. Es la misma condición que aplica la Fase 4 del skill [`issue-workflow`](../skills/issue-workflow/SKILL.md); correrlos sobre un diff que no los toca no verifica nada.
-- **Si quien te invoca ya los corrió y te pasa el resultado observado, no los repitas.** La Fase 4 los corre antes de delegar en vos: volver a ejecutarlos es la parte más cara de la review y no agrega información.
+- **Si quien te invoca ya te pasa el resultado observado, no los repitas.** La Fase 4 corre en la sesión solo el **tier local** (`typecheck`, `lint`, `stylelint`, `test`, `check-agents`); los otros —`build`, `storybook`, `studio-build`, `e2e`— los corre la integración continua sobre el PR en borrador, y su resultado te llega igual. Que un gate no se haya corrido en la sesión **no** es motivo para correrlo vos: volver a ejecutarlos es la parte más cara de la review y no agrega información.
+- **La columna "quién lo corrió" admite tres valores:** vos, quien te invoca, o **CI del borrador** (con el enlace a la corrida). La regla de abajo no se relaja por eso.
 - **Nunca reportes un estado que no observaste ni te fue reportado.** Cada fila de la tabla de resultados declara **quién** lo corrió. Si el resultado ajeno te resulta dudoso, o si tocaste archivos después de que se corriera, corré ese gate vos mismo — la duda se resuelve ejecutando, no asumiendo.
 
 ## Falsos positivos conocidos — NO marcar

--- a/.claude/references/coding-agent-policies.md
+++ b/.claude/references/coding-agent-policies.md
@@ -99,7 +99,7 @@ Pushear la rama está bien. También lo está abrir un **PR en borrador** (`gh p
 La licencia se concede bajo tres condiciones, las tres verificables:
 
 1. El PR se crea con `--draft` y **permanece** en borrador hasta que la review local terminó y sus hallazgos Críticos tienen disposición.
-2. `gh pr ready` no se ejecuta con un Crítico sin disposición ni con un check de CI en rojo.
+2. `gh pr ready` no se ejecuta con un Crítico sin disposición, ni mientras algún check de CI no esté **verde** — rojo, pendiente, cancelado o ausente cuentan por igual.
 3. La review local corre igual y completa: el borrador no la reemplaza, no la acorta y no cambia qué se revisa.
 
 Marcar listo para review un PR sin la pasada de review local es bloqueante, exactamente como antes lo era abrirlo.

--- a/.claude/references/coding-agent-policies.md
+++ b/.claude/references/coding-agent-policies.md
@@ -92,7 +92,17 @@ Si el cambio tocó muchos archivos, `git status --short` y armar la lista es bar
 
 ### "La code review puede esperar hasta después de abrir el PR"
 
-Prohibido. La review local del agente (p. ej. el agente `code-reviewer` / skill de code review) corre **antes de abrir el PR**, para que quienes revisen el PR vean código ya pulido. Pushear la rama está bien; abrir el PR antes de la review local, no.
+Prohibido. La review local del agente (p. ej. el agente `code-reviewer` / skill de code review) corre **antes de pedir la review humana**. El evento regulado es el que convoca a otra persona: `gh pr ready`, o abrir el PR directamente en estado listo.
+
+Pushear la rama está bien. También lo está abrir un **PR en borrador** (`gh pr create --draft`), que no convoca a nadie: GitHub no solicita reviewers, no notifica codeowners y bloquea el merge. El borrador existe para una sola cosa — que la integración continua empiece a correr mientras la review local sucede, en vez de después.
+
+La licencia se concede bajo tres condiciones, las tres verificables:
+
+1. El PR se crea con `--draft` y **permanece** en borrador hasta que la review local terminó y sus hallazgos Críticos tienen disposición.
+2. `gh pr ready` no se ejecuta con un Crítico sin disposición ni con un check de CI en rojo.
+3. La review local corre igual y completa: el borrador no la reemplaza, no la acorta y no cambia qué se revisa.
+
+Marcar listo para review un PR sin la pasada de review local es bloqueante, exactamente como antes lo era abrirlo.
 
 ### "Documentemos el edge case en un comentario y listo"
 
@@ -285,7 +295,7 @@ El principio: **el documento es canónico; la memoria es refuerzo**. Si los dos 
 
 - Una descripción de PR que contenga cualquiera de los framings prohibidos es bloqueante. Pedí cambios citando este documento por sección.
 - Un PR que omite tests sobre la base de "es chico" es bloqueante. Pedí los tests faltantes.
-- Un PR abierto sin la pasada de review local (cuando el flujo la especifica) es bloqueante. Pedí la pasada antes de mergear.
+- Un PR **marcado listo para review** sin la pasada de review local (cuando el flujo la especifica) es bloqueante. Pedí la pasada antes de mergear. Un PR **en borrador** no: ahí la review local puede estar corriendo todavía, que es para lo que existe el borrador.
 - Un componente nuevo sin su `*.stories.ts` es bloqueante, salvo que cumpla las cuatro condiciones de la excepción por delegación total (Sección 2). Verificalas contra la plantilla, no contra la descripción del PR; si alguna no se cumple, pedí la story.
 
 ### Gates de CI
@@ -311,4 +321,4 @@ Las definiciones de agentes (`.claude/agents/*.md`) enuncian la regla en una lí
 
 ---
 
-_Última actualización: 2026-08-03. Este documento evoluciona por enmiendas (ver Sección 7); su historial detallado —qué se agregó, cuándo y por qué— vive en el log de git y en los PRs. Cambios mayores: versión inicial (CLAUDE.md + archivos de referencia); Sección 3 (Disciplina de comentarios) y sus ampliaciones sobre visibilidad de API y reemplazos canónicos; regla de story intercambiable para estados de carga; regla de child issues reales en epics; "Gates de CI" convertida a remisión a CLAUDE.md; prohibición de `git add -A`; Sección 8 (regla anti-`cd`) consolidada desde las copias de los agentes; la política de menciones a issues en la documentación de agentes (Sección 3); la regla de títulos de issue sin prefijo de categoría (Sección 2); la generalización de los ejemplos que citaban issues reales; el enforcement de esas menciones en el gate `check-agents`; la excepción de `TODO` con issue abierto en comentarios de código (Sección 3) junto con el versionado de su hook; y el enforcement de la prohibición de identificadores de hallazgo sobre mensajes de commit y cuerpo de PR (hook `commit-msg` + gate `check-findings`), que cierra el hueco que dejaba la cobertura previa solo sobre comentarios de código y documentación de agentes; y la excepción por delegación total a la exigencia de story (Sección 2), junto con la precisión de que el estado de carga lo cataloga quien renderiza el esqueleto._
+_Última actualización: 2026-08-03. Este documento evoluciona por enmiendas (ver Sección 7); su historial detallado —qué se agregó, cuándo y por qué— vive en el log de git y en los PRs. Cambios mayores: versión inicial (CLAUDE.md + archivos de referencia); Sección 3 (Disciplina de comentarios) y sus ampliaciones sobre visibilidad de API y reemplazos canónicos; regla de story intercambiable para estados de carga; regla de child issues reales en epics; "Gates de CI" convertida a remisión a CLAUDE.md; prohibición de `git add -A`; Sección 8 (regla anti-`cd`) consolidada desde las copias de los agentes; la política de menciones a issues en la documentación de agentes (Sección 3); la regla de títulos de issue sin prefijo de categoría (Sección 2); la generalización de los ejemplos que citaban issues reales; el enforcement de esas menciones en el gate `check-agents`; la excepción de `TODO` con issue abierto en comentarios de código (Sección 3) junto con el versionado de su hook; y el enforcement de la prohibición de identificadores de hallazgo sobre mensajes de commit y cuerpo de PR (hook `commit-msg` + gate `check-findings`), que cierra el hueco que dejaba la cobertura previa solo sobre comentarios de código y documentación de agentes; y la excepción por delegación total a la exigencia de story (Sección 2), junto con la precisión de que el estado de carga lo cataloga quien renderiza el esqueleto; y el corrimiento del evento que regula la review local, de abrir el PR a pedir la review humana, que habilita el PR en borrador._

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -45,7 +45,7 @@ La Fase 0 corre en **toda** invocación (fresca o reanudación), así que es ac�
 
    El `// empty` garantiza salida **vacía** (no el literal `null`) cuando el issue no tiene parent, para no generar un `Parte de #null.` en la Fase 6.
 
-Estos datos alimentan la Fase 1 (reporte + nombre de rama), la Fase 2 (body → `plan-writer`) y la Fase 6 (milestone → `gh pr create --milestone`; labels → `gh pr create --label`; parent → `Parte de #<epic>.`).
+Estos datos alimentan la Fase 1 (reporte + nombre de rama), la Fase 2 (body → `plan-writer`) y el cierre de la Fase 3, que abre el borrador con ellos (milestone → `--milestone`; labels → `--label`; parent → `Parte de #<epic>.`). La Fase 6 solo verifica que estén.
 
 ### Base de la rama (apilado)
 
@@ -228,6 +228,11 @@ Terminados los pasos del plan, la fase cierra abriendo el PR **en borrador**, pa
 1. `git push -u origin feat/<number>-<kebab>`.
 2. `gh pr create --draft` con los mismos datos que usaría la Fase 6: base `<rama-base>`, `--milestone` y `--label` recolectados en la Fase 0, título `[#<issue>] - <título del issue>`, y cuerpo con la descripción, `Closes #<issue>.`, `Parte de #<epic>.` cuando el issue tenga parent, y el aviso de apilado cuando `<rama-base> ≠ develop`. El **plan de pruebas queda como marcador**: lo completa la Fase 6, cuando ya se sabe qué se verificó.
 
+   Dos restricciones duras del cuerpo rigen desde acá, porque acá es donde se escribe por primera vez:
+
+   - **Termina en el plan de pruebas:** sin leyenda de atribución de agente (`🤖 Generated with …`, `Co-Authored-By: Claude …`, `Claude-Session: …`) y **sin citar un identificador de hallazgo de review** (`R<n>`, `S<n>`), que el gate `check-findings` verifica sobre el cuerpo.
+   - **Enlaza su issue de origen:** el cuerpo debe contener un keyword de cierre — `Closes #<issue>` (o `Fixes`/`Resolves`). El prefijo `[#<issue>]` del título **no** crea el enlace.
+
 Qué **no** habilita el borrador, para que no se lea como un atajo:
 
 - **No reemplaza la review local.** La Fase 4 corre igual y completa.
@@ -252,10 +257,10 @@ La licencia y sus tres condiciones viven en [`coding-agent-policies.md`](../../r
 
 1. Correr **el tier local** de los [gates de CI](../../../CLAUDE.md#comandos-comunes) (con `pnpm`, nunca `nx` directo). Los gates se reparten en dos tiers, porque el borrador que abrió la Fase 3 ya está corriendo los diez en GitHub Actions:
 
-   | Tier                      | Gates                                                    | Por qué                                                                                                                                                               |
-   | ------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-   | **Local, siempre**        | `typecheck`, `lint`, `stylelint`, `test`, `check-agents` | Baratos (~45s en paralelo) y son el único feedback rápido sobre las reglas ESLint propias del repo, que es donde más reincide un agente.                              |
-   | **Delegados al borrador** | `build`, `storybook`, `studio-build`, `e2e`              | Lentos y de salida voluminosa. `e2e` además es el más frágil, porque depende del dataset. El borrador los corre igual, sobre el mismo commit, y sin ocupar la sesión. |
+   | Tier                      | Gates                                                       | Por qué                                                                                                                                                                                                                                                         |
+   | ------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Local, siempre**        | `typecheck`, `lint`, `stylelint`, `test`, `check-agents`    | Baratos (~45s en paralelo) y son el único feedback rápido sobre las reglas ESLint propias del repo, que es donde más reincide un agente.                                                                                                                        |
+   | **Delegados al borrador** | `build`, `storybook`, `studio-build`, `e2e`, `guard-config` | Lentos y de salida voluminosa. `e2e` además es el más frágil, porque depende del dataset, y `guard-config` solo tiene efecto en PRs desde forks, así que en local no verifica nada. El borrador los corre igual, sobre el mismo commit, y sin ocupar la sesión. |
    - **Silenciar la salida en verde.** Capturar y emitir solo ante fallo, para no volcar el log completo de un gate que pasó:
 
      ```bash
@@ -270,9 +275,9 @@ La licencia y sus tres condiciones viven en [`coding-agent-policies.md`](../../r
 
    **Correr un gate delegado en local es válido** cuando el diff lo toca de lleno y conviene el ciclo corto — p. ej. `storybook` ante un cambio de stories. Lo que la tabla evita es correrlos _por rutina_.
 
-1. **Leer la señal del borrador, sin esperarla.** `gh pr checks <pr>` sobre el PR que abrió la Fase 3 da el estado de los gates delegados. Para no bloquear la sesión, vigilarlos en segundo plano (`gh pr checks <pr> --watch --fail-fast`) y seguir con la review: si algo se pone rojo, la notificación llega sola. Si al momento de delegar la review el borrador sigue corriendo, se reporta **en curso** — la Fase 6 verifica el verde final antes de marcar listo.
+1. **Leer la señal del borrador, sin esperarla.** `gh pr checks <pr>` sobre el PR que abrió la Fase 3 da el estado de los gates delegados, junto con `setup` y las integraciones externas del repo (los despliegues de Vercel, que el borrador también dispara). Para no bloquear la sesión, vigilarlos en segundo plano (`gh pr checks <pr> --watch --fail-fast`) y seguir con la review: si algo se pone rojo, la notificación llega sola. Si al momento de delegar la review el borrador sigue corriendo, se reporta **en curso** — la Fase 6 verifica el verde final antes de marcar listo.
 1. **Determinar si el diff toca superficie de seguridad.** La lista de disparadores es la sección **"Cuándo correr"** del agente `security-auditor`: `src/api/**` (endpoints, GROQ, mappers), manejo de contenido externo (PortableText/HTML del CMS, `bypassSecurityTrust*`, fetch a servicios externos, `localStorage`), variables de entorno / secrets / config de Sanity o Clarity, y dependencias (`package.json` / `pnpm-lock.yaml`). Un diff que no toca nada de eso —solo documentación, estilos o UI sin datos externos— **no** la amerita; el auditor también puede invocarse a demanda si surge una preocupación puntual.
-1. **Delegar las reviews — en paralelo si corren ambas.** Si el diff toca superficie de seguridad, lanzar al **`security-auditor`** y al **`code-reviewer`** en el **mismo turno** (ambas delegaciones en una única respuesta, igual que los gates del paso 1): sus reviews son independientes y no comparten archivo de salida. Si no la toca, delegar solo al `code-reviewer`. Cada delegación incluye la ruta de salida completa del agente (ver paso 4); en modo worktree, adjuntar además la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales" a cada Task delegada. En ambos casos el `code-reviewer` revisa todos los cambios de la rama vs. `<base>` (la ref resuelta en la Fase 0 → "Base de la rama"; default `develop`/`origin/develop`) y recibe **el resultado observado de los gates del paso 1** (qué corriste, con qué resultado, y cuáles omitiste por no aplicar al diff) — sin ese dato los vuelve a correr, que es la parte más cara de la review.
+1. **Delegar las reviews — en paralelo si corren ambas.** Si el diff toca superficie de seguridad, lanzar al **`security-auditor`** y al **`code-reviewer`** en el **mismo turno** (ambas delegaciones en una única respuesta, igual que los gates del paso 1): sus reviews son independientes y no comparten archivo de salida. Si no la toca, delegar solo al `code-reviewer`. Cada delegación incluye la ruta de salida completa del agente (ver el paso siguiente); en modo worktree, adjuntar además la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales" a cada Task delegada. En ambos casos el `code-reviewer` revisa todos los cambios de la rama vs. `<base>` (la ref resuelta en la Fase 0 → "Base de la rama"; default `develop`/`origin/develop`) y recibe **el resultado observado de los gates del paso 1** (qué corriste, con qué resultado, y cuáles omitiste por no aplicar al diff) — sin ese dato los vuelve a correr, que es la parte más cara de la review.
 1. Cada agente escribe su propio archivo: el `code-reviewer` en `workspace/<number>/CODE_REVIEW.md` y el `security-auditor` en `workspace/<number>/SECURITY_REVIEW.md`.
 1. Presentar la tabla de hallazgos al usuario (Críticos, Advertencias, Sugerencias), combinando ambos archivos cuando corrió el auditor, e indicando si corrió o por qué no correspondía. Al combinar, cada hallazgo se cita con el identificador tal como aparece en su documento de origen: los del `code-reviewer` llevan el prefijo `R` (p. ej. `R6`) y los de seguridad el prefijo `S` (p. ej. `S3`). Ninguno usa `#`, que queda reservado para los issues de GitHub.
 
@@ -301,9 +306,9 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 4. Si un hallazgo se **difiere**, proponer el issue al usuario y **esperar su confirmación** antes de crearlo (`gh issue create`); una vez creado, anotar su URL junto al valor **Diferido** en la columna **Estado**. Crear un issue es una acción hacia afuera: la misma política rige en la Fase 6.
    - **Título sin prefijo de categoría** (`[Tooling]`, `[SEO]`, `[#<id>]`, ni variantes con guion o dos puntos): la categoría va en `--label` y la pertenencia a una iniciativa en la relación de sub-issue. Si ningún label existente encaja, proponer su creación al usuario en vez de codificar la categoría en el título. Ver [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 2.
 5. Tras abordar Críticos y Advertencias, re-correr **solo los gates del tier local que el diff de los fixes toca**, con el mismo patrón de silenciado en verde de la Fase 4. Arreglar regresiones. Re-correr el tier entero solo si los fixes tocaron superficie compartida.
-6. **Pushear los fixes** al borrador. Eso refresca la señal de los gates delegados sobre el commit final, que es la que la Fase 6 verifica antes de marcar listo.
-7. Las **Sugerencias** son opcionales: presentarlas y dejar que el usuario decida.
-8. Si un hallazgo es específicamente un **gap de cobertura de tests**, el orquestador **puede** delegar en **`test-generator`** el scaffolding de los specs faltantes (en modo worktree, adjuntar la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales"). Es un aid opcional, **no** un gate: los tests igual deben existir y pasar; el agente es solo una vía para producirlos.
+6. Las **Sugerencias** son opcionales: presentarlas y dejar que el usuario decida.
+7. Si un hallazgo es específicamente un **gap de cobertura de tests**, el orquestador **puede** delegar en **`test-generator`** el scaffolding de los specs faltantes (en modo worktree, adjuntar la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales"). Es un aid opcional, **no** un gate: los tests igual deben existir y pasar; el agente es solo una vía para producirlos.
+8. **Pushear al borrador**, como último paso de la fase. Va al final para que también viaje lo que produzcan los pasos 6 y 7: refresca la señal de los gates delegados sobre el commit final, que es la que la Fase 6 verifica antes de marcar listo.
 
 ---
 
@@ -311,14 +316,14 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 
 **Propósito:** verificar la señal del borrador, completar su cuerpo, marcarlo listo para review y actualizar el issue original. El PR ya existe: lo abrió la Fase 3 en borrador.
 
-**Modo worktree:** el worktree **no se limpia en esta fase** — se mantiene hasta que el PR mergee, para permitir reanudar la sesión (ver [Modo worktree](#modo-worktree) → "Ciclo de vida"). Push y creación del PR corren igual, con cwd ya resuelto al worktree.
+**Modo worktree:** el worktree **no se limpia en esta fase** — se mantiene hasta que el PR mergee, para permitir reanudar la sesión (ver [Modo worktree](#modo-worktree) → "Ciclo de vida"). La verificación de los checks y el `gh pr ready` corren igual, con cwd ya resuelto al worktree.
 
-1. **Verificar la señal del borrador.** `gh pr checks <pr>` sobre el PR que abrió la Fase 3. Los diez gates deben estar **verdes** sobre el commit final (el que dejaron los fixes de la Fase 5):
+1. **Verificar la señal del borrador.** `gh pr checks <pr>` sobre el PR que abrió la Fase 3. Todos los checks deben estar **verdes** sobre el commit final (el que dejaron los fixes de la Fase 5). Ojo con el conteo: la salida trae más filas que los diez gates requeridos —`setup`, y las integraciones externas como los despliegues de Vercel—, así que se verifica que **ninguna** esté en rojo o pendiente, en vez de contar contra un número fijo:
    - Alguno **rojo** → no se marca listo: volver a la Fase 5.
    - Alguno **en curso** → esperar acá. Es el único punto del flujo donde esperar tiene sentido, porque ya no queda trabajo en paralelo que hacer.
 2. **Completar el cuerpo del PR** con el plan de pruebas ya verificado, que en la Fase 3 quedó como marcador: `gh pr edit <pr> --body-file <archivo>`. Eso emite `pull_request.edited`, así que `check-findings` re-evalúa el cuerpo final sin un paso extra.
    - El resto de los datos —base, `--milestone`, `--label`, título, `Closes #<issue>.`, `Parte de #<epic>.` y el aviso de apilado— ya los fijó la Fase 3: acá solo se verifica que estén.
-   - **El cuerpo termina en el plan de pruebas (restricción dura):** sin leyenda de atribución de agente (`🤖 Generated with …`, `Co-Authored-By: Claude …`, `Claude-Session: …`). Ver [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 2.
+   - **El cuerpo termina en el plan de pruebas (restricción dura):** sin leyenda de atribución de agente (`🤖 Generated with …`, `Co-Authored-By: Claude …`, `Claude-Session: …`) y **sin citar un identificador de hallazgo de review** (`R<n>`, `S<n>`). Ver [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 2 y Sección 3.
    - **El PR DEBE enlazar su issue de origen (restricción dura):** el cuerpo debe contener un keyword de cierre — `Closes #<issue>` (o `Fixes`/`Resolves`). El prefijo `[#<issue>]` del título **no** crea el enlace.
 3. **Marcar listo para review:** `gh pr ready <pr>`. Es el evento que convoca a otra persona, así que sus precondiciones son duras:
    - Ningún Crítico de `workspace/<number>/CODE_REVIEW.md` ni `workspace/<number>/SECURITY_REVIEW.md` sin **disposición** (definida en la pausa de la Fase 4).
@@ -337,19 +342,19 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
    ```markdown
    **Workflow completo.**
 
-   | Item                | Valor                                                             |
-   | ------------------- | ----------------------------------------------------------------- |
-   | Issue               | [#<número>](issue-url) — <título>                                 |
-   | Rama                | `feat/<number>-<kebab>`                                           |
-   | PR                  | [#<pr>](pr-url)                                                   |
-   | Commits             | <N> commits atómicos                                              |
-   | Hallazgos abordados | <X> críticos · <Y> advertencias · <Z> sugerencias — <disposición> |
-   | Entorno             | `worktree` (`.claude/worktrees/<number>`) / `raíz`                |
-   | CI                  | <tier local: verde/rojo · borrador: N/10 verdes — <url>>          |
+   | Item                | Valor                                                                 |
+   | ------------------- | --------------------------------------------------------------------- |
+   | Issue               | [#<número>](issue-url) — <título>                                     |
+   | Rama                | `feat/<number>-<kebab>`                                               |
+   | PR                  | [#<pr>](pr-url)                                                       |
+   | Commits             | <N> commits atómicos                                                  |
+   | Hallazgos abordados | <X> críticos · <Y> advertencias · <Z> sugerencias — <disposición>     |
+   | Entorno             | `worktree` (`.claude/worktrees/<number>`) / `raíz`                    |
+   | CI                  | <tier local: verde/rojo · borrador: todos verdes / N en rojo — <url>> |
    ```
 
    - `Commits` cuenta solo los de la rama (`git rev-list --count <base>..HEAD`, con `<base>` = `<rama-base>` en modo raíz y `origin/<rama-base>` en modo worktree; default `develop`). Cuando `<rama-base> ≠ develop`, sumar el dato de base apilada bajo la tabla con el aviso de orden de merge (sin alterar la tabla en el caso `develop`).
-   - `CI` reporta las **dos puntas**: el tier local corrido en la sesión y el estado de los diez checks del borrador, con su URL.
+   - `CI` reporta las **dos puntas**: el tier local corrido en la sesión y el estado de los checks del borrador, con su URL.
 
 ---
 
@@ -363,4 +368,4 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 - En modo worktree (ver [Modo worktree](#modo-worktree)), el cwd de la sesión y de los subagentes delegados ya está resuelto al worktree tras `EnterWorktree`: la regla anti-`cd` sigue rigiendo igual, y toda comparación de rango git usa `<base>` (`origin/<rama-base>`, default `origin/develop`) como base, nunca la rama base local.
 - Toda delegación a un subagente que compute un diff de rango (`plan-writer`, advisors, `code-reviewer`, `security-auditor`, `test-generator`, `documentation-writer`) recibe la base `<base>` resuelta en la Fase 0: en worktree via la nota de delegación (que ya la incluye); en modo raíz con base apilada (`<rama-base> ≠ develop`), como una línea explícita en la instrucción. Los cuerpos de los agentes usan `develop...HEAD` como default de invocación standalone; esta instrucción lo overridea.
 - Nunca saltear la fase Plan — aun cambios triviales se benefician de un plan breve.
-- Aplican siempre las reglas de [`.claude/references/coding-agent-policies.md`](../../references/coding-agent-policies.md): sin framings de mantenedor único, sin "salteá el test por ser chico" (salvo cambios solo-doc), sin diferir la review más allá de abrir el PR, y sin comentarios redundantes (Sección 3).
+- Aplican siempre las reglas de [`.claude/references/coding-agent-policies.md`](../../references/coding-agent-policies.md): sin framings de mantenedor único, sin "salteá el test por ser chico" (salvo cambios solo-doc), sin diferir la review más allá de pedir la review humana (`gh pr ready`), y sin comentarios redundantes (Sección 3).

--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -70,7 +70,7 @@ Con el entorno ya resuelto (y el cwd ya en el worktree si corresponde), relevar 
 2. `workspace/<number>/PLAN.md` — ¿existe el plan? Si existe, contar sus marcadores de paso `[ ]` vs. `[x]`.
 3. `workspace/<number>/CODE_REVIEW.md` y/o `workspace/<number>/SECURITY_REVIEW.md` — ¿existe la review?
 4. Si la rama existe: `git rev-list --count <base>..<rama>` — ¿cuántos commits tiene sobre la base? `<base>` es `<rama-base>` en modo raíz y `origin/<rama-base>` en modo worktree, con `<rama-base>` resuelta en "Base de la rama" (default `develop`).
-5. Si la rama existe: `gh pr list --head feat/<number>-<kebab> --state open` — ¿hay un PR abierto de esa rama?
+5. Si la rama existe: `gh pr list --head feat/<number>-<kebab> --state open --json number,isDraft,url` — ¿hay un PR abierto de esa rama, y en qué estado?
 
 | Rama | `PLAN.md`                  | Review | Commits | Interpretación → fase sugerida                                                                                                |
 | ---- | -------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
@@ -83,7 +83,12 @@ Con el entorno ya resuelto (y el cwd ya en el worktree si corresponde), relevar 
 | Sí   | Sí                         | Sí     | >0      | Review ya escrita → **Fase 5**, abordando los hallazgos con Estado pendiente                                                  |
 | No   | Sí                         | —      | —       | El plan sobrevivió pero la rama no → recrear la rama (Fase 1) y re-confirmar el plan existente en **Fase 2**, sin regenerarlo |
 
-Si además existe un **PR abierto** para la rama (señal 5), el flujo ya completó la **Fase 6**: reportar la URL del PR y pausar — el trabajo restante, si lo hay, es abordar feedback de ese PR, no re-ejecutar el flujo.
+Si además existe un **PR abierto** para la rama (señal 5), el estado del PR distingue dos situaciones muy distintas:
+
+- **`isDraft: false`** → el flujo completó la **Fase 6**: reportar la URL y pausar. El trabajo restante, si lo hay, es abordar feedback de ese PR, no re-ejecutar el flujo.
+- **`isDraft: true`** → el flujo llegó al **cierre de la Fase 3** y quedó en Fase 4 o 5. La fase sugerida la sigue dando la tabla de artefactos de arriba; el borrador **no** la overridea. Reportar su URL y que la implementación ya está pusheada.
+
+El borrador mejora la reanudación: una sesión que muere en Fase 4 deja hoy el trabajo solo en el worktree local, y con el borrador queda pusheado y visible.
 
 Si se detecta cualquier señal, pausar con `AskUserQuestion`:
 
@@ -171,7 +176,7 @@ En modo raíz, el flujo de Fase 1 queda **igual que hoy**.
 
 **Propósito:** producir un plan de implementación detallado para aprobación.
 
-1. **Determinar si el issue amerita asesoría previa de dominio o de arquitectura** (mismo patrón que el paso 2 de la Fase 4 con el `security-auditor`, pero _antes_ de planificar). A partir del alcance del issue (el body de la Fase 0 + una exploración inicial):
+1. **Determinar si el issue amerita asesoría previa de dominio o de arquitectura** (mismo patrón con el que la Fase 4 decide si convoca al `security-auditor`, pero _antes_ de planificar). A partir del alcance del issue (el body de la Fase 0 + una exploración inicial):
    - **`domain-model-advisor`** si el issue crea o modifica entidades de dominio o value objects (`@models/*`, `src/models/`), mappers del ACL (`src/api/_utils/`), queries GROQ (`src/api/_queries/`) o tipos de dominio compartidos.
    - **`architecture-advisor`** solo ante un cambio **estructuralmente significativo**: módulo nuevo bajo `src/api/modules/<dominio>/`, feature/provider/interfaz `-api` nuevo en el frontend, bounded context nuevo, o cambio de límites de módulo / dirección de dependencias. Un ajuste localizado —UI, copy, estilos, un campo puntual— **no** lo amerita: el `plan-writer` ya carga las mismas referencias según el diff y su pasada basta.
 2. **Delegar en paralelo los advisors que matcheen** (ambas delegaciones en el mismo turno si aplican los dos; son independientes y devuelven su evaluación como **texto**, no como archivo — no tienen `Write`). En modo worktree, adjuntar la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales". Capturar su salida.
@@ -216,9 +221,25 @@ No avanzar a la Fase 3 sin una respuesta "Aprobar".
 - Nunca `--amend`; crear commits nuevos tras fallos de los hooks de git — hoy son dos: `pre-commit` (formato) y `commit-msg` (rechaza un mensaje que cite un identificador de hallazgo de review).
 - **En modo raíz**, antes de cada commit confirmar la rama activa con `git branch --show-current` contra `feat/<number>-<kebab>`; si un subagente con Bash la cambió en el medio, re-checkoutear la rama correcta antes de commitear. En **modo worktree** se omite: `EnterWorktree` fija el cwd/rama del worktree y los subagentes lo heredan (ver [Modo worktree](#modo-worktree)).
 
+### Cierre de la fase — PR en borrador
+
+Terminados los pasos del plan, la fase cierra abriendo el PR **en borrador**, para que la integración continua empiece a correr mientras la Fase 4 revisa, en vez de después.
+
+1. `git push -u origin feat/<number>-<kebab>`.
+2. `gh pr create --draft` con los mismos datos que usaría la Fase 6: base `<rama-base>`, `--milestone` y `--label` recolectados en la Fase 0, título `[#<issue>] - <título del issue>`, y cuerpo con la descripción, `Closes #<issue>.`, `Parte de #<epic>.` cuando el issue tenga parent, y el aviso de apilado cuando `<rama-base> ≠ develop`. El **plan de pruebas queda como marcador**: lo completa la Fase 6, cuando ya se sabe qué se verificó.
+
+Qué **no** habilita el borrador, para que no se lea como un atajo:
+
+- **No reemplaza la review local.** La Fase 4 corre igual y completa.
+- **No adelanta la Fase 6.** El PR no se marca listo acá: eso pasa recién cuando la review terminó y sus Críticos tienen disposición.
+- **No cambia la precondición de merge.** Un borrador bloquea el merge por definición.
+
+La licencia y sus tres condiciones viven en [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 2, que regula la review local por el **pedido de review humana** (`gh pr ready`) y no por la apertura del PR.
+
 ### No hacer en esta fase
 
-- Pushear.
+- Pushear antes de terminar los pasos del plan (el push va en el cierre de la fase, con el borrador).
+- Marcar el PR listo para review — eso es Fase 6.
 - Saltear tests ante un cambio de comportamiento en runtime.
 - Crear barrels (`index.ts` re-export).
 - Dejar código comentado.
@@ -229,14 +250,31 @@ No avanzar a la Fase 3 sin una respuesta "Aprobar".
 
 **Propósito:** verificar que pasen los gates de CI y correr los agentes de review.
 
-1. Correr localmente (con `pnpm`, nunca `nx` directo) los **gates de CI** definidos en la sección [Comandos comunes](../../../CLAUDE.md#comandos-comunes) de `CLAUDE.md` (párrafo **Gates de CI**). `test:e2e` y `studio-build` son costosos de correr en cada iteración: corré `test:e2e` si el diff toca `e2e/**`, `src/app/pages/**`, rutas/navegación (`app.routes*.ts`) o superficie SSR/SEO (meta tags, JSON-LD, sitemap); `studio-build` si toca `cms/`; el resto, siempre.
+1. Correr **el tier local** de los [gates de CI](../../../CLAUDE.md#comandos-comunes) (con `pnpm`, nunca `nx` directo). Los gates se reparten en dos tiers, porque el borrador que abrió la Fase 3 ya está corriendo los diez en GitHub Actions:
+
+   | Tier                      | Gates                                                    | Por qué                                                                                                                                                               |
+   | ------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Local, siempre**        | `typecheck`, `lint`, `stylelint`, `test`, `check-agents` | Baratos (~45s en paralelo) y son el único feedback rápido sobre las reglas ESLint propias del repo, que es donde más reincide un agente.                              |
+   | **Delegados al borrador** | `build`, `storybook`, `studio-build`, `e2e`              | Lentos y de salida voluminosa. `e2e` además es el más frágil, porque depende del dataset. El borrador los corre igual, sobre el mismo commit, y sin ocupar la sesión. |
+   - **Silenciar la salida en verde.** Capturar y emitir solo ante fallo, para no volcar el log completo de un gate que pasó:
+
+     ```bash
+     out=$(pnpm lint 2>&1) || echo "$out"
+     ```
+
+     Ante rojo el log aparece entero, así que el diagnóstico no pierde nada.
+
    - **En modo worktree**, anteponer `NX_DAEMON=false` a todo gate de Nx y reemplazar `pnpm typecheck` por `pnpm exec tsc -p tsconfig.typecheck.json --noEmit` — ver [Modo worktree](#modo-worktree) → "Ajustes transversales" (evita falsos rojos de teardown y resultados stale del daemon).
-   - **Lanzalos concurrentemente**, no uno tras otro: son independientes entre sí y así los corre CI (todos los jobs cuelgan de `setup` y van en runners separados). En serie tardan la **suma**; en paralelo, lo que tarde el más lento (medido: 105s → 29s).
+   - **Lanzalos concurrentemente**, no uno tras otro: son independientes entre sí. En serie tardan la **suma**; en paralelo, lo que tarde el más lento.
    - Si alguno falla: reportar cuál, diagnosticar, arreglar, commitear el fix (reglas de Fase 3) y re-correr **solo el que falló** mientras el resto sigue verde; re-correr todo solo si el fix toca superficie compartida.
-2. **Determinar si el diff toca superficie de seguridad.** La lista de disparadores es la sección **"Cuándo correr"** del agente `security-auditor`: `src/api/**` (endpoints, GROQ, mappers), manejo de contenido externo (PortableText/HTML del CMS, `bypassSecurityTrust*`, fetch a servicios externos, `localStorage`), variables de entorno / secrets / config de Sanity o Clarity, y dependencias (`package.json` / `pnpm-lock.yaml`). Un diff que no toca nada de eso —solo documentación, estilos o UI sin datos externos— **no** la amerita; el auditor también puede invocarse a demanda si surge una preocupación puntual.
-3. **Delegar las reviews — en paralelo si corren ambas.** Si el diff toca superficie de seguridad, lanzar al **`security-auditor`** y al **`code-reviewer`** en el **mismo turno** (ambas delegaciones en una única respuesta, igual que los gates del paso 1): sus reviews son independientes y no comparten archivo de salida. Si no la toca, delegar solo al `code-reviewer`. Cada delegación incluye la ruta de salida completa del agente (ver paso 4); en modo worktree, adjuntar además la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales" a cada Task delegada. En ambos casos el `code-reviewer` revisa todos los cambios de la rama vs. `<base>` (la ref resuelta en la Fase 0 → "Base de la rama"; default `develop`/`origin/develop`) y recibe **el resultado observado de los gates del paso 1** (qué corriste, con qué resultado, y cuáles omitiste por no aplicar al diff) — sin ese dato los vuelve a correr, que es la parte más cara de la review.
-4. Cada agente escribe su propio archivo: el `code-reviewer` en `workspace/<number>/CODE_REVIEW.md` y el `security-auditor` en `workspace/<number>/SECURITY_REVIEW.md`.
-5. Presentar la tabla de hallazgos al usuario (Críticos, Advertencias, Sugerencias), combinando ambos archivos cuando corrió el auditor, e indicando si corrió o por qué no correspondía. Al combinar, cada hallazgo se cita con el identificador tal como aparece en su documento de origen: los del `code-reviewer` llevan el prefijo `R` (p. ej. `R6`) y los de seguridad el prefijo `S` (p. ej. `S3`). Ninguno usa `#`, que queda reservado para los issues de GitHub.
+
+   **Correr un gate delegado en local es válido** cuando el diff lo toca de lleno y conviene el ciclo corto — p. ej. `storybook` ante un cambio de stories. Lo que la tabla evita es correrlos _por rutina_.
+
+1. **Leer la señal del borrador, sin esperarla.** `gh pr checks <pr>` sobre el PR que abrió la Fase 3 da el estado de los gates delegados. Para no bloquear la sesión, vigilarlos en segundo plano (`gh pr checks <pr> --watch --fail-fast`) y seguir con la review: si algo se pone rojo, la notificación llega sola. Si al momento de delegar la review el borrador sigue corriendo, se reporta **en curso** — la Fase 6 verifica el verde final antes de marcar listo.
+1. **Determinar si el diff toca superficie de seguridad.** La lista de disparadores es la sección **"Cuándo correr"** del agente `security-auditor`: `src/api/**` (endpoints, GROQ, mappers), manejo de contenido externo (PortableText/HTML del CMS, `bypassSecurityTrust*`, fetch a servicios externos, `localStorage`), variables de entorno / secrets / config de Sanity o Clarity, y dependencias (`package.json` / `pnpm-lock.yaml`). Un diff que no toca nada de eso —solo documentación, estilos o UI sin datos externos— **no** la amerita; el auditor también puede invocarse a demanda si surge una preocupación puntual.
+1. **Delegar las reviews — en paralelo si corren ambas.** Si el diff toca superficie de seguridad, lanzar al **`security-auditor`** y al **`code-reviewer`** en el **mismo turno** (ambas delegaciones en una única respuesta, igual que los gates del paso 1): sus reviews son independientes y no comparten archivo de salida. Si no la toca, delegar solo al `code-reviewer`. Cada delegación incluye la ruta de salida completa del agente (ver paso 4); en modo worktree, adjuntar además la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales" a cada Task delegada. En ambos casos el `code-reviewer` revisa todos los cambios de la rama vs. `<base>` (la ref resuelta en la Fase 0 → "Base de la rama"; default `develop`/`origin/develop`) y recibe **el resultado observado de los gates del paso 1** (qué corriste, con qué resultado, y cuáles omitiste por no aplicar al diff) — sin ese dato los vuelve a correr, que es la parte más cara de la review.
+1. Cada agente escribe su propio archivo: el `code-reviewer` en `workspace/<number>/CODE_REVIEW.md` y el `security-auditor` en `workspace/<number>/SECURITY_REVIEW.md`.
+1. Presentar la tabla de hallazgos al usuario (Críticos, Advertencias, Sugerencias), combinando ambos archivos cuando corrió el auditor, e indicando si corrió o por qué no correspondía. Al combinar, cada hallazgo se cita con el identificador tal como aparece en su documento de origen: los del `code-reviewer` llevan el prefijo `R` (p. ej. `R6`) y los de seguridad el prefijo `S` (p. ej. `S3`). Ninguno usa `#`, que queda reservado para los issues de GitHub.
 
 **⏸ PAUSA — decisión vía `AskUserQuestion`.**
 
@@ -262,45 +300,39 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
    - ❌ `[#<issue>] - Arregla el hallazgo R2`
 4. Si un hallazgo se **difiere**, proponer el issue al usuario y **esperar su confirmación** antes de crearlo (`gh issue create`); una vez creado, anotar su URL junto al valor **Diferido** en la columna **Estado**. Crear un issue es una acción hacia afuera: la misma política rige en la Fase 6.
    - **Título sin prefijo de categoría** (`[Tooling]`, `[SEO]`, `[#<id>]`, ni variantes con guion o dos puntos): la categoría va en `--label` y la pertenencia a una iniciativa en la relación de sub-issue. Si ningún label existente encaja, proponer su creación al usuario en vez de codificar la categoría en el título. Ver [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 2.
-5. Tras abordar Críticos y Advertencias, re-correr los gates de CI. Arreglar regresiones.
-6. Las **Sugerencias** son opcionales: presentarlas y dejar que el usuario decida.
-7. Si un hallazgo es específicamente un **gap de cobertura de tests**, el orquestador **puede** delegar en **`test-generator`** el scaffolding de los specs faltantes (en modo worktree, adjuntar la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales"). Es un aid opcional, **no** un gate: los tests igual deben existir y pasar; el agente es solo una vía para producirlos.
+5. Tras abordar Críticos y Advertencias, re-correr **solo los gates del tier local que el diff de los fixes toca**, con el mismo patrón de silenciado en verde de la Fase 4. Arreglar regresiones. Re-correr el tier entero solo si los fixes tocaron superficie compartida.
+6. **Pushear los fixes** al borrador. Eso refresca la señal de los gates delegados sobre el commit final, que es la que la Fase 6 verifica antes de marcar listo.
+7. Las **Sugerencias** son opcionales: presentarlas y dejar que el usuario decida.
+8. Si un hallazgo es específicamente un **gap de cobertura de tests**, el orquestador **puede** delegar en **`test-generator`** el scaffolding de los specs faltantes (en modo worktree, adjuntar la nota de delegación de [Modo worktree](#modo-worktree) → "Ajustes transversales"). Es un aid opcional, **no** un gate: los tests igual deben existir y pasar; el agente es solo una vía para producirlos.
 
 ---
 
 ## Fase 6 — Ship
 
-**Propósito:** pushear, crear el PR y actualizar el issue original.
+**Propósito:** verificar la señal del borrador, completar su cuerpo, marcarlo listo para review y actualizar el issue original. El PR ya existe: lo abrió la Fase 3 en borrador.
 
 **Modo worktree:** el worktree **no se limpia en esta fase** — se mantiene hasta que el PR mergee, para permitir reanudar la sesión (ver [Modo worktree](#modo-worktree) → "Ciclo de vida"). Push y creación del PR corren igual, con cwd ya resuelto al worktree.
 
-1. `git push -u origin feat/<number>-<kebab>`.
-2. Crear el PR con `gh pr create` (base **`<rama-base>`**, default `develop`, resuelta en la Fase 0 → "Base de la rama"; con `--milestone` = el milestone recolectado en la Fase 0 → "Datos del issue", y `--label` por cada label del issue recolectado ahí, para que el PR herede la categorización del issue):
-   - **Apilado (`<rama-base> ≠ develop`):** agregar al cuerpo del PR la línea `> Apilado sobre #<X> — este PR no debe mergearse antes que el PR de su rama base.` (con `#<X>` = el issue base detectado en la Fase 0), y surfacear ese aviso de forma prominente al presentar la URL (paso 3) y en el resumen final (paso 5). Un PR apilado mergeado antes que su base ensucia el diff de la base.
-   - **Precondición:** ningún Crítico de `workspace/<number>/CODE_REVIEW.md` ni `workspace/<number>/SECURITY_REVIEW.md` sin **disposición** (definida en la pausa de la Fase 4). Si lo hay, no crear el PR: volver a la Fase 5, o a la vía "Disponer y ship" de la Fase 4.
-   - Título: `[#<issue>] - <título del issue>`.
-   - Cuerpo (en **español**):
+1. **Verificar la señal del borrador.** `gh pr checks <pr>` sobre el PR que abrió la Fase 3. Los diez gates deben estar **verdes** sobre el commit final (el que dejaron los fixes de la Fase 5):
+   - Alguno **rojo** → no se marca listo: volver a la Fase 5.
+   - Alguno **en curso** → esperar acá. Es el único punto del flujo donde esperar tiene sentido, porque ya no queda trabajo en paralelo que hacer.
+2. **Completar el cuerpo del PR** con el plan de pruebas ya verificado, que en la Fase 3 quedó como marcador: `gh pr edit <pr> --body-file <archivo>`. Eso emite `pull_request.edited`, así que `check-findings` re-evalúa el cuerpo final sin un paso extra.
+   - El resto de los datos —base, `--milestone`, `--label`, título, `Closes #<issue>.`, `Parte de #<epic>.` y el aviso de apilado— ya los fijó la Fase 3: acá solo se verifica que estén.
+   - **El cuerpo termina en el plan de pruebas (restricción dura):** sin leyenda de atribución de agente (`🤖 Generated with …`, `Co-Authored-By: Claude …`, `Claude-Session: …`). Ver [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 2.
+   - **El PR DEBE enlazar su issue de origen (restricción dura):** el cuerpo debe contener un keyword de cierre — `Closes #<issue>` (o `Fixes`/`Resolves`). El prefijo `[#<issue>]` del título **no** crea el enlace.
+3. **Marcar listo para review:** `gh pr ready <pr>`. Es el evento que convoca a otra persona, así que sus precondiciones son duras:
+   - Ningún Crítico de `workspace/<number>/CODE_REVIEW.md` ni `workspace/<number>/SECURITY_REVIEW.md` sin **disposición** (definida en la pausa de la Fase 4).
+   - El `code-reviewer` corrió y sus hallazgos están abordados o dispuestos.
+   - Los checks del borrador, verdes (paso 1).
 
-     ```
-     ## Descripción
-     <1-3 bullets>
+   La licencia del borrador y sus tres condiciones viven en [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 2.
 
-     Closes #<issue>.
-
-     ## Plan de pruebas
-     [checklist de lo verificado]
-     ```
-
-   - **El cuerpo termina en el plan de pruebas (restricción dura):** sin leyenda de atribución de agente (`🤖 Generated with …`, `Co-Authored-By: Claude …`, `Claude-Session: …`) y sin citar un identificador de hallazgo de review. Ver [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 2. El gate `check-findings` valida el cuerpo del PR y vuelve a evaluarlo en cada edición (el workflow escucha `pull_request.edited`): corregir el cuerpo después de abrirlo re-dispara el check, no hace falta ningún paso adicional.
-   - **El PR DEBE enlazar su issue de origen (restricción dura):** el cuerpo debe contener un keyword de cierre — `Closes #<issue>` (o `Fixes`/`Resolves`). El prefijo `[#<issue>]` del título **no** crea el enlace; el keyword en el cuerpo es obligatorio.
-   - Si el issue es **hijo de un epic** — el **parent detectado en la Fase 0** (vía el comando GraphQL de "Datos del issue") devolvió un número —, agregar además una línea `Parte de #<epic>.` (sin keyword de cierre) para cross-linkear el epic sin auto-cerrarlo.
-
-3. Presentar la URL del PR al usuario.
-4. Escanear la sesión por ítems **fuera de alcance** (fixes/hallazgos/mejoras más allá del issue). Si hay:
+4. Presentar la URL del PR al usuario, ya listo para review.
+5. Escanear la sesión por ítems **fuera de alcance** (fixes/hallazgos/mejoras más allá del issue). Si hay:
    - Actualizar la descripción del issue (`gh issue edit`) con una sección "Fuera de alcance (abordado en este PR)".
    - Preguntar al usuario si quiere crear issues separados para follow-ups. Esperar confirmación antes de crearlos. **Nunca crear issues en repos donde el usuario no es contribuidor.**
    - Al crearlos, aplican las mismas reglas de la Fase 5 paso 4: **título sin prefijo de categoría**, categoría en `--label`, y sub-issue del epic cuando el follow-up pertenece a una iniciativa.
-5. Presentar el resumen final como **exactamente** esta tabla Item/Valor (renderizar solo después de que push + PR + edición del issue se completaron con artefactos reales):
+6. Presentar el resumen final como **exactamente** esta tabla Item/Valor (renderizar solo después de que el PR quedó listo para review y la edición del issue se completó con artefactos reales):
 
    ```markdown
    **Workflow completo.**
@@ -313,11 +345,11 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
    | Commits             | <N> commits atómicos                                              |
    | Hallazgos abordados | <X> críticos · <Y> advertencias · <Z> sugerencias — <disposición> |
    | Entorno             | `worktree` (`.claude/worktrees/<number>`) / `raíz`                |
-   | CI local            | <Verde / Rojo — ver <motivo>>                                     |
+   | CI                  | <tier local: verde/rojo · borrador: N/10 verdes — <url>>          |
    ```
 
    - `Commits` cuenta solo los de la rama (`git rev-list --count <base>..HEAD`, con `<base>` = `<rama-base>` en modo raíz y `origin/<rama-base>` en modo worktree; default `develop`). Cuando `<rama-base> ≠ develop`, sumar el dato de base apilada bajo la tabla con el aviso de orden de merge (sin alterar la tabla en el caso `develop`).
-   - `CI local` reporta el resultado de la última corrida de los gates.
+   - `CI` reporta las **dos puntas**: el tier local corrido en la sesión y el estado de los diez checks del borrador, con su URL.
 
 ---
 
@@ -325,9 +357,9 @@ Antes de armar las `options`, revisar la columna **Estado** de los Críticos en 
 
 - Usar `pnpm <script>` para ejecutar tareas; no construir variantes de `nx` directas a mano.
 - Nunca prefijar comandos git con `cd` — el working dir ya está resuelto (raíz del repo, o del worktree según el entorno); regla completa en [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 8.
-- Nunca abrir el PR antes de que pasen los gates de CI y haya corrido el `code-reviewer`.
-- Nunca abrir el PR sin el keyword de cierre (`Closes #<issue>`) en el cuerpo enlazando el issue de origen.
-- Nunca abrir el PR con un Crítico sin disposición confirmada — definición en la pausa de la Fase 4; verificación en la Fase 6 paso 2.
+- Nunca **marcar listo** (`gh pr ready`) un PR antes de que pasen los gates de CI —el tier local **y** los checks del borrador— y haya corrido el `code-reviewer`. Crear el PR **en borrador** al cerrar la Fase 3 es parte del flujo y no cuenta como abrirlo: la licencia y sus tres condiciones están en [`coding-agent-policies.md`](../../references/coding-agent-policies.md) Sección 2.
+- Nunca marcar listo un PR sin el keyword de cierre (`Closes #<issue>`) en el cuerpo enlazando el issue de origen.
+- Nunca marcar listo un PR con un Crítico sin disposición confirmada — definición en la pausa de la Fase 4; verificación en la Fase 6.
 - En modo worktree (ver [Modo worktree](#modo-worktree)), el cwd de la sesión y de los subagentes delegados ya está resuelto al worktree tras `EnterWorktree`: la regla anti-`cd` sigue rigiendo igual, y toda comparación de rango git usa `<base>` (`origin/<rama-base>`, default `origin/develop`) como base, nunca la rama base local.
 - Toda delegación a un subagente que compute un diff de rango (`plan-writer`, advisors, `code-reviewer`, `security-auditor`, `test-generator`, `documentation-writer`) recibe la base `<base>` resuelta en la Fase 0: en worktree via la nota de delegación (que ya la incluye); en modo raíz con base apilada (`<rama-base> ≠ develop`), como una línea explícita en la instrucción. Los cuerpos de los agentes usan `develop...HEAD` como default de invocación standalone; esta instrucción lo overridea.
 - Nunca saltear la fase Plan — aun cambios triviales se benefician de un plan breve.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ on:
   # excepción (sí corre invocado por el token), así que da señal de CI sobre `develop` para el release.
   workflow_dispatch:
 
+# El flujo de trabajo abre un PR en borrador al terminar la implementación y le pushea los fixes de la
+# review, así que un mismo PR acumula varias corridas. Sin esto, cada push encola un run nuevo sin
+# cancelar el anterior y ambos compiten por runners para un resultado que ya no interesa.
+#
+# En `push` a `develop` NO se cancela: ese run es el que guarda el cache de Nx en la rama default (ver
+# el comentario del trigger), y cancelarlo dejaría a todos los PRs sin cache base.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,12 @@ on:
 #
 # En `push` a `develop` NO se cancela: ese run es el que guarda el cache de Nx en la rama default (ver
 # el comentario del trigger), y cancelarlo dejaría a todos los PRs sin cache base.
+# El `group` incluye el evento a propósito: sin eso, el `workflow_dispatch` que dispara
+# `prepare-release-pr.yml` sobre `develop` cae en el mismo grupo que el `push` a `develop`, queda
+# encolado detrás de él, y un merge posterior lo cancela en silencio — justo la corrida que le da
+# señal de CI al release.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/docs/ISSUE_WORKFLOW.md
+++ b/docs/ISSUE_WORKFLOW.md
@@ -1,0 +1,133 @@
+# Flujo de resolución de issues (`/issue-workflow`)
+
+Este documento describe, para lectura humana, cómo funciona el skill [`issue-workflow`](../.claude/skills/issue-workflow/SKILL.md): sus seis fases, en qué puntos se detiene a preguntar, qué artefactos deja y qué subagentes despierta en cada tramo.
+
+La **especificación normativa** del flujo es el `SKILL.md` — es lo que el agente ejecuta. Este documento es su mapa: si alguno de los dos se desactualiza, manda el `SKILL.md`.
+
+## Mapa del flujo
+
+Los rombos son pausas con `AskUserQuestion`: el flujo no avanza sin respuesta del usuario. Los nodos con doble borde son subagentes; los que tienen forma de paralelogramo, los artefactos que quedan escritos en `workspace/<number>/`.
+
+La Fase 3 cierra abriendo un **PR en borrador**, así que la integración continua corre mientras la Fase 4 revisa, en vez de después. Eso reparte los gates en dos tiers: la sesión corre localmente los baratos (`typecheck`, `lint`, `stylelint`, `test`, `check-agents`) y delega al borrador los lentos (`build`, `storybook`, `studio-build`, `e2e`). El borrador no convoca a nadie —no solicita reviewers ni notifica codeowners— y bloquea el merge; el evento que pide la review humana es `gh pr ready`, en la Fase 6.
+
+```mermaid
+flowchart TD
+    START(["Invocación con la URL del issue"]) --> F0
+
+    subgraph F0 ["Fase 0 · Detección de estado"]
+        direction TB
+        F0A["Entorno: worktree o raíz"] --> F0B["Datos del issue: número, título, body, milestone, labels, parent"]
+        F0B --> F0C["Base de la rama: develop o apilada"]
+        F0C --> F0D["Señales de reanudación: rama, PLAN, review, commits, PR"]
+    end
+
+    F0 --> Q0{"¿Hay trabajo previo?"}
+    Q0 -->|"Sesión nueva"| F1
+    Q0 -->|"Reanudar"| SALTO["Saltar a la fase sugerida"]
+    Q0 -->|"Rehacer"| F1
+    SALTO -.-> F2
+    SALTO -.-> F3
+    SALTO -.-> F4
+    SALTO -.-> F5
+
+    subgraph F1 ["Fase 1 · Setup"]
+        direction TB
+        F1A["Derivar rama feat/número-kebab"] --> F1B["Crear rama o worktree desde la base actualizada"]
+    end
+
+    F1 --> F2
+
+    subgraph F2 ["Fase 2 · Plan"]
+        direction TB
+        F2A["Evaluar si el issue amerita asesoría"] --> F2B[["domain-model-advisor"]]
+        F2A --> F2C[["architecture-advisor"]]
+        F2B --> F2D[["plan-writer"]]
+        F2C --> F2D
+        F2A -->|"Cambio localizado"| F2D
+        F2D --> F2E[/"workspace/número/PLAN.md"/]
+    end
+
+    F2 --> Q2{"Pausa: ¿se aprueba el plan?"}
+    Q2 -->|"Dar feedback"| F2D
+    Q2 -->|"Aprobar"| F3
+
+    subgraph F3 ["Fase 3 · Implement"]
+        direction TB
+        F3A["Ejecutar los pasos del plan"] --> F3B["Verificación barata antes de cada commit: typecheck + vitest related"]
+        F3B --> F3C["Commit atómico y marcado del paso en PLAN.md"]
+        F3C --> F3A
+        F3A --> F3D["Scan de impacto en documentación"]
+        F3D --> F3E[["documentation-writer"]]
+        F3D --> F3F["Push de la rama y PR en borrador"]
+    end
+
+    F3 --> F4
+
+    subgraph F4 ["Fase 4 · Review"]
+        direction TB
+        F4A["Gates del tier local en paralelo"] --> F4G["Leer los checks del borrador, sin esperarlos"]
+        F4G --> F4B["Evaluar si el diff toca superficie de seguridad"]
+        F4B --> F4C[["code-reviewer"]]
+        F4B --> F4D[["security-auditor"]]
+        F4C --> F4E[/"workspace/número/CODE_REVIEW.md"/]
+        F4D --> F4F[/"workspace/número/SECURITY_REVIEW.md"/]
+    end
+
+    F4 --> Q4{"Pausa: ¿hay Críticos sin disposición?"}
+    Q4 -->|"Proceder"| F5
+    Q4 -->|"Ship o Disponer y ship"| F6
+
+    subgraph F5 ["Fase 5 · Fix"]
+        direction TB
+        F5A["Abordar Críticos y luego Advertencias"] --> F5B["Commit atómico por fix y actualización del Estado"]
+        F5B --> F5C[["test-generator"]]
+        F5B --> F5D["Re-correr los gates del tier local que el diff toca"]
+        F5D --> F5E["Push de los fixes al borrador"]
+    end
+
+    F5 --> F6
+
+    subgraph F6 ["Fase 6 · Ship"]
+        direction TB
+        F6A["Verificar que los diez checks del borrador estén verdes"] --> F6B["Completar el cuerpo y marcar listo (gh pr ready)"]
+        F6B --> F6C["Escanear ítems fuera de alcance"]
+        F6C --> F6D["Resumen final"]
+    end
+
+    F6 --> FIN(["El worktree se mantiene hasta que el PR mergee"])
+
+    classDef agente fill:#1f2937,stroke:#60a5fa,stroke-width:2px,color:#e5e7eb
+    classDef artefacto fill:#1f2937,stroke:#34d399,stroke-width:2px,color:#e5e7eb
+    class F2B,F2C,F2D,F3E,F4C,F4D,F5C agente
+    class F2E,F4E,F4F artefacto
+```
+
+## Los tres puntos de pausa
+
+El flujo se detiene exactamente en tres lugares, siempre vía `AskUserQuestion`:
+
+1. **Fase 0 — reanudación.** Solo si detecta trabajo previo sobre el issue (rama, plan, review o commits). Una sesión nueva no pausa acá.
+2. **Fase 2 — aprobación del plan.** No se implementa nada sin un "Aprobar" explícito. El feedback se reenvía a la misma tarea del `plan-writer`, que reescribe el plan en el mismo archivo.
+3. **Fase 4 — disposición de los hallazgos.** Si quedan hallazgos Críticos sin disposición, la opción de shipear directo no se ofrece.
+
+Además hay pausas puntuales para acciones hacia afuera: crear un issue diferido (Fase 5) o los follow-ups fuera de alcance (Fase 6) requieren confirmación previa.
+
+## Subagentes: qué despierta a cada uno
+
+| Subagente              | Fase | Se despierta cuando…                                                                                            | Devuelve             |
+| ---------------------- | ---- | --------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `domain-model-advisor` | 2    | el issue crea o modifica entidades de dominio, value objects, mappers del ACL, queries GROQ o tipos compartidos | texto al orquestador |
+| `architecture-advisor` | 2    | el cambio es estructuralmente significativo — módulo, capa, bounded context o dirección de dependencias         | texto al orquestador |
+| `plan-writer`          | 2    | siempre — recibe el aporte de los advisors que hayan corrido                                                    | `PLAN.md`            |
+| `documentation-writer` | 3    | el cambio toca tipos, schemas de Sanity/Zod, contratos de API o terminología de dominio                         | archivos de doc      |
+| `code-reviewer`        | 4    | siempre — recibe el resultado observado de los gates, locales y del borrador, para no re-correrlos              | `CODE_REVIEW.md`     |
+| `security-auditor`     | 4    | el diff toca superficie de seguridad — ver la sección "Cuándo correr" de su propio agente                       | `SECURITY_REVIEW.md` |
+| `test-generator`       | 5    | opcional, ante un hallazgo que sea un gap de cobertura                                                          | specs                |
+
+Los dos advisors de la Fase 2 corren **antes** de planificar y en paralelo entre sí: su evaluación entra en el prompt del `plan-writer`, que no puede delegar por su cuenta. En la Fase 4, `code-reviewer` y `security-auditor` también corren en paralelo y escriben archivos distintos.
+
+## Entornos: worktree o raíz
+
+El flujo puede correr en un worktree propio bajo `.claude/worktrees/<number>` o en el working tree principal. La Fase 0 lo resuelve —por declaración explícita, por detección de un worktree previo, o preguntando— y esa decisión rige para toda la sesión, incluidos los subagentes delegados.
+
+El worktree aísla la sesión de cualquier otra corriendo en paralelo, a cambio de un setup propio (`pnpm install` + `pnpm run config`). Se mantiene hasta que el PR mergee, para permitir reanudar; la limpieza se ofrece al reanudar un issue cuyo PR ya está mergeado.


### PR DESCRIPTION
## Descripción

El flujo de `/issue-workflow` corría tres tramos en serie que no necesitan estarlo: gates locales → `code-reviewer` → CI en GitHub Actions. Ahora la **Fase 3 cierra abriendo un PR en borrador**, así que los gates corren mientras la review sucede, en vez de después.

- **Enmienda a la Sección 2 de `coding-agent-policies.md`** (aprobada explícitamente): el evento que regula la review local pasa de *abrir el PR* a *pedir la review humana* (`gh pr ready`). La regla protege el tiempo de quien revisa, y un borrador no lo consume: no solicita reviewers, no notifica codeowners y bloquea el merge. La licencia se concede bajo tres condiciones verificables.
- **Tiering de gates.** Local quedan los baratos (`typecheck`, `lint`, `stylelint`, `test`, `check-agents`), que además son el único feedback rápido sobre las reglas ESLint propias del repo — donde más reincide un agente. Al borrador se delegan `build`, `storybook`, `studio-build`, `e2e` y `guard-config`.
- **Salida silenciada en verde.** El log completo de un gate que pasó no aporta nada y eran ~561 líneas por pasada; ante rojo aparece entero, así que el diagnóstico no pierde nada.
- **La Fase 6 deja de crear el PR** y pasa a verificar su señal, completar el cuerpo y marcarlo listo.

## La enmienda fortalece la garantía que reemplaza

Hoy la precondición «los gates pasan» se verifica contra una corrida local que **omite** `e2e` y `studio-build` cuando el diff no los dispara. Con el borrador se verifica contra los diez gates reales, corridos siempre, sobre el mismo commit que se mergea.

## Verificación empírica: el repo nunca había tenido un draft

La premisa central —que CI dispara sobre un borrador— no tenía precedente en este repo (0 drafts en los últimos 60 PRs). Se confirmó en vivo sobre este mismo PR: al crearlo arrancaron solos `setup`, `studio-build`, `check-findings`, `guard-config` y los tres despliegues de Vercel.

**Efecto colateral que el plan no contemplaba:** los previews de Vercel también corren sobre el borrador. Es a favor —el preview está disponible durante la review—, pero significa que un borrador consume build minutes igual que un PR normal.

## Hallazgos de review abordados

**Dos críticos, ambos contradicciones introducidas por el propio cambio:**

1. Las restricciones transversales seguían enunciando la regla que la enmienda deroga, así que el documento afirmaba **las dos versiones del flujo a la vez**.
2. El cuerpo del PR pasó a escribirse en la Fase 3, pero sus dos restricciones duras quedaron enunciadas en la Fase 6 — y al reescribirla se perdió la prohibición de citar identificadores de hallazgo, que es justamente lo que `check-findings` verifica sobre el cuerpo.

**Advertencias destacadas:**

- **El `concurrency` tenía el agujero en el grupo, no en la condición.** El `workflow_dispatch` que le da señal de CI al release cae en el mismo `github.ref` que el `push` a `develop`: quedaba encolado detrás y un merge posterior lo cancelaba en silencio. El evento entra ahora en el grupo.
- **La licencia quedó más laxa que el flujo que la implementa:** exigía «ningún check en rojo», que deja pasar pendiente, cancelado o ausente. Ahora exige verde.
- **El conteo fijo de gates era incorrecto:** `gh pr checks` devuelve 15 filas, no 10. Se verifica que ninguna esté en rojo o pendiente en vez de contar contra un número.
- El push de la Fase 5 estaba antes del `test-generator`, así que lo que produjera quedaba sin viajar al borrador.
- `guard-config` no estaba en ninguna columna del tiering.

## Alcance ampliado

Se absorbieron de #2103 los cuatro ítems que caen dentro de los mismos hunks —silenciado de output, `e2e` fuera del tier local, Fase 5 acotada y `concurrency`—, porque dejarlos afuera garantizaba conflicto y doble reescritura. #2103 **sigue abierto** con el resto (batcheo de sondas, fusión de verificación y commit, higiene de worktrees, wall clock).

`docs/ISSUE_WORKFLOW.md` **existía sin trackear** en el working tree principal — por eso no aparecía en los worktrees, que solo traen archivos versionados. Se versiona y se alinea al flujo nuevo.

## Plan de pruebas

- [x] **Tier local en verde:** `typecheck`, `lint`, `stylelint`, `test`, `check-agents`.
- [x] **Los 15 checks del borrador en verde**, incluidos los cinco gates delegados y los tres despliegues de Vercel.
- [x] Confirmado empíricamente que CI dispara sobre un borrador, que era la hipótesis que sostenía todo el diseño.
- [x] `ci.yml` parseado con un parser real tras el cambio de `concurrency`.
- [x] Diagrama Mermaid verificado: las clases resuelven a nodos existentes y los tres nodos nuevos están declarados.
- [x] Referencias cruzadas revisadas tras la renumeración de las Fases 4, 5 y 6.
- [x] `prettier --check` sobre los archivos tocados.

Closes #2102.

Parte de #1907.
