### PR TITLE
[#1828] - Define el modelo de dominio Collection

### DIFF
--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -147,6 +147,9 @@ AuthorTeaser;
 
 Storylist;
 StorylistTeaser;
+
+Collection;
+CollectionTeaser;
 ```
 
 Cada vista es una proyección coherente del mismo agregado; el mapper correspondiente del ACL produce exactamente la vista que la query GROQ pidió.

--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -39,7 +39,7 @@
 
 ## Estructura por bounded context
 
-Organizá el modelo de dominio por **contexto acotado**. Cuentoneta define cuatro (ver `docs/DOMAIN_MODEL.md`): **Catálogo de Contenido** (`Story`, `Author`, `Resource`, `Media`, `Epigraph`, `LiteraryWork`), **Curación y Colecciones** (`Storylist`), **Administración del Proyecto** (`Contributor`) y **Página de Inicio** (`LandingPageContent`, `ContentCampaign`).
+Organizá el modelo de dominio por **contexto acotado**. Cuentoneta define cuatro (ver `docs/DOMAIN_MODEL.md`): **Catálogo de Contenido** (`Story`, `Author`, `Resource`, `Media`, `Epigraph`, `LiteraryWork`), **Curación y Colecciones** (`Storylist`, `Collection`), **Administración del Proyecto** (`Contributor`) y **Página de Inicio** (`LandingPageContent`, `ContentCampaign`).
 
 Hoy los tipos de dominio viven en `src/models/` (frontend) y la ACL/dominio del backend en `src/api/`. La estructura **objetivo** por contexto (roadmap #1503) agrupa, por agregado, el contrato + el modelo + el mapper + su spec:
 
@@ -291,7 +291,7 @@ Un **agregado** es un cluster de objetos de dominio tratado como una unidad para
 
 **Cómo identificar la raíz:** buscá la entidad que **posee más invariantes de negocio**; esa entidad es la raíz, porque las invariantes solo se garantizan si toda mutación pasa por ella.
 
-En cuentoneta, **`LiteraryWork`** es la raíz de agregado con invariantes **hechas cumplir en código**: posee `authors: Author[]` (1..N), `content: LiteraryWorkSection[]`, `resources`, `tags` y `mediaSources`. Sus invariantes, garantizadas por la factory `createLiteraryWork` (`src/models/literary-work.model.ts`):
+En cuentoneta hay dos raíces de agregado con invariantes **hechas cumplir en código**: `LiteraryWork` y `Collection` — las dos más nuevas del catálogo, que es la dirección hacia la que el resto se mueve. **`LiteraryWork`** posee `authors: Author[]` (1..N), `content: LiteraryWorkSection[]`, `resources`, `tags` y `mediaSources`. Sus invariantes, garantizadas por la factory `createLiteraryWork` (`src/models/literary-work.model.ts`):
 
 - El `slug` tiene formato válido (VO `Slug`) e inmutable una vez creado.
 - El `title` no puede estar vacío.
@@ -341,7 +341,9 @@ export function createStory(options: CreateStoryOptions): Story {
 }
 ```
 
-`Author` y `Storylist` son raíces de sus propios agregados. **`Storylist`** posee la invariante _`count` coincide con el número real de `stories`_; **`Author`** posee _`diedOn` (si existe) es posterior a `bornOn`_ y _`nationality` siempre presente_ — ambas, como las de `Story`, descritas pero no hechas cumplir en código (roadmap #1503).
+**`Collection`** es la otra raíz con enforcement real: la factory `createCollection` (`src/models/collection.model.ts`) exige título no vacío, al menos una obra y un `slug` válido, y **deriva** `count` de las obras que transporta en vez de recibirlo — válido mientras la query no acote el listado.
+
+`Author` y `Storylist` son raíces de sus propios agregados, con invariantes solo descritas. **`Storylist`** posee la invariante _`count` coincide con el número real de `stories`_; **`Author`** posee _`diedOn` (si existe) es posterior a `bornOn`_ y _`nationality` siempre presente_ — ambas, como las de `Story`, descritas pero no hechas cumplir en código (roadmap #1503).
 
 > **Nota:** la frontera del agregado es también la frontera de consistencia — ver [Decisiones de consistencia](#decisiones-de-consistencia).
 >
@@ -410,7 +412,7 @@ Un **bounded context** es un ámbito dentro del cual aplican consistentemente un
 | Contexto                   | Agregados raíz                          | Perspectiva                                        |
 | -------------------------- | --------------------------------------- | -------------------------------------------------- |
 | **Catálogo de Contenido**  | `Story`, `Author`, `LiteraryWork`       | Inventario completo de historias y autores         |
-| **Curación y Colecciones** | `Storylist`                             | Agrupar y ordenar historias en colecciones         |
+| **Curación y Colecciones** | `Storylist`, `Collection`               | Agrupar y ordenar obras en colecciones             |
 | **Administración**         | `Contributor`                           | Colaboradores del proyecto por área                |
 | **Página de Inicio**       | `LandingPageContent`, `ContentCampaign` | Agregar contenido de varios contextos para el home |
 
@@ -427,7 +429,7 @@ Cada contexto **posee las definiciones** de sus términos, co-localizadas con su
 | **Slug**           | Identificador amigable, único e inmutable basado en el título                        | Todos                 |
 | **Epígrafe**       | Cita literaria que precede al texto principal                                        | Catálogo de Contenido |
 | **Teaser**         | Vista reducida de una entidad para listados y navegación                             | Todos                 |
-| **Colección**      | Agrupación temática u editorial de historias (`Storylist`)                           | Curación              |
+| **Colección**      | Agrupación temática u editorial de obras (`Collection`; `Storylist`, en baja)        | Curación              |
 | **Recurso**        | Enlace externo a información complementaria (`Resource`)                             | Catálogo de Contenido |
 | **Etiqueta**       | Tag de taxonomía (`Tag`) referenciable desde `Story`, `Author` y `Storylist`         | Todos                 |
 | **Curaduría**      | Proceso de seleccionar, ordenar y presentar historias                                | Curación              |

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -70,7 +70,7 @@ POST /api/story/most-read          # Obtener historias más leídas
 **Agregados Raíz:**
 
 - `Storylist` - Colecciones de historias
-- `Collection` - Colecciones de obras literarias (entidad paralela a `Storylist`, que la reemplaza). Hoy existe solo como document type del Studio: el modelo de dominio, el backend y el traspaso del contenido son trabajo posterior, y `Storylist` sigue vigente hasta que se complete
+- `Collection` - Colecciones de obras literarias (entidad paralela a `Storylist`, no la reemplaza todavía). El modelo de dominio ya existe (`createCollection`, con invariantes hechas cumplir en código, y su propio corpus de mocks); el backend (repository/service/controller) y el traspaso del contenido real desde el Studio siguen siendo trabajo posterior, y `Storylist` sigue vigente hasta que se complete
 
 **Responsabilidades:**
 
@@ -393,6 +393,69 @@ Las historias se referencian directamente en el array `stories`. Cada entrada es
 
 ---
 
+### Agregado: Collection (Colección de obras literarias)
+
+**Raíz de Agregado:** `Collection`
+
+> `Collection` es una **entidad paralela e independiente** a `Storylist`: agrupa `LiteraryWork` en vez de `Story`. Nace **en paralelo**, no la reemplaza — `Storylist` sigue vigente y sirviendo la página actual hasta su baja, que es un trabajo aparte. Es la **segunda** raíz de agregado con **invariantes hechas cumplir en código** (factory `createCollection` + el value object `Slug`, en `src/models/collection.model.ts`), después de `LiteraryWork`: `Storylist` y `Author` siguen teniendo las suyas descritas más abajo, pero no exigidas por un constructor. Esa es la dirección del proyecto, no una excepción puntual — cada entidad nueva del catálogo suma sus invariantes al código en vez de solo documentarlas.
+
+```typescript
+interface Collection {
+	// Identidad
+	_id: string; // Identificador único (Sanity)
+	slug: Slug; // Clave de negocio, invariante única (value object brandeado)
+	title: string; // Título de la colección
+
+	// Contenido
+	description: SanitizedHtml; // Markdown saneado a HTML — a diferencia de Storylist.description, no es Portable Text
+	imagery: CollectionImagery; // representative (portada editorial) o sample (portadas de las 3 primeras obras)
+	tags: Tag[]; // Etiquetas de categorización
+
+	// Configuración
+	config: {
+		showAuthors: boolean; // ¿Mostrar información de autores?
+	};
+
+	// Recursos Multimedia
+	mediaSources: Media[]; // Contenido multimedia asociado; alineado con el schema y con LiteraryWork.mediaSources (no `media`, como en Storylist)
+
+	// Metadatos
+	count: number; // Derivado: total real de obras literarias
+
+	// Composición
+	literaryWorks: LiteraryWorkTeaser[]; // Obras literarias en la colección (ordenadas)
+}
+```
+
+**Invariantes de Negocio (hechas cumplir en código por la factory `createCollection`):**
+
+- El `title` no puede estar vacío.
+- Debe tener **al menos una** obra literaria (`literaryWorks.length >= 1`).
+- El `slug` tiene formato válido (value object `Slug`, delegado a `createSlug`).
+- `count` se deriva en la factory (`literaryWorks.length`); no se recibe como dato, así que no puede discrepar del número real de obras.
+
+**Ciclo de Vida:**
+
+```
+Creación de colección → Adición de obras literarias → Publicación de colección
+```
+
+**Relación con LiteraryWork:**
+Las obras se referencian directamente en el array `literaryWorks`. Cada entrada es una proyección de tipo `LiteraryWorkTeaser`, igual que `Storylist.stories` proyecta `Story` a `StoryTeaserWithAuthor`.
+
+**Tres diferencias con `Storylist`** (más allá de agrupar `LiteraryWork` en vez de `Story`):
+
+- **Sin pestañas.** El diseño de la página nueva no las contempla.
+- **`description` es `SanitizedHtml`**, no `TextBlockContent[]`: el schema declara el campo como Markdown, lo que la saca del pipeline de Portable Text.
+- **El campo de multimedia se llama `mediaSources`**, no `media` — alineado con el schema y con `LiteraryWork`.
+
+**Vistas Polimórficas:**
+
+- `Collection` - Vista completa (incluye todas las obras literarias)
+- `CollectionTeaser` - Vista sin obras (`literaryWorks: Array<never>`)
+
+---
+
 ### Agregado: Contributor (Colaborador)
 
 **Raíz de Agregado:** `Contributor`
@@ -577,7 +640,7 @@ interface ResourceType {
 
 > El ícono que acompaña a un recurso en la interfaz lo resuelve el frontend a partir del `slug` del tipo, contra el mapa local de `@models/icon.model`. No viaja desde el CMS.
 
-> El nombre `description` no implica un mismo tipo en todo el modelo: en `ResourceType` y en [`Tag`](#tag-etiqueta) es texto plano, mientras que `Storylist.description` es Portable Text (`TextBlockContent[]`) y `Media.description` es HTML saneado. Conviene mirar la interfaz antes de asumir el formato.
+> El nombre `description` no implica un mismo tipo en todo el modelo: en `ResourceType` y en [`Tag`](#tag-etiqueta) es texto plano, mientras que `Storylist.description` es Portable Text (`TextBlockContent[]`), `Media.description` es HTML saneado y `Collection.description` es Markdown saneado a HTML. Conviene mirar la interfaz antes de asumir el formato.
 
 **Ejemplos de tipos:**
 
@@ -603,7 +666,7 @@ interface Tag {
 
 **Uso:** Clasificar contenido por tema, género, etc.
 
-> El nombre `description` no implica un mismo tipo en todo el modelo: en `Tag` y en [`ResourceType`](#resource-recurso-externo) es texto plano, mientras que `Storylist.description` es Portable Text (`TextBlockContent[]`) y `Media.description` es HTML saneado. Conviene mirar la interfaz antes de asumir el formato.
+> El nombre `description` no implica un mismo tipo en todo el modelo: en `Tag` y en [`ResourceType`](#resource-recurso-externo) es texto plano, mientras que `Storylist.description` es Portable Text (`TextBlockContent[]`), `Media.description` es HTML saneado y `Collection.description` es Markdown saneado a HTML. Conviene mirar la interfaz antes de asumir el formato.
 
 > Una etiqueta no lleva ícono: `TagComponent` renderiza solo su título. El CMS supo tener un campo de ícono, pero ninguna superficie lo mostraba.
 
@@ -686,20 +749,20 @@ El **Lenguaje Ubicuo** es el lenguaje estructurado alrededor del modelo de domin
 
 ### Términos Clave
 
-| Término                  | Definición                                                                                                        | Contexto              |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------- | --------------------- |
-| **Historia**             | Obra literaria curada y publicada en la plataforma                                                                | Catálogo de Contenido |
-| **Obra literaria**       | Obra con secciones/capítulos (`LiteraryWork`), paralela a Historia                                                | Catálogo de Contenido |
-| **Sección / Capítulo**   | Unidad de contenido de una obra literaria: epígrafes + cuerpo Markdown saneado                                    | Catálogo de Contenido |
-| **Anónimo**              | Author real del catálogo (slug `anonimo`) que representa la obra sin autoría atribuida (policy `isAnonymous`)     | Catálogo de Contenido |
-| **Slug**                 | Identificador amigable, único e inmutable basado en el título                                                     | Todos                 |
-| **Epígrafe**             | Cita literaria que precede al texto principal                                                                     | Catálogo de Contenido |
-| **Teaser**               | Vista reducida de una entidad para listados y navegación                                                          | Todos                 |
-| **Colección**            | Agrupación temática u editorial de historias (`Storylist`) o de obras literarias (`Collection`, que la reemplaza) | Curación              |
-| **Colaborador**          | Persona que contribuye al proyecto en algún rol                                                                   | Administración        |
-| **Recurso**              | Enlace externo a información complementaria                                                                       | Catálogo de Contenido |
-| **Campaña de Contenido** | Promoción temporal de contenido con variantes responsivas                                                         | Página de Inicio      |
-| **Curaduría**            | Proceso de seleccionar, ordenar y presentar historias                                                             | Curación              |
+| Término                  | Definición                                                                                                                             | Contexto              |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| **Historia**             | Obra literaria curada y publicada en la plataforma                                                                                     | Catálogo de Contenido |
+| **Obra literaria**       | Obra con secciones/capítulos (`LiteraryWork`), paralela a Historia                                                                     | Catálogo de Contenido |
+| **Sección / Capítulo**   | Unidad de contenido de una obra literaria: epígrafes + cuerpo Markdown saneado                                                         | Catálogo de Contenido |
+| **Anónimo**              | Author real del catálogo (slug `anonimo`) que representa la obra sin autoría atribuida (policy `isAnonymous`)                          | Catálogo de Contenido |
+| **Slug**                 | Identificador amigable, único e inmutable basado en el título                                                                          | Todos                 |
+| **Epígrafe**             | Cita literaria que precede al texto principal                                                                                          | Catálogo de Contenido |
+| **Teaser**               | Vista reducida de una entidad para listados y navegación                                                                               | Todos                 |
+| **Colección**            | Agrupación temática u editorial de historias (`Storylist`) o de obras literarias (`Collection`, en paralelo — no la reemplaza todavía) | Curación              |
+| **Colaborador**          | Persona que contribuye al proyecto en algún rol                                                                                        | Administración        |
+| **Recurso**              | Enlace externo a información complementaria                                                                                            | Catálogo de Contenido |
+| **Campaña de Contenido** | Promoción temporal de contenido con variantes responsivas                                                                              | Página de Inicio      |
+| **Curaduría**            | Proceso de seleccionar, ordenar y presentar historias                                                                                  | Curación              |
 
 ---
 

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -420,7 +420,7 @@ interface Collection {
 	mediaSources: Media[]; // Contenido multimedia asociado; alineado con el schema y con LiteraryWork.mediaSources (no `media`, como en Storylist)
 
 	// Metadatos
-	count: number; // Derivado: total real de obras literarias
+	count: number; // Derivado: total de las obras que el agregado transporta
 
 	// Composición
 	literaryWorks: LiteraryWorkTeaser[]; // Obras literarias en la colección (ordenadas)
@@ -432,7 +432,7 @@ interface Collection {
 - El `title` no puede estar vacío.
 - Debe tener **al menos una** obra literaria (`literaryWorks.length >= 1`).
 - El `slug` tiene formato válido (value object `Slug`, delegado a `createSlug`).
-- `count` se deriva en la factory (`literaryWorks.length`); no se recibe como dato, así que no puede discrepar del número real de obras.
+- `count` se deriva en la factory (`literaryWorks.length`); no se recibe como dato, así que no puede discrepar del número real de obras **mientras la query no acote `literaryWorks`**. Si el listado se pagina, el total pasa a ser un dato de entrada y la derivación deja de valer.
 
 **Ciclo de Vida:**
 

--- a/src/app/components/collection-teaser-card/collection-teaser-card-skeleton.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card-skeleton.ts
@@ -4,7 +4,7 @@ import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton.component';
 
 @Component({
-	selector: 'cuentoneta-collection-teaser-skeleton',
+	selector: 'cuentoneta-collection-teaser-card-skeleton',
 	imports: [SkeletonComponent, CoverImageSkeletonComponent],
 	template: `
 		<article class="flex items-start gap-5">
@@ -26,4 +26,4 @@ import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton
 		</article>
 	`,
 })
-export class CollectionTeaserSkeletonComponent {}
+export class CollectionTeaserCardSkeletonComponent {}

--- a/src/app/components/collection-teaser-card/collection-teaser-card.spec.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card.spec.ts
@@ -3,7 +3,7 @@ import { render, screen, within } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
 
 // Componentes
-import { CollectionTeaser } from './collection-teaser';
+import { CollectionTeaserCard } from './collection-teaser-card';
 
 // Mocks
 import { storylistTeaserRepresentativeMock, storylistTeaserSampleMock } from '@mocks/storylist.mock';
@@ -16,7 +16,7 @@ import { clearAllMocks } from '@test-utils';
 
 const collectionTeaserMock: StorylistTeaser = storylistTeaserRepresentativeMock;
 
-describe('CollectionTeaser', () => {
+describe('CollectionTeaserCard', () => {
 	const defaultProviders = [provideRouter([])];
 
 	beforeEach(() => {
@@ -26,7 +26,7 @@ describe('CollectionTeaser', () => {
 	// Pruebas de renderizado básico
 	describe('Renderizado del componente', () => {
 		it('should render the component', async () => {
-			const { container } = await render(CollectionTeaser, {
+			const { container } = await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -34,7 +34,7 @@ describe('CollectionTeaser', () => {
 		});
 
 		it('should render an article element', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -44,7 +44,7 @@ describe('CollectionTeaser', () => {
 		});
 
 		it('should not render link when collection is undefined', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				providers: defaultProviders,
 			});
 
@@ -57,7 +57,7 @@ describe('CollectionTeaser', () => {
 	// Pruebas del enlace de navegación
 	describe('Enlace de navegación', () => {
 		it('should render a link to the storylist page', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -67,7 +67,7 @@ describe('CollectionTeaser', () => {
 		});
 
 		it('should have correct routerLink with storylist slug', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -80,7 +80,7 @@ describe('CollectionTeaser', () => {
 	// Pruebas del cover de la colección
 	describe('Imagen de la colección', () => {
 		it('should render the cover image', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -89,7 +89,7 @@ describe('CollectionTeaser', () => {
 		});
 
 		it('should render a decorative cover with empty alt', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -101,7 +101,7 @@ describe('CollectionTeaser', () => {
 	// Variantes del objeto de valor `imagery`
 	describe('Variante de imagery', () => {
 		it('should render a single cover for representative imagery', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: storylistTeaserRepresentativeMock },
 				providers: defaultProviders,
 			});
@@ -110,7 +110,7 @@ describe('CollectionTeaser', () => {
 		});
 
 		it('should render 3 covers for sample imagery with three images', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: storylistTeaserSampleMock },
 				providers: defaultProviders,
 			});
@@ -124,7 +124,7 @@ describe('CollectionTeaser', () => {
 				imagery: { kind: 'sample', images: ['assets/img/mocks/stories/el-odio.png', '', ''] },
 			};
 
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: teaser },
 				providers: defaultProviders,
 			});
@@ -137,7 +137,7 @@ describe('CollectionTeaser', () => {
 	// Pruebas del título
 	describe('Título de la colección', () => {
 		it('should display the collection title', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -146,7 +146,7 @@ describe('CollectionTeaser', () => {
 		});
 
 		it('should render title inside the link', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -159,7 +159,7 @@ describe('CollectionTeaser', () => {
 	// Pruebas del footer con tags y contador
 	describe('Footer con tags y contador de historias', () => {
 		it('should display the story count', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -168,7 +168,7 @@ describe('CollectionTeaser', () => {
 		});
 
 		it('should display the tags', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -184,7 +184,7 @@ describe('CollectionTeaser', () => {
 	// Pruebas de inputs
 	describe('Inputs del componente', () => {
 		it('should accept a collection input', async () => {
-			const { fixture } = await render(CollectionTeaser, {
+			const { fixture } = await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -193,7 +193,7 @@ describe('CollectionTeaser', () => {
 		});
 
 		it('should have undefined collection by default', async () => {
-			const { fixture } = await render(CollectionTeaser, {
+			const { fixture } = await render(CollectionTeaserCard, {
 				providers: defaultProviders,
 			});
 
@@ -201,7 +201,7 @@ describe('CollectionTeaser', () => {
 		});
 
 		it('should update when collection input changes', async () => {
-			const { fixture } = await render(CollectionTeaser, {
+			const { fixture } = await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -222,7 +222,7 @@ describe('CollectionTeaser', () => {
 	// Pruebas de accesibilidad
 	describe('Accesibilidad', () => {
 		it('should have accessible link', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -232,7 +232,7 @@ describe('CollectionTeaser', () => {
 		});
 
 		it('should have a decorative cover and the link named by the collection title', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});
@@ -244,7 +244,7 @@ describe('CollectionTeaser', () => {
 		});
 
 		it('should use semantic article element', async () => {
-			await render(CollectionTeaser, {
+			await render(CollectionTeaserCard, {
 				inputs: { collection: collectionTeaserMock },
 				providers: defaultProviders,
 			});

--- a/src/app/components/collection-teaser-card/collection-teaser-card.stories.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card.stories.ts
@@ -1,18 +1,18 @@
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { CollectionTeaser } from './collection-teaser';
+import { CollectionTeaserCard } from './collection-teaser-card';
 import { provideRouter } from '@angular/router';
-import { CollectionTeaserSkeletonComponent } from './collection-teaser-skeleton';
+import { CollectionTeaserCardSkeletonComponent } from './collection-teaser-card-skeleton';
 import { storylistTeaserRepresentativeMock, storylistTeaserSampleMock } from '@mocks/storylist.mock';
 
-const meta: Meta<CollectionTeaser> = {
-	component: CollectionTeaser,
-	title: 'Componentes V3/CollectionTeaser',
+const meta: Meta<CollectionTeaserCard> = {
+	component: CollectionTeaserCard,
+	title: 'Componentes V3/CollectionTeaserCard',
 	decorators: [
 		applicationConfig({
 			providers: [provideRouter([])],
 		}),
 		moduleMetadata({
-			imports: [CollectionTeaserSkeletonComponent],
+			imports: [CollectionTeaserCardSkeletonComponent],
 		}),
 	],
 	parameters: {
@@ -21,7 +21,7 @@ const meta: Meta<CollectionTeaser> = {
 				sourceState: 'shown',
 			},
 			description: {
-				component: `<div><p>El <strong>CollectionTeaser</strong> es la tarjeta de una colección (storylist) para el Design System v3: portada, título, descripción y footer con tag y contador de historias. La portada se resuelve con el objeto de valor <strong>imagery</strong>: <strong>representative</strong> (una portada editorial propia de la colección) o <strong>sample</strong> (composición de 3 portadas de sus historias, con placeholder en los slots vacíos). Usa <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> para cada portada.</p></div>`,
+				component: `<div><p>El <strong>CollectionTeaserCard</strong> es la tarjeta de una colección (storylist) para el Design System v3: portada, título, descripción y footer con tag y contador de historias. La portada se resuelve con el objeto de valor <strong>imagery</strong>: <strong>representative</strong> (una portada editorial propia de la colección) o <strong>sample</strong> (composición de 3 portadas de sus historias, con placeholder en los slots vacíos). Usa <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> para cada portada.</p></div>`,
 			},
 		},
 	},
@@ -35,13 +35,13 @@ const meta: Meta<CollectionTeaser> = {
 };
 export default meta;
 
-export const Primary: StoryObj<CollectionTeaser> = {
+export const Primary: StoryObj<CollectionTeaserCard> = {
 	render: () => ({
 		props: { representative: storylistTeaserRepresentativeMock, sample: storylistTeaserSampleMock },
 		template: `
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 p-4">
-          <cuentoneta-collection-teaser class="card" [collection]="representative"/>
-          <cuentoneta-collection-teaser class="card" [collection]="sample"/>
+          <cuentoneta-collection-teaser-card class="card" [collection]="representative"/>
+          <cuentoneta-collection-teaser-card class="card" [collection]="sample"/>
     </div>
 `,
 	}),
@@ -54,7 +54,7 @@ export const Primary: StoryObj<CollectionTeaser> = {
 	},
 };
 
-export const Interactiva: StoryObj<CollectionTeaser & { kind: 'representative' | 'sample' }> = {
+export const Interactiva: StoryObj<CollectionTeaserCard & { kind: 'representative' | 'sample' }> = {
 	argTypes: {
 		kind: {
 			control: { type: 'inline-radio' },
@@ -68,7 +68,7 @@ export const Interactiva: StoryObj<CollectionTeaser & { kind: 'representative' |
 		},
 		template: `
 			<div class="card p-4">
-				<cuentoneta-collection-teaser [collection]="collection" />
+				<cuentoneta-collection-teaser-card [collection]="collection" />
 			</div>
 		`,
 	}),
@@ -82,16 +82,16 @@ export const Interactiva: StoryObj<CollectionTeaser & { kind: 'representative' |
 	},
 };
 
-export const Estados: StoryObj<CollectionTeaser & { loading: boolean }> = {
+export const Estados: StoryObj<CollectionTeaserCard & { loading: boolean }> = {
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
 	render: (args) => ({
 		props: args,
 		template: `
 			<div class="card p-4">
 				@if (loading) {
-					<cuentoneta-collection-teaser-skeleton class="w-full" />
+					<cuentoneta-collection-teaser-card-skeleton class="w-full" />
 				} @else {
-					<cuentoneta-collection-teaser [collection]="collection" />
+					<cuentoneta-collection-teaser-card [collection]="collection" />
 				}
 			</div>
 		`,

--- a/src/app/components/collection-teaser-card/collection-teaser-card.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card.ts
@@ -13,7 +13,7 @@ import { PortableTextParserComponent } from '../portable-text-parser/portable-te
 import { CoverImageComponent } from '../cover-image/cover-image.component';
 
 @Component({
-	selector: 'cuentoneta-collection-teaser',
+	selector: 'cuentoneta-collection-teaser-card',
 	imports: [RouterLink, PortableTextParserComponent, CoverImageComponent],
 
 	template: `
@@ -55,7 +55,7 @@ import { CoverImageComponent } from '../cover-image/cover-image.component';
 		</article>
 	`,
 })
-export class CollectionTeaser {
+export class CollectionTeaserCard {
 	public readonly collection = input<StorylistTeaser>();
 	protected readonly appRoutes = AppRoutes;
 

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.spec.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.spec.ts
@@ -5,8 +5,8 @@ import { provideRouter } from '@angular/router';
 
 // Componentes
 import { CollectionTeasersDeck } from './collection-teasers-deck';
-import { CollectionTeaser } from '@components/collection-teaser/collection-teaser';
-import { CollectionTeaserSkeletonComponent } from '@components/collection-teaser/collection-teaser-skeleton';
+import { CollectionTeaserCard } from '@components/collection-teaser-card/collection-teaser-card';
+import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
 
 // Mocks
 import { storylistTeaserRepresentativeMock } from '@mocks/storylist.mock';
@@ -29,7 +29,7 @@ describe('CollectionTeasersDeck', () => {
 	const defaultProviders = [provideRouter([])];
 
 	// Imports por defecto incluyendo los componentes reales
-	const defaultImports = [CollectionTeasersDeck, CollectionTeaser, CollectionTeaserSkeletonComponent];
+	const defaultImports = [CollectionTeasersDeck, CollectionTeaserCard, CollectionTeaserCardSkeletonComponent];
 
 	// Pruebas de renderizado básico
 	describe('Renderizado del componente', () => {

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.ts
@@ -1,11 +1,11 @@
 import { Component, input } from '@angular/core';
 import { StorylistTeaser } from '@models/storylist.model';
-import { CollectionTeaser } from '@components/collection-teaser/collection-teaser';
-import { CollectionTeaserSkeletonComponent } from '@components/collection-teaser/collection-teaser-skeleton';
+import { CollectionTeaserCard } from '@components/collection-teaser-card/collection-teaser-card';
+import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
 
 @Component({
 	selector: 'cuentoneta-collection-teasers-deck',
-	imports: [CollectionTeaser, CollectionTeaserSkeletonComponent],
+	imports: [CollectionTeaserCard, CollectionTeaserCardSkeletonComponent],
 	template: ` <div class="flex items-center justify-between">
 			<div class="flex flex-col content-between gap-1">
 				<h2 class="font-inter text-2xl font-bold">Colecciones</h2>
@@ -18,11 +18,11 @@ import { CollectionTeaserSkeletonComponent } from '@components/collection-teaser
 		<section class="mb-8 grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2">
 			@defer (when teasers().length > 0) {
 				@for (storylist of teasers(); track storylist.slug) {
-					<cuentoneta-collection-teaser [collection]="storylist" class="card w-full" />
+					<cuentoneta-collection-teaser-card [collection]="storylist" class="card w-full" />
 				}
 			} @loading (minimum 500ms) {
 				@for (_ of [].constructor(SKELETON_COUNT); track $index) {
-					<cuentoneta-collection-teaser-skeleton class="card w-full" />
+					<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
 				}
 			}
 		</section>`,

--- a/src/app/components/tag/tag.component.stories.ts
+++ b/src/app/components/tag/tag.component.stories.ts
@@ -36,7 +36,7 @@ export const Soft: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Variante <strong>soft</strong> (default): solo texto en brand-500, sin fondo. Comportamiento (Figma): la primera letra del texto en mayúscula y el resto en minúsculas (sentence-case).</p><p><strong>Usos:</strong> Home (en <a href="./?path=/docs/componentes-v3-collectionteaser--docs" target="_top"><strong>CollectionTeaser</strong></a> y <a href="./?path=/docs/componentes-v3-literaryworkhomecardteaser--docs" target="_top"><strong>LiteraryWorkHomeCardTeaser</strong></a>); Story, Story List y Author Profile (en <a href="./?path=/docs/componentes-v3-literaryworkcardteaser--docs" target="_top"><strong>LiteraryWorkCardTeaser</strong></a>).</p>`,
+				story: `<p>Variante <strong>soft</strong> (default): solo texto en brand-500, sin fondo. Comportamiento (Figma): la primera letra del texto en mayúscula y el resto en minúsculas (sentence-case).</p><p><strong>Usos:</strong> Home (en <a href="./?path=/docs/componentes-v3-collectionteasercard--docs" target="_top"><strong>CollectionTeaserCard</strong></a> y <a href="./?path=/docs/componentes-v3-literaryworkhomecardteaser--docs" target="_top"><strong>LiteraryWorkHomeCardTeaser</strong></a>); Story, Story List y Author Profile (en <a href="./?path=/docs/componentes-v3-literaryworkcardteaser--docs" target="_top"><strong>LiteraryWorkCardTeaser</strong></a>).</p>`,
 			},
 		},
 	},

--- a/src/mocks/onoff-collections.mock.spec.ts
+++ b/src/mocks/onoff-collections.mock.spec.ts
@@ -4,6 +4,8 @@ import {
 	onoffCollectionsMock,
 	onoffCollectionTeasersMock,
 } from './onoff-collections.mock';
+import geometriasDescriptionMd from './onoff/geometrias-del-desvelo.collection.md?raw';
+import inventarioDescriptionMd from './onoff/inventario-de-las-pasiones.collection.md?raw';
 
 describe('onoff collections mock', () => {
 	// Que la factory los construya sin lanzar es la prueba de que el contrato es satisfacible con
@@ -29,11 +31,21 @@ describe('onoff collections mock', () => {
 		expect(imagery.kind === 'sample' && imagery.images).toEqual(literaryWorks.map((work) => work.coverImage));
 	});
 
-	// La prosa viene del canon en Markdown y atraviesa el mismo pipeline que el backend.
+	// La prosa viene del canon en Markdown y atraviesa el mismo pipeline que el backend: se afirma que
+	// el HTML conserva el texto del crudo, no solo que tiene forma de HTML.
 	it('renders the description as sanitized html', () => {
-		onoffCollectionsMock.forEach((collection) => {
+		const rawByCollection = new Map([
+			[geometriasDelDesveloCollectionMock, geometriasDescriptionMd],
+			[inventarioDeLasPasionesCollectionMock, inventarioDescriptionMd],
+		]);
+
+		rawByCollection.forEach((raw, collection) => {
 			expect(collection.description).toContain('<p>');
-			expect(collection.description).not.toContain('_key');
+			raw
+				.split(/\s+/)
+				.filter((word) => /^[a-záéíóúñ]{6,}$/i.test(word))
+				.slice(0, 3)
+				.forEach((word) => expect(collection.description).toContain(word));
 		});
 	});
 

--- a/src/mocks/onoff-collections.mock.spec.ts
+++ b/src/mocks/onoff-collections.mock.spec.ts
@@ -1,0 +1,47 @@
+import {
+	geometriasDelDesveloCollectionMock,
+	inventarioDeLasPasionesCollectionMock,
+	onoffCollectionsMock,
+	onoffCollectionTeasersMock,
+} from './onoff-collections.mock';
+
+describe('onoff collections mock', () => {
+	// Que la factory los construya sin lanzar es la prueba de que el contrato es satisfacible con
+	// datos del canon, no solo que compila.
+	it('builds every collection through the factory', () => {
+		expect(onoffCollectionsMock).toHaveLength(2);
+		onoffCollectionsMock.forEach((collection) => {
+			expect(Object.isFrozen(collection)).toBe(true);
+			expect(collection.count).toBe(collection.literaryWorks.length);
+		});
+	});
+
+	// Las dos ramas de imagery existen en el corpus: sin una de las dos, el componente que las
+	// discrimina quedaría con un camino sin fixture.
+	it('covers both branches of imagery', () => {
+		expect(geometriasDelDesveloCollectionMock.imagery.kind).toBe('representative');
+		expect(inventarioDeLasPasionesCollectionMock.imagery.kind).toBe('sample');
+	});
+
+	it('derives the sample images from the works it carries', () => {
+		const { imagery, literaryWorks } = inventarioDeLasPasionesCollectionMock;
+
+		expect(imagery.kind === 'sample' && imagery.images).toEqual(literaryWorks.map((work) => work.coverImage));
+	});
+
+	// La prosa viene del canon en Markdown y atraviesa el mismo pipeline que el backend.
+	it('renders the description as sanitized html', () => {
+		onoffCollectionsMock.forEach((collection) => {
+			expect(collection.description).toContain('<p>');
+			expect(collection.description).not.toContain('_key');
+		});
+	});
+
+	it('projects teasers that carry no works', () => {
+		expect(onoffCollectionTeasersMock).toHaveLength(2);
+		onoffCollectionTeasersMock.forEach((teaser, index) => {
+			expect(teaser.literaryWorks).toEqual([]);
+			expect(teaser.count).toBe(onoffCollectionsMock[index]?.count);
+		});
+	});
+});

--- a/src/mocks/onoff-collections.mock.ts
+++ b/src/mocks/onoff-collections.mock.ts
@@ -4,22 +4,43 @@ import {
 	type CollectionImagery,
 	type CollectionTeaser,
 } from '@models/collection.model';
+import type { LiteraryWorkTeaser } from '@models/literary-work.model';
 import { createMarkdown } from '@models/markdown.model';
 import { markdownToSanitizedHtml } from '@utils/markdown-pipeline.utils';
 
 import geometriasDescriptionMd from './onoff/geometrias-del-desvelo.collection.md?raw';
 import inventarioDescriptionMd from './onoff/inventario-de-las-pasiones.collection.md?raw';
-import { onoffLiteraryWorkTeasersMock } from './onoff-literary-work-teasers.mock';
+import { onoffMediaMock } from './onoff-media.mock';
+import {
+	elOdioLiteraryWorkTeaserMock,
+	elTratadoDeLosPlaceresLiteraryWorkTeaserMock,
+	geometriaLiteraryWorkTeaserMock,
+	lasDosAntorchasLiteraryWorkTeaserMock,
+	lasEscalerasLiteraryWorkTeaserMock,
+	losPeldanosLiteraryWorkTeaserMock,
+} from './onoff-literary-work-teasers.mock';
 import { colaborativaTagMock, cuentoTagMock } from './onoff-tags.mock';
 
-const geometriasWorks = onoffLiteraryWorkTeasersMock.slice(0, 3);
-const inventarioWorks = onoffLiteraryWorkTeasersMock.slice(0, 3);
+// Cada colección se cura con las obras que su propia prosa nombra, no con un corte arbitrario del
+// agregador: así las dos son distinguibles por contenido y no solo por la rama de `imagery`.
+const geometriasWorks = [
+	geometriaLiteraryWorkTeaserMock,
+	losPeldanosLiteraryWorkTeaserMock,
+	lasEscalerasLiteraryWorkTeaserMock,
+] as const;
+
+const inventarioWorks = [
+	elTratadoDeLosPlaceresLiteraryWorkTeaserMock,
+	elOdioLiteraryWorkTeaserMock,
+	lasDosAntorchasLiteraryWorkTeaserMock,
+] as const;
 
 // Las tres portadas salen de las propias obras, no escritas a mano: es lo que el mapper deriva
-// cuando la colección no tiene portada editorial.
-function sampleFrom(works: typeof onoffLiteraryWorkTeasersMock): CollectionImagery {
-	const [first, second, third] = works.map((work) => work.coverImage);
-	return { kind: 'sample', images: [first ?? '', second ?? '', third ?? ''] };
+// cuando la colección no tiene portada editorial. La firma exige exactamente tres para que el largo
+// sea una garantía del tipo y no un fallback que tape en silencio un corpus mal curado.
+function sampleFrom(works: readonly [LiteraryWorkTeaser, LiteraryWorkTeaser, LiteraryWorkTeaser]): CollectionImagery {
+	const [first, second, third] = works;
+	return { kind: 'sample', images: [first.coverImage, second.coverImage, third.coverImage] };
 }
 
 /** Colección con portada editorial propia — la rama `representative` de `imagery`. */
@@ -31,7 +52,7 @@ export const geometriasDelDesveloCollectionMock: Collection = createCollection({
 	imagery: { kind: 'representative', image: 'assets/img/mocks/collections/geometrias-del-desvelo.png' },
 	tags: [colaborativaTagMock],
 	config: { showAuthors: true },
-	mediaSources: [],
+	mediaSources: onoffMediaMock,
 	literaryWorks: geometriasWorks,
 });
 
@@ -39,7 +60,7 @@ export const geometriasDelDesveloCollectionMock: Collection = createCollection({
 export const inventarioDeLasPasionesCollectionMock: Collection = createCollection({
 	_id: 'collection-inventario-de-las-pasiones',
 	slug: 'inventario-de-las-pasiones',
-	title: 'Inventario de las pasiones',
+	title: 'El inventario de las pasiones',
 	description: markdownToSanitizedHtml(createMarkdown(inventarioDescriptionMd)),
 	imagery: sampleFrom(inventarioWorks),
 	tags: [cuentoTagMock],
@@ -52,6 +73,21 @@ export const onoffCollectionsMock: Collection[] = [
 	geometriasDelDesveloCollectionMock,
 	inventarioDeLasPasionesCollectionMock,
 ];
+
+// Selectores por capacidad: un consumidor que necesita una rama concreta de `imagery` la pide por lo
+// que hace falta, no por el nombre de una colección puntual, y filtrarlos evita que sean listas
+// paralelas que se desincronicen del agregador.
+export const onoffCollectionsWithRepresentativeImageryMock: Collection[] = onoffCollectionsMock.filter(
+	(collection) => collection.imagery.kind === 'representative',
+);
+
+export const onoffCollectionsWithSampleImageryMock: Collection[] = onoffCollectionsMock.filter(
+	(collection) => collection.imagery.kind === 'sample',
+);
+
+export const onoffCollectionsWithMediaSourcesMock: Collection[] = onoffCollectionsMock.filter(
+	(collection) => collection.mediaSources.length > 0,
+);
 
 // El teaser es una proyección: no pasa por la factory porque no transporta obras, igual que lo
 // construye el mapper a partir de la query.

--- a/src/mocks/onoff-collections.mock.ts
+++ b/src/mocks/onoff-collections.mock.ts
@@ -1,0 +1,67 @@
+import {
+	createCollection,
+	type Collection,
+	type CollectionImagery,
+	type CollectionTeaser,
+} from '@models/collection.model';
+import { createMarkdown } from '@models/markdown.model';
+import { markdownToSanitizedHtml } from '@utils/markdown-pipeline.utils';
+
+import geometriasDescriptionMd from './onoff/geometrias-del-desvelo.collection.md?raw';
+import inventarioDescriptionMd from './onoff/inventario-de-las-pasiones.collection.md?raw';
+import { onoffLiteraryWorkTeasersMock } from './onoff-literary-work-teasers.mock';
+import { colaborativaTagMock, cuentoTagMock } from './onoff-tags.mock';
+
+const geometriasWorks = onoffLiteraryWorkTeasersMock.slice(0, 3);
+const inventarioWorks = onoffLiteraryWorkTeasersMock.slice(0, 3);
+
+// Las tres portadas salen de las propias obras, no escritas a mano: es lo que el mapper deriva
+// cuando la colección no tiene portada editorial.
+function sampleFrom(works: typeof onoffLiteraryWorkTeasersMock): CollectionImagery {
+	const [first, second, third] = works.map((work) => work.coverImage);
+	return { kind: 'sample', images: [first ?? '', second ?? '', third ?? ''] };
+}
+
+/** Colección con portada editorial propia — la rama `representative` de `imagery`. */
+export const geometriasDelDesveloCollectionMock: Collection = createCollection({
+	_id: 'collection-geometrias-del-desvelo',
+	slug: 'geometrias-del-desvelo',
+	title: 'Geometrías del desvelo',
+	description: markdownToSanitizedHtml(createMarkdown(geometriasDescriptionMd)),
+	imagery: { kind: 'representative', image: 'assets/img/mocks/collections/geometrias-del-desvelo.png' },
+	tags: [colaborativaTagMock],
+	config: { showAuthors: true },
+	mediaSources: [],
+	literaryWorks: geometriasWorks,
+});
+
+/** Colección sin portada propia — la rama `sample`, derivada de las portadas de sus obras. */
+export const inventarioDeLasPasionesCollectionMock: Collection = createCollection({
+	_id: 'collection-inventario-de-las-pasiones',
+	slug: 'inventario-de-las-pasiones',
+	title: 'Inventario de las pasiones',
+	description: markdownToSanitizedHtml(createMarkdown(inventarioDescriptionMd)),
+	imagery: sampleFrom(inventarioWorks),
+	tags: [cuentoTagMock],
+	config: { showAuthors: false },
+	mediaSources: [],
+	literaryWorks: inventarioWorks,
+});
+
+export const onoffCollectionsMock: Collection[] = [
+	geometriasDelDesveloCollectionMock,
+	inventarioDeLasPasionesCollectionMock,
+];
+
+// El teaser es una proyección: no pasa por la factory porque no transporta obras, igual que lo
+// construye el mapper a partir de la query.
+function toTeaser(collection: Collection): CollectionTeaser {
+	return { ...collection, literaryWorks: [] };
+}
+
+export const geometriasDelDesveloCollectionTeaserMock: CollectionTeaser = toTeaser(geometriasDelDesveloCollectionMock);
+export const inventarioDeLasPasionesCollectionTeaserMock: CollectionTeaser = toTeaser(
+	inventarioDeLasPasionesCollectionMock,
+);
+
+export const onoffCollectionTeasersMock: CollectionTeaser[] = onoffCollectionsMock.map(toTeaser);

--- a/src/mocks/onoff/README.md
+++ b/src/mocks/onoff/README.md
@@ -49,7 +49,9 @@ Corpus mínimo de dos colecciones de `LiteraryWork`, una por cada rama de `image
 
 - **Descripciones:** Markdown plano por colección — `geometrias-del-desvelo.collection.md` e `inventario-de-las-pasiones.collection.md`, importados con `?raw` y saneados con `markdownToSanitizedHtml`, misma convención que `<slug>.editorial-note.md` de `LiteraryWork`.
 - **Colecciones:** `../onoff-collections.mock.ts`, export `geometriasDelDesveloCollectionMock` (rama `representative`, con portada editorial propia) e `inventarioDeLasPasionesCollectionMock` (rama `sample`, sin portada propia) — ambas construidas vía `createCollection`.
+- **Obras:** cada colección se cura con las obras que su propia prosa nombra —`geometria`/`losPeldanos`/`lasEscaleras` y `elTratadoDeLosPlaceres`/`elOdio`/`lasDosAntorchas`—, importadas del agregador por nombre. No cortar el agregador por índice: las dos colecciones quedarían indistinguibles por contenido.
 - **Agregador:** `onoffCollectionsMock: Collection[]`.
+- **Selectores por capacidad:** `onoffCollectionsWithRepresentativeImageryMock`, `onoffCollectionsWithSampleImageryMock` y `onoffCollectionsWithMediaSourcesMock`, derivados por predicado sobre el agregador.
 - **Teasers derivados:** `toTeaser` (vacía `literaryWorks`) → `onoffCollectionTeasersMock: CollectionTeaser[]`.
 - **Nada se escribe a mano:** las obras (`literaryWorks`), los tags y las tres portadas de la rama `sample` se **derivan** del canon existente — `onoffLiteraryWorkTeasersMock` y `onoff-tags.mock.ts` — en vez de hardcodearse.
 

--- a/src/mocks/onoff/README.md
+++ b/src/mocks/onoff/README.md
@@ -43,6 +43,16 @@ Archivos:
 
 La biografía de François Onoff vive como Markdown plano en un único archivo, `francois-onoff.biography.md` (solo la prosa, sin metadata), importado con `?raw` — misma convención que `<slug>.editorial-note.md` para `LiteraryWork`. `../onoff-raw-author.mock.ts` (`rawOnoffAuthor.biography`) transporta ese Markdown crudo; `../author.mock.ts` deriva el `SanitizedHtml` corriendo `markdownToSanitizedHtml(createMarkdown(...))` sobre la misma fuente. Es el único archivo de biografía del corpus: el elenco modela un solo autor (Onoff), así que no hay un `<slug>.biography.md` por obra. `rawOnoffAuthorTeaser` no declara `biography`, en paridad con `AuthorTeaser` de dominio.
 
+## Corpus de dominio: `Collection`
+
+Corpus mínimo de dos colecciones de `LiteraryWork`, una por cada rama de `imagery`.
+
+- **Descripciones:** Markdown plano por colección — `geometrias-del-desvelo.collection.md` e `inventario-de-las-pasiones.collection.md`, importados con `?raw` y saneados con `markdownToSanitizedHtml`, misma convención que `<slug>.editorial-note.md` de `LiteraryWork`.
+- **Colecciones:** `../onoff-collections.mock.ts`, export `geometriasDelDesveloCollectionMock` (rama `representative`, con portada editorial propia) e `inventarioDeLasPasionesCollectionMock` (rama `sample`, sin portada propia) — ambas construidas vía `createCollection`.
+- **Agregador:** `onoffCollectionsMock: Collection[]`.
+- **Teasers derivados:** `toTeaser` (vacía `literaryWorks`) → `onoffCollectionTeasersMock: CollectionTeaser[]`.
+- **Nada se escribe a mano:** las obras (`literaryWorks`), los tags y las tres portadas de la rama `sample` se **derivan** del canon existente — `onoffLiteraryWorkTeasersMock` y `onoff-tags.mock.ts` — en vez de hardcodearse.
+
 ## Corpus raw: `Story` (shape de Sanity)
 
 Contraparte cruda del corpus de dominio `Story` — lo que devuelven las queries GROQ antes del ACL/mapper. La consume el backend (`src/api`).

--- a/src/mocks/onoff/geometrias-del-desvelo.collection.md
+++ b/src/mocks/onoff/geometrias-del-desvelo.collection.md
@@ -1,0 +1,1 @@
+Onoff lleva la precisión del compás al territorio de lo humano: insomnios que se vuelven una geometría del tiempo, vidas reducidas a coordenadas, figuras que prometen un orden perfecto y terminan revelando, en algún vértice, su grieta.

--- a/src/mocks/onoff/inventario-de-las-pasiones.collection.md
+++ b/src/mocks/onoff/inventario-de-las-pasiones.collection.md
@@ -1,0 +1,1 @@
+Una colección sobre el deseo de ordenar lo inordenable. Onoff cataloga el placer, retrata el odio sin causa y enfrenta dos antorchas que nunca alumbran lo mismo: tratados que terminan por descubrir que toda taxonomía de lo humano es una forma elegante de perderlo.

--- a/src/models/collection.model.spec.ts
+++ b/src/models/collection.model.spec.ts
@@ -25,14 +25,14 @@ describe('createCollection', () => {
 	it('builds a frozen aggregate with a branded slug', () => {
 		const collection = createCollection(buildOptions());
 
-		expect(collection.slug).toBe('geometrias-del-desvelo');
-		expect(collection.title).toBe('Geometrías del desvelo');
+		expect(collection.slug).toBe(buildOptions().slug);
+		expect(collection.title).toBe(buildOptions().title);
 		expect(Object.isFrozen(collection)).toBe(true);
 	});
 
-	// Derivarlo es lo que vuelve imposible que discrepe del número real de obras.
+	// Derivarlo descarta que discrepe del número real de obras que el agregado transporta.
 	it('derives count from the works it carries', () => {
-		expect(createCollection(buildOptions()).count).toBe(3);
+		expect(createCollection(buildOptions()).count).toBe(canon.literaryWorks.length);
 		expect(createCollection(buildOptions({ literaryWorks: onoffLiteraryWorkTeasersMock.slice(0, 1) })).count).toBe(1);
 	});
 
@@ -51,12 +51,29 @@ describe('createCollection', () => {
 		expect(() => createCollection(buildOptions({ slug: 'Geometrías Del Desvelo' }))).toThrow(/Slug inválido/);
 	});
 
+	// Se afirma el discriminante y su payload contra valores independientes del objeto pasado: si la
+	// factory normalizara, reordenara o colapsara la unión, comparar contra la misma referencia no lo
+	// detectaría.
 	it('preserves both branches of imagery untouched', () => {
-		const [first, second, third] = canon.literaryWorks.map((work) => work.coverImage);
-		const sample: CollectionImagery = { kind: 'sample', images: [first ?? '', second ?? '', third ?? ''] };
+		const covers = canon.literaryWorks.map((work) => work.coverImage);
+		const sample: CollectionImagery = { kind: 'sample', images: [covers[0] ?? '', covers[1] ?? '', covers[2] ?? ''] };
 
-		expect(createCollection(buildOptions()).imagery).toEqual(canon.imagery);
-		expect(createCollection(buildOptions({ imagery: sample })).imagery).toEqual(sample);
+		const representative = createCollection(buildOptions()).imagery;
+		expect(representative.kind).toBe('representative');
+		expect(representative.kind === 'representative' && representative.image).toBe(
+			'assets/img/mocks/collections/geometrias-del-desvelo.png',
+		);
+
+		const sampled = createCollection(buildOptions({ imagery: sample })).imagery;
+		expect(sampled.kind).toBe('sample');
+		expect(sampled.kind === 'sample' && sampled.images).toEqual(covers);
+	});
+
+	// El abanico llega desde GROQ, donde nada garantiza el largo que la tupla promete en compilación.
+	it('rejects a sample of imagery without three covers', () => {
+		const twoCovers = { kind: 'sample', images: ['a.png', 'b.png'] } as unknown as CollectionImagery;
+
+		expect(() => createCollection(buildOptions({ imagery: twoCovers }))).toThrow(/abanico de portadas/);
 	});
 
 	// Normalizar el opcional del schema es trabajo del mapper, no de la factory.
@@ -65,12 +82,14 @@ describe('createCollection', () => {
 		expect(createCollection(buildOptions({ config: { showAuthors: false } })).config.showAuthors).toBe(false);
 	});
 
-	it('passes through tags, media sources and description without copying', () => {
+	// Se afirma el contenido, no la identidad: que la factory copie o no los arrays es una decisión
+	// libre, y fijarla con `toBe` rompería el test ante un cambio deseable.
+	it('passes through tags, media sources and description', () => {
 		const options = buildOptions();
 		const collection = createCollection(options);
 
-		expect(collection.tags).toBe(options.tags);
-		expect(collection.mediaSources).toBe(options.mediaSources);
-		expect(collection.description).toBe(options.description);
+		expect(collection.tags).toEqual(options.tags);
+		expect(collection.mediaSources).toEqual(options.mediaSources);
+		expect(collection.description).toEqual(options.description);
 	});
 });

--- a/src/models/collection.model.spec.ts
+++ b/src/models/collection.model.spec.ts
@@ -1,0 +1,77 @@
+import { createCollection, type CollectionImagery } from './collection.model';
+import { createSanitizedHtml } from './sanitized-html.model';
+import { onoffLiteraryWorkTeasersMock } from '@mocks/onoff-literary-work-teasers.mock';
+import { onoffTagsMock } from '@mocks/onoff-tags.mock';
+
+const representative: CollectionImagery = { kind: 'representative', image: 'https://cdn/portada.webp' };
+
+function buildOptions(overrides: Partial<Parameters<typeof createCollection>[0]> = {}) {
+	return {
+		_id: 'collection-1',
+		slug: 'la-coleccion',
+		title: 'La colección',
+		description: createSanitizedHtml('<p>Una colección.</p>'),
+		imagery: representative,
+		tags: onoffTagsMock.slice(0, 2),
+		config: { showAuthors: true },
+		mediaSources: [],
+		literaryWorks: onoffLiteraryWorkTeasersMock.slice(0, 3),
+		...overrides,
+	};
+}
+
+describe('createCollection', () => {
+	it('builds a frozen aggregate with a branded slug', () => {
+		const collection = createCollection(buildOptions());
+
+		expect(collection.slug).toBe('la-coleccion');
+		expect(collection.title).toBe('La colección');
+		expect(Object.isFrozen(collection)).toBe(true);
+	});
+
+	// Derivarlo es lo que vuelve imposible que discrepe del número real de obras.
+	it('derives count from the works it carries', () => {
+		expect(createCollection(buildOptions()).count).toBe(3);
+		expect(createCollection(buildOptions({ literaryWorks: onoffLiteraryWorkTeasersMock.slice(0, 1) })).count).toBe(1);
+	});
+
+	it('rejects a collection without a title', () => {
+		expect(() => createCollection(buildOptions({ title: '' }))).toThrow(/título vacío/);
+		expect(() => createCollection(buildOptions({ title: '   ' }))).toThrow(/título vacío/);
+	});
+
+	// Una colección vacía no es un estado válido: es un dato incompleto que fallaría al renderizarse.
+	it('rejects a collection without literary works', () => {
+		expect(() => createCollection(buildOptions({ literaryWorks: [] }))).toThrow(/sin obras literarias/);
+	});
+
+	// El formato del slug lo valida el value object, no la factory.
+	it('delegates slug validation to the value object', () => {
+		expect(() => createCollection(buildOptions({ slug: 'La Colección' }))).toThrow(/Slug inválido/);
+	});
+
+	it('preserves both branches of imagery untouched', () => {
+		const sample: CollectionImagery = {
+			kind: 'sample',
+			images: ['https://cdn/a.webp', 'https://cdn/b.webp', 'https://cdn/c.webp'],
+		};
+
+		expect(createCollection(buildOptions()).imagery).toEqual(representative);
+		expect(createCollection(buildOptions({ imagery: sample })).imagery).toEqual(sample);
+	});
+
+	// Normalizar el opcional del schema es trabajo del mapper, no de la factory.
+	it('preserves showAuthors as received', () => {
+		expect(createCollection(buildOptions()).config.showAuthors).toBe(true);
+		expect(createCollection(buildOptions({ config: { showAuthors: false } })).config.showAuthors).toBe(false);
+	});
+
+	it('passes through tags, media sources and description without copying', () => {
+		const options = buildOptions();
+		const collection = createCollection(options);
+
+		expect(collection.tags).toBe(options.tags);
+		expect(collection.mediaSources).toBe(options.mediaSources);
+		expect(collection.description).toBe(options.description);
+	});
+});

--- a/src/models/collection.model.spec.ts
+++ b/src/models/collection.model.spec.ts
@@ -1,21 +1,22 @@
 import { createCollection, type CollectionImagery } from './collection.model';
-import { createSanitizedHtml } from './sanitized-html.model';
+import { geometriasDelDesveloCollectionMock } from '@mocks/onoff-collections.mock';
 import { onoffLiteraryWorkTeasersMock } from '@mocks/onoff-literary-work-teasers.mock';
-import { onoffTagsMock } from '@mocks/onoff-tags.mock';
 
-const representative: CollectionImagery = { kind: 'representative', image: 'https://cdn/portada.webp' };
+// "Geometrías del desvelo" del canon de Onoff: la colección con portada editorial propia. Se
+// descompone en las opciones que la construyeron, en vez de inventar una colección de prueba.
+const canon = geometriasDelDesveloCollectionMock;
 
 function buildOptions(overrides: Partial<Parameters<typeof createCollection>[0]> = {}) {
 	return {
-		_id: 'collection-1',
-		slug: 'la-coleccion',
-		title: 'La colección',
-		description: createSanitizedHtml('<p>Una colección.</p>'),
-		imagery: representative,
-		tags: onoffTagsMock.slice(0, 2),
-		config: { showAuthors: true },
-		mediaSources: [],
-		literaryWorks: onoffLiteraryWorkTeasersMock.slice(0, 3),
+		_id: canon._id,
+		slug: canon.slug,
+		title: canon.title,
+		description: canon.description,
+		imagery: canon.imagery,
+		tags: canon.tags,
+		config: canon.config,
+		mediaSources: canon.mediaSources,
+		literaryWorks: canon.literaryWorks,
 		...overrides,
 	};
 }
@@ -24,8 +25,8 @@ describe('createCollection', () => {
 	it('builds a frozen aggregate with a branded slug', () => {
 		const collection = createCollection(buildOptions());
 
-		expect(collection.slug).toBe('la-coleccion');
-		expect(collection.title).toBe('La colección');
+		expect(collection.slug).toBe('geometrias-del-desvelo');
+		expect(collection.title).toBe('Geometrías del desvelo');
 		expect(Object.isFrozen(collection)).toBe(true);
 	});
 
@@ -47,16 +48,14 @@ describe('createCollection', () => {
 
 	// El formato del slug lo valida el value object, no la factory.
 	it('delegates slug validation to the value object', () => {
-		expect(() => createCollection(buildOptions({ slug: 'La Colección' }))).toThrow(/Slug inválido/);
+		expect(() => createCollection(buildOptions({ slug: 'Geometrías Del Desvelo' }))).toThrow(/Slug inválido/);
 	});
 
 	it('preserves both branches of imagery untouched', () => {
-		const sample: CollectionImagery = {
-			kind: 'sample',
-			images: ['https://cdn/a.webp', 'https://cdn/b.webp', 'https://cdn/c.webp'],
-		};
+		const [first, second, third] = canon.literaryWorks.map((work) => work.coverImage);
+		const sample: CollectionImagery = { kind: 'sample', images: [first ?? '', second ?? '', third ?? ''] };
 
-		expect(createCollection(buildOptions()).imagery).toEqual(representative);
+		expect(createCollection(buildOptions()).imagery).toEqual(canon.imagery);
 		expect(createCollection(buildOptions({ imagery: sample })).imagery).toEqual(sample);
 	});
 

--- a/src/models/collection.model.ts
+++ b/src/models/collection.model.ts
@@ -21,6 +21,8 @@ interface CollectionBase {
 	readonly config: { readonly showAuthors: boolean };
 	readonly mediaSources: readonly Media[];
 	// Las dos vistas lo muestran, y el teaser lo necesita justamente porque no transporta las obras.
+	// Es el total real solo mientras la query traiga todas las obras: si el listado se pagina o se
+	// acota, el total pasa a ser un dato de entrada y la derivación de la factory deja de valer.
 	readonly count: number;
 }
 
@@ -49,9 +51,11 @@ interface CreateCollectionOptions {
  * respete. Una colección sin obras no es un estado válido: es un dato incompleto que fallaría recién
  * al renderizarse, lejos de donde se puede corregir.
  *
- * `count` se deriva y no se recibe, que es lo que vuelve imposible que discrepe del número real de
- * obras. La vista de teaser no pasa por acá —no transporta obras, así que no puede sostener la
- * invariante—: la construye el mapper como proyección, igual que `LiteraryWorkTeaser`.
+ * `count` se deriva y no se recibe, lo que descarta que discrepe del número real de obras **mientras
+ * la query no acote `literaryWorks`**. Si el listado se pagina, el total tiene que entrar como dato
+ * y esta derivación deja de ser válida. La vista de teaser no pasa por acá —no transporta obras, así
+ * que no puede sostener la invariante—: la construye el mapper como proyección, igual que
+ * `LiteraryWorkTeaser`.
  */
 export function createCollection(options: CreateCollectionOptions): Collection {
 	if (options.title.trim() === '') {
@@ -59,6 +63,11 @@ export function createCollection(options: CreateCollectionOptions): Collection {
 	}
 	if (options.literaryWorks.length === 0) {
 		throw new Error(`Collection inválida: sin obras literarias (slug "${options.slug}")`);
+	}
+	// La tupla de tres solo garantiza el largo en compilación, y el abanico se va a construir desde
+	// GROQ, donde un `sample` de dos portadas encaja igual.
+	if (options.imagery.kind === 'sample' && options.imagery.images.length !== 3) {
+		throw new Error(`Collection inválida: el abanico de portadas necesita tres (slug "${options.slug}")`);
 	}
 	return Object.freeze({
 		...options,

--- a/src/models/collection.model.ts
+++ b/src/models/collection.model.ts
@@ -1,0 +1,68 @@
+import { createSlug, type Slug } from './slug.model';
+import type { LiteraryWorkTeaser } from './literary-work.model';
+import type { Media } from './media.model';
+import type { SanitizedHtml } from './sanitized-html.model';
+import type { Tag } from './tag.model';
+
+// Si la colección tiene portada editorial propia se usa (`representative`); si no, las primeras
+// portadas de sus obras (`sample`). El campo del schema es opcional, así que el fallback no es un
+// caso de borde sino la mitad de los casos.
+export type CollectionImagery =
+	| { readonly kind: 'representative'; readonly image: string }
+	| { readonly kind: 'sample'; readonly images: readonly [string, string, string] };
+
+interface CollectionBase {
+	readonly _id: string;
+	readonly slug: Slug;
+	readonly title: string;
+	readonly description: SanitizedHtml;
+	readonly imagery: CollectionImagery;
+	readonly tags: readonly Tag[];
+	readonly config: { readonly showAuthors: boolean };
+	readonly mediaSources: readonly Media[];
+	// Las dos vistas lo muestran, y el teaser lo necesita justamente porque no transporta las obras.
+	readonly count: number;
+}
+
+export interface Collection extends CollectionBase {
+	readonly literaryWorks: readonly LiteraryWorkTeaser[];
+}
+
+export interface CollectionTeaser extends CollectionBase {
+	readonly literaryWorks: Array<never>;
+}
+
+interface CreateCollectionOptions {
+	_id: string;
+	slug: string;
+	title: string;
+	description: SanitizedHtml;
+	imagery: CollectionImagery;
+	tags: readonly Tag[];
+	config: { readonly showAuthors: boolean };
+	mediaSources: readonly Media[];
+	literaryWorks: readonly LiteraryWorkTeaser[];
+}
+
+/**
+ * Construye el agregado haciendo cumplir sus invariantes, en vez de confiar en que quien lo arma las
+ * respete. Una colección sin obras no es un estado válido: es un dato incompleto que fallaría recién
+ * al renderizarse, lejos de donde se puede corregir.
+ *
+ * `count` se deriva y no se recibe, que es lo que vuelve imposible que discrepe del número real de
+ * obras. La vista de teaser no pasa por acá —no transporta obras, así que no puede sostener la
+ * invariante—: la construye el mapper como proyección, igual que `LiteraryWorkTeaser`.
+ */
+export function createCollection(options: CreateCollectionOptions): Collection {
+	if (options.title.trim() === '') {
+		throw new Error(`Collection inválida: título vacío (slug "${options.slug}")`);
+	}
+	if (options.literaryWorks.length === 0) {
+		throw new Error(`Collection inválida: sin obras literarias (slug "${options.slug}")`);
+	}
+	return Object.freeze({
+		...options,
+		slug: createSlug(options.slug),
+		count: options.literaryWorks.length,
+	});
+}


### PR DESCRIPTION
Define el modelo de dominio `Collection` — interfaces, vistas polimórficas y factory con invariantes — más el corpus de mocks que lo materializa.

`Collection` **no es `Storylist` renombrado**: nace en paralelo y aquel sigue vigente sirviendo la página actual hasta su baja, que es un trabajo aparte. Es el segundo eslabón de la secuencia que arrancó con el document type: modelo de dominio → GROQ y repository → mapper y service → controller → provider → traspaso del contenido.

## Alcance ampliado: el rename del componente

El issue se titula "modelo de dominio", y este PR además **renombra un componente**. La razón es que sin eso el nombre del tipo no se podía tomar.

`src/app/components/collection-teaser/` declaraba `export class CollectionTeaser` **y consumía el tipo de dominio**. Al migrar al tipo nuevo, ese archivo habría tenido la clase y el import homónimos: un choque dentro del mismo archivo, no una molestia de alias.

La capa que cede es la que estaba mal nombrada. En este código `Teaser` nombra la **forma reducida de una entidad de dominio**; el componente no es eso, es la **tarjeta que la renderiza**. Pasa a `CollectionTeaserCard`, y el tipo de dominio se queda con `CollectionTeaser`, respetando la convención `<Entidad>Teaser` que el repo usa sin excepciones.

El nombre adopta además el orden **head-final** —el último sustantivo dice qué *es* la cosa—, que el repo ya aplica en los `*-card-deck`. Los cuatro componentes que hoy llevan los sufijos invertidos se renombran en un issue propio; `collection` queda fuera de ese barrido justamente por nacer con el nombre destino, para no renombrarlo dos veces en el mismo milestone.

El rename es mecánico: no cambia inputs, plantilla ni comportamiento, y el spec existente pasa con las mismas aserciones. El componente sigue tipando contra `StorylistTeaser` hasta que la página nueva lo conecte.

## El contrato

Refleja las tres decisiones que el schema ya había tomado: **sin pestañas**, **`description` como `SanitizedHtml`** en vez de Portable Text, y **`literaryWorks`** en vez de `stories`. El campo de multimedia se llama `mediaSources`, alineado con el schema y con `LiteraryWork`, en lugar de arrastrar el `media` que `Storylist` heredó.

`CollectionBase` es privada y las dos vistas la extienden — el patrón de `LiteraryWorkBase`, no el genérico de `StorylistBase<T>`. Ese genérico existía para colapsar **dos** arrays paralelos (`stories` y `tabs`); sin pestañas queda uno solo y deja de ganar algo.

`imagery` conserva la unión discriminada de `Storylist` (`representative` / `sample`) en vez del `coverImage` plano de `LiteraryWork`: el componente ya renderiza las dos ramas, el render del abanico es trabajo activo del epic, y la imagen destacada es **opcional** en el schema, así que el fallback no es un caso de borde.

## Una elección que conviene explicitar

`createCollection` **hace cumplir** sus invariantes —título no vacío, al menos una obra, slug válido— siguiendo a `createLiteraryWork`. El resto del catálogo (`Storylist`, `Author`) tiene las suyas **descritas** en la documentación pero no exigidas.

O sea que esto es una **elección**, no una obligación del modelo documentado. Se toma porque el issue pide que la infraestructura sea rename-friendly hacia `LiteraryWork`, y construir hoy con el patrón que se va a abandonar sería deuda a sabiendas.

`count` se **deriva** de las obras y no se recibe, lo que descarta que discrepe del número real **mientras la query no acote `literaryWorks`**. Esa precondición queda anotada donde vive la derivación: si el listado se pagina, el total tiene que entrar como dato y la derivación deja de valer. La vista de teaser no pasa por la factory: no transporta obras, así que no puede sostener esa invariante — la construye el mapper como proyección, igual que `LiteraryWorkTeaser`.

**Consecuencia para el traspaso de contenido:** con la invariante "≥1 obra", esa migración tiene que **abortar o filtrar con registro explícito** ante una colección de origen sin obras, nunca escribir una vacía en silencio. Cambia su criterio de éxito.

## El mock

Entra en este PR porque sin él el contrato no tiene ningún consumidor que lo materialice: el tipo compilaría y nadie sabría si es construible con datos reales. Es además la pieza que va a permitir migrar los componentes sin depender del provider ni de Sanity.

**Todo se deriva del canon de Onoff, nada se escribe a mano.** La prosa de las descripciones ya existía en el corpus —en Portable Text— y se traslada verbatim a dos archivos Markdown que atraviesan el mismo pipeline de saneado que el backend. Obras y tags salen de sus colecciones; las tres portadas de la variante sin imagen editorial se derivan de las propias obras.

Las dos colecciones cubren las dos ramas de `imagery`, para que el componente que las discrimina no quede con un camino sin fixture.

## Notas para los issues que siguen

- **La conexión de los componentes al tipo nuevo no entra acá.** `description` pasa de Portable Text a HTML saneado, lo que cambia plantillas, y sin el provider nada alimenta el tipo. Durante la convivencia el componente va a tener que servir las dos formas: el repo ya resuelve ese caso con un input de tipo unión, como hace la tarjeta de obra literaria, sin duplicar el componente.
- **`config.showAuthors` no está bloqueado** por la iniciativa de autores múltiples: el input de la tarjeta sigue siendo booleano y solo renderiza el primer autor, así que la semántica se preserva tal cual.
- **El ACL tiene una pregunta abierta**: la obra literaria diverge del patrón de mappers sueltos y aloja su traducción dentro del repository. Cabe la misma pregunta para `Collection`, y conviene decidirlo en vez de asumir el patrón legacy.
- **`Collection` ya existe como tipo generado de Sanity.** No colisiona hoy, pero el ACL va a tener ambos a la vista: ahí se aliasa el crudo en el import, no se renombra el tipo de dominio.

## Plan de pruebas

- **Los once gates de CI, verdes**, más los tres deploys de Vercel. En local: `tsc -p tsconfig.typecheck.json --noEmit`, `lint`, `stylelint`, `check:agents` y la suite completa (**1445 pasando**, 3 skipped, 142 archivos).
- **El rename se verificó mecánico**: el diff con `-M` solo cambia `selector`, nombre de clase, paths e identificadores; plantilla, `input()` y `host` quedan idénticos. Sin residuo de los nombres viejos —lo que aparece en la búsqueda es el componente no relacionado `NavigableCollectionTeaser*`—, y los tres consumidores reales actualizados, incluido el enlace de autodocs.
- **La prosa de las descripciones se comparó verbatim** contra los `description` en Portable Text del corpus, y la portada editorial contra la del canon equivalente: nada del mock está escrito a mano.
- **La aserción de `imagery` se verificó falsable mutando la factory** para invertir el abanico: el caso falla. La versión anterior comparaba el objeto contra sí mismo y pasaba con esa misma mutación.
- **El guard nuevo del abanico tiene su caso**, construido como lo produciría GROQ (un `sample` de dos portadas), y la suite del corpus cubre que las dos ramas de `imagery` existan y que el abanico derive de las obras que cada colección transporta.

## Hallazgos de la review, abordados

La review dejó un crítico, cuatro advertencias y siete sugerencias; se atendieron todos salvo uno, que se documenta acá.

- **Crítico** — la referencia de dominio que cargan los agentes había quedado afirmando lo contrario de lo que este PR escribió en `docs/DOMAIN_MODEL.md`: una sola raíz con invariantes en código, y un solo agregado en el contexto de curación. Corregido en cinco puntos.
- **Corpus** — las dos colecciones cargaban las mismas tres obras por un corte por índice. Ahora cada una lleva las que su propia prosa nombra; se sumaron los selectores por capacidad y `mediaSources` derivados del canon, y el título se alineó con el canon (`El inventario…`).
- **Tests** — se derivaron del fixture las aserciones con prosa clavada, se hizo falsable la de `imagery`, se cambió por contrato la que fijaba un detalle de implementación con `toBe`, y se reemplazó la de `_key` —que no podía fallar— por una que afirma que el HTML conserva el texto del Markdown crudo.
- **La única sugerencia no aplicada** es el guard de descripción vacía en la factory: `createSanitizedHtml` ya rechaza el vacío, así que duplicarlo movería una invariante fuera de su value object. La circularidad del spec —importa un mock construido por la función bajo prueba— se deja como está: el spec del corpus diagnostica ese fallo por separado.

Closes #1828.

Parte de #1472.
