### PR TITLE
[#2114] - Enlaza el catálogo de cuentos y autores desde la navegación principal

### DIFF
--- a/e2e/seo/home.spec.ts
+++ b/e2e/seo/home.spec.ts
@@ -6,6 +6,8 @@
  *       link canonical, robots indexable y keywords.
  *  - B+C. Datos estructurados sitewide: bloques JSON-LD Organization y WebSite (la home no
  *         tiene una entidad propia, solo los sitewide del app initializer).
+ *  - E. Enlaces a los hubs del catálogo (/story y /authors), que son la vía por la que el
+ *       crawler alcanza el corpus.
  *
  * Sobre el DOM hidratado, vía navegación in-app (router):
  *  - D. Al navegar de la home a una story, los bloques sitewide persisten y aparece el Article;
@@ -13,7 +15,7 @@
  */
 import { test, expect } from '@playwright/test';
 
-import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
+import { parseHtml, parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
 import { assertValidJsonLd } from '@testing/json-ld-validation';
 import type { SeoInvariantViolation } from '@testing/seo-invariant-violation';
 import {
@@ -55,6 +57,18 @@ test('home — B/C: bloques JSON-LD sitewide Organization y WebSite', async () =
 	const website = blocks.get(SCHEMA_IDS.website);
 	await assertValidJsonLd(website);
 	expect(website?.['name']).toBe('La Cuentoneta');
+});
+
+// Los hubs concentran los enlaces a todo el corpus, y hasta este cambio ninguna página los
+// enlazaba: el crawler solo los conocía por el sitemap. Se afirma sobre el HTML crudo porque lo
+// que importa es que estén sin ejecutar JS. Igualdad exacta del href: /story/<slug> no cuenta.
+test('home — E: enlaza los hubs del catálogo en el HTML server-rendered', async () => {
+	const hrefs = parseHtml(html)
+		.querySelectorAll('a')
+		.map((anchor) => anchor.getAttribute('href'));
+
+	expect(hrefs).toContain('/story');
+	expect(hrefs).toContain('/authors');
 });
 
 test('home — invariantes de indexado para crawlers (ssr, h1 real, contenido primario, jsonld sitewide)', async () => {

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -1,29 +1,64 @@
 import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { RouterModule, provideRouter } from '@angular/router';
 import { HeaderComponent } from './header.component';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 describe('HeaderComponent', () => {
-	const setup = async () =>
+	const renderHeader = async () =>
 		await render(HeaderComponent, {
 			componentImports: [CommonModule, NgOptimizedImage, RouterModule],
 			providers: [provideRouter([]), provideNoopAnimations()],
 		});
 
 	it('should render Header component', async () => {
-		const { container } = await setup();
+		const { container } = await renderHeader();
 		expect(container).toBeInTheDocument();
 	});
 
 	it('should show the Cuentoneta alt text', async () => {
-		await setup();
+		await renderHeader();
 		expect(screen.getByAltText(/Cuentoneta/)).toBeInTheDocument();
 	});
 
 	it('should show the navbar links', async () => {
-		await setup();
+		await renderHeader();
 		expect(screen.getByText(/Inicio/)).toHaveProperty('href', expect.stringMatching(/home/));
 		expect(screen.getByText(/Nosotros/)).toHaveProperty('href', expect.stringMatching(/about/));
+	});
+
+	it('should link the catalog pages from the navbar', async () => {
+		await renderHeader();
+		expect(screen.getByText(/Obras/)).toHaveProperty('href', expect.stringMatching(/\/story$/));
+		expect(screen.getByText(/Autores/)).toHaveProperty('href', expect.stringMatching(/\/authors$/));
+	});
+
+	it('should expose the catalog links to assistive tech and keyboard navigation', async () => {
+		await renderHeader();
+
+		// getByRole descarta lo marcado aria-hidden: que los encuentre prueba que están expuestos.
+		expect(screen.getByRole('link', { name: 'Obras' })).toHaveAttribute('tabindex', '0');
+		expect(screen.getByRole('link', { name: 'Autores' })).toHaveAttribute('tabindex', '0');
+	});
+
+	// Fija que la excepción del enlace que duplica al logo depende de una propiedad y no de la
+	// etiqueta: renombrar 'Inicio' no debe reexponerlo, ni ocultar una entrada nueva por accidente.
+	it('should keep the brand-duplicating link visible but out of the accessibility tree', async () => {
+		await renderHeader();
+
+		expect(screen.queryByRole('link', { name: 'Inicio' })).toBeNull();
+		expect(screen.getByText(/Inicio/)).toBeInTheDocument();
+	});
+
+	it('should show the catalog links in the mobile menu', async () => {
+		const user = userEvent.setup();
+		await renderHeader();
+
+		await user.click(screen.getByRole('button'));
+
+		// Dos por enlace: el de escritorio (presente en el DOM, oculto solo por CSS) y el del menú.
+		expect(screen.getAllByRole('link', { name: 'Obras' })).toHaveLength(2);
+		expect(screen.getAllByRole('link', { name: 'Autores' })).toHaveLength(2);
 	});
 });

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -34,21 +34,25 @@ describe('HeaderComponent', () => {
 		expect(screen.getByText(/Autores/)).toHaveProperty('href', expect.stringMatching(/\/authors$/));
 	});
 
-	it('should expose the catalog links to assistive tech and keyboard navigation', async () => {
+	// Toda la navegación queda expuesta: getByRole descarta lo marcado aria-hidden, así que
+	// encontrar las cuatro entradas prueba que ninguna quedó fuera del árbol de accesibilidad.
+	it('should expose every navbar link to assistive tech', async () => {
 		await renderHeader();
 
-		// getByRole descarta lo marcado aria-hidden: que los encuentre prueba que están expuestos.
-		expect(screen.getByRole('link', { name: 'Obras' })).toHaveAttribute('tabindex', '0');
-		expect(screen.getByRole('link', { name: 'Autores' })).toHaveAttribute('tabindex', '0');
+		for (const label of ['Inicio', 'Obras', 'Autores', 'Nosotros']) {
+			expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
+		}
 	});
 
-	// Fija que la excepción del enlace que duplica al logo depende de una propiedad y no de la
-	// etiqueta: renombrar 'Inicio' no debe reexponerlo, ni ocultar una entrada nueva por accidente.
-	it('should keep the brand-duplicating link visible but out of the accessibility tree', async () => {
+	// El logo lleva a la home igual que la entrada 'Inicio', pero su contenido lee
+	// "Logo de 'La Cuentoneta' La Cuentoneta", que no dice a dónde va.
+	it('should give the brand link an accessible name that states its destination', async () => {
 		await renderHeader();
 
-		expect(screen.queryByRole('link', { name: 'Inicio' })).toBeNull();
-		expect(screen.getByText(/Inicio/)).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'La Cuentoneta — Inicio' })).toHaveProperty(
+			'href',
+			expect.stringMatching(/home$/),
+		);
 	});
 
 	it('should show the catalog links in the mobile menu', async () => {

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,9 +1,10 @@
 import { Component, effect, input, signal } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { InternalLink } from '@models/link.model';
+import { HeaderNavLink } from '@models/link.model';
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { HEADER_HEIGHT_STRING_PX } from '@utils/spacing.utils';
+import { AppRoutes } from '../../app.routes';
 
 const VisibilityState = Object.freeze({
 	Visible: 'visible',
@@ -31,11 +32,11 @@ type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 			<nav class="navigation flex items-center justify-end">
 				<ul class="flex hidden md:flex">
 					@for (navLink of navLinks; track $index) {
-						<li class="font-inter text-sm font-semibold text-neutral-900 hover:text-neutral-900/60 md:ml-12">
+						<li class="font-inter text-sm font-semibold text-neutral-900 hover:text-neutral-900/60 md:ml-8 lg:ml-12">
 							<a
 								[routerLink]="navLink.path"
-								[tabindex]="navLink.label === 'Inicio' ? -1 : 0"
-								[attr.aria-hidden]="navLink.label === 'Inicio'"
+								[tabindex]="navLink.duplicatesBrandLink ? -1 : 0"
+								[attr.aria-hidden]="navLink.duplicatesBrandLink ?? false"
 								>{{ navLink.label }}</a
 							>
 						</li>
@@ -62,8 +63,8 @@ type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 							<a
 								(click)="onMenuTogglerClicked()"
 								[routerLink]="navLink.path"
-								[tabindex]="navLink.label === 'Inicio' ? -1 : 0"
-								[attr.aria-hidden]="navLink.label === 'Inicio'"
+								[tabindex]="navLink.duplicatesBrandLink ? -1 : 0"
+								[attr.aria-hidden]="navLink.duplicatesBrandLink ?? false"
 								>{{ navLink.label }}</a
 							>
 						</li>
@@ -104,9 +105,11 @@ type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 	],
 })
 export class HeaderComponent {
-	protected readonly navLinks: InternalLink[] = [
-		{ label: 'Inicio', path: '/home' },
-		{ label: 'Nosotros', path: '/about' },
+	protected readonly navLinks: HeaderNavLink[] = [
+		{ label: 'Inicio', path: `/${AppRoutes.Home}`, duplicatesBrandLink: true },
+		{ label: 'Obras', path: `/${AppRoutes.Story}` },
+		{ label: 'Autores', path: `/${AppRoutes.Authors}` },
+		{ label: 'Nosotros', path: `/${AppRoutes.About}` },
 	];
 	protected readonly displayMenu = signal(false);
 

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,7 +1,7 @@
 import { Component, effect, input, signal } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { HeaderNavLink } from '@models/link.model';
+import { InternalLink } from '@models/link.model';
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { HEADER_HEIGHT_STRING_PX } from '@utils/spacing.utils';
 import { AppRoutes } from '../../app.routes';
@@ -23,22 +23,21 @@ type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 			class="nav-container grid w-full grid-cols-[1fr_theme(spacing.6)] grid-rows-[theme(spacing.16)_1fr] bg-neutral-50 px-5 md:grid-cols-2 md:grid-rows-1"
 		>
 			<section class="flex items-center">
-				<a [routerLink]="['/', 'home']" class="flex">
+				<!-- El nombre accesible sale del aria-label y no del contenido: el alt del logo más el
+				texto de la marca leen "Logo de 'La Cuentoneta' La Cuentoneta", que no dice a dónde lleva. -->
+				<a [routerLink]="['/', appRoutes.Home]" aria-label="La Cuentoneta — Inicio" class="flex">
 					<img [ngSrc]="'./assets/svg/logo.svg'" class="mr-3" width="59" height="32" alt="Logo de 'La Cuentoneta'" />
 					<span class="flex items-center font-inter text-lg font-bold">La Cuentoneta</span>
 				</a>
 			</section>
 
 			<nav class="navigation flex items-center justify-end">
-				<ul class="flex hidden md:flex">
-					@for (navLink of navLinks; track $index) {
-						<li class="font-inter text-sm font-semibold text-neutral-900 hover:text-neutral-900/60 md:ml-8 lg:ml-12">
-							<a
-								[routerLink]="navLink.path"
-								[tabindex]="navLink.duplicatesBrandLink ? -1 : 0"
-								[attr.aria-hidden]="navLink.duplicatesBrandLink ?? false"
-								>{{ navLink.label }}</a
-							>
+				<!-- El espaciado va como gap del contenedor y no como margen por ítem: así son N-1
+				separaciones en vez de N, sin un margen inicial que no separa nada. -->
+				<ul class="hidden md:flex md:gap-12">
+					@for (navLink of navLinks; track navLink.path) {
+						<li class="font-inter text-sm font-semibold text-neutral-900 hover:text-neutral-900/60">
+							<a [routerLink]="navLink.path">{{ navLink.label }}</a>
 						</li>
 					}
 				</ul>
@@ -56,17 +55,11 @@ type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 		@if (displayMenu()) {
 			<nav class="block grid-cols-2 grid-rows-2 border-t-2 border-neutral-200 bg-neutral-50 md:hidden">
 				<ul>
-					@for (navLink of navLinks; track $index) {
+					@for (navLink of navLinks; track navLink.path) {
 						<li
 							class="flex h-12 items-center border-b-2 border-neutral-200 px-5 font-inter text-lg font-semibold text-neutral-900 hover:text-neutral-900/60"
 						>
-							<a
-								(click)="onMenuTogglerClicked()"
-								[routerLink]="navLink.path"
-								[tabindex]="navLink.duplicatesBrandLink ? -1 : 0"
-								[attr.aria-hidden]="navLink.duplicatesBrandLink ?? false"
-								>{{ navLink.label }}</a
-							>
+							<a (click)="onMenuTogglerClicked()" [routerLink]="navLink.path">{{ navLink.label }}</a>
 						</li>
 					}
 				</ul>
@@ -105,8 +98,9 @@ type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 	],
 })
 export class HeaderComponent {
-	protected readonly navLinks: HeaderNavLink[] = [
-		{ label: 'Inicio', path: `/${AppRoutes.Home}`, duplicatesBrandLink: true },
+	protected readonly appRoutes = AppRoutes;
+	protected readonly navLinks: InternalLink[] = [
+		{ label: 'Inicio', path: `/${AppRoutes.Home}` },
 		{ label: 'Obras', path: `/${AppRoutes.Story}` },
 		{ label: 'Autores', path: `/${AppRoutes.Authors}` },
 		{ label: 'Nosotros', path: `/${AppRoutes.About}` },

--- a/src/app/pages/authors/authors.component.ts
+++ b/src/app/pages/authors/authors.component.ts
@@ -1,28 +1,68 @@
 import { Component, computed, inject } from '@angular/core';
+import { NgOptimizedImage } from '@angular/common';
 
 import { AuthorApi } from '../../providers/author-api.interface';
+import type { AuthorTeaser } from '@models/author.model';
 import { ssrBlockingRxResource } from '@app-utils/ssr-resource';
 import { RouterLink } from '@angular/router';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+import { AppRoutes } from '../../app.routes';
 
 @Component({
-	imports: [RouterLink],
+	selector: 'cuentoneta-authors',
+	imports: [RouterLink, NgOptimizedImage],
 	hostDirectives: [HeadMetadataDirective],
-	template: `<main class="content horizontal-layout-spacing vertical-layout-spacing">
-		<ul class="list-inside list-disc">
-			@for (author of authors(); track author.slug) {
-				<li>
-					<span>
-						<a [routerLink]="['/', 'author', author.slug]" class="underline">{{ author.name }}</a>
-					</span>
-				</li>
-			}
-		</ul>
-	</main>`,
-	styles: ``,
+	template: `
+		<main class="content vertical-layout-spacing horizontal-layout-spacing">
+			<article class="grid grid-cols-1 gap-8">
+				<section class="flex flex-col gap-4">
+					<h1 class="font-inter text-xl font-bold">Índice de autores</h1>
+					<p class="font-inter text-base text-neutral-600">
+						Explorá el índice completo de autores disponible en La Cuentoneta
+					</p>
+				</section>
+
+				<div class="overflow-x-auto rounded-lg border border-neutral-200">
+					<table class="w-full border-collapse">
+						<thead class="bg-neutral-50">
+							<tr class="border-b border-neutral-200">
+								<th class="px-6 py-4 text-left text-sm font-semibold text-neutral-900">Nombre</th>
+								<th class="px-6 py-4 text-left text-sm font-semibold text-neutral-900">Nacionalidad</th>
+								<th class="px-6 py-4 text-left text-sm font-semibold text-neutral-900">Años</th>
+							</tr>
+						</thead>
+						<tbody class="divide-y divide-neutral-200">
+							@for (author of authors(); track author.slug) {
+								<tr class="transition-colors hover:bg-neutral-50">
+									<td class="px-6 py-4">
+										<a
+											[routerLink]="['/', appRoutes.Author, author.slug]"
+											class="text-blue-600 hover:text-blue-800 hover:underline"
+										>
+											{{ author.name }}
+										</a>
+									</td>
+									<td class="px-6 py-4 text-neutral-700">
+										<span class="flex items-center gap-2">
+											@if (author.nationality.flag) {
+												<img [ngSrc]="author.nationality.flag" width="20" height="15" class="rounded" alt="" />
+											}
+											{{ author.nationality.country }}
+										</span>
+									</td>
+									<td class="px-6 py-4 text-neutral-700">{{ lifespanOf(author) }}</td>
+								</tr>
+							}
+						</tbody>
+					</table>
+				</div>
+			</article>
+		</main>
+	`,
 })
 export default class AuthorsComponent {
+	protected readonly appRoutes = AppRoutes;
 	private readonly authorService = inject(AuthorApi);
 	private readonly metaTagsDirective = inject(HeadMetadataDirective);
 
@@ -31,14 +71,35 @@ export default class AuthorsComponent {
 		defaultValue: [],
 	});
 
-	protected readonly authors = computed(() => this.authorsResource.value());
+	// El `order(name asc)` de GROQ compara por punto de código, así que manda al final del listado a
+	// todo nombre que empiece con acento o eñe (`Í` > `Z`). Sanity no expone una colación con plegado
+	// de acentos, así que el orden alfabético real se resuelve acá, sobre el resultado ya traído.
+	private readonly collator = new Intl.Collator('es');
+
+	// Se recorta antes de comparar porque hay fichas con un espacio al inicio del nombre, y el espacio
+	// ordena antes que cualquier letra: sin esto, esos autores encabezan el índice. Es defensa contra
+	// el dato, no su arreglo — la ficha sigue guardando el nombre con el espacio.
+	protected readonly authors = computed(() =>
+		[...this.authorsResource.value()].sort((first, second) =>
+			this.collator.compare(first.name.trim(), second.name.trim()),
+		),
+	);
+
+	// El corpus mezcla autores históricos con contemporáneos, así que la celda tiene que servir a
+	// una ficha completa, a una con solo el nacimiento y a una sin ninguna de las dos fechas.
+	protected lifespanOf(author: AuthorTeaser): string {
+		if (!author.bornOnYear) {
+			return '—';
+		}
+		return author.diedOnYear ? `${author.bornOnYear}–${author.diedOnYear}` : `${author.bornOnYear}–`;
+	}
 
 	constructor() {
 		this.updateMetaTags();
 	}
 
 	private updateMetaTags() {
-		this.metaTagsDirective.setTitle('Índice de Autores');
+		this.metaTagsDirective.setTitle('Todas las Autoras y Autores - La Cuentoneta');
 		this.metaTagsDirective.setDefaultDescription();
 		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl('authors'));
 		this.metaTagsDirective.setRobots('noindex, follow');

--- a/src/app/pages/stories/stories.component.ts
+++ b/src/app/pages/stories/stories.component.ts
@@ -28,9 +28,9 @@ import { AppRoutes } from '../../app.routes';
 		<main class="content vertical-layout-spacing horizontal-layout-spacing">
 			<article class="grid grid-cols-1 gap-8">
 				<section class="flex flex-col gap-4">
-					<h1 class="font-inter text-xl font-bold">Todas las Historias</h1>
+					<h1 class="font-inter text-xl font-bold">Todas las Obras</h1>
 					<p class="font-inter text-base text-neutral-600">
-						Explora nuestra colección completa de historias de La Cuentoneta
+						Explora nuestra colección completa de obras de La Cuentoneta
 					</p>
 				</section>
 
@@ -90,9 +90,9 @@ export default class StoriesComponent {
 	}
 
 	private updateMetaTags() {
-		this.metaTagsDirective.setTitle('Todas las Historias - La Cuentoneta');
+		this.metaTagsDirective.setTitle('Todas las Obras - La Cuentoneta');
 		this.metaTagsDirective.setDescription(
-			'Explora la colección completa de historias publicadas en La Cuentoneta y descubre nuevos autores y lecturas',
+			'Explora la colección completa de obras publicadas en La Cuentoneta y descubre nuevos autores y lecturas',
 		);
 		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl(this.appRoutes.Story));
 		this.metaTagsDirective.setRobots('noindex, follow');

--- a/src/models/link.model.ts
+++ b/src/models/link.model.ts
@@ -10,3 +10,8 @@ export interface UrlLink {
 	icon: string;
 	alt: string;
 }
+
+export interface HeaderNavLink extends InternalLink {
+	// El logo ya enlaza la home: esta entrada la repite, así que se muestra pero no se expone.
+	readonly duplicatesBrandLink?: boolean;
+}

--- a/src/models/link.model.ts
+++ b/src/models/link.model.ts
@@ -10,8 +10,3 @@ export interface UrlLink {
 	icon: string;
 	alt: string;
 }
-
-export interface HeaderNavLink extends InternalLink {
-	// El logo ya enlaza la home: esta entrada la repite, así que se muestra pero no se expone.
-	readonly duplicatesBrandLink?: boolean;
-}


### PR DESCRIPTION
## Qué resuelve

`/story` y `/authors` concentran 613 y 325 enlaces internos, y hasta ahora **ninguna página del sitio las enlazaba**. No era un defecto de SSR: esas rutas no estaban en la navegación, así que solo se llegaba escribiendo la URL a mano — tanto una persona como un crawler.

La medición con la URL Inspection API que motiva el issue muestra el efecto: de las 142 URLs que Search Console reporta como *"Discovered - currently not indexed"*, **141 nunca fueron rastreadas**, y 22 figuran como *"URL is unknown to Google"* pese a estar las 142 en un sitemap sano (enviado, procesado, sin errores). El sitemap dice "estas URLs existen"; nada decía "estas URLs importan".

## Qué cambia

- Suma `Obras` (`/story`) y `Autores` (`/authors`) a la navegación del header, que alimenta tanto el nav de escritorio como el menú móvil. Los cuatro paths se derivan de `AppRoutes` en vez de literales.
- **Expone toda la navegación al árbol de accesibilidad.** La entrada `Inicio` se renderizaba visible pero con `aria-hidden` y `tabindex="-1"`, porque el logo ya lleva al mismo destino — solo que el logo no lo anunciaba: su contenido lee "Logo de 'La Cuentoneta' La Cuentoneta", que no dice a dónde va. Ahora el logo declara su propio nombre accesible y las cuatro entradas son enlaces normales.
- **Mueve el espaciado del nav al contenedor como `gap`.** Con margen por ítem el primero arrastraba una separación que no separa nada, y por eso cuatro entradas desbordaban entre 768 y 840 px; con `gap` son N−1 separaciones y el espaciado original vuelve a entrar. De paso quita un `flex` redundante que convivía con `hidden`.
- **Alinea los textos del listado.** La página destino se titulaba "Todas las Historias" mientras el enlace decía "Obras": quien hacía clic aterrizaba en una página con otro nombre. Texto ancla y título del destino conviene que coincidan justamente en un cambio motivado por rastreo.

## Decisiones

**No se replican los enlaces en el footer.** El header ya renderiza en todas las páginas y su nav de escritorio está en el HTML SSR (solo se oculta por CSS), así que el crawler ya ve los dos enlaces desde cualquier URL: replicarlos no agrega ninguna página fuente nueva. Además, el `<nav>` del footer es una fila de altura fija que quedaría al borde del desborde entre 360 y 640 px. Queda como hipótesis siguiente si la medición no mueve la aguja.

**Los enlaces son visibles y normales.** Se descartó explícitamente ocultarlos por CSS para que solo los viera el crawler: es la definición de *hidden links* en las políticas de spam de Google, y no hay nada que esconder — estos enlaces le sirven al usuario, que hasta ahora tampoco podía llegar al catálogo.

**Alcance acotado a propósito.** Hay una línea de base medida de 309 URLs; shippear varios cambios juntos impediría atribuir cuál movió la aguja. Quedan fuera los enlaces de las storylists y el `lastmod` del sitemap derivado de `_updatedAt`.

**Indexabilidad de los hubs.** La review detectó que `/story` y `/authors` emiten `noindex, follow`. El enlazado sirve igual porque `follow` es lo que importa para el rastreo, pero con un `noindex` sostenido Google termina tratándolas como `nofollow`. No se resuelve acá: está acoplado al guardrail `seo-host-directives`, que al volverlas indexables les va a exigir directivas de meta y structured data que hoy no existen. Registrado en #1727, que ya cubría esa cobertura SEO.

## Plan de pruebas

Verificado contra un build de producción con SSR real (`curl`, sin ejecutar JS):

```
/home                      href="/authors" href="/story"
/story/a-la-deriva         href="/authors" href="/story"
/author/alice-munro        href="/authors" href="/story"

ng-server-context="ssr"
```

Los dos hubs quedan alcanzables desde cualquier página del sitio.

Cobertura automatizada:

- **Unitarios** (`header.component.spec.ts`, 7 casos): destino de los enlaces nuevos, exposición de las cuatro entradas al árbol de accesibilidad, nombre accesible del enlace de marca con su destino, y presencia de los enlaces en el menú móvil.
- **E2E** (`e2e/seo/home.spec.ts`): sobre el HTML server-rendered de `/home`, existen un ancla a `/story` y otra a `/authors`, con igualdad exacta del href para que `/story/<slug>` no satisfaga la invariante.

Gates corridos en local: `typecheck`, `lint`, `stylelint`, `test`, `check-agents` y `build`. La integración continua corre los once sobre el commit final.

Closes #2114.
