### PR TITLE
[#2118] - Generar release para versión 2.9.2 de La Cuentoneta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,28 @@ La lista de características futuras a implementar puede hallarse en la sección
 
 Los hitos futuros de desarrollo, en los cuales se detallan las funcionalidades a desarrollar y los cambios a implementar, pueden encontrarse en las secciones [milestones](https://github.com/cuentoneta/cuentoneta/milestones) y [projects](https://github.com/cuentoneta/cuentoneta/projects) del repositorio de Github del proyecto.
 
+## Versión 2.9.2 (2026-08-04)
+
+La versión 2.9.2 es un patch de dos frentes independientes.
+
+El primero es de **indexado**: `/story` y `/authors` concentran 613 y 325 enlaces internos y ninguna página del sitio las enlazaba —solo se llegaba escribiendo la URL a mano, tanto una persona como un crawler—, así que pasan a formar parte de la navegación principal (#2114). En el mismo movimiento se expone toda la navegación al árbol de accesibilidad —la entrada `Inicio` estaba visible pero con `aria-hidden`, y el logo no anunciaba su destino—, se rediseña el índice de autores con el mismo formato que el listado de obras y se corrige su orden alfabético, que comparaba por punto de código y mandaba al final a todo nombre con acento.
+
+El segundo es de **tooling**: el target de tests usaba el ejecutor `@nx/vitest:test`, deprecado y removido en Nx v24, lo que bloqueaba esa actualización; migra al plugin inferido `@nx/vitest` (#2115). Se suma la instalación de `@vitest/ui` —el script `test:ui` estaba publicado pero roto— y la limpieza de los últimos rastros de Jest y Cypress de la configuración de Nx.
+
+### Cambios completos
+
+Ver el changelog completo en [2.9.2](https://github.com/cuentoneta/cuentoneta/releases/tag/2.9.2)
+
+### Cambios
+
+#### Indexado
+
+- [#2114] - Enlaza el catálogo de cuentos y autores desde la navegación principal.
+
+#### Tooling
+
+- [#2115] - Migra el target de tests al plugin inferido de Nx y elimina el ejecutor deprecado.
+
 ## Versión 2.9.1 (2026-08-04)
 
 La versión 2.9.1 no cambia nada de lo que ve quien lee el sitio: es una versión de **tooling y flujos de trabajo**, y su tema es el tiempo que tarda el ciclo de desarrollo en dar señal. La corrida de integración continua deja de esperar a que termine la review y pasa a solaparse con ella mediante un **PR en borrador** (#2102), y el propio pipeline se reescribe para que los gates arranquen en paralelo desde el primer segundo, sin el job intermedio que empaquetaba y distribuía el workspace entre ellos (#2103).

--- a/cms/package.json
+++ b/cms/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/cms",
 	"private": true,
-	"version": "2.9.1",
+	"version": "2.9.2",
 	"description": "",
 	"main": "package.json",
 	"author": "Ramiro Olivencia <ramiro@olivencia.com.ar>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/app",
 	"type": "module",
-	"version": "2.9.1",
+	"version": "2.9.2",
 	"imports": {
 		"#tailwind-theme": "./src/tailwind.css"
 	},


### PR DESCRIPTION
Prepara la release **2.9.2**: bump de versión en lockstep y entrada de CHANGELOG.

## Contenido de la versión

Patch de dos frentes independientes, ambos ya mergeados a `develop`:

- **Indexado (#2114).** `/story` y `/authors` se suman a la navegación principal; incluye exponer toda la navegación al árbol de accesibilidad, el rediseño del índice de autores y su orden alfabético real.
- **Tooling (#2115).** Migra el target de tests del ejecutor `@nx/vitest:test` —deprecado y removido en Nx v24— al plugin inferido; instala `@vitest/ui` y limpia los últimos rastros de Jest y Cypress de la configuración de Nx.

## Cambios de este PR

- Bump de versión a `2.9.2` en `package.json` (raíz) y `cms/package.json`, en lockstep.
- Entrada `## Versión 2.9.2` en `CHANGELOG.md`, agrupada por los dos frentes.

## Verificación

Gates corridos en local, todos verdes: `test` (139 archivos / 1396 tests), `lint`, `stylelint`, `typecheck`, `build`, `storybook`, `studio-build` (typecheck + test + build) y `check-agents`. El `e2e` no se corrió en local: la release no toca flujos de usuario.

Además:

- **Dry-run de la extracción de notas de `release.yml`**: el `awk` sobre `## Versión 2.9.2` devuelve la sección completa y no vacía.
- **Lockstep** verificado: raíz y `cms/` en `2.9.2`.
- **Issues citados ↔ shipped**: #2114 → PR #2116 y #2115 → PR #2117, ambos mergeados; no hay commits en la ventana `2.9.1..develop` fuera de esos dos PRs.
- **Migraciones de Sanity**: ningún commit de la ventana toca `cms/migrations/`. No hay migraciones nuevas que correr.
- **Documentación**: `docs/DEVELOPMENT_GUIDE.md` ya declara Node 24, consistente con `engines.node`. Sin delta.

### Particulares de esta versión

- **Gate `test` con el target renombrado.** `ci.yml` invoca `npx nx vitest:test`, pero el id del job sigue siendo `test`, así que el required status check conserva su nombre.
- **Cobertura.** Los `outputs` del target ahora se infieren de `vitest.config.ts`: `nx show project` reporta `outputs: ["{projectRoot}/coverage/cuentoneta"]`. Forzando la cobertura en local se generan `coverage-summary.json`, `coverage-final.json` y `lcov.info` con números reales (Statements 91.64%, Branches 82.29%) — los tres archivos que consumen el artefacto, el comentario de PR y Codecov. `CI` figura entre los `inputs` del target, así que la corrida de CI no puede recibir del cache un resultado producido sin cobertura.

## Pasos manuales para completar la release

1. Mergear este PR a `develop`.
2. Tras el merge, el workflow `prepare-release-pr` crea/actualiza el PR `develop → master` y dispara `ci.yml` sobre `develop` (el PR no gatilla checks por sí mismo por la anti-recursión del `GITHUB_TOKEN`; la señal de CI está en la corrida sobre `develop`). Revisarlo y mergearlo a `master` → dispara `release.yml` (tag `2.9.2` + GitHub Release + deploy de Sanity Studio). El deploy de la app lo cubre Vercel por integración Git nativa.
3. Verificar post-release: workflow Release verde (jobs `release` y `deploy-studio`), Release `2.9.2` publicado, Studio con el schema nuevo, app en producción sin regresiones.
4. Medición post-deploy de indexado: contra la línea de base de 309 URLs tomada con la URL Inspection API antes de #2114, mirar cuántas pasan de "nunca rastreada" a tener `lastCrawlTime`.

Closes #2118
