### PR TITLE
[#2066] - Renombra shortDescription a description en resourceType y tag

### DIFF
--- a/.claude/references/sanity-migrations.md
+++ b/.claude/references/sanity-migrations.md
@@ -18,8 +18,30 @@ A diferencia de los scripts one-off (que se borran del working tree tras correr)
 - Preferir las utilidades declarativas (`at`, `setIfMissing`, `set`, `unset`, …) sobre mutaciones crudas.
 - Comentar el **porqué** de la migración (qué la motiva, qué caso cubre que `initialValue` no cubre), no el qué.
 - Migraciones idempotentes cuando sea posible (p. ej. `setIfMissing` para backfills).
+- La migración lleva su **spec co-locado**: `index.spec.ts` al lado del `index.ts`, con un `describe` nombrado por el slug de la migración. Como `defineMigration` conserva el objeto tal cual, el spec ejercita `migrate.document` directamente —es la función pura que decide el patch de cada documento— con el mismo helper que usan los specs existentes (`migration.migrate?.document`, casteado al tipo de parámetro inferido). Corre como Vitest standalone de `cms/` dentro del gate `studio-build` (`pnpm sanity:test`) — ver [Segunda config de Vitest: el Studio](testing.md#segunda-config-de-vitest-el-studio-cms). Como mínimo cubre el camino feliz, la idempotencia (una segunda corrida no produce mutación) y el aborto de cada guard.
 
 Ejemplo vivo: [`cms/migrations/set-default-story-coverimage/index.ts`](../../cms/migrations/set-default-story-coverimage/index.ts) — backfill de `coverImage` (ahora requerido) en historias previas al campo.
+
+## Rename de un campo requerido: patrón expand/contract
+
+Cuando la migración renombra un campo **requerido** y el código lo lee sin fallback, una migración única de `set` + `unset` no tiene ningún orden de despliegue seguro: migrar antes de desplegar deja el código ya corriendo leyendo un campo que todavía no existe; desplegar antes de migrar deja la proyección nueva devolviendo `null` para los documentos no migrados. No hay ventana en la que ambas versiones —código y dato— coincidan.
+
+La falla, además, es **silenciosa**: GROQ devuelve `null` para un campo ausente, y el mapper lo propaga tal cual a un contrato declarado `string`. Nada lanza ni loguea; el síntoma aparece recién en la superficie que renderiza ese campo (o ni ahí, si nada lo renderiza todavía).
+
+La solución es partir el rename en dos migraciones —**expand** y **contract**— separadas por el despliegue del código:
+
+1. **Expand** (`set`, sin `unset`): copia el valor del campo viejo al nuevo, sin dar de baja el viejo. Corre **antes** de desplegar el código que proyecta el nombre nuevo. Deja un estado intermedio con **ambos** nombres poblados — el único que las dos versiones del código (la que todavía lee el nombre viejo y la que ya lee el nuevo) pueden servir por igual.
+   - **Semántica de backfill, no de sincronización:** puebla el campo nuevo solo si está vacío, nunca lo sobrescribe. Comparar por igualdad alcanzaría para reintentar una corrida que se cortó a mitad de camino, pero una corrida tardía —con el schema nuevo ya desplegado— leería una edición legítima como "todavía sin copiar" y la pisaría con el valor viejo.
+2. **Contract** (`unset`): da de baja el campo viejo. Corre **después** de verificar el código nuevo en producción, y después de que la fase expand ya corrió sobre ese dataset.
+   - **Interlock:** al ser destructiva y sin más recuperación que el historial de Sanity, no confía en el orden de las corridas — verifica **documento a documento** que el campo nuevo ya esté poblado, y **lanza** en lugar de borrar la única copia si no lo está.
+
+Ejemplo vivo: [`cms/migrations/copy-short-description-to-description/index.ts`](../../cms/migrations/copy-short-description-to-description/index.ts) (expand) y [`cms/migrations/unset-legacy-short-description/index.ts`](../../cms/migrations/unset-legacy-short-description/index.ts) (contract) — rename de `shortDescription` a `description` en `resourceType` y `tag`.
+
+### Cada fase corre por dataset
+
+Los datasets son `development`, `staging` y `production`, y son independientes entre sí: correr una fase en uno no la aplica a los otros. Correr expand y contract **en cada dataset**, en su propio momento respecto del despliegue de ese dataset — no alcanza con correrlas una sola vez contra `production` y asumir que los demás quedaron al día.
+
+Ningún gate de CI detecta un dataset que quedó sin migrar: el job `e2e` corre contra `staging` (`SANITY_STUDIO_DATASET` en `.github/workflows/ci.yml`), y pasaría en verde aunque `staging` no tuviera corrida la migración, porque el campo no se renderiza en ninguna superficie que el e2e recorra. Es responsabilidad de quien despliega, no de un chequeo automático.
 
 ## Cómo correrlas
 

--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -287,7 +287,7 @@ Reglas del patrón:
 
 ### Qué cubre y qué no
 
-Cubre **lógica Node pura del Studio**: resolvers de Desk Structure, utils que corren dentro del proceso del Studio (p. ej. `cms/utils/landing-page.ts`). No hay nada de Angular, ni Angular Testing Library, ni `happy-dom` — el Studio no renderiza componentes Angular ni corre en un DOM simulado con esa configuración.
+Cubre **lógica Node pura del Studio**: resolvers de Desk Structure, utils que corren dentro del proceso del Studio (p. ej. `cms/utils/landing-page.ts`), y las migraciones de datos de `cms/migrations/` (ver [`sanity-migrations.md`](sanity-migrations.md)). No hay nada de Angular, ni Angular Testing Library, ni `happy-dom` — el Studio no renderiza componentes Angular ni corre en un DOM simulado con esa configuración.
 
 ### Por qué es una config aparte
 
@@ -447,3 +447,4 @@ Si el componente **renderiza su propio skeleton** según un input (p. ej. cuando
 - **Mocks/timers** → siempre desde `@test-utils`; `clearAllMocks()` en `beforeEach`.
 - **Componente que usa `IntersectionObserver`** → `installIntersectionObserverStub()` en `beforeEach`; simular overflow con `markOutsideViewport` / `markInsideViewport`.
 - **Lógica Node pura de `cms/`** → spec propio con Vitest standalone (`pnpm sanity:test`); dobles escritos a mano (`Spy*`/`Stub*`/`Fake*`), sin `@test-utils`.
+- **Migración de datos de Sanity (`cms/migrations/<slug>/`)** → `index.spec.ts` co-locado que ejercita `migrate.document`; corre con `pnpm sanity:test` dentro del gate `studio-build`; sin `@test-utils` (imports explícitos de `vitest`, igual que el resto de `cms/`) — ver [`sanity-migrations.md`](sanity-migrations.md).

--- a/cms/migrations/copy-short-description-to-description/index.spec.ts
+++ b/cms/migrations/copy-short-description-to-description/index.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import migration from './index';
+
+// La migración se define con `defineMigration`, que conserva el objeto tal cual: `migrate.document`
+// es la función pura que decide el patch de cada documento, y es lo único que hace falta ejercitar.
+const migrateDocument = (doc: { _id: string; shortDescription?: unknown; description?: unknown }) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never);
+};
+
+describe('copy-short-description-to-description', () => {
+	it('alcanza a los dos tipos que renombran el campo', () => {
+		expect(migration.documentTypes).toEqual(['resourceType', 'tag']);
+	});
+
+	it('copia la descripción al nombre nuevo', () => {
+		const patches = migrateDocument({ _id: 'tag-1', shortDescription: 'Relato breve de ficción.' });
+
+		expect(patches).toMatchObject([{ path: ['description'], op: { value: 'Relato breve de ficción.' } }]);
+	});
+
+	// Idempotencia: permite reintentar la migración si una corrida se cortó a mitad de camino.
+	it('no vuelve a tocar un documento ya copiado', () => {
+		const doc = { _id: 'tag-1', shortDescription: 'Relato breve.', description: 'Relato breve.' };
+
+		expect(migrateDocument(doc)).toEqual([]);
+	});
+
+	it('no toca un documento sin el campo viejo', () => {
+		expect(migrateDocument({ _id: 'tag-1', description: 'Ya migrada.' })).toEqual([]);
+	});
+
+	// El campo es requerido: copiar whitespace deja el documento inválido en cuanto el código nuevo lo lee.
+	it('aborta en vez de copiar una descripción en blanco', () => {
+		expect(() => migrateDocument({ _id: 'tag-1', shortDescription: '   ' })).toThrow(/en blanco/);
+	});
+});

--- a/cms/migrations/copy-short-description-to-description/index.spec.ts
+++ b/cms/migrations/copy-short-description-to-description/index.spec.ts
@@ -4,10 +4,12 @@ import migration from './index';
 
 // La migración se define con `defineMigration`, que conserva el objeto tal cual: `migrate.document`
 // es la función pura que decide el patch de cada documento, y es lo único que hace falta ejercitar.
+type MigratedDocument = Parameters<NonNullable<NonNullable<typeof migration.migrate>['document']>>[0];
+
 const migrateDocument = (doc: { _id: string; shortDescription?: unknown; description?: unknown }) => {
 	const document = migration.migrate?.document;
 	if (!document) throw new Error('La migración no define migrate.document');
-	return document(doc as never);
+	return document(doc as MigratedDocument);
 };
 
 describe('copy-short-description-to-description', () => {
@@ -35,18 +37,26 @@ describe('copy-short-description-to-description', () => {
 		expect(migrateDocument(doc)).toEqual([]);
 	});
 
+	// El estado en que queda el documento tras la fase 2: sin campo viejo y con el nuevo poblado.
+	it('no toca un documento que ya perdió el campo viejo', () => {
+		expect(migrateDocument({ _id: 'tag-1', description: 'Ya migrada.' })).toEqual([]);
+	});
+
 	it('completa una descripción presente pero en blanco', () => {
 		const doc = { _id: 'tag-1', shortDescription: 'Relato breve.', description: '   ' };
 
 		expect(migrateDocument(doc)).toMatchObject([{ path: ['description'], op: { value: 'Relato breve.' } }]);
 	});
 
-	it('no toca un documento sin el campo viejo', () => {
-		expect(migrateDocument({ _id: 'tag-1', description: 'Ya migrada.' })).toEqual([]);
+	// El campo lo exige el editor del Studio, no la API: un documento creado por API puede llegar sin
+	// ninguna de las dos formas, y ese hueco no lo señala ninguna superficie aguas abajo.
+	it('aborta ante un documento sin descripción bajo ninguno de los dos nombres', () => {
+		expect(() => migrateDocument({ _id: 'tag-1' })).toThrow(/ninguno de los dos nombres/);
 	});
 
-	// El campo es requerido: copiar whitespace deja el documento inválido en cuanto el código nuevo lo lee.
-	it('aborta en vez de copiar una descripción en blanco', () => {
-		expect(() => migrateDocument({ _id: 'tag-1', shortDescription: '   ' })).toThrow(/en blanco/);
+	it('aborta cuando las dos formas del campo están en blanco', () => {
+		expect(() => migrateDocument({ _id: 'tag-1', shortDescription: '   ', description: '' })).toThrow(
+			/ninguno de los dos nombres/,
+		);
 	});
 });

--- a/cms/migrations/copy-short-description-to-description/index.spec.ts
+++ b/cms/migrations/copy-short-description-to-description/index.spec.ts
@@ -28,6 +28,19 @@ describe('copy-short-description-to-description', () => {
 		expect(migrateDocument(doc)).toEqual([]);
 	});
 
+	// Una corrida tardía, con el schema nuevo ya desplegado, no debe pisar lo que alguien editó.
+	it('respeta una descripción que divergió del valor viejo', () => {
+		const doc = { _id: 'tag-1', shortDescription: 'Relato breve.', description: 'Relato breve de ficción.' };
+
+		expect(migrateDocument(doc)).toEqual([]);
+	});
+
+	it('completa una descripción presente pero en blanco', () => {
+		const doc = { _id: 'tag-1', shortDescription: 'Relato breve.', description: '   ' };
+
+		expect(migrateDocument(doc)).toMatchObject([{ path: ['description'], op: { value: 'Relato breve.' } }]);
+	});
+
 	it('no toca un documento sin el campo viejo', () => {
 		expect(migrateDocument({ _id: 'tag-1', description: 'Ya migrada.' })).toEqual([]);
 	});

--- a/cms/migrations/copy-short-description-to-description/index.ts
+++ b/cms/migrations/copy-short-description-to-description/index.ts
@@ -28,7 +28,11 @@ export default defineMigration({
 	migrate: {
 		document(doc: RenamableDocument) {
 			if (typeof doc.shortDescription !== 'string') return [];
-			if (doc.description === doc.shortDescription) return [];
+
+			// Backfill, no sincronización: el campo nuevo se puebla solo si está vacío. Comparar por igualdad
+			// bastaría para reintentar una corrida cortada, pero una corrida tardía —con el schema nuevo ya
+			// desplegado— leería una edición legítima como "todavía sin copiar" y la pisaría con el valor viejo.
+			if (typeof doc.description === 'string' && doc.description.trim() !== '') return [];
 
 			// El campo es requerido en ambos schemas: persistir un valor en blanco lo dejaría inválido sin
 			// que nada lo señale, y el mapper lo propaga a un contrato declarado `string`.

--- a/cms/migrations/copy-short-description-to-description/index.ts
+++ b/cms/migrations/copy-short-description-to-description/index.ts
@@ -9,17 +9,28 @@ interface RenamableDocument {
 	description?: unknown;
 }
 
+// Un valor en blanco no cuenta como descripción: persistirlo dejaría el documento inválido sin que nada
+// lo señale, porque el mapper lo propaga a un contrato declarado `string`.
+function hasText(value: unknown): value is string {
+	return typeof value === 'string' && value.trim() !== '';
+}
+
 /**
  * Copia `shortDescription` a `description` en los tipos que renombran el campo, sin dar de baja el
  * viejo.
  *
  * **Orden de despliegue:** esta migración corre **antes** de desplegar el código que proyecta
- * `description`. Es la mitad no destructiva del rename: mientras el campo viejo siga presente, el código
- * ya desplegado lo sigue leyendo, así que no hay ventana en la que alguna superficie sirva la
- * descripción vacía. La baja de `shortDescription` vive en la migración `unset-legacy-short-description`
- * y corre recién con el código nuevo verificado.
+ * `description`, y **en cada dataset** (development, staging y production), no una sola vez. Es la mitad
+ * no destructiva del rename: los documentos que existían al momento de la corrida quedan con ambos
+ * nombres poblados, que es el único estado que las dos versiones del código pueden servir. La baja de
+ * `shortDescription` vive en la migración `unset-legacy-short-description` y corre recién con el código
+ * nuevo verificado.
  *
- * Es idempotente: un documento cuya `description` ya coincide no produce mutación, lo que permite
+ * Queda un residuo que la migración no puede cubrir: un documento **creado** entre el despliegue del
+ * schema del Studio y esta corrida nace solo con `description`, así que el código todavía viejo lo lee
+ * vacío. Se cierra volviendo a correr la migración justo antes de desplegar la app.
+ *
+ * Es idempotente: un documento cuya `description` ya tiene contenido no produce mutación, lo que permite
  * reintentar una corrida que se cortó a la mitad.
  */
 export default defineMigration({
@@ -27,23 +38,25 @@ export default defineMigration({
 	documentTypes: ['resourceType', 'tag'],
 	migrate: {
 		document(doc: RenamableDocument) {
-			if (typeof doc.shortDescription !== 'string') return [];
+			const legacy = hasText(doc.shortDescription) ? doc.shortDescription : undefined;
+
+			// El campo es requerido en ambos schemas, pero eso lo hace cumplir el editor del Studio, no la API:
+			// un documento creado por API puede llegar sin ninguna de las dos formas. Sin este aborto quedaría
+			// con el campo requerido sin poblar, y nada lo señalaría — el mapper propaga el hueco a un contrato
+			// declarado `string` y ninguna superficie lo valida.
+			if (!hasText(doc.description) && legacy === undefined) {
+				throw new Error(
+					`${doc._id} no tiene descripción bajo ninguno de los dos nombres: el campo es requerido y la ` +
+						`migración no tiene de dónde copiarla.`,
+				);
+			}
 
 			// Backfill, no sincronización: el campo nuevo se puebla solo si está vacío. Comparar por igualdad
 			// bastaría para reintentar una corrida cortada, pero una corrida tardía —con el schema nuevo ya
 			// desplegado— leería una edición legítima como "todavía sin copiar" y la pisaría con el valor viejo.
-			if (typeof doc.description === 'string' && doc.description.trim() !== '') return [];
+			if (hasText(doc.description) || legacy === undefined) return [];
 
-			// El campo es requerido en ambos schemas: persistir un valor en blanco lo dejaría inválido sin
-			// que nada lo señale, y el mapper lo propaga a un contrato declarado `string`.
-			if (doc.shortDescription.trim() === '') {
-				throw new Error(
-					`La descripción de ${doc._id} está en blanco: el campo es requerido y copiarla así dejaría el ` +
-						`documento inválido al leerlo bajo el nombre nuevo.`,
-				);
-			}
-
-			return [at('description', set(doc.shortDescription))];
+			return [at('description', set(legacy))];
 		},
 	},
 });

--- a/cms/migrations/copy-short-description-to-description/index.ts
+++ b/cms/migrations/copy-short-description-to-description/index.ts
@@ -1,0 +1,45 @@
+import { at, defineMigration, set } from 'sanity/migrate';
+
+// El shape mínimo que la migración necesita del documento. No se importan los tipos del typegen porque
+// describen el schema **nuevo** (donde el campo ya se llama `description`), y lo que esta migración lee
+// es el viejo.
+interface RenamableDocument {
+	_id: string;
+	shortDescription?: unknown;
+	description?: unknown;
+}
+
+/**
+ * Copia `shortDescription` a `description` en los tipos que renombran el campo, sin dar de baja el
+ * viejo.
+ *
+ * **Orden de despliegue:** esta migración corre **antes** de desplegar el código que proyecta
+ * `description`. Es la mitad no destructiva del rename: mientras el campo viejo siga presente, el código
+ * ya desplegado lo sigue leyendo, así que no hay ventana en la que alguna superficie sirva la
+ * descripción vacía. La baja de `shortDescription` vive en la migración `unset-legacy-short-description`
+ * y corre recién con el código nuevo verificado.
+ *
+ * Es idempotente: un documento cuya `description` ya coincide no produce mutación, lo que permite
+ * reintentar una corrida que se cortó a la mitad.
+ */
+export default defineMigration({
+	title: 'Copiar shortDescription a description en resourceType y tag',
+	documentTypes: ['resourceType', 'tag'],
+	migrate: {
+		document(doc: RenamableDocument) {
+			if (typeof doc.shortDescription !== 'string') return [];
+			if (doc.description === doc.shortDescription) return [];
+
+			// El campo es requerido en ambos schemas: persistir un valor en blanco lo dejaría inválido sin
+			// que nada lo señale, y el mapper lo propaga a un contrato declarado `string`.
+			if (doc.shortDescription.trim() === '') {
+				throw new Error(
+					`La descripción de ${doc._id} está en blanco: el campo es requerido y copiarla así dejaría el ` +
+						`documento inválido al leerlo bajo el nombre nuevo.`,
+				);
+			}
+
+			return [at('description', set(doc.shortDescription))];
+		},
+	},
+});

--- a/cms/migrations/unset-legacy-short-description/index.spec.ts
+++ b/cms/migrations/unset-legacy-short-description/index.spec.ts
@@ -4,10 +4,12 @@ import migration from './index';
 
 // La migración se define con `defineMigration`, que conserva el objeto tal cual: `migrate.document`
 // es la función pura que decide el patch de cada documento, y es lo único que hace falta ejercitar.
+type MigratedDocument = Parameters<NonNullable<NonNullable<typeof migration.migrate>['document']>>[0];
+
 const migrateDocument = (doc: { _id: string; shortDescription?: unknown; description?: unknown }) => {
 	const document = migration.migrate?.document;
 	if (!document) throw new Error('La migración no define migrate.document');
-	return document(doc as never);
+	return document(doc as MigratedDocument);
 };
 
 describe('unset-legacy-short-description', () => {
@@ -35,5 +37,13 @@ describe('unset-legacy-short-description', () => {
 		const doc = { _id: 'tag-1', shortDescription: 'Relato breve.', description: '   ' };
 
 		expect(() => migrateDocument(doc)).toThrow(/nombre nuevo/);
+	});
+
+	// La presencia se comprueba con `in` y no con `typeof` a propósito: un campo puesto en null sigue
+	// estando en el documento, y darlo de baja es justamente lo que corresponde.
+	it('da de baja un campo viejo presente pero nulo', () => {
+		const doc = { _id: 'tag-1', shortDescription: null, description: 'Relato breve.' };
+
+		expect(migrateDocument(doc)).toMatchObject([{ path: ['shortDescription'], op: { type: 'unset' } }]);
 	});
 });

--- a/cms/migrations/unset-legacy-short-description/index.spec.ts
+++ b/cms/migrations/unset-legacy-short-description/index.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import migration from './index';
+
+// La migración se define con `defineMigration`, que conserva el objeto tal cual: `migrate.document`
+// es la función pura que decide el patch de cada documento, y es lo único que hace falta ejercitar.
+const migrateDocument = (doc: { _id: string; shortDescription?: unknown; description?: unknown }) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never);
+};
+
+describe('unset-legacy-short-description', () => {
+	it('alcanza a los dos tipos que renombran el campo', () => {
+		expect(migration.documentTypes).toEqual(['resourceType', 'tag']);
+	});
+
+	it('da de baja el campo viejo cuando la descripción ya vive bajo el nombre nuevo', () => {
+		const patches = migrateDocument({ _id: 'tag-1', shortDescription: 'Relato breve.', description: 'Relato breve.' });
+
+		expect(patches).toMatchObject([{ path: ['shortDescription'], op: { type: 'unset' } }]);
+	});
+
+	// Idempotencia: permite reintentar la migración si una corrida se cortó a mitad de camino.
+	it('no toca un documento que ya perdió el campo viejo', () => {
+		expect(migrateDocument({ _id: 'tag-1', description: 'Relato breve.' })).toEqual([]);
+	});
+
+	// El interlock es lo que vuelve segura una corrida fuera de orden: sin él, borraría la única copia.
+	it('aborta cuando la descripción todavía no está bajo el nombre nuevo', () => {
+		expect(() => migrateDocument({ _id: 'tag-1', shortDescription: 'Relato breve.' })).toThrow(/nombre nuevo/);
+	});
+
+	it('aborta cuando la descripción del nombre nuevo está en blanco', () => {
+		const doc = { _id: 'tag-1', shortDescription: 'Relato breve.', description: '   ' };
+
+		expect(() => migrateDocument(doc)).toThrow(/nombre nuevo/);
+	});
+});

--- a/cms/migrations/unset-legacy-short-description/index.ts
+++ b/cms/migrations/unset-legacy-short-description/index.ts
@@ -1,0 +1,41 @@
+import { at, defineMigration, unset } from 'sanity/migrate';
+
+// El shape mínimo que la migración necesita del documento. No se importan los tipos del typegen porque
+// ya no declaran `shortDescription`, que es justamente lo que esta migración busca.
+interface RenamedDocument {
+	_id: string;
+	shortDescription?: unknown;
+	description?: unknown;
+}
+
+/**
+ * Da de baja `shortDescription` en los tipos que ya renombraron el campo.
+ *
+ * **Orden de despliegue:** corre **después** de que el código que lee `description` esté verificado en
+ * producción, y después de que `copy-short-description-to-description` haya poblado el nombre nuevo.
+ * Adelantarla deja al código todavía desplegado leyendo un campo ausente.
+ *
+ * **Es destructiva** y el dato solo se recupera del historial de Sanity, así que en vez de confiar en el
+ * orden de las corridas lo verifica documento a documento: si la descripción no está bajo el nombre
+ * nuevo, lanza en lugar de borrar la única copia que queda.
+ *
+ * Es idempotente: un documento sin `shortDescription` no produce mutación.
+ */
+export default defineMigration({
+	title: 'Dar de baja el shortDescription heredado de resourceType y tag',
+	documentTypes: ['resourceType', 'tag'],
+	migrate: {
+		document(doc: RenamedDocument) {
+			if (!('shortDescription' in doc)) return [];
+
+			if (typeof doc.description !== 'string' || doc.description.trim() === '') {
+				throw new Error(
+					`${doc._id} todavía no tiene su descripción bajo el nombre nuevo: correr primero ` +
+						`copy-short-description-to-description, porque dar de baja el campo viejo acá borraría la única copia.`,
+				);
+			}
+
+			return [at('shortDescription', unset())];
+		},
+	},
+});

--- a/cms/schema.json
+++ b/cms/schema.json
@@ -285,7 +285,7 @@
 				},
 				"optional": false
 			},
-			"shortDescription": {
+			"description": {
 				"type": "objectAttribute",
 				"value": {
 					"type": "string"
@@ -3169,7 +3169,7 @@
 				},
 				"optional": false
 			},
-			"shortDescription": {
+			"description": {
 				"type": "objectAttribute",
 				"value": {
 					"type": "string"

--- a/cms/schemas/resourceType.ts
+++ b/cms/schemas/resourceType.ts
@@ -63,7 +63,7 @@ export const resourceType = defineType({
 		}),
 		defineField({
 			name: 'description',
-			title: 'Descripción breve',
+			title: 'Descripción',
 			type: 'string',
 			validation: (Rule) => Rule.required(),
 		}),

--- a/cms/schemas/resourceType.ts
+++ b/cms/schemas/resourceType.ts
@@ -41,7 +41,7 @@ export const resourceType = defineType({
 	preview: {
 		select: {
 			title: 'title',
-			subtitle: 'shortDescription',
+			subtitle: 'description',
 		},
 	},
 	fields: [
@@ -62,7 +62,7 @@ export const resourceType = defineType({
 			validation: (Rule) => Rule.required(),
 		}),
 		defineField({
-			name: 'shortDescription',
+			name: 'description',
 			title: 'Descripción breve',
 			type: 'string',
 			validation: (Rule) => Rule.required(),

--- a/cms/schemas/tag.ts
+++ b/cms/schemas/tag.ts
@@ -31,7 +31,7 @@ export default defineType({
 		}),
 		defineField({
 			name: 'description',
-			title: 'Descripción breve',
+			title: 'Descripción',
 			type: 'string',
 			validation: (Rule) => Rule.required(),
 		}),

--- a/cms/schemas/tag.ts
+++ b/cms/schemas/tag.ts
@@ -9,7 +9,7 @@ export default defineType({
 	preview: {
 		select: {
 			title: 'title',
-			subtitle: 'shortDescription',
+			subtitle: 'description',
 		},
 	},
 	fields: [
@@ -30,7 +30,7 @@ export default defineType({
 			validation: (Rule) => Rule.required(),
 		}),
 		defineField({
-			name: 'shortDescription',
+			name: 'description',
 			title: 'Descripción breve',
 			type: 'string',
 			validation: (Rule) => Rule.required(),

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -576,6 +576,8 @@ interface ResourceType {
 
 > El ícono que acompaña a un recurso en la interfaz lo resuelve el frontend a partir del `slug` del tipo, contra el mapa local de `@models/icon.model`. No viaja desde el CMS.
 
+> El nombre `description` no implica un mismo tipo en todo el modelo: en `ResourceType` y en [`Tag`](#tag-etiqueta) es texto plano, mientras que `Storylist.description` es Portable Text (`TextBlockContent[]`) y `Media.description` es HTML saneado. Conviene mirar la interfaz antes de asumir el formato.
+
 **Ejemplos de tipos:**
 
 - `wikipedia` - Artículos en Wikipedia
@@ -600,9 +602,7 @@ interface Tag {
 
 **Uso:** Clasificar contenido por tema, género, etc.
 
-> El nombre `description` no implica un mismo tipo en todo el modelo: en `Tag` y en `ResourceType` es
-> texto plano, mientras que `Storylist.description` es Portable Text (`TextBlockContent[]`) y
-> `Media.description` es HTML saneado. Conviene mirar la interfaz antes de asumir el formato.
+> El nombre `description` no implica un mismo tipo en todo el modelo: en `Tag` y en [`ResourceType`](#resource-recurso-externo) es texto plano, mientras que `Storylist.description` es Portable Text (`TextBlockContent[]`) y `Media.description` es HTML saneado. Conviene mirar la interfaz antes de asumir el formato.
 
 > Una etiqueta no lleva ícono: `TagComponent` renderiza solo su título. El CMS supo tener un campo de ícono, pero ninguna superficie lo mostraba.
 

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -570,7 +570,7 @@ interface Resource {
 interface ResourceType {
 	slug: string; // Identificador único del tipo
 	title: string; // Nombre del tipo (ej: "Wikipedia")
-	shortDescription: string; // Descripción corta
+	description: string; // Texto plano que explica qué es el tipo
 }
 ```
 
@@ -594,11 +594,15 @@ interface ResourceType {
 interface Tag {
 	slug: string; // Identificador único
 	title: string; // Nombre de la etiqueta
-	shortDescription: string; // Breve descripción
+	description: string; // Texto plano que explica qué agrupa la etiqueta
 }
 ```
 
 **Uso:** Clasificar contenido por tema, género, etc.
+
+> El nombre `description` no implica un mismo tipo en todo el modelo: en `Tag` y en `ResourceType` es
+> texto plano, mientras que `Storylist.description` es Portable Text (`TextBlockContent[]`) y
+> `Media.description` es HTML saneado. Conviene mirar la interfaz antes de asumir el formato.
 
 > Una etiqueta no lleva ícono: `TagComponent` renderiza solo su título. El CMS supo tener un campo de ícono, pero ninguna superficie lo mostraba.
 

--- a/src/api/_queries/author.query.ts
+++ b/src/api/_queries/author.query.ts
@@ -21,13 +21,13 @@ export const authorBySlugQuery = defineQuery(`
         resourceType->{
         	'slug': slug.current,
         	title,
-        	shortDescription
+        	description
         }
     }, []),
     'tags': coalesce(tags[] -> {
         title,
         'slug': slug.current,
-        shortDescription
+        description
     }, [])
 }`);
 

--- a/src/api/_queries/content.query.ts
+++ b/src/api/_queries/content.query.ts
@@ -63,7 +63,7 @@ export const landingPageContentQuery = defineQuery(`
         'tags': coalesce(tags[] -> {
             title,
             'slug': slug.current,
-            shortDescription
+            description
         }, []),
         'storyCoverImages': coalesce(stories[]->coverImage, []),
         'count': coalesce(count(stories), 0),

--- a/src/api/_queries/literary-work.query.ts
+++ b/src/api/_queries/literary-work.query.ts
@@ -24,7 +24,7 @@ export const literaryWorkBySlugQuery = defineQuery(`
     'tags': coalesce(tags[] -> {
         title,
         'slug': slug.current,
-        shortDescription
+        description
     }, []),
     'mediaSources': coalesce(mediaSources[]{
         ...,
@@ -38,7 +38,7 @@ export const literaryWorkBySlugQuery = defineQuery(`
         resourceType->{
             'slug': slug.current,
             title,
-            shortDescription
+            description
         }
     }, []),
     'authors': coalesce(authors[]-> {
@@ -58,7 +58,7 @@ export const literaryWorkBySlugQuery = defineQuery(`
             resourceType->{
                 'slug': slug.current,
                 title,
-                shortDescription
+                description
             }
         }, []),
         'tags': []
@@ -92,7 +92,7 @@ export const literaryWorkSectionBySlugQuery = defineQuery(`
     'tags': coalesce(tags[] -> {
         title,
         'slug': slug.current,
-        shortDescription
+        description
     }, []),
     'mediaSources': coalesce(mediaSources[]{
         ...,
@@ -106,7 +106,7 @@ export const literaryWorkSectionBySlugQuery = defineQuery(`
         resourceType->{
             'slug': slug.current,
             title,
-            shortDescription
+            description
         }
     }, []),
     'authors': coalesce(authors[]-> {
@@ -126,7 +126,7 @@ export const literaryWorkSectionBySlugQuery = defineQuery(`
             resourceType->{
                 'slug': slug.current,
                 title,
-                shortDescription
+                description
             }
         }, []),
         'tags': []

--- a/src/api/_queries/story.query.ts
+++ b/src/api/_queries/story.query.ts
@@ -18,7 +18,7 @@ export const storiesByAuthorSlugQuery = defineQuery(`
         resourceType->{
             'slug': slug.current,
             title,
-            shortDescription
+            description
         }
     }, []),
 }|order(title asc)`);
@@ -53,13 +53,13 @@ export const storyBySlugQuery = defineQuery(`
         resourceType->{
             'slug': slug.current,
             title,
-            shortDescription
+            description
         }
     }, []),
     'tags': coalesce(tags[] -> {
         title,
         'slug': slug.current,
-        shortDescription
+        description
     }, []),
     'author': author-> {
         _id,
@@ -78,7 +78,7 @@ export const storyBySlugQuery = defineQuery(`
             resourceType->{
                 'slug': slug.current,
                 title,
-                shortDescription
+                description
             }
         }, []),
         'tags': []

--- a/src/api/_queries/storylist.query.ts
+++ b/src/api/_queries/storylist.query.ts
@@ -10,7 +10,7 @@ export const storylistTeasersQuery = defineQuery(`
     'tags': coalesce(tags[] -> {
         title,
         'slug': slug.current,
-        shortDescription
+        description
     }, []),
     'storyCoverImages': coalesce(stories[]->coverImage, []),
     'count': coalesce(count(stories), 0),
@@ -32,7 +32,7 @@ export const storylistQuery = defineQuery(`
     'tags': coalesce(tags[] -> {
         title,
         'slug': slug.current,
-        shortDescription
+        description
     }, []),
     'stories': coalesce(stories[]->{
         _id,

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -23,12 +23,12 @@ describe('mapTags (ACL)', () => {
 
 		expect(result.map((tag) => tag.title)).toEqual(onoffRawTagsMock.map((raw) => raw.title));
 		expect(result.map((tag) => tag.slug)).toEqual(onoffRawTagsMock.map((raw) => raw.slug));
-		expect(result.map((tag) => tag.shortDescription)).toEqual(onoffRawTagsMock.map((raw) => raw.shortDescription));
+		expect(result.map((tag) => tag.description)).toEqual(onoffRawTagsMock.map((raw) => raw.description));
 	});
 
 	it('exposes exactly the domain contract, dropping everything else from the raw result', () => {
 		mapTags(onoffRawTagsMock).forEach((tag) => {
-			expect(Object.keys(tag).sort()).toEqual(['shortDescription', 'slug', 'title']);
+			expect(Object.keys(tag).sort()).toEqual(['description', 'slug', 'title']);
 		});
 	});
 
@@ -114,7 +114,7 @@ describe('mapResources (ACL)', () => {
 		expect(resource.resourceType).toMatchObject({
 			slug: rawResource.resourceType.slug,
 			title: rawResource.resourceType.title,
-			shortDescription: rawResource.resourceType.shortDescription,
+			description: rawResource.resourceType.description,
 		});
 	});
 
@@ -122,7 +122,7 @@ describe('mapResources (ACL)', () => {
 		const [resource] = mapResources(rawOnoffAuthor.resources);
 
 		expect(Object.keys(resource).sort()).toEqual(['resourceType', 'title', 'url']);
-		expect(Object.keys(resource.resourceType).sort()).toEqual(['shortDescription', 'slug', 'title']);
+		expect(Object.keys(resource.resourceType).sort()).toEqual(['description', 'slug', 'title']);
 	});
 
 	it('returns an empty array for an empty, null or undefined input', () => {

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -148,7 +148,7 @@ export function mapResources(resources: ResourcesSubQuery): Resource[] {
 			resourceType: {
 				slug: resource.resourceType.slug,
 				title: resource.resourceType.title,
-				shortDescription: resource.resourceType.shortDescription,
+				description: resource.resourceType.description,
 			},
 		})) ?? []
 	);
@@ -163,7 +163,7 @@ export function mapTags(tags: TagsSubQuery): Tag[] {
 	return tags.map((tag) => ({
 		title: tag.title,
 		slug: tag.slug,
-		shortDescription: tag.shortDescription,
+		description: tag.description,
 	}));
 }
 

--- a/src/mocks/author.mock.ts
+++ b/src/mocks/author.mock.ts
@@ -21,7 +21,7 @@ export const authorMock: AuthorProfile = {
 			resourceType: {
 				slug: 'wikipedia',
 				title: 'Wikipedia',
-				shortDescription: 'Enlace a artículo de Wikipedia',
+				description: 'Enlace a artículo de Wikipedia',
 			},
 		},
 	],

--- a/src/mocks/onoff-raw-author.mock.ts
+++ b/src/mocks/onoff-raw-author.mock.ts
@@ -33,7 +33,7 @@ export const rawOnoffAuthor: NonNullable<StoryBySlugQueryResult>['author'] = {
 			resourceType: {
 				slug: 'wikipedia',
 				title: 'Wikipedia',
-				shortDescription: 'Enlace a artículo de Wikipedia',
+				description: 'Enlace a artículo de Wikipedia',
 			},
 		},
 	],

--- a/src/mocks/onoff-raw-tags.mock.ts
+++ b/src/mocks/onoff-raw-tags.mock.ts
@@ -7,76 +7,76 @@ export type RawTag = NonNullable<StoryBySlugQueryResult>['tags'][number];
 export const cuentoRawTag: RawTag = {
 	title: 'Cuento',
 	slug: 'cuento',
-	shortDescription: 'Relato breve de ficción.',
+	description: 'Relato breve de ficción.',
 };
 export const novelaRawTag: RawTag = {
 	title: 'Novela',
 	slug: 'novela',
-	shortDescription: 'Narrativa extensa de ficción.',
+	description: 'Narrativa extensa de ficción.',
 };
 export const ensayoRawTag: RawTag = {
 	title: 'Ensayo',
 	slug: 'ensayo',
-	shortDescription: 'Prosa reflexiva que argumenta en torno a un tema.',
+	description: 'Prosa reflexiva que argumenta en torno a un tema.',
 };
 export const teatroRawTag: RawTag = {
 	title: 'Teatro',
 	slug: 'teatro',
-	shortDescription: 'Obra escrita para ser representada en escena.',
+	description: 'Obra escrita para ser representada en escena.',
 };
 
 // Género de la obra.
 export const dramaPsicologicoRawTag: RawTag = {
 	title: 'Drama psicológico',
 	slug: 'drama-psicologico',
-	shortDescription: 'Conflicto centrado en la vida interior de los personajes.',
+	description: 'Conflicto centrado en la vida interior de los personajes.',
 };
 export const metaficcionRawTag: RawTag = {
 	title: 'Metaficción',
 	slug: 'metaficcion',
-	shortDescription: 'Obras que se vuelven sobre su propia escritura y la exhiben como tema.',
+	description: 'Obras que se vuelven sobre su propia escritura y la exhiben como tema.',
 };
 export const absurdoRawTag: RawTag = {
 	title: 'Absurdo',
 	slug: 'absurdo',
-	shortDescription: 'Rutinas y gestos cotidianos llevados hasta perder todo sentido.',
+	description: 'Rutinas y gestos cotidianos llevados hasta perder todo sentido.',
 };
 export const surrealismoRawTag: RawTag = {
 	title: 'Surrealismo',
 	slug: 'surrealismo',
-	shortDescription: 'Imágenes oníricas que desbordan la lógica cotidiana.',
+	description: 'Imágenes oníricas que desbordan la lógica cotidiana.',
 };
 export const alegoriaRawTag: RawTag = {
 	title: 'Alegoría',
 	slug: 'alegoria',
-	shortDescription: 'Relato cuyo sentido literal remite a otro figurado.',
+	description: 'Relato cuyo sentido literal remite a otro figurado.',
 };
 export const filosoficoRawTag: RawTag = {
 	title: 'Filosófico',
 	slug: 'filosofico',
-	shortDescription: 'Ficción organizada en torno a una pregunta o una idea abstracta.',
+	description: 'Ficción organizada en torno a una pregunta o una idea abstracta.',
 };
 export const experimentalRawTag: RawTag = {
 	title: 'Experimental',
 	slug: 'experimental',
-	shortDescription: 'Obras que anteponen el procedimiento formal a la trama.',
+	description: 'Obras que anteponen el procedimiento formal a la trama.',
 };
 export const tragediaRawTag: RawTag = {
 	title: 'Tragedia',
 	slug: 'tragedia',
-	shortDescription: 'Pieza dramática de desenlace adverso.',
+	description: 'Pieza dramática de desenlace adverso.',
 };
 export const dramaHistoricoRawTag: RawTag = {
 	title: 'Drama histórico',
 	slug: 'drama-historico',
-	shortDescription: 'Ficción dramática ambientada en hechos o figuras del pasado.',
+	description: 'Ficción dramática ambientada en hechos o figuras del pasado.',
 };
 
 // Curaduría de la colección: no describe la obra sino cómo se armó la lista que la contiene.
 export const colaborativaRawTag: RawTag = {
 	title: 'Colaborativa',
 	slug: 'colaborativa',
-	shortDescription: 'Lista de textos generada colaborativamente por la comunidad.',
+	description: 'Lista de textos generada colaborativamente por la comunidad.',
 };
 
 export const onoffRawTagsMock: RawTag[] = [

--- a/src/mocks/onoff-tags.mock.ts
+++ b/src/mocks/onoff-tags.mock.ts
@@ -25,7 +25,7 @@ export function toDomainTag(raw: RawTag): Tag {
 	return {
 		title: raw.title,
 		slug: raw.slug,
-		shortDescription: raw.shortDescription,
+		description: raw.description,
 	};
 }
 

--- a/src/mocks/resource.mock.ts
+++ b/src/mocks/resource.mock.ts
@@ -6,6 +6,6 @@ export const resourceMock: Resource = {
 	resourceType: {
 		slug: 'recurso-original',
 		title: 'Recurso Original',
-		shortDescription: 'Recurso original de este contenido',
+		description: 'Recurso original de este contenido',
 	},
 };

--- a/src/mocks/story.mock.ts
+++ b/src/mocks/story.mock.ts
@@ -11,7 +11,7 @@ export const storyMock: Story = {
 			resourceType: {
 				slug: 'recurso-original',
 				title: 'Recurso Original',
-				shortDescription: 'Recurso original de este contenido',
+				description: 'Recurso original de este contenido',
 			},
 		},
 	],
@@ -276,7 +276,7 @@ export const storyTeaserWithAuthorMock: StoryTeaserWithAuthor = {
 			resourceType: {
 				slug: 'recurso-original',
 				title: 'Recurso Original',
-				shortDescription: 'Recurso original de este contenido',
+				description: 'Recurso original de este contenido',
 			},
 		},
 	],
@@ -363,7 +363,7 @@ export const storyTeaserMock: StoryTeaser = {
 			resourceType: {
 				slug: 'recurso-original',
 				title: 'Recurso Original',
-				shortDescription: 'Recurso original de este contenido',
+				description: 'Recurso original de este contenido',
 			},
 		},
 	],

--- a/src/models/resource.model.ts
+++ b/src/models/resource.model.ts
@@ -7,5 +7,5 @@ export interface Resource {
 export interface ResourceType {
 	slug: string;
 	title: string;
-	shortDescription: string;
+	description: string;
 }

--- a/src/models/tag.model.ts
+++ b/src/models/tag.model.ts
@@ -1,5 +1,5 @@
 export interface Tag {
 	title: string;
 	slug: string;
-	shortDescription: string;
+	description: string;
 }

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -72,7 +72,7 @@ export type Tag = {
 	_rev: string;
 	title: string;
 	slug: Slug;
-	shortDescription: string;
+	description: string;
 };
 
 export type Slug = {
@@ -550,7 +550,7 @@ export type ResourceType = {
 	_rev: string;
 	title: string;
 	slug: Slug;
-	shortDescription: string;
+	description: string;
 };
 
 export type Contributor = {
@@ -716,7 +716,7 @@ export type AllSanitySchemaTypes =
 
 // Source: ../src/api/_queries/author.query.ts
 // Variable: authorBySlugQuery
-// Query: *[_type == 'author' && slug.current == $slug && !(_id in path('drafts.**'))][0]{    _id,    'slug': slug.current,    'createdAt': _createdAt,    'updatedAt': _updatedAt,    name,    image,    nationality->,    biography,    bornOn,		bornOnYear,    diedOn,		diedOnYear,    'resources': coalesce(resources[]{        title,        url,        resourceType->{        	'slug': slug.current,        	title,        	shortDescription        }    }, []),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, [])}
+// Query: *[_type == 'author' && slug.current == $slug && !(_id in path('drafts.**'))][0]{    _id,    'slug': slug.current,    'createdAt': _createdAt,    'updatedAt': _updatedAt,    name,    image,    nationality->,    biography,    bornOn,		bornOnYear,    diedOn,		diedOnYear,    'resources': coalesce(resources[]{        title,        url,        resourceType->{        	'slug': slug.current,        	title,        	description        }    }, []),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        description    }, [])}
 export type AuthorBySlugQueryResult = {
 	_id: string;
 	slug: string;
@@ -757,7 +757,7 @@ export type AuthorBySlugQueryResult = {
 				resourceType: {
 					slug: string;
 					title: string;
-					shortDescription: string;
+					description: string;
 				};
 		  }>
 		| Array<never>;
@@ -765,7 +765,7 @@ export type AuthorBySlugQueryResult = {
 		| Array<{
 				title: string;
 				slug: string;
-				shortDescription: string;
+				description: string;
 		  }>
 		| Array<never>;
 } | null;
@@ -950,7 +950,7 @@ export type LatestLandingPageReferencesQueryResult = {
 
 // Source: ../src/api/_queries/content.query.ts
 // Variable: landingPageContentQuery
-// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{    _id,    'slug': slug.current,    config,    'cards': coalesce(cards[]->{        _id,        title,        'slug': slug.current,        description,        featuredImage,        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            shortDescription        }, []),        'storyCoverImages': coalesce(stories[]->coverImage, []),        'count': coalesce(count(stories), 0),				config,				'tabs': [],	      'mediaSources': coalesce(mediaSources[], []),    },[]),    'campaigns': coalesce(campaigns[]->{        _id,        'title': coalesce(title, ''),        'slug': coalesce(slug.current, ''),        'url': coalesce(url, ''),        'contents': {            'xs': {                'image': contents.xs.image            },            'md': {                'image': contents.md.image            }        }    },[]),    'latestReads': coalesce(latestReads[]->{        _id,        'slug': slug.current,        title,        badLanguage,        'body': [],        originalPublication,        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {             _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[]),}
+// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{    _id,    'slug': slug.current,    config,    'cards': coalesce(cards[]->{        _id,        title,        'slug': slug.current,        description,        featuredImage,        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'storyCoverImages': coalesce(stories[]->coverImage, []),        'count': coalesce(count(stories), 0),				config,				'tabs': [],	      'mediaSources': coalesce(mediaSources[], []),    },[]),    'campaigns': coalesce(campaigns[]->{        _id,        'title': coalesce(title, ''),        'slug': coalesce(slug.current, ''),        'url': coalesce(url, ''),        'contents': {            'xs': {                'image': contents.xs.image            },            'md': {                'image': contents.md.image            }        }    },[]),    'latestReads': coalesce(latestReads[]->{        _id,        'slug': slug.current,        title,        badLanguage,        'body': [],        originalPublication,        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {             _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[]),}
 export type LandingPageContentQueryResult = {
 	_id: string;
 	slug: string;
@@ -972,7 +972,7 @@ export type LandingPageContentQueryResult = {
 					| Array<{
 							title: string;
 							slug: string;
-							shortDescription: string;
+							description: string;
 					  }>
 					| Array<never>;
 				storyCoverImages:
@@ -1174,7 +1174,7 @@ export type AllContributorsQueryResult = Array<{
 
 // Source: ../src/api/_queries/literary-work.query.ts
 // Variable: literaryWorkBySlugQuery
-// Query: *[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    coverImage,    editorialNote,    'badLanguage': coalesce(badLanguage, false),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    totalReadingTime,    'sectionCount': count(content),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, []),    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription        }    }, []),    'authors': coalesce(authors[]-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                shortDescription            }        }, []),        'tags': []    }, []),    'content': coalesce(content[]{        _key,        title,        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),        body,        readingTime    }, [])}[0]
+// Query: *[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    coverImage,    editorialNote,    'badLanguage': coalesce(badLanguage, false),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    totalReadingTime,    'sectionCount': count(content),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        description    }, []),    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            description        }    }, []),    'authors': coalesce(authors[]-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                description            }        }, []),        'tags': []    }, []),    'content': coalesce(content[]{        _key,        title,        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),        body,        readingTime    }, [])}[0]
 export type LiteraryWorkBySlugQueryResult = {
 	_id: string;
 	slug: string;
@@ -1196,7 +1196,7 @@ export type LiteraryWorkBySlugQueryResult = {
 		| Array<{
 				title: string;
 				slug: string;
-				shortDescription: string;
+				description: string;
 		  }>
 		| Array<never>;
 	mediaSources:
@@ -1250,7 +1250,7 @@ export type LiteraryWorkBySlugQueryResult = {
 				resourceType: {
 					slug: string;
 					title: string;
-					shortDescription: string;
+					description: string;
 				};
 		  }>
 		| Array<never>;
@@ -1292,7 +1292,7 @@ export type LiteraryWorkBySlugQueryResult = {
 					resourceType: {
 						slug: string;
 						title: string;
-						shortDescription: string;
+						description: string;
 					};
 			  }>
 			| Array<never>;
@@ -1314,7 +1314,7 @@ export type LiteraryWorkBySlugQueryResult = {
 
 // Source: ../src/api/_queries/literary-work.query.ts
 // Variable: literaryWorkSectionBySlugQuery
-// Query: *[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    coverImage,    editorialNote,    'badLanguage': coalesce(badLanguage, false),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    totalReadingTime,    'sectionCount': count(content),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, []),    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription        }    }, []),    'authors': coalesce(authors[]-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                shortDescription            }        }, []),        'tags': []    }, []),    'section': content[$section...$sectionEnd]{        _key,        title,        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),        body,        readingTime    }}[0]
+// Query: *[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    coverImage,    editorialNote,    'badLanguage': coalesce(badLanguage, false),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    totalReadingTime,    'sectionCount': count(content),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        description    }, []),    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            description        }    }, []),    'authors': coalesce(authors[]-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                description            }        }, []),        'tags': []    }, []),    'section': content[$section...$sectionEnd]{        _key,        title,        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),        body,        readingTime    }}[0]
 export type LiteraryWorkSectionBySlugQueryResult = {
 	_id: string;
 	slug: string;
@@ -1336,7 +1336,7 @@ export type LiteraryWorkSectionBySlugQueryResult = {
 		| Array<{
 				title: string;
 				slug: string;
-				shortDescription: string;
+				description: string;
 		  }>
 		| Array<never>;
 	mediaSources:
@@ -1390,7 +1390,7 @@ export type LiteraryWorkSectionBySlugQueryResult = {
 				resourceType: {
 					slug: string;
 					title: string;
-					shortDescription: string;
+					description: string;
 				};
 		  }>
 		| Array<never>;
@@ -1432,7 +1432,7 @@ export type LiteraryWorkSectionBySlugQueryResult = {
 					resourceType: {
 						slug: string;
 						title: string;
-						shortDescription: string;
+						description: string;
 					};
 			  }>
 			| Array<never>;
@@ -1486,7 +1486,7 @@ export type SitemapSlugsQueryResult = {
 
 // Source: ../src/api/_queries/story.query.ts
 // Variable: storiesByAuthorSlugQuery
-// Query: *[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))][$start...$end]{    _id,    'slug': slug.current,    title,    'badLanguage': coalesce(badLanguage, false),    'body': coalesce(body[0...3], []),    'originalPublication': coalesce(originalPublication, ''),    approximateReadingTime,    coverImage,    'mediaSources': coalesce(mediaSources[], []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription        }    }, []),}|order(title asc)
+// Query: *[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))][$start...$end]{    _id,    'slug': slug.current,    title,    'badLanguage': coalesce(badLanguage, false),    'body': coalesce(body[0...3], []),    'originalPublication': coalesce(originalPublication, ''),    approximateReadingTime,    coverImage,    'mediaSources': coalesce(mediaSources[], []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            description        }    }, []),}|order(title asc)
 export type StoriesByAuthorSlugQueryResult = Array<{
 	_id: string;
 	slug: string;
@@ -1581,7 +1581,7 @@ export type StoriesByAuthorSlugQueryResult = Array<{
 				resourceType: {
 					slug: string;
 					title: string;
-					shortDescription: string;
+					description: string;
 				};
 		  }>
 		| Array<never>;
@@ -1589,7 +1589,7 @@ export type StoriesByAuthorSlugQueryResult = Array<{
 
 // Source: ../src/api/_queries/story.query.ts
 // Variable: storyBySlugQuery
-// Query: *[_type == 'story' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,     'badLanguage': coalesce(badLanguage, false),    'epigraphs': coalesce(epigraphs[]{        text,        'reference': coalesce(reference[], [])    }, []),    'body': coalesce(body, []),    'review': coalesce(review, []),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    'updatedAt': _updatedAt,    approximateReadingTime,    coverImage,    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            shortDescription        }    }, []),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, []),    'author': author-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                shortDescription            }        }, []),        'tags': []    }}[0]
+// Query: *[_type == 'story' && slug.current == $slug && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,     'badLanguage': coalesce(badLanguage, false),    'epigraphs': coalesce(epigraphs[]{        text,        'reference': coalesce(reference[], [])    }, []),    'body': coalesce(body, []),    'review': coalesce(review, []),    'originalPublication': coalesce(originalPublication, ''),    'publishedAt': coalesce(publishedAt, _createdAt),    'updatedAt': _updatedAt,    approximateReadingTime,    coverImage,    'mediaSources': coalesce(mediaSources[]{        ...,        _type == 'spaceRecording' => {            'audioUrl': audioFile.asset->url        }    }, []),    'resources': coalesce(resources[]{        title,        url,        resourceType->{            'slug': slug.current,            title,            description        }    }, []),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        description    }, []),    'author': author-> {        _id,        'slug': slug.current,        name,        image,        nationality->,        biography,        bornOn,        bornOnYear,        diedOn,        diedOnYear,        'resources': coalesce(resources[]{            title,            url,            resourceType->{                'slug': slug.current,                title,                description            }        }, []),        'tags': []    }}[0]
 export type StoryBySlugQueryResult = {
 	_id: string;
 	slug: string;
@@ -1694,7 +1694,7 @@ export type StoryBySlugQueryResult = {
 				resourceType: {
 					slug: string;
 					title: string;
-					shortDescription: string;
+					description: string;
 				};
 		  }>
 		| Array<never>;
@@ -1702,7 +1702,7 @@ export type StoryBySlugQueryResult = {
 		| Array<{
 				title: string;
 				slug: string;
-				shortDescription: string;
+				description: string;
 		  }>
 		| Array<never>;
 	author: {
@@ -1743,7 +1743,7 @@ export type StoryBySlugQueryResult = {
 					resourceType: {
 						slug: string;
 						title: string;
-						shortDescription: string;
+						description: string;
 					};
 			  }>
 			| Array<never>;
@@ -1948,7 +1948,7 @@ export type AllStoriesQueryResult = Array<{
 
 // Source: ../src/api/_queries/storylist.query.ts
 // Variable: storylistTeasersQuery
-// Query: *[_type == 'storylist' && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    description,    featuredImage,    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, []),    'storyCoverImages': coalesce(stories[]->coverImage, []),    'count': coalesce(count(stories), 0),    config,    'tabs': [],		'mediaSources': coalesce(mediaSources[], []),    }
+// Query: *[_type == 'storylist' && !(_id in path('drafts.**'))]{    _id,    'slug': slug.current,    title,    description,    featuredImage,    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        description    }, []),    'storyCoverImages': coalesce(stories[]->coverImage, []),    'count': coalesce(count(stories), 0),    config,    'tabs': [],		'mediaSources': coalesce(mediaSources[], []),    }
 export type StorylistTeasersQueryResult = Array<{
 	_id: string;
 	slug: string;
@@ -1965,7 +1965,7 @@ export type StorylistTeasersQueryResult = Array<{
 		| Array<{
 				title: string;
 				slug: string;
-				shortDescription: string;
+				description: string;
 		  }>
 		| Array<never>;
 	storyCoverImages:
@@ -2029,7 +2029,7 @@ export type StorylistTeasersQueryResult = Array<{
 
 // Source: ../src/api/_queries/storylist.query.ts
 // Variable: storylistQuery
-// Query: *[_type == 'storylist' && slug.current == $slug && !(_id in path('drafts.**'))][0]{    _id,    'slug': slug.current,    title,    description,    featuredImage,    'storyCoverImages': coalesce(stories[0...3]->coverImage, []),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        shortDescription    }, []),    'stories': coalesce(stories[]->{        _id,        'slug': slug.current,        title,        badLanguage,        'body': coalesce(body[0...3], []),        originalPublication,        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author->{            _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    }, []),    'count': coalesce(count(stories), 0),    config,    'tabs': coalesce(tabs[], []),		'mediaSources': coalesce(mediaSources[]{			...,			_type == 'spaceRecording' => {				'audioUrl': audioFile.asset->url			}		}, []),    }
+// Query: *[_type == 'storylist' && slug.current == $slug && !(_id in path('drafts.**'))][0]{    _id,    'slug': slug.current,    title,    description,    featuredImage,    'storyCoverImages': coalesce(stories[0...3]->coverImage, []),    'tags': coalesce(tags[] -> {        title,        'slug': slug.current,        description    }, []),    'stories': coalesce(stories[]->{        _id,        'slug': slug.current,        title,        badLanguage,        'body': coalesce(body[0...3], []),        originalPublication,        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author->{            _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    }, []),    'count': coalesce(count(stories), 0),    config,    'tabs': coalesce(tabs[], []),		'mediaSources': coalesce(mediaSources[]{			...,			_type == 'spaceRecording' => {				'audioUrl': audioFile.asset->url			}		}, []),    }
 export type StorylistQueryResult = {
 	_id: string;
 	slug: string;
@@ -2055,7 +2055,7 @@ export type StorylistQueryResult = {
 		| Array<{
 				title: string;
 				slug: string;
-				shortDescription: string;
+				description: string;
 		  }>
 		| Array<never>;
 	stories:
@@ -2245,22 +2245,22 @@ export type StorylistQueryResult = {
 import '@sanity/client';
 declare module '@sanity/client' {
 	interface SanityQueries {
-		"\n*[_type == 'author' && slug.current == $slug && !(_id in path('drafts.**'))][0]\n{\n    _id,\n    'slug': slug.current,\n    'createdAt': _createdAt,\n    'updatedAt': _updatedAt,\n    name,\n    image,\n    nationality->,\n    biography,\n    bornOn,\n\t\tbornOnYear,\n    diedOn,\n\t\tdiedOnYear,\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n        \t'slug': slug.current,\n        \ttitle,\n        \tshortDescription\n        }\n    }, []),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, [])\n}": AuthorBySlugQueryResult;
+		"\n*[_type == 'author' && slug.current == $slug && !(_id in path('drafts.**'))][0]\n{\n    _id,\n    'slug': slug.current,\n    'createdAt': _createdAt,\n    'updatedAt': _updatedAt,\n    name,\n    image,\n    nationality->,\n    biography,\n    bornOn,\n\t\tbornOnYear,\n    diedOn,\n\t\tdiedOnYear,\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n        \t'slug': slug.current,\n        \ttitle,\n        \tdescription\n        }\n    }, []),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, [])\n}": AuthorBySlugQueryResult;
 		"\n*[_type == 'author' && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    name,\n    image,\n    nationality->,\n    bornOn,\n \t\tbornOnYear,\n    diedOn,\n    diedOnYear,\n    'resources': []\n}|order(name asc)": AuthorsQueryResult;
 		"\n*[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{\n    _id,\n    name,\n    'mostRead': coalesce(mostRead[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        badLanguage,\n        'body': [],\n        originalPublication,\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[])\n}": RotatingContentQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current in $slugs]{\n\t\t_id,\n\t\t'slug': slug.current,\n\t\tconfig,\n}": LandingPageListQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{\n    _id,\n    _type,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[],[]),\n    'campaigns': coalesce(campaigns[],[]),\n    'latestReads': coalesce(latestReads,[]),\n} | order(config desc, _createdAt desc)[0]\n": LatestLandingPageReferencesQueryResult;
-		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{\n    _id,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[]->{\n        _id,\n        title,\n        'slug': slug.current,\n        description,\n        featuredImage,\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            shortDescription\n        }, []),\n        'storyCoverImages': coalesce(stories[]->coverImage, []),\n        'count': coalesce(count(stories), 0),\n\t\t\t\tconfig,\n\t\t\t\t'tabs': [],\n\t      'mediaSources': coalesce(mediaSources[], []),\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'image': contents.xs.image\n            },\n            'md': {\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'latestReads': coalesce(latestReads[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        badLanguage,\n        'body': [],\n        originalPublication,\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> { \n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[]),\n}": LandingPageContentQueryResult;
+		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{\n    _id,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[]->{\n        _id,\n        title,\n        'slug': slug.current,\n        description,\n        featuredImage,\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCoverImages': coalesce(stories[]->coverImage, []),\n        'count': coalesce(count(stories), 0),\n\t\t\t\tconfig,\n\t\t\t\t'tabs': [],\n\t      'mediaSources': coalesce(mediaSources[], []),\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'image': contents.xs.image\n            },\n            'md': {\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'latestReads': coalesce(latestReads[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        badLanguage,\n        'body': [],\n        originalPublication,\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> { \n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[]),\n}": LandingPageContentQueryResult;
 		"\n*[_type == 'contributor' && !(_id in path('drafts.**'))]\n{\n\tname,\n\t'slug': slug.current,\n\tarea,\n\tlink {\n\t\thandle,\n\t\turl\n\t},\n\tnotes\n}|order(name asc)\n": AllContributorsQueryResult;
-		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                shortDescription\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'content': coalesce(content[]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }, [])\n}[0]": LiteraryWorkBySlugQueryResult;
-		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                shortDescription\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'section': content[$section...$sectionEnd]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }\n}[0]": LiteraryWorkSectionBySlugQueryResult;
+		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            description\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                description\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'content': coalesce(content[]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }, [])\n}[0]": LiteraryWorkBySlugQueryResult;
+		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            description\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                description\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'section': content[$section...$sectionEnd]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }\n}[0]": LiteraryWorkSectionBySlugQueryResult;
 		"\n*[_type == 'literaryWork' && !(_id in path('drafts.**')) && _id > $cursor\n  && (!defined(totalReadingTime) || count(content[!defined(readingTime)]) > 0)]\n| order(_id asc) [0...$pageSize] {\n    _id,\n    'slug': slug.current,\n    totalReadingTime,\n    'content': coalesce(content[]{ _key, body, readingTime }, [])\n}": ReadingTimeBackfillCandidatesQueryResult;
 		'{\n\t"stories": *[_type == "story" && !(_id in path(\'drafts.**\'))]{ "slug": slug.current, "lastmod": _updatedAt },\n\t"authors": *[_type == "author" && !(_id in path(\'drafts.**\'))]{ "slug": slug.current, "lastmod": _updatedAt },\n\t"storylists": *[_type == "storylist" && !(_id in path(\'drafts.**\'))]{ "slug": slug.current, "lastmod": _updatedAt }\n}': SitemapSlugsQueryResult;
-		"\n*[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))][$start...$end]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'badLanguage': coalesce(badLanguage, false),\n    'body': coalesce(body[0...3], []),\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription\n        }\n    }, []),\n}|order(title asc)": StoriesByAuthorSlugQueryResult;
-		"\n*[_type == 'story' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title, \n    'badLanguage': coalesce(badLanguage, false),\n    'epigraphs': coalesce(epigraphs[]{\n        text,\n        'reference': coalesce(reference[], [])\n    }, []),\n    'body': coalesce(body, []),\n    'review': coalesce(review, []),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    'updatedAt': _updatedAt,\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            shortDescription\n        }\n    }, []),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'author': author-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                shortDescription\n            }\n        }, []),\n        'tags': []\n    }\n}[0]": StoryBySlugQueryResult;
+		"\n*[_type == 'story' && author->slug.current == $slug && !(_id in path('drafts.**'))][$start...$end]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'badLanguage': coalesce(badLanguage, false),\n    'body': coalesce(body[0...3], []),\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            description\n        }\n    }, []),\n}|order(title asc)": StoriesByAuthorSlugQueryResult;
+		"\n*[_type == 'story' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title, \n    'badLanguage': coalesce(badLanguage, false),\n    'epigraphs': coalesce(epigraphs[]{\n        text,\n        'reference': coalesce(reference[], [])\n    }, []),\n    'body': coalesce(body, []),\n    'review': coalesce(review, []),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    'updatedAt': _updatedAt,\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            description\n        }\n    }, []),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'author': author-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                description\n            }\n        }, []),\n        'tags': []\n    }\n}[0]": StoryBySlugQueryResult;
 		"\n*[_type == 'story' && slug.current in $slugs && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'badLanguage': coalesce(badLanguage, false),\n    'epigraphs': [],\n    'body': [],\n    'review': [],\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': [],\n    'author': author-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': []\n    }\n}": StoriesBySlugsQueryResult;
 		"\n*[_type == 'story' && !(_id in path('drafts.**'))]\n[$start...$end]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    'badLanguage': coalesce(badLanguage, false),\n    'body': [],\n    'review': [],\n    'originalPublication': coalesce(originalPublication, ''),\n    approximateReadingTime,\n    coverImage,\n    'mediaSources': coalesce(mediaSources[], []),\n    'resources': [],\n    'author': author-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': []\n    }\n}|order(title asc)": AllStoriesQueryResult;
-		"\n*[_type == 'storylist' && !(_id in path('drafts.**'))]{\n    _id,\n    'slug': slug.current,\n    title,\n    description,\n    featuredImage,\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'storyCoverImages': coalesce(stories[]->coverImage, []),\n    'count': coalesce(count(stories), 0),\n    config,\n    'tabs': [],\n\t\t'mediaSources': coalesce(mediaSources[], []),\n    }\n": StorylistTeasersQueryResult;
-		"\n*[_type == 'storylist' && slug.current == $slug && !(_id in path('drafts.**'))][0]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    description,\n    featuredImage,\n    'storyCoverImages': coalesce(stories[0...3]->coverImage, []),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        shortDescription\n    }, []),\n    'stories': coalesce(stories[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        badLanguage,\n        'body': coalesce(body[0...3], []),\n        originalPublication,\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    }, []),\n    'count': coalesce(count(stories), 0),\n    config,\n    'tabs': coalesce(tabs[], []),\n\t\t'mediaSources': coalesce(mediaSources[]{\n\t\t\t...,\n\t\t\t_type == 'spaceRecording' => {\n\t\t\t\t'audioUrl': audioFile.asset->url\n\t\t\t}\n\t\t}, []),\n    }\n": StorylistQueryResult;
+		"\n*[_type == 'storylist' && !(_id in path('drafts.**'))]{\n    _id,\n    'slug': slug.current,\n    title,\n    description,\n    featuredImage,\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'storyCoverImages': coalesce(stories[]->coverImage, []),\n    'count': coalesce(count(stories), 0),\n    config,\n    'tabs': [],\n\t\t'mediaSources': coalesce(mediaSources[], []),\n    }\n": StorylistTeasersQueryResult;
+		"\n*[_type == 'storylist' && slug.current == $slug && !(_id in path('drafts.**'))][0]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    description,\n    featuredImage,\n    'storyCoverImages': coalesce(stories[0...3]->coverImage, []),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'stories': coalesce(stories[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        badLanguage,\n        'body': coalesce(body[0...3], []),\n        originalPublication,\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    }, []),\n    'count': coalesce(count(stories), 0),\n    config,\n    'tabs': coalesce(tabs[], []),\n\t\t'mediaSources': coalesce(mediaSources[]{\n\t\t\t...,\n\t\t\t_type == 'spaceRecording' => {\n\t\t\t\t'audioUrl': audioFile.asset->url\n\t\t\t}\n\t\t}, []),\n    }\n": StorylistQueryResult;
 	}
 }


### PR DESCRIPTION
Renombra `shortDescription` a `description` en `resourceType` y `tag`, con su cadena completa: schema de Sanity → GROQ → typegen → ACL → modelo de dominio → corpus de mocks → documentación.

El prefijo `short` distinguía el campo del `description` de tipo `blockContent` que convivía con él en ambos tipos. Dados de baja aquellos, el nombre describía una contraposición que ya no existe.

## Divergencia respecto del alcance del issue

El punto 5 del issue pide **una** migración que copie el campo y elimine el viejo en la misma corrida. Se implementaron **dos**, y conviene explicar por qué.

El campo es `Rule.required()`, el mapper lo asigna sin fallback y la proyección GROQ cambia de nombre en el mismo commit. Con una corrida única no hay orden seguro:

| Orden | Qué pasa |
| --- | --- |
| Migrar y después desplegar | El código todavía desplegado proyecta `shortDescription`, que ya no existe → `null` en un contrato declarado `string` |
| Desplegar y después migrar | El código nuevo proyecta `description`, que todavía no existe → `null` en el mismo contrato |

La ventana no es un error ruidoso: GROQ devuelve `null` para un campo ausente y el mapper lo propaga, así que serían cuatro módulos sirviendo la descripción vacía sin que nada lo señale. A diferencia de la migración de la biografía a Markdown —donde las dos formas del dato son estructuralmente incompatibles bajo la misma clave y no había alternativa—, acá el costo de eliminar la ventana es un directorio de migración más.

Se descartaron también un fallback `description ?? shortDescription` en el mapper (introduce opcionalidad en el contrato requerido, justo la deuda que el issue viene a saldar) y un alias en GROQ (deja el nombre viejo vivo en el documento, incumpliendo el criterio de aceptación).

Otras dos precisiones sobre el alcance declarado, verificadas contra el código: los schemas **no** declaran `prepare` —es una sola referencia de preview por schema, `select.subtitle`—, y los mappers **no** construyen con spread, así que el rename no viajaba solo (`functions.ts:151` y `:166` asignan explícitamente).

## Cambios

- **Schemas** (`cms/schemas/tag.ts`, `cms/schemas/resourceType.ts`): el campo y su `preview.select.subtitle`. Se conserva `Rule.required()` — el rename no introduce opcionalidad.
- **GROQ**: 15 proyecciones en los cinco archivos de `src/api/_queries/`. Al ser proyecciones bare quedan como `description` a secas, sin alias.
- **ACL y dominio**: `mapResources`, `mapTags`, `ResourceType.description: string` y `Tag.description: string`.
- **Corpus**: los literales de `src/mocks/`. El barrido lo guió `tsc`, porque `RawTag` deriva del typegen.
- **Generados**: `cms/schema.json` y `src/sanity/types.ts`. Salen de `pnpm sanity:run-typegen-generator`, corrido desde el worktree con `cms/` instalado — el target re-extrae el schema antes de generar, así que no hay riesgo de tipar contra un `schema.json` viejo. El diff de ambos se verificó acotado al rename, sin churn ajeno.
- **Studio**: el label del campo pasó de `'Descripción breve'` a `'Descripción'`. Está fuera del alcance literal del issue, pero el término que el rename retira del modelo no tenía por qué sobrevivir en la única superficie donde el modelo se edita.
- **Referencias**: `sanity-migrations.md` gana el patrón expand/contract para renames de campo requerido —con su interlock, la semántica de backfill y la nota de que cada fase corre por dataset— y la convención de spec co-locado, que este PR estrena; `testing.md` suma la fila correspondiente a su checklist.
- **Documentación**: `docs/DOMAIN_MODEL.md`, más una nota de desambiguación — tras el rename el nombre `description` convive con tres tipos distintos en el modelo (texto plano en `Tag`/`ResourceType`, Portable Text en `Storylist`, HTML saneado en `Media`). `.claude/references/**` no tenía ocurrencias.

## Pasos manuales pendientes

Ninguna de las dos migraciones se corrió: la sesión no tiene token de escritura y el dry-run contra el dataset quedó fuera de su alcance de permisos. **Quedan pendientes y ninguno es opcional.**

**Antes de mergear este PR**, aplicar la fase 1 (`copy-short-description-to-description`) en los **tres** datasets, con dry-run previo:

```bash
pnpm exec sanity migration run copy-short-description-to-description                   # dry-run
pnpm exec sanity migration run copy-short-description-to-description --no-dry-run
```

Los tres datasets son `development`, `staging` y `production`. `staging` es el que consumen los e2e de CI (`.github/workflows/ci.yml:184` y `:221`) y es el más fácil de pasar por alto: como el campo no se renderiza en ninguna superficie, un `staging` sin migrar deja ese gate **en verde sobre datos incompletos**.

**Después de verificar el código nuevo en producción**, aplicar la fase 2 (`unset-legacy-short-description`) en los mismos tres datasets. Si alguna corrida lanza, el interlock está señalando un documento al que la fase 1 no llegó: corresponde corregir ese documento, no saltear el guard.

Conviene anotar en el issue el conteo de documentos que reporte cada dry-run, que es lo que su criterio de aceptación pide como dry-run documentado.

## Plan de pruebas

Gates corridos en local, todos en verde sobre el commit final: `typecheck` (`tsc --noEmit`), `test` (1409 pasados, 3 salteados), `lint`, `stylelint`, `check-agents`, más `sanity:typecheck` y `sanity:test` (52 pasados). Los cinco restantes —`build`, `storybook`, `studio-build`, `e2e`, `guard-config`— corren en este PR.

Cobertura nueva: las dos migraciones traen su `index.spec.ts`, que ejercita `migrate.document` como la función pura que es. Entre ambas cubren el camino feliz, la idempotencia en cada estado por el que pasa un documento, y cada uno de los abortos:

- La fase de copia no pisa una descripción que divergió del valor viejo (una edición hecha con el schema ya desplegado), completa una presente pero en blanco, y aborta cuando el documento no tiene descripción bajo **ninguno** de los dos nombres. Ese último caso no es hipotético: el campo requerido lo hace cumplir el editor del Studio, no la API, y sin el aborto un documento así atravesaba las dos fases en silencio.
- La fase de baja da de baja el campo viejo incluso puesto en `null` —la presencia se comprueba por clave, no por tipo— y aborta si la descripción todavía no está bajo el nombre nuevo.

Del lado del ACL, los asserts de `functions.spec.ts` que comparan la forma exacta del objeto emitido (`Object.keys(...).sort()`) son los que impiden que el rename pase a medias: fallarían si el mapper emitiera el nombre viejo o los dos a la vez.

Lo que **no** se verificó y queda para los pasos manuales de arriba: el comportamiento contra un dataset real. Ninguna de las dos migraciones se corrió.

Closes #2066.
