### PR TITLE
[#2150] - Renombra la fixture cruda de storylist a su nombre real

### DIFF
--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -75,7 +75,7 @@ Un spec o una story que importa una obra concreta queda atado a ella: sus aserci
 | Una obra con epígrafes                    | `onoffLiteraryWorksWithEpigraphs` / `onoffRawLiteraryWorksWithEpigraphs`                              |
 | Una obra con o sin nota editorial         | `onoffLiteraryWorksWith(out)EditorialNote` / `onoffRawLiteraryWorksWith(out)EditorialNote`            |
 | Un texto con atribución (epígrafe o nota) | `onoffLiteraryWorkEpigraphsMock`; en stories, `corpusAttributedTexts` + `attributedTextSelectArgType` |
-| Una story o colección crudas              | `onoffRawStoriesMock`, `onoffRawCollectionsMock`, `onoffRawNavCollectionsMock`                        |
+| Una story o storylist crudas              | `onoffRawStoriesMock`, `onoffRawStorylistsMock`, `onoffRawNavTeasersMock`                             |
 | Una story o teaser crudos con multimedia  | `onoffRawStoriesWithMediaSources` / `onoffRawTeasersWithMediaSources`                                 |
 | Una obra con o sin etiquetas              | `onoffRawLiteraryWorksWith(out)Tags`                                                                  |
 | Una etiqueta cualquiera                   | `onoffTagsMock` (o `onoffRawTagsMock` en el backend), y tomá un slice                                 |

--- a/src/api/modules/storylist/storylist.repository.spec.ts
+++ b/src/api/modules/storylist/storylist.repository.spec.ts
@@ -1,6 +1,6 @@
 import { clearAllMocks, type Mock } from '@test-utils';
 import { client } from '../../_helpers/sanity-connector';
-import { onoffRawCollectionsMock } from '@mocks/onoff-raw-collections.mock';
+import { onoffRawStorylistsMock } from '@mocks/onoff-raw-storylists.mock';
 import { fetchStorylistBySlug } from './storylist.repository';
 
 /* eslint-disable no-restricted-syntax -- vi.mock/vi.fn: mock del cliente de Sanity y del builder de imágenes para aislar el mapeo del repository; se migra a inyección de dependencias en #1503 */
@@ -14,9 +14,9 @@ vi.mock('@sanity/image-url', () => ({
 }));
 /* eslint-enable no-restricted-syntax */
 
-// Fragmentos de los `_ref` reales del corpus: la collection (featuredImage) y las 3 primeras
+// Fragmentos de los `_ref` reales del corpus: la storylist (featuredImage) y las 3 primeras
 // stories de `onoffRawNavTeasersMock` (el-palacio, geometria, los-peldanos), que alimentan `storyCoverImages`.
-const [rawCollection] = onoffRawCollectionsMock;
+const [rawStorylist] = onoffRawStorylistsMock;
 
 const geometriasFeaturedRef = '6efd3e53eec8dfab23e1c0109027be9f58a01f8c';
 const elPalacioCoverRef = '3f8774ea01abc54483829d982035a810667240e1';
@@ -30,7 +30,7 @@ describe('storylist.repository', () => {
 
 	describe('fetchStorylistBySlug', () => {
 		it('maps a present featuredImage to representative imagery', async () => {
-			(client.fetch as Mock).mockResolvedValue(rawCollection);
+			(client.fetch as Mock).mockResolvedValue(rawStorylist);
 
 			const result = await fetchStorylistBySlug('geometrias-del-desvelo');
 
@@ -41,7 +41,7 @@ describe('storylist.repository', () => {
 		});
 
 		it('falls back to sample imagery (story covers) when featuredImage is null', async () => {
-			(client.fetch as Mock).mockResolvedValue({ ...rawCollection, featuredImage: null });
+			(client.fetch as Mock).mockResolvedValue({ ...rawStorylist, featuredImage: null });
 
 			const result = await fetchStorylistBySlug('geometrias-del-desvelo');
 

--- a/src/mocks/onoff-raw-collections.mock.ts
+++ b/src/mocks/onoff-raw-collections.mock.ts
@@ -1,6 +1,0 @@
-import type { StorylistQueryResult } from '@sanity-types';
-import { geometriasDelDesveloRawCollection } from './onoff/geometrias-del-desvelo.collection.raw.mock';
-
-// Colecciones crudas del corpus. Los specs toman de acá en vez de importar una colección puntual,
-// para no atarse a la que exista hoy.
-export const onoffRawCollectionsMock: NonNullable<StorylistQueryResult>[] = [geometriasDelDesveloRawCollection];

--- a/src/mocks/onoff-raw-storylists.mock.ts
+++ b/src/mocks/onoff-raw-storylists.mock.ts
@@ -1,0 +1,6 @@
+import type { StorylistQueryResult } from '@sanity-types';
+import { geometriasDelDesveloRawStorylist } from './onoff/geometrias-del-desvelo.storylist.raw.mock';
+
+// Storylists crudas del corpus. Los specs toman de acá en vez de importar una puntual, para no
+// atarse a la que exista hoy.
+export const onoffRawStorylistsMock: NonNullable<StorylistQueryResult>[] = [geometriasDelDesveloRawStorylist];

--- a/src/mocks/onoff/geometrias-del-desvelo.storylist.raw.mock.ts
+++ b/src/mocks/onoff/geometrias-del-desvelo.storylist.raw.mock.ts
@@ -1,9 +1,9 @@
 import type { StorylistQueryResult } from '@sanity-types';
 import { onoffRawNavTeasersMock } from '../onoff-raw-stories.mock';
 
-// Collection cruda Onoff — "Geometrías del desvelo" (obsesión por el orden y el tiempo).
+// Storylist cruda Onoff — "Geometrías del desvelo" (obsesión por el orden y el tiempo).
 // Forma cruda de `storylistQuery` (StorylistQueryResult), para testear `fetchStorylistBySlug`.
-export const geometriasDelDesveloRawCollection: NonNullable<StorylistQueryResult> = {
+export const geometriasDelDesveloRawStorylist: NonNullable<StorylistQueryResult> = {
 	_id: 'onoff-geometrias-del-desvelo',
 	slug: 'geometrias-del-desvelo',
 	title: 'Geometrías del desvelo',


### PR DESCRIPTION
Renombra la fixture cruda de `Storylist`, que ocupaba el nombre de `Collection`.

## El nombre mentía

`onoffRawCollectionsMock`, en `<slug>.collection.raw.mock.ts`, está tipada contra `StorylistQueryResult` y su propio comentario dice que existe para testear `fetchStorylistBySlug`. Es una fixture de storylist con nombre de colección: el nombre viene de cuando "colección" nombraba a la storylist, y hoy induce a error porque `Collection` es un agregado distinto que convive con aquel.

Pasa a `onoffRawStorylistsMock` y `<slug>.storylist.raw.mock.ts`, con su único consumidor actualizado —el spec del repository de storylist, donde la variable local también se llamaba `rawCollection`—.

De paso corrige la fila del corpus en la referencia de testing, que además citaba un mock de navegación inexistente con ese nombre.

## Por qué va solo en su PR

Este trabajo salió de la implementación de la capa de datos de `Collection`, donde el renombrado era un requisito previo: la fixture cruda de `Collection` necesita ese nombre. Pero el cambio es enteramente de `Storylist` y no tiene relación con lo otro, así que mezclarlos obligaba a quien revisa a separar mentalmente dos cosas sin nada en común.

Queda como base de esa secuencia: es mecánico, verde por sí solo, y se revisa en un minuto.

## Plan de pruebas

- **Tier local verde**: typecheck estricto, lint y la suite completa — **1445 pasando**, 3 skipped, 142 archivos, sin cambios respecto de `develop`.
- **El renombrado es puramente mecánico**: git detecta el archivo como renombrado con 80% de similitud, y las únicas diferencias son el símbolo, el tipo citado en el comentario y el nombre de la variable local del spec.

Closes #2150.
