### PR TITLE
[#2143] - Suma la capa de documentos al corpus de Onoff

### DIFF
--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -64,22 +64,23 @@ beforeEach(() => {
 
 ## Regla dura: el corpus se consume por colecciones, nunca por obra
 
-ESLint (`no-single-work-corpus-imports` en `eslint.config.mjs`) **prohíbe** importar una pieza puntual del corpus desde cualquier archivo fuera de `src/mocks/**` — los agregadores son justamente quienes las importan. El glob es `@mocks/onoff/**`, así que cubre las subcarpetas por entidad —`story/`, `literary-work/`, `collection/`, `storylist/`, `author/`, `media/`— a cualquier profundidad.
+ESLint (`no-single-work-corpus-imports` en `eslint.config.mjs`) **prohíbe** importar una pieza puntual del corpus desde cualquier archivo fuera de `src/mocks/**` — los agregadores son justamente quienes las importan. El glob es `@mocks/onoff/**`, así que cubre las subcarpetas por entidad —`story/`, `literary-work/`, `collection/`, `storylist/`, `author/`, `media/`, `document/`— a cualquier profundidad.
 
 Un spec o una story que importa una obra concreta queda atado a ella: sus aserciones citan la prosa de esa obra y enriquecer el canon no las alcanza. Las colecciones y los **selectores por capacidad** declaran el shape que el caso necesita y crecen solos.
 
-| Necesitás…                                | Importá                                                                                               |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Una obra cualquiera                       | `onoffLiteraryWorksMock` (o `onoffRawLiteraryWorksMock` en el backend), y desestructurá la primera    |
-| Una obra con título de sección            | `onoffLiteraryWorksWithSectionTitles`                                                                 |
-| Una obra con epígrafes                    | `onoffLiteraryWorksWithEpigraphs` / `onoffRawLiteraryWorksWithEpigraphs`                              |
-| Una obra con o sin nota editorial         | `onoffLiteraryWorksWith(out)EditorialNote` / `onoffRawLiteraryWorksWith(out)EditorialNote`            |
-| Un texto con atribución (epígrafe o nota) | `onoffLiteraryWorkEpigraphsMock`; en stories, `corpusAttributedTexts` + `attributedTextSelectArgType` |
-| Una story o storylist crudas              | `onoffRawStoriesMock`, `onoffRawStorylistsMock`, `onoffRawNavTeasersMock`                             |
-| Una story o teaser crudos con multimedia  | `onoffRawStoriesWithMediaSources` / `onoffRawTeasersWithMediaSources`                                 |
-| Una obra con o sin etiquetas              | `onoffRawLiteraryWorksWith(out)Tags`                                                                  |
-| Una etiqueta cualquiera                   | `onoffTagsMock` (o `onoffRawTagsMock` en el backend), y tomá un slice                                 |
-| Etiquetas de título corto                 | `onoffTagsWithShortTitles` — para stories donde un título de dos palabras fuerza el recorte por ancho |
+| Necesitás…                                      | Importá                                                                                                              |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Una obra cualquiera                             | `onoffLiteraryWorksMock` (o `onoffRawLiteraryWorksMock` en el backend), y desestructurá la primera                   |
+| Una obra con título de sección                  | `onoffLiteraryWorksWithSectionTitles`                                                                                |
+| Una obra con epígrafes                          | `onoffLiteraryWorksWithEpigraphs` / `onoffRawLiteraryWorksWithEpigraphs`                                             |
+| Una obra con o sin nota editorial               | `onoffLiteraryWorksWith(out)EditorialNote` / `onoffRawLiteraryWorksWith(out)EditorialNote`                           |
+| Un texto con atribución (epígrafe o nota)       | `onoffLiteraryWorkEpigraphsMock`; en stories, `corpusAttributedTexts` + `attributedTextSelectArgType`                |
+| Una story o storylist crudas                    | `onoffRawStoriesMock`, `onoffRawStorylistsMock`, `onoffRawNavTeasersMock`                                            |
+| Un dataset para evaluar una query con `groq-js` | `onoffDatasetMock` — el dataset entero, no un subconjunto: una referencia sin documento resuelve a `null` sin fallar |
+| Una story o teaser crudos con multimedia        | `onoffRawStoriesWithMediaSources` / `onoffRawTeasersWithMediaSources`                                                |
+| Una obra con o sin etiquetas                    | `onoffRawLiteraryWorksWith(out)Tags`                                                                                 |
+| Una etiqueta cualquiera                         | `onoffTagsMock` (o `onoffRawTagsMock` en el backend), y tomá un slice                                                |
+| Etiquetas de título corto                       | `onoffTagsWithShortTitles` — para stories donde un título de dos palabras fuerza el recorte por ancho                |
 
 Corolario: **las aserciones se derivan del fixture**, no de prosa clavada. Si el caso necesita una palabra del texto, extraela del propio mock (`bodyHtml.replace(/<[^>]+>/g, ' ')` y tomá una palabra) en vez de escribirla a mano — así sigue pasando cuando el canon cambie. Si falta un selector para el shape que necesitás, **agregalo al agregador** (derivado por predicado, no una lista en paralelo) en vez de importar la obra.
 

--- a/src/api/_queries/collection.query.spec.ts
+++ b/src/api/_queries/collection.query.spec.ts
@@ -21,6 +21,10 @@ const dataset = onoffDatasetMock;
 
 const [firstCollection] = onoffCollectionDocumentsMock;
 
+function canonCollectionFor(slug: string) {
+	return { ...firstCollection, _id: slug, slug: { _type: 'slug' as const, current: slug } };
+}
+
 describe('collectionBySlugQuery', () => {
 	it('resolves the collection whose slug matches the parameter', async () => {
 		const result = await run(collectionBySlugQuery, dataset, { slug: firstCollection?.slug.current });
@@ -121,16 +125,30 @@ describe('collectionsQuery', () => {
 		expect(target?.literaryWorkCoverImages).toEqual([null]);
 	});
 
-	// El orden esperado se aproxima con `localeCompare('es')`: GROQ ordena por collation, no por unidades
-	// UTF-16, así que un `sort()` pelado divergiría ante el primer título acentuado.
+	// `sort()` pelado y no `localeCompare`: verificado contra el dataset de producción, `order(title asc)`
+	// ordena por codepoint —`A Palmira` antes que `A la deriva`, `Antieros` antes que `Antártida`—, que es
+	// justamente lo que compara `sort()`. Una collation local invertiría los dos pares.
 	it('orders by title ascending and leaves drafts out', async () => {
 		const withDraft = [...dataset, draftCollectionDocument];
 
 		const result = (await run(collectionsQuery, withDraft)) as { title: string }[];
-		const expected = onoffCollectionDocumentsMock
-			.map((collection) => collection.title)
-			.sort((a, b) => a.localeCompare(b, 'es'));
+		const expected = onoffCollectionDocumentsMock.map((collection) => collection.title).sort();
 
 		expect(result.map(({ title }) => title)).toEqual(expected);
+	});
+
+	// El corpus actual no tiene títulos acentuados ni mayúsculas intercaladas, así que el caso de arriba
+	// pasaría con cualquiera de los dos criterios. Éste los separa: el orden esperado es el que devolvió
+	// el dataset de producción para estos mismos títulos.
+	it('orders accented titles by codepoint, as the content lake does', async () => {
+		const titles = ['Antieros', 'Antártida', 'A Palmira', 'A la deriva'];
+		const collections = titles.map((title, index) => ({
+			...canonCollectionFor(`orden-${index}`),
+			title,
+		}));
+
+		const result = (await run(collectionsQuery, collections)) as { title: string }[];
+
+		expect(result.map(({ title }) => title)).toEqual(['A Palmira', 'A la deriva', 'Antieros', 'Antártida']);
 	});
 });

--- a/src/api/_queries/collection.query.spec.ts
+++ b/src/api/_queries/collection.query.spec.ts
@@ -1,5 +1,6 @@
 import { evaluate, parse } from 'groq-js';
 import {
+	configlessCollectionDocument,
 	coverlessLiteraryWorkDocument,
 	draftCollectionDocument,
 	emptyCollectionDocument,
@@ -16,13 +17,7 @@ async function run(query: string, dataset: unknown[], params: Record<string, unk
 	return result.get();
 }
 
-// El dataset se resuelve una vez por archivo y fuera del tiempo de carga del módulo: si el corpus se
-// rompiera, falla como hook con nombre propio en vez de como un crash al importar.
-let dataset: unknown[];
-
-beforeAll(() => {
-	dataset = [...onoffDatasetMock];
-});
+const dataset = onoffDatasetMock;
 
 const [firstCollection] = onoffCollectionDocumentsMock;
 
@@ -69,13 +64,9 @@ describe('collectionBySlugQuery', () => {
 	});
 
 	it('defaults showAuthors to false when the config is absent', async () => {
-		const { config: _config, ...withoutConfig } = {
-			...firstCollection,
-			_id: 'sin-config',
-			slug: { _type: 'slug' as const, current: 'sin-config' },
-		};
-
-		const result = await run(collectionBySlugQuery, [...dataset, withoutConfig], { slug: 'sin-config' });
+		const result = await run(collectionBySlugQuery, [...dataset, configlessCollectionDocument], {
+			slug: configlessCollectionDocument.slug.current,
+		});
 
 		expect((result as { config: { showAuthors: boolean } }).config.showAuthors).toBe(false);
 	});
@@ -101,13 +92,15 @@ describe('collectionsQuery', () => {
 	});
 
 	it('yields an empty cover list for a collection without works', async () => {
-		const result = (await run(collectionsQuery, [emptyCollectionDocument])) as {
+		const result = (await run(collectionsQuery, [...dataset, emptyCollectionDocument])) as {
+			_id: string;
 			count: number;
 			literaryWorkCoverImages: unknown[];
 		}[];
+		const target = result.find((collection) => collection._id === emptyCollectionDocument._id);
 
-		expect(result[0]?.count).toBe(0);
-		expect(result[0]?.literaryWorkCoverImages).toEqual([]);
+		expect(target?.count).toBe(0);
+		expect(target?.literaryWorkCoverImages).toEqual([]);
 	});
 
 	// La obra sin portada es una rama que el tipo declara opcional y que el canon nunca ejercitó.
@@ -119,18 +112,24 @@ describe('collectionsQuery', () => {
 			literaryWorks: [{ _key: 'k', _type: 'reference' as const, _ref: coverlessLiteraryWorkDocument._id }],
 		};
 
-		const result = (await run(collectionsQuery, [collection, coverlessLiteraryWorkDocument])) as {
+		const result = (await run(collectionsQuery, [...dataset, collection, coverlessLiteraryWorkDocument])) as {
+			_id: string;
 			literaryWorkCoverImages: unknown[];
 		}[];
+		const target = result.find((entry) => entry._id === collection._id);
 
-		expect(result[0]?.literaryWorkCoverImages).toEqual([null]);
+		expect(target?.literaryWorkCoverImages).toEqual([null]);
 	});
 
+	// El orden esperado se aproxima con `localeCompare('es')`: GROQ ordena por collation, no por unidades
+	// UTF-16, así que un `sort()` pelado divergiría ante el primer título acentuado.
 	it('orders by title ascending and leaves drafts out', async () => {
 		const withDraft = [...dataset, draftCollectionDocument];
 
 		const result = (await run(collectionsQuery, withDraft)) as { title: string }[];
-		const expected = onoffCollectionDocumentsMock.map((collection) => collection.title).sort();
+		const expected = onoffCollectionDocumentsMock
+			.map((collection) => collection.title)
+			.sort((a, b) => a.localeCompare(b, 'es'));
 
 		expect(result.map(({ title }) => title)).toEqual(expected);
 	});

--- a/src/api/_queries/collection.query.spec.ts
+++ b/src/api/_queries/collection.query.spec.ts
@@ -1,101 +1,81 @@
 import { evaluate, parse } from 'groq-js';
+import {
+	coverlessLiteraryWorkDocument,
+	draftCollectionDocument,
+	emptyCollectionDocument,
+	multiSectionCollectionDocument,
+	multiSectionLiteraryWorkDocument,
+	onoffCollectionDocumentsMock,
+	onoffDatasetMock,
+} from '@mocks/onoff-documents.mock';
 
 import { collectionBySlugQuery, collectionsQuery } from './collection.query';
 
-// Los documentos son sintéticos porque el corpus de Onoff modela el **resultado** de estas queries,
-// no los documentos del content lake que las alimentan: no hay canon del que derivar esta entrada.
-// Es el mismo criterio del spec de la migración de borradores.
-//
-// No están tipados contra los tipos de documento del typegen, así que su forma puede divergir de la
-// real sin que nada avise — `coverImage` acá es un string y en el documento es un objeto de imagen.
-// Alcanza para lo que estos casos verifican, que es el filtrado, el orden y los recortes, no el
-// contenido de los campos. La capa de documentos del corpus es trabajo aparte.
-function work(id: string, overrides: Record<string, unknown> = {}) {
-	return {
-		_id: id,
-		_type: 'literaryWork',
-		title: `Obra ${id}`,
-		slug: { current: id },
-		coverImage: `${id}.png`,
-		content: [{ _key: 's1', title: 'Uno', body: 'Texto' }],
-		...overrides,
-	};
-}
-
-function reference(id: string) {
-	return { _type: 'reference', _ref: id, _key: id };
-}
-
-function collection(id: string, overrides: Record<string, unknown> = {}) {
-	return {
-		_id: id,
-		_type: 'collection',
-		title: `Colección ${id}`,
-		slug: { current: id },
-		description: 'Prosa de la colección.',
-		literaryWorks: [reference('uno')],
-		...overrides,
-	};
-}
-
-async function run(query: string, dataset: Record<string, unknown>[], params: Record<string, unknown> = {}) {
+async function run(query: string, dataset: unknown[], params: Record<string, unknown> = {}) {
 	const result = await evaluate(parse(query), { dataset, params });
 	return result.get();
 }
 
-const works = [work('uno'), work('dos'), work('tres'), work('cuatro')];
-const everyWork = [reference('uno'), reference('dos'), reference('tres'), reference('cuatro')];
+// El dataset se resuelve una vez por archivo y fuera del tiempo de carga del módulo: si el corpus se
+// rompiera, falla como hook con nombre propio en vez de como un crash al importar.
+let dataset: unknown[];
+
+beforeAll(() => {
+	dataset = [...onoffDatasetMock];
+});
+
+const [firstCollection] = onoffCollectionDocumentsMock;
 
 describe('collectionBySlugQuery', () => {
 	it('resolves the collection whose slug matches the parameter', async () => {
-		const dataset = [...works, collection('geometrias'), collection('inventario')];
+		const result = await run(collectionBySlugQuery, dataset, { slug: firstCollection?.slug.current });
 
-		const result = await run(collectionBySlugQuery, dataset, { slug: 'geometrias' });
-
-		expect(result).toMatchObject({ _id: 'geometrias', slug: 'geometrias' });
+		expect(result).toMatchObject({ _id: firstCollection?._id, slug: firstCollection?.slug.current });
 	});
 
 	it('resolves null when no collection carries the slug', async () => {
-		const result = await run(collectionBySlugQuery, [...works, collection('geometrias')], { slug: 'inexistente' });
-
-		expect(result).toBeNull();
+		expect(await run(collectionBySlugQuery, dataset, { slug: 'inexistente' })).toBeNull();
 	});
 
-	// El sitio público sirve solo contenido publicado; un borrador que se colara acá lo expondría.
+	// El sitio público sirve solo contenido publicado; un borrador que se colara acá lo expondría. El
+	// dataset lleva **solo** el borrador: con la publicada al lado, el caso podría pasar por el orden
+	// en que la query las encuentra en vez de por el filtro.
 	it('leaves drafts out', async () => {
-		const dataset = [...works, collection('drafts.geometrias', { slug: { current: 'geometrias' } })];
+		const result = await run(collectionBySlugQuery, [draftCollectionDocument], {
+			slug: draftCollectionDocument.slug?.current,
+		});
 
-		expect(await run(collectionBySlugQuery, dataset, { slug: 'geometrias' })).toBeNull();
+		expect(result).toBeNull();
 	});
 
 	// No acotar el listado es la precondición de la invariante `count`, que el agregado deriva de las
 	// obras que transporta: un slice acá la volvería silenciosamente el tamaño de la página.
 	it('carries every literary work, uncapped', async () => {
-		const dataset = [...works, collection('geometrias', { literaryWorks: everyWork })];
+		const result = await run(collectionBySlugQuery, dataset, { slug: firstCollection?.slug.current });
 
-		const result = await run(collectionBySlugQuery, dataset, { slug: 'geometrias' });
-
-		expect((result as { literaryWorks: unknown[] }).literaryWorks).toHaveLength(everyWork.length);
+		expect((result as { literaryWorks: unknown[] }).literaryWorks).toHaveLength(
+			firstCollection?.literaryWorks?.length ?? 0,
+		);
 	});
 
 	it('projects the opening section alone, not the whole body', async () => {
-		const multiSection = work('uno', {
-			content: [
-				{ _key: 's1', title: 'Primera', body: 'Una' },
-				{ _key: 's2', title: 'Segunda', body: 'Dos' },
-			],
-		});
-		const dataset = [multiSection, collection('geometrias')];
+		const withMultiSection = [...dataset, multiSectionLiteraryWorkDocument, multiSectionCollectionDocument];
 
-		const result = await run(collectionBySlugQuery, dataset, { slug: 'geometrias' });
-		const [first] = (result as { literaryWorks: { teaserSection: unknown[]; sectionCount: number }[] }).literaryWorks;
+		const result = await run(collectionBySlugQuery, withMultiSection, { slug: 'multi-seccion' });
+		const [work] = (result as { literaryWorks: { teaserSection: unknown[]; sectionCount: number }[] }).literaryWorks;
 
-		expect(first?.teaserSection).toHaveLength(1);
-		expect(first?.sectionCount).toBe(2);
+		expect(work?.teaserSection).toHaveLength(1);
+		expect(work?.sectionCount).toBe(multiSectionLiteraryWorkDocument.content.length);
 	});
 
 	it('defaults showAuthors to false when the config is absent', async () => {
-		const result = await run(collectionBySlugQuery, [...works, collection('geometrias')], { slug: 'geometrias' });
+		const { config: _config, ...withoutConfig } = {
+			...firstCollection,
+			_id: 'sin-config',
+			slug: { _type: 'slug' as const, current: 'sin-config' },
+		};
+
+		const result = await run(collectionBySlugQuery, [...dataset, withoutConfig], { slug: 'sin-config' });
 
 		expect((result as { config: { showAuthors: boolean } }).config.showAuthors).toBe(false);
 	});
@@ -103,45 +83,55 @@ describe('collectionBySlugQuery', () => {
 
 describe('collectionsQuery', () => {
 	it('counts the works without dereferencing them', async () => {
-		const dataset = [...works, collection('geometrias', { literaryWorks: everyWork })];
-
 		const result = (await run(collectionsQuery, dataset)) as Record<string, unknown>[];
+		const target = result.find((collection) => collection['_id'] === firstCollection?._id);
 
-		expect(result[0]?.['count']).toBe(everyWork.length);
-		expect(result[0]).not.toHaveProperty('literaryWorks');
+		expect(target?.['count']).toBe(firstCollection?.literaryWorks?.length);
+		expect(target).not.toHaveProperty('literaryWorks');
 	});
 
 	// La rama `sample` de imagery necesita exactamente tres portadas, y solo esas tres se resuelven.
+	// Se afirma contra los objetos de imagen de las obras referenciadas, que es la forma real.
 	it('resolves the cover of the first three works alone', async () => {
-		const dataset = [...works, collection('geometrias', { literaryWorks: everyWork })];
+		const result = (await run(collectionsQuery, dataset)) as { _id: string; literaryWorkCoverImages: unknown[] }[];
+		const target = result.find((collection) => collection._id === firstCollection?._id);
 
-		const result = (await run(collectionsQuery, dataset)) as { literaryWorkCoverImages: string[] }[];
-
-		expect(result[0]?.literaryWorkCoverImages).toEqual(['uno.png', 'dos.png', 'tres.png']);
+		expect(target?.literaryWorkCoverImages).toHaveLength(Math.min(3, firstCollection?.literaryWorks?.length ?? 0));
+		target?.literaryWorkCoverImages.forEach((cover) => expect(cover).toMatchObject({ _type: 'image' }));
 	});
 
 	it('yields an empty cover list for a collection without works', async () => {
-		const dataset = [collection('vacia', { literaryWorks: [] })];
-
-		const result = (await run(collectionsQuery, dataset)) as {
+		const result = (await run(collectionsQuery, [emptyCollectionDocument])) as {
 			count: number;
-			literaryWorkCoverImages: string[];
+			literaryWorkCoverImages: unknown[];
 		}[];
 
 		expect(result[0]?.count).toBe(0);
 		expect(result[0]?.literaryWorkCoverImages).toEqual([]);
 	});
 
+	// La obra sin portada es una rama que el tipo declara opcional y que el canon nunca ejercitó.
+	it('projects null for a work that carries no cover', async () => {
+		const collection = {
+			...firstCollection,
+			_id: 'sin-portada',
+			slug: { _type: 'slug' as const, current: 'sin-portada' },
+			literaryWorks: [{ _key: 'k', _type: 'reference' as const, _ref: coverlessLiteraryWorkDocument._id }],
+		};
+
+		const result = (await run(collectionsQuery, [collection, coverlessLiteraryWorkDocument])) as {
+			literaryWorkCoverImages: unknown[];
+		}[];
+
+		expect(result[0]?.literaryWorkCoverImages).toEqual([null]);
+	});
+
 	it('orders by title ascending and leaves drafts out', async () => {
-		const dataset = [
-			...works,
-			collection('c', { title: 'Zorro' }),
-			collection('a', { title: 'Almanaque' }),
-			collection('drafts.b', { title: 'Borrador' }),
-		];
+		const withDraft = [...dataset, draftCollectionDocument];
 
-		const result = (await run(collectionsQuery, dataset)) as { title: string }[];
+		const result = (await run(collectionsQuery, withDraft)) as { title: string }[];
+		const expected = onoffCollectionDocumentsMock.map((collection) => collection.title).sort();
 
-		expect(result.map(({ title }) => title)).toEqual(['Almanaque', 'Zorro']);
+		expect(result.map(({ title }) => title)).toEqual(expected);
 	});
 });

--- a/src/mocks/onoff-documents.mock.spec.ts
+++ b/src/mocks/onoff-documents.mock.spec.ts
@@ -1,0 +1,54 @@
+import { evaluate, parse } from 'groq-js';
+import { collectionBySlugQuery, collectionsQuery } from '../api/_queries/collection.query';
+import { literaryWorkBySlugQuery } from '../api/_queries/literary-work.query';
+import { onoffRawCollectionsMock } from './onoff-raw-collections.mock';
+import { onoffRawLiteraryWorksMock } from './onoff-raw-literary-works.mock';
+import { onoffDatasetMock } from './onoff-documents.mock';
+
+async function run(query: string, params: Record<string, unknown> = {}) {
+	const result = await evaluate(parse(query), { dataset: onoffDatasetMock, params });
+	return result.get();
+}
+
+// Los documentos se derivan invirtiendo la proyección de la query. La única forma de saber que esa
+// inversión no miente es volver a aplicar la query: si el resultado no reproduce el canon crudo, los
+// documentos afirman un content lake que no existe.
+describe('el dataset de documentos reproduce el corpus crudo', () => {
+	it.each(onoffRawCollectionsMock.map((collection) => collection.slug))(
+		'evaluates the collection query for "%s" into its raw fixture',
+		async (slug) => {
+			const expected = onoffRawCollectionsMock.find((collection) => collection.slug === slug);
+
+			await expect(run(collectionBySlugQuery, { slug })).resolves.toEqual(expected);
+		},
+	);
+
+	it.each(onoffRawLiteraryWorksMock.map((work) => work.slug))(
+		'evaluates the literary work query for "%s" into its raw fixture',
+		async (slug) => {
+			const expected = onoffRawLiteraryWorksMock.find((work) => work.slug === slug);
+
+			await expect(run(literaryWorkBySlugQuery, { slug })).resolves.toEqual(expected);
+		},
+	);
+
+	it('evaluates the listing query into every collection of the corpus', async () => {
+		const result = (await run(collectionsQuery)) as { slug: string }[];
+
+		expect(result.map(({ slug }) => slug).sort()).toEqual(onoffRawCollectionsMock.map(({ slug }) => slug).sort());
+	});
+
+	// El modo de falla que `groq-js` no reporta: si el documento de asset no está en el dataset, la
+	// dereferencia resuelve a null y el fixture derivado queda mudo sobre la diferencia.
+	it('resolves the audio url of the work that carries a space recording', async () => {
+		const withRecording = onoffRawLiteraryWorksMock.find((work) =>
+			(work.mediaSources ?? []).some((source) => source._type === 'spaceRecording'),
+		);
+		const result = (await run(literaryWorkBySlugQuery, { slug: withRecording?.slug })) as {
+			mediaSources: { _type: string; audioUrl?: string | null }[];
+		};
+		const recording = result.mediaSources.find((source) => source._type === 'spaceRecording');
+
+		expect(recording?.audioUrl).toBeTruthy();
+	});
+});

--- a/src/mocks/onoff-documents.mock.spec.ts
+++ b/src/mocks/onoff-documents.mock.spec.ts
@@ -3,7 +3,8 @@ import { collectionBySlugQuery, collectionsQuery } from '../api/_queries/collect
 import { literaryWorkBySlugQuery } from '../api/_queries/literary-work.query';
 import { onoffRawCollectionsMock } from './onoff-raw-collections.mock';
 import { onoffRawLiteraryWorksMock } from './onoff-raw-literary-works.mock';
-import { onoffDatasetMock } from './onoff-documents.mock';
+import type { LiteraryWork } from '@sanity-types';
+import { onoffDatasetMock, onoffLiteraryWorkDocumentsMock } from './onoff-documents.mock';
 
 async function run(query: string, params: Record<string, unknown> = {}) {
 	const result = await evaluate(parse(query), { dataset: onoffDatasetMock, params });
@@ -36,6 +37,20 @@ describe('el dataset de documentos reproduce el corpus crudo', () => {
 		const result = (await run(collectionsQuery)) as { slug: string }[];
 
 		expect(result.map(({ slug }) => slug).sort()).toEqual(onoffRawCollectionsMock.map(({ slug }) => slug).sort());
+	});
+
+	// La razón de ser de la capa: los documentos sintéticos que esta reemplaza declaraban la portada
+	// como string, y nada lo detectaba. Tipar contra el documento lo vuelve un error de compilación.
+	// Si el campo alguna vez se aflojara, el `@ts-expect-error` quedaría sin usar y `tsc` cortaría —
+	// el gate de typecheck cubre los spec.
+	it('rejects a cover image declared as a string', () => {
+		const document: LiteraryWork = {
+			...(onoffLiteraryWorkDocumentsMock[0] as LiteraryWork),
+			// @ts-expect-error la portada es un objeto de imagen en el documento, no una ruta
+			coverImage: 'uno.png',
+		};
+
+		expect(document.coverImage).toBe('uno.png');
 	});
 
 	// El modo de falla que `groq-js` no reporta: si el documento de asset no está en el dataset, la

--- a/src/mocks/onoff-documents.mock.spec.ts
+++ b/src/mocks/onoff-documents.mock.spec.ts
@@ -36,7 +36,7 @@ describe('el dataset de documentos reproduce el corpus crudo', () => {
 	// verifica —el total, el abanico de portadas y la imagen destacada—, y su canon ya existe.
 	it('evaluates the listing query into the raw teaser fixtures', async () => {
 		const result = (await run(collectionsQuery)) as { slug: string }[];
-		const expected = [...onoffRawCollectionTeasersMock].sort((a, b) => a.title.localeCompare(b.title, 'es'));
+		const expected = [...onoffRawCollectionTeasersMock].sort((a, b) => (a.title < b.title ? -1 : 1));
 
 		expect(result).toStrictEqual(expected);
 	});

--- a/src/mocks/onoff-documents.mock.spec.ts
+++ b/src/mocks/onoff-documents.mock.spec.ts
@@ -1,10 +1,9 @@
 import { evaluate, parse } from 'groq-js';
 import { collectionBySlugQuery, collectionsQuery } from '../api/_queries/collection.query';
 import { literaryWorkBySlugQuery } from '../api/_queries/literary-work.query';
-import { onoffRawCollectionsMock } from './onoff-raw-collections.mock';
+import { onoffRawCollectionsMock, onoffRawCollectionTeasersMock } from './onoff-raw-collections.mock';
 import { onoffRawLiteraryWorksMock } from './onoff-raw-literary-works.mock';
-import type { LiteraryWork } from '@sanity-types';
-import { onoffDatasetMock, onoffLiteraryWorkDocumentsMock } from './onoff-documents.mock';
+import { onoffDatasetMock } from './onoff-documents.mock';
 
 async function run(query: string, params: Record<string, unknown> = {}) {
 	const result = await evaluate(parse(query), { dataset: onoffDatasetMock, params });
@@ -20,7 +19,7 @@ describe('el dataset de documentos reproduce el corpus crudo', () => {
 		async (slug) => {
 			const expected = onoffRawCollectionsMock.find((collection) => collection.slug === slug);
 
-			await expect(run(collectionBySlugQuery, { slug })).resolves.toEqual(expected);
+			await expect(run(collectionBySlugQuery, { slug })).resolves.toStrictEqual(expected);
 		},
 	);
 
@@ -29,28 +28,17 @@ describe('el dataset de documentos reproduce el corpus crudo', () => {
 		async (slug) => {
 			const expected = onoffRawLiteraryWorksMock.find((work) => work.slug === slug);
 
-			await expect(run(literaryWorkBySlugQuery, { slug })).resolves.toEqual(expected);
+			await expect(run(literaryWorkBySlugQuery, { slug })).resolves.toStrictEqual(expected);
 		},
 	);
 
-	it('evaluates the listing query into every collection of the corpus', async () => {
+	// Se compara el objeto entero y no solo los slugs: el listado proyecta cosas que ninguna otra query
+	// verifica —el total, el abanico de portadas y la imagen destacada—, y su canon ya existe.
+	it('evaluates the listing query into the raw teaser fixtures', async () => {
 		const result = (await run(collectionsQuery)) as { slug: string }[];
+		const expected = [...onoffRawCollectionTeasersMock].sort((a, b) => a.title.localeCompare(b.title, 'es'));
 
-		expect(result.map(({ slug }) => slug).sort()).toEqual(onoffRawCollectionsMock.map(({ slug }) => slug).sort());
-	});
-
-	// La razón de ser de la capa: los documentos sintéticos que esta reemplaza declaraban la portada
-	// como string, y nada lo detectaba. Tipar contra el documento lo vuelve un error de compilación.
-	// Si el campo alguna vez se aflojara, el `@ts-expect-error` quedaría sin usar y `tsc` cortaría —
-	// el gate de typecheck cubre los spec.
-	it('rejects a cover image declared as a string', () => {
-		const document: LiteraryWork = {
-			...(onoffLiteraryWorkDocumentsMock[0] as LiteraryWork),
-			// @ts-expect-error la portada es un objeto de imagen en el documento, no una ruta
-			coverImage: 'uno.png',
-		};
-
-		expect(document.coverImage).toBe('uno.png');
+		expect(result).toStrictEqual(expected);
 	});
 
 	// El modo de falla que `groq-js` no reporta: si el documento de asset no está en el dataset, la

--- a/src/mocks/onoff-documents.mock.ts
+++ b/src/mocks/onoff-documents.mock.ts
@@ -1,0 +1,48 @@
+import { onoffAuthorDocument } from './onoff/author/author.document.projection';
+import { onoffCollectionDocumentsMock } from './onoff/collection/collection.document.projection';
+import {
+	onoffNationalityDocumentsMock,
+	onoffResourceTypeDocumentsMock,
+	onoffTagDocumentsMock,
+} from './onoff/document/support-documents.projection';
+import { asDraft } from './onoff/document/sanity-document.factory';
+import {
+	onoffLiteraryWorkAssetDocumentsMock,
+	onoffLiteraryWorkDocumentsMock,
+} from './onoff/literary-work/literary-work.document.projection';
+
+export {
+	onoffCollectionDocumentsMock,
+	onoffLiteraryWorkDocumentsMock,
+	onoffNationalityDocumentsMock,
+	onoffResourceTypeDocumentsMock,
+	onoffTagDocumentsMock,
+};
+
+export const onoffAuthorDocumentsMock = [onoffAuthorDocument];
+
+// El dataset plano que consume `groq-js`: lleva todos los documentos, incluidos los de soporte y los
+// de asset. Un documento que falte no hace fallar la evaluación — la dereferencia queda en null sin
+// avisar—, así que conviene pedir el dataset entero y no armar subconjuntos por caso.
+export const onoffDatasetMock: Record<string, unknown>[] = [
+	...onoffLiteraryWorkDocumentsMock,
+	...onoffCollectionDocumentsMock,
+	...onoffAuthorDocumentsMock,
+	...onoffTagDocumentsMock,
+	...onoffNationalityDocumentsMock,
+	...onoffResourceTypeDocumentsMock,
+	...onoffLiteraryWorkAssetDocumentsMock,
+];
+
+// Escenarios de borde por spread sobre el canon, para que sigan al corpus.
+
+export const emptyCollectionDocument = { ...onoffCollectionDocumentsMock[0], literaryWorks: [] };
+
+// El tipo de documento declara `coverImage` opcional; el raw nunca ejercitó esa rama porque las ocho
+// obras del canon la traen.
+export const coverlessLiteraryWorkDocument = (() => {
+	const { coverImage: _cover, ...rest } = onoffLiteraryWorkDocumentsMock[0] ?? ({} as never);
+	return rest;
+})();
+
+export const draftCollectionDocument = asDraft(onoffCollectionDocumentsMock[0] ?? ({ _id: '' } as never));

--- a/src/mocks/onoff-documents.mock.ts
+++ b/src/mocks/onoff-documents.mock.ts
@@ -5,11 +5,13 @@ import {
 	onoffResourceTypeDocumentsMock,
 	onoffTagDocumentsMock,
 } from './onoff/document/support-documents.projection';
-import { asDraft } from './onoff/document/sanity-document.factory';
+import { asDraft, slugField } from './onoff/document/sanity-document.factory';
 import {
 	onoffLiteraryWorkAssetDocumentsMock,
 	onoffLiteraryWorkDocumentsMock,
+	toLiteraryWorkDocument,
 } from './onoff/literary-work/literary-work.document.projection';
+import { multiSectionRawLiteraryWork } from './onoff-raw-literary-works.mock';
 
 export {
 	onoffCollectionDocumentsMock,
@@ -37,6 +39,23 @@ export const onoffDatasetMock: Record<string, unknown>[] = [
 // Escenarios de borde por spread sobre el canon, para que sigan al corpus.
 
 export const emptyCollectionDocument = { ...onoffCollectionDocumentsMock[0], literaryWorks: [] };
+
+// El canon ya declara la obra de dos secciones como escenario del raw; acá se deriva su documento,
+// más una colección que la referencia, para poder evaluar el recorte de la sección de apertura.
+export const multiSectionLiteraryWorkDocument = toLiteraryWorkDocument(multiSectionRawLiteraryWork);
+
+export const multiSectionCollectionDocument = {
+	...onoffCollectionDocumentsMock[0],
+	_id: 'onoff-collection-multi-seccion',
+	slug: slugField('multi-seccion'),
+	literaryWorks: [
+		{
+			_key: multiSectionLiteraryWorkDocument._id,
+			_type: 'reference' as const,
+			_ref: multiSectionLiteraryWorkDocument._id,
+		},
+	],
+};
 
 // El tipo de documento declara `coverImage` opcional; el raw nunca ejercitó esa rama porque las ocho
 // obras del canon la traen.

--- a/src/mocks/onoff-documents.mock.ts
+++ b/src/mocks/onoff-documents.mock.ts
@@ -1,27 +1,25 @@
 import { onoffAuthorDocument } from './onoff/author/author.document.projection';
-import { onoffCollectionDocumentsMock } from './onoff/collection/collection.document.projection';
+import { toCollectionDocument } from './onoff/collection/collection.document.projection';
 import {
 	onoffNationalityDocumentsMock,
 	onoffResourceTypeDocumentsMock,
 	onoffTagDocumentsMock,
 } from './onoff/document/support-documents.projection';
-import { asDraft, slugField } from './onoff/document/sanity-document.factory';
+import { asDraft, slugField, withoutKey } from './onoff/document/sanity-document.factory';
 import {
 	onoffLiteraryWorkAssetDocumentsMock,
 	onoffLiteraryWorkDocumentsMock,
 	toLiteraryWorkDocument,
 } from './onoff/literary-work/literary-work.document.projection';
 import { multiSectionRawLiteraryWork } from './onoff-raw-literary-works.mock';
-
-export {
-	onoffCollectionDocumentsMock,
-	onoffLiteraryWorkDocumentsMock,
-	onoffNationalityDocumentsMock,
-	onoffResourceTypeDocumentsMock,
-	onoffTagDocumentsMock,
-};
+import { onoffRawCollectionsMock } from './onoff-raw-collections.mock';
+import type { Collection } from '@sanity-types';
 
 export const onoffAuthorDocumentsMock = [onoffAuthorDocument];
+
+// Se declara acá y no en el módulo de proyección porque es el agregado que consumen los specs de fuera
+// de `src/mocks`, y re-exportarlo sería un barrel.
+export const onoffCollectionDocumentsMock: Collection[] = onoffRawCollectionsMock.map(toCollectionDocument);
 
 // El dataset plano que consume `groq-js`: lleva todos los documentos, incluidos los de soporte y los
 // de asset. Un documento que falte no hace fallar la evaluación — la dereferencia queda en null sin
@@ -36,16 +34,35 @@ export const onoffDatasetMock: Record<string, unknown>[] = [
 	...onoffLiteraryWorkAssetDocumentsMock,
 ];
 
-// Escenarios de borde por spread sobre el canon, para que sigan al corpus.
+// Escenarios de borde por spread sobre el canon, para que sigan al corpus. Cada uno estrena `_id` y
+// slug: compartiéndolos, sumarlos a `onoffDatasetMock` duplicaría el `_id` y el resultado de la query
+// pasaría a depender del orden del array. El borrador es la excepción, y a propósito: un borrador de
+// Sanity es el mismo documento con el prefijo `drafts.`, así que convive con su publicado.
 
-export const emptyCollectionDocument = { ...onoffCollectionDocumentsMock[0], literaryWorks: [] };
+function first<T>(documents: T[], label: string): T {
+	const [document] = documents;
+	if (!document) {
+		throw new Error(`El corpus de Onoff no declara ningún documento de ${label}`);
+	}
+	return document;
+}
+
+const canonCollection = first(onoffCollectionDocumentsMock, 'colección');
+const canonLiteraryWork = first(onoffLiteraryWorkDocumentsMock, 'obra');
+
+export const emptyCollectionDocument = {
+	...canonCollection,
+	_id: 'onoff-collection-sin-obras',
+	slug: slugField('sin-obras'),
+	literaryWorks: [],
+};
 
 // El canon ya declara la obra de dos secciones como escenario del raw; acá se deriva su documento,
 // más una colección que la referencia, para poder evaluar el recorte de la sección de apertura.
 export const multiSectionLiteraryWorkDocument = toLiteraryWorkDocument(multiSectionRawLiteraryWork);
 
 export const multiSectionCollectionDocument = {
-	...onoffCollectionDocumentsMock[0],
+	...canonCollection,
 	_id: 'onoff-collection-multi-seccion',
 	slug: slugField('multi-seccion'),
 	literaryWorks: [
@@ -60,8 +77,15 @@ export const multiSectionCollectionDocument = {
 // El tipo de documento declara `coverImage` opcional; el raw nunca ejercitó esa rama porque las ocho
 // obras del canon la traen.
 export const coverlessLiteraryWorkDocument = (() => {
-	const { coverImage: _cover, ...rest } = onoffLiteraryWorkDocumentsMock[0] ?? ({} as never);
-	return rest;
+	const rest = withoutKey(canonLiteraryWork, 'coverImage');
+	return { ...rest, _id: 'onoff-obra-sin-portada', slug: slugField('sin-portada') };
 })();
 
-export const draftCollectionDocument = asDraft(onoffCollectionDocumentsMock[0] ?? ({ _id: '' } as never));
+export const draftCollectionDocument = asDraft(canonCollection);
+
+// `config` es opcional en el documento, y la query lo resuelve con `coalesce`; el canon nunca lo omite.
+export const configlessCollectionDocument = {
+	...withoutKey(canonCollection, 'config'),
+	_id: 'onoff-collection-sin-config',
+	slug: slugField('sin-config'),
+};

--- a/src/mocks/onoff/README.md
+++ b/src/mocks/onoff/README.md
@@ -16,13 +16,32 @@ onoff/
 ├── story/          <slug>.story.mock.ts · <slug>.story.raw.mock.ts
 ├── literary-work/  <slug>.literary-work.mock.ts · <slug>.literary-work.raw.mock.ts
 │                   + su prosa: <slug>.md · <slug>.editorial-note.md · <slug>.epigraph.ts
-├── collection/     <slug>.collection.raw.mock.ts · <slug>.collection.md · la proyección compartida
+├── collection/     <slug>.collection.raw.mock.ts · <slug>.collection.md · las proyecciones
 ├── storylist/      <slug>.storylist.raw.mock.ts
-├── author/         francois-onoff.biography.md
-└── media/          <slug>.media.ts · <slug>.media.mock.ts · <slug>.media.raw.mock.ts
+├── author/         francois-onoff.biography.md · author.document.projection.ts
+├── media/          <slug>.media.ts · <slug>.media.mock.ts · <slug>.media.raw.mock.ts
+└── document/       la factory de campos de sistema y los documentos de soporte
 ```
 
 **Los agregadores no viven acá:** están un nivel arriba, en `src/mocks/`, y son lo que el resto del repo importa. Una regla de ESLint prohíbe importar una pieza puntual desde fuera de `src/mocks/**`.
+
+## Las tres capas
+
+```
+documentos  →  (query GROQ)  →  raw  →  (ACL del repository)  →  dominio
+```
+
+- **Documentos** (`<entidad>.document.projection.ts`): lo que vive en el content lake. Los consume un test que evalúa una query con `groq-js` sobre `onoffDatasetMock`.
+- **Raw** (`<slug>.<entidad>.raw.mock.ts`): el resultado de la query, tipado contra los `*QueryResult`. Lo consumen los specs de repository y mapper.
+- **Dominio** (`<slug>.<entidad>.mock.ts`): el agregado construido por su factory. Lo consume el frontend.
+
+**Los documentos se derivan del raw, no al revés**, aunque el flujo real vaya en la dirección opuesta. El raw es lo que ya existía escrito, así que invertir la proyección de la query evita duplicar contenido: es el mismo criterio con el que el dominio se deriva del raw. Invertir es desanidar lo que la query aplana —el slug vuelve a ser objeto, las etiquetas vuelven a ser referencias— y descartar lo que la query agrega, como el conteo de secciones.
+
+**Qué impide que la inversión mienta:** `onoff-documents.mock.spec.ts` vuelve a aplicar las queries reales sobre los documentos derivados y compara contra el canon crudo. Si el resultado no lo reprodujera, los documentos estarían afirmando un content lake que no existe.
+
+**Un documento faltante no falla.** Si una referencia apunta a un `_id` que no está en el dataset, `groq-js` la resuelve a `null` en silencio — no lanza. Por eso el dataset se pide entero (`onoffDatasetMock`) en vez de armar subconjuntos por caso, y por eso cada proyección emite también los documentos de soporte que sus referencias necesitan, incluido el asset de audio.
+
+**`document/` no es una entidad**, como `media/`: aloja la factory de campos de sistema y los documentos que varias entidades referencian (etiquetas, nacionalidades, tipos de recurso).
 
 **Las carpetas no son independientes entre sí.** `literary-work/<slug>.literary-work.mock.ts` importa a su hermano de `story/`: la obra deriva de la story siete campos —slug, título, autor, portada, recursos, publicación original y fecha—. Esa relación existía antes, escondida por vivir las dos caras en el mismo archivo; separarlas la volvió visible en vez de crearla.
 

--- a/src/mocks/onoff/author/author.document.projection.spec.ts
+++ b/src/mocks/onoff/author/author.document.projection.spec.ts
@@ -1,0 +1,45 @@
+import { rawOnoffAuthor } from '../../onoff-raw-author.mock';
+import {
+	onoffAuthorDocument,
+	onoffAuthorNationalityDocuments,
+	onoffAuthorResourceTypeDocuments,
+} from './author.document.projection';
+
+describe('documento de author', () => {
+	it('preserves what the raw carries', () => {
+		expect(onoffAuthorDocument._id).toBe(rawOnoffAuthor._id);
+		expect(onoffAuthorDocument.name).toBe(rawOnoffAuthor.name);
+		expect(onoffAuthorDocument.slug.current).toBe(rawOnoffAuthor.slug);
+		expect(onoffAuthorDocument.biography).toBe(rawOnoffAuthor.biography);
+		expect(onoffAuthorDocument.image).toEqual(rawOnoffAuthor.image);
+	});
+
+	// Una referencia que no resuelve contra el dataset no falla: `groq-js` la deja en null sin avisar.
+	// Esta guarda es lo que evita que el dataset quede incompleto sin que ningún test lo note.
+	it('emits a document for every reference it points to', () => {
+		const emitted = new Set([
+			...onoffAuthorNationalityDocuments.map((document) => document._id),
+			...onoffAuthorResourceTypeDocuments.map((document) => document._id),
+		]);
+
+		expect(emitted).toContain(onoffAuthorDocument.nationality._ref);
+		(onoffAuthorDocument.resources ?? []).forEach((resource) => {
+			expect(emitted).toContain(resource.resourceType._ref);
+		});
+	});
+
+	it('turns the flattened resource type back into a reference', () => {
+		const [resource] = onoffAuthorDocument.resources ?? [];
+		const [rawResource] = rawOnoffAuthor.resources ?? [];
+
+		expect(resource?.title).toBe(rawResource?.title);
+		expect(resource?.url).toBe(rawResource?.url);
+		expect(resource?.resourceType._ref).toBe(onoffAuthorResourceTypeDocuments[0]?._id);
+	});
+
+	// Cada elemento de un array de Sanity necesita su `_key`, y su ausencia solo se nota al editar en
+	// el Studio, no al leer.
+	it('keys every array element', () => {
+		(onoffAuthorDocument.resources ?? []).forEach((resource) => expect(resource._key).toBeTruthy());
+	});
+});

--- a/src/mocks/onoff/author/author.document.projection.spec.ts
+++ b/src/mocks/onoff/author/author.document.projection.spec.ts
@@ -1,9 +1,11 @@
 import { rawOnoffAuthor } from '../../onoff-raw-author.mock';
+import { onoffAuthorDocument } from './author.document.projection';
+// El subgrafo se afirma contra lo que realmente entra al dataset, no contra una copia local: comparar
+// contra otra derivación del mismo raw pasaría igual con el dataset incompleto.
 import {
-	onoffAuthorDocument,
-	onoffAuthorNationalityDocuments,
-	onoffAuthorResourceTypeDocuments,
-} from './author.document.projection';
+	onoffNationalityDocumentsMock,
+	onoffResourceTypeDocumentsMock,
+} from '../document/support-documents.projection';
 
 describe('documento de author', () => {
 	it('preserves what the raw carries', () => {
@@ -18,11 +20,12 @@ describe('documento de author', () => {
 	// Esta guarda es lo que evita que el dataset quede incompleto sin que ningún test lo note.
 	it('emits a document for every reference it points to', () => {
 		const emitted = new Set([
-			...onoffAuthorNationalityDocuments.map((document) => document._id),
-			...onoffAuthorResourceTypeDocuments.map((document) => document._id),
+			...onoffNationalityDocumentsMock.map((document) => document._id),
+			...onoffResourceTypeDocumentsMock.map((document) => document._id),
 		]);
 
 		expect(emitted).toContain(onoffAuthorDocument.nationality._ref);
+		expect(onoffAuthorDocument.resources?.length).toBeGreaterThan(0);
 		(onoffAuthorDocument.resources ?? []).forEach((resource) => {
 			expect(emitted).toContain(resource.resourceType._ref);
 		});
@@ -34,12 +37,13 @@ describe('documento de author', () => {
 
 		expect(resource?.title).toBe(rawResource?.title);
 		expect(resource?.url).toBe(rawResource?.url);
-		expect(resource?.resourceType._ref).toBe(onoffAuthorResourceTypeDocuments[0]?._id);
+		expect(resource?.resourceType._ref).toBe(onoffResourceTypeDocumentsMock[0]?._id);
 	});
 
 	// Cada elemento de un array de Sanity necesita su `_key`, y su ausencia solo se nota al editar en
 	// el Studio, no al leer.
 	it('keys every array element', () => {
+		expect(onoffAuthorDocument.resources?.length).toBeGreaterThan(0);
 		(onoffAuthorDocument.resources ?? []).forEach((resource) => expect(resource._key).toBeTruthy());
 	});
 });

--- a/src/mocks/onoff/author/author.document.projection.ts
+++ b/src/mocks/onoff/author/author.document.projection.ts
@@ -1,0 +1,48 @@
+import type { Author, Nationality, ResourceType } from '@sanity-types';
+import { rawOnoffAuthor } from '../../onoff-raw-author.mock';
+import { documentReference, documentSystemFields, slugField } from '../document/sanity-document.factory';
+import {
+	resourceTypeDocumentId,
+	toNationalityDocument,
+	toResourceTypeDocument,
+} from '../document/support-documents.projection';
+
+type RawAuthor = typeof rawOnoffAuthor;
+
+// La query aplana la referencia de nacionalidad y la de tipo de recurso; el documento las guarda como
+// referencias. Invertirlo obliga a emitir también esos documentos, porque una referencia que no
+// resuelve contra el dataset no falla: `groq-js` la deja en null sin avisar.
+export function toAuthorDocument(raw: RawAuthor): Author {
+	return {
+		...documentSystemFields(raw._id),
+		_type: 'author',
+		name: raw.name,
+		slug: slugField(raw.slug),
+		image: raw.image,
+		nationality: documentReference(raw.nationality._id),
+		bornOn: raw.bornOn ?? undefined,
+		bornOnYear: raw.bornOnYear ?? undefined,
+		diedOn: raw.diedOn ?? undefined,
+		diedOnYear: raw.diedOnYear ?? undefined,
+		biography: raw.biography,
+		resources: (raw.resources ?? []).map((resource, index) => ({
+			_type: 'resource' as const,
+			_key: `resource-${index}`,
+			title: resource.title,
+			url: resource.url,
+			resourceType: documentReference(resourceTypeDocumentId(resource.resourceType.slug)),
+		})),
+		// La query de autor proyecta `'tags': []` fijo, así que el raw no transporta ninguna que invertir.
+		// El documento las declara opcionales, y dejarlas vacías es fiel a lo que el raw permite afirmar.
+		tags: [],
+	};
+}
+
+export const onoffAuthorDocument: Author = toAuthorDocument(rawOnoffAuthor);
+
+// El subgrafo que el documento de autor necesita para que sus referencias resuelvan.
+export const onoffAuthorNationalityDocuments: Nationality[] = [toNationalityDocument(rawOnoffAuthor.nationality)];
+
+export const onoffAuthorResourceTypeDocuments: ResourceType[] = (rawOnoffAuthor.resources ?? []).map((resource) =>
+	toResourceTypeDocument(resource.resourceType),
+);

--- a/src/mocks/onoff/author/author.document.projection.ts
+++ b/src/mocks/onoff/author/author.document.projection.ts
@@ -1,11 +1,7 @@
-import type { Author, Nationality, ResourceType } from '@sanity-types';
+import type { Author } from '@sanity-types';
 import { rawOnoffAuthor } from '../../onoff-raw-author.mock';
 import { documentReference, documentSystemFields, slugField } from '../document/sanity-document.factory';
-import {
-	resourceTypeDocumentId,
-	toNationalityDocument,
-	toResourceTypeDocument,
-} from '../document/support-documents.projection';
+import { resourceTypeDocumentId } from '../document/support-documents.projection';
 
 type RawAuthor = typeof rawOnoffAuthor;
 
@@ -39,10 +35,3 @@ export function toAuthorDocument(raw: RawAuthor): Author {
 }
 
 export const onoffAuthorDocument: Author = toAuthorDocument(rawOnoffAuthor);
-
-// El subgrafo que el documento de autor necesita para que sus referencias resuelvan.
-export const onoffAuthorNationalityDocuments: Nationality[] = [toNationalityDocument(rawOnoffAuthor.nationality)];
-
-export const onoffAuthorResourceTypeDocuments: ResourceType[] = (rawOnoffAuthor.resources ?? []).map((resource) =>
-	toResourceTypeDocument(resource.resourceType),
-);

--- a/src/mocks/onoff/collection/collection.document.projection.spec.ts
+++ b/src/mocks/onoff/collection/collection.document.projection.spec.ts
@@ -1,0 +1,41 @@
+import { onoffRawCollectionsMock } from '../../onoff-raw-collections.mock';
+import { onoffLiteraryWorkDocumentsMock } from '../literary-work/literary-work.document.projection';
+import { onoffCollectionDocumentsMock } from './collection.document.projection';
+
+describe('documento de collection', () => {
+	// Si una referencia apuntara a un `_id` que no está en el dataset, la query la resolvería a null
+	// sin fallar, y la colección saldría con menos obras de las que declara.
+	it('references works that exist in the corpus', () => {
+		const workIds = new Set(onoffLiteraryWorkDocumentsMock.map((work) => work._id));
+
+		onoffCollectionDocumentsMock.forEach((collection) => {
+			expect(collection.literaryWorks?.length).toBeGreaterThan(0);
+			collection.literaryWorks?.forEach((reference) => expect(workIds).toContain(reference._ref));
+		});
+	});
+
+	it('keeps the reference order the raw carries', () => {
+		onoffCollectionDocumentsMock.forEach((collection, index) => {
+			expect(collection.literaryWorks?.map((reference) => reference._ref)).toEqual(
+				onoffRawCollectionsMock[index]?.literaryWorks.map((work) => work._id),
+			);
+		});
+	});
+
+	// El raw usa null para la portada ausente; el documento simplemente no trae la clave, y el
+	// `coalesce` de la query solo se comporta igual ante la clave ausente.
+	it('omits the featured image when the raw carries none', () => {
+		const withoutCover = onoffCollectionDocumentsMock.find(
+			(_, index) => onoffRawCollectionsMock[index]?.featuredImage === null,
+		);
+
+		expect(withoutCover).toBeDefined();
+		expect(withoutCover).not.toHaveProperty('featuredImage');
+	});
+
+	it('keys every reference, which Sanity needs to edit the array', () => {
+		onoffCollectionDocumentsMock.forEach((collection) => {
+			collection.literaryWorks?.forEach((reference) => expect(reference._key).toBeTruthy());
+		});
+	});
+});

--- a/src/mocks/onoff/collection/collection.document.projection.spec.ts
+++ b/src/mocks/onoff/collection/collection.document.projection.spec.ts
@@ -1,6 +1,6 @@
 import { onoffRawCollectionsMock } from '../../onoff-raw-collections.mock';
 import { onoffLiteraryWorkDocumentsMock } from '../literary-work/literary-work.document.projection';
-import { onoffCollectionDocumentsMock } from './collection.document.projection';
+import { onoffCollectionDocumentsMock } from '../../onoff-documents.mock';
 
 describe('documento de collection', () => {
 	// Si una referencia apuntara a un `_id` que no está en el dataset, la query la resolvería a null
@@ -22,8 +22,6 @@ describe('documento de collection', () => {
 		});
 	});
 
-	// El raw usa null para la portada ausente; el documento simplemente no trae la clave, y el
-	// `coalesce` de la query solo se comporta igual ante la clave ausente.
 	it('omits the featured image when the raw carries none', () => {
 		const withoutCover = onoffCollectionDocumentsMock.find(
 			(_, index) => onoffRawCollectionsMock[index]?.featuredImage === null,
@@ -34,7 +32,9 @@ describe('documento de collection', () => {
 	});
 
 	it('keys every reference, which Sanity needs to edit the array', () => {
+		expect(onoffCollectionDocumentsMock.length).toBeGreaterThan(0);
 		onoffCollectionDocumentsMock.forEach((collection) => {
+			expect(collection.literaryWorks?.length).toBeGreaterThan(0);
 			collection.literaryWorks?.forEach((reference) => expect(reference._key).toBeTruthy());
 		});
 	});

--- a/src/mocks/onoff/collection/collection.document.projection.ts
+++ b/src/mocks/onoff/collection/collection.document.projection.ts
@@ -1,0 +1,25 @@
+import type { Collection } from '@sanity-types';
+import { onoffRawCollectionsMock } from '../../onoff-raw-collections.mock';
+import { documentReference, documentSystemFields, slugField } from '../document/sanity-document.factory';
+import { tagDocumentId } from '../document/support-documents.projection';
+
+type RawCollection = (typeof onoffRawCollectionsMock)[number];
+
+// La query dereferencia `literaryWorks[]->` y proyecta cada obra; el documento solo guarda la
+// referencia. El `_id` de cada obra sí viaja en el raw, así que la referencia se reconstruye desde ahí.
+export function toCollectionDocument(raw: RawCollection): Collection {
+	return {
+		...documentSystemFields(raw._id),
+		_type: 'collection',
+		title: raw.title,
+		slug: slugField(raw.slug),
+		description: raw.description,
+		...(raw.featuredImage ? { featuredImage: raw.featuredImage } : {}),
+		config: { showAuthors: raw.config.showAuthors },
+		literaryWorks: raw.literaryWorks.map((work) => ({ _key: work._id, ...documentReference(work._id) })),
+		tags: raw.tags.map((tag) => ({ _key: tag.slug, ...documentReference(tagDocumentId(tag.slug)) })),
+		mediaSources: raw.mediaSources,
+	};
+}
+
+export const onoffCollectionDocumentsMock: Collection[] = onoffRawCollectionsMock.map(toCollectionDocument);

--- a/src/mocks/onoff/collection/collection.document.projection.ts
+++ b/src/mocks/onoff/collection/collection.document.projection.ts
@@ -1,7 +1,7 @@
 import type { Collection } from '@sanity-types';
 import { onoffRawCollectionsMock } from '../../onoff-raw-collections.mock';
 import { documentReference, documentSystemFields, slugField } from '../document/sanity-document.factory';
-import { tagDocumentId } from '../document/support-documents.projection';
+import { tagReference } from '../document/support-documents.projection';
 
 type RawCollection = (typeof onoffRawCollectionsMock)[number];
 
@@ -17,9 +17,7 @@ export function toCollectionDocument(raw: RawCollection): Collection {
 		...(raw.featuredImage ? { featuredImage: raw.featuredImage } : {}),
 		config: { showAuthors: raw.config.showAuthors },
 		literaryWorks: raw.literaryWorks.map((work) => ({ _key: work._id, ...documentReference(work._id) })),
-		tags: raw.tags.map((tag) => ({ _key: tag.slug, ...documentReference(tagDocumentId(tag.slug)) })),
+		tags: raw.tags.map((tag) => tagReference(tag.slug)),
 		mediaSources: raw.mediaSources,
 	};
 }
-
-export const onoffCollectionDocumentsMock: Collection[] = onoffRawCollectionsMock.map(toCollectionDocument);

--- a/src/mocks/onoff/document/sanity-document.factory.ts
+++ b/src/mocks/onoff/document/sanity-document.factory.ts
@@ -1,0 +1,45 @@
+import type { SanityFileAsset, Slug } from '@sanity-types';
+
+// Fecha fija y reconocible en vez de la de hoy: `_createdAt` no siempre es ruido de sistema. La query
+// de obra proyecta `coalesce(publishedAt, _createdAt)`, así que ante una obra sin fecha de publicación
+// el valor se vuelve observable en el resultado, y una fecha variable haría fallar al azar.
+const SYSTEM_TIMESTAMP = '1974-06-12T00:00:00Z';
+
+export function documentSystemFields(id: string) {
+	return {
+		_id: id,
+		_createdAt: SYSTEM_TIMESTAMP,
+		_updatedAt: SYSTEM_TIMESTAMP,
+		_rev: `rev-${id}`,
+	} as const;
+}
+
+export function slugField(current: string): Slug {
+	return { _type: 'slug', current };
+}
+
+export function documentReference(id: string, key?: string) {
+	return { _type: 'reference' as const, _ref: id, ...(key !== undefined ? { _key: key } : {}) };
+}
+
+// Sanity marca el borrador de un documento con este prefijo de path en su `_id`.
+export function asDraft<T extends { _id: string }>(document: T): T {
+	return { ...document, _id: `drafts.${document._id}` };
+}
+
+// El `url` es un campo propio del documento de asset, no algo que resuelva el CDN al leer: por eso
+// `asset->url` se puede derivar sin red, siempre que el documento esté en el dataset.
+export function createFileAssetDocument({ ref, url }: { ref: string; url: string }): SanityFileAsset {
+	const extension = url.split('.').pop() ?? 'bin';
+	return {
+		...documentSystemFields(ref),
+		_type: 'sanity.fileAsset',
+		assetId: ref,
+		sha1hash: ref,
+		extension,
+		mimeType: `audio/${extension}`,
+		size: 1024,
+		path: `files/onoff/${ref}.${extension}`,
+		url,
+	};
+}

--- a/src/mocks/onoff/document/sanity-document.factory.ts
+++ b/src/mocks/onoff/document/sanity-document.factory.ts
@@ -18,18 +18,24 @@ export function slugField(current: string): Slug {
 	return { _type: 'slug', current };
 }
 
+export function withoutKey<T extends object, K extends keyof T>(source: T, key: K): Omit<T, K> {
+	const clone: Partial<T> = { ...source };
+	delete clone[key];
+	return clone as Omit<T, K>;
+}
+
 export function documentReference(id: string, key?: string) {
 	return { _type: 'reference' as const, _ref: id, ...(key !== undefined ? { _key: key } : {}) };
 }
 
-// Sanity marca el borrador de un documento con este prefijo de path en su `_id`.
 export function asDraft<T extends { _id: string }>(document: T): T {
 	return { ...document, _id: `drafts.${document._id}` };
 }
 
 // El `url` es un campo propio del documento de asset, no algo que resuelva el CDN al leer: por eso
-// `asset->url` se puede derivar sin red, siempre que el documento esté en el dataset.
-export function createFileAssetDocument({ ref, url }: { ref: string; url: string }): SanityFileAsset {
+// `asset->url` se puede derivar sin red, siempre que el documento esté en el dataset. Es el único campo
+// load-bearing: hash, tamaño y path son relleno consistente que ninguna query lee.
+export function createAudioAssetDocument({ ref, url }: { ref: string; url: string }): SanityFileAsset {
 	const extension = url.split('.').pop() ?? 'bin';
 	return {
 		...documentSystemFields(ref),

--- a/src/mocks/onoff/document/support-documents.projection.spec.ts
+++ b/src/mocks/onoff/document/support-documents.projection.spec.ts
@@ -1,0 +1,63 @@
+import { onoffRawTagsMock } from '../../onoff-raw-tags.mock';
+import { rawOnoffAuthor } from '../../onoff-raw-author.mock';
+import { createFileAssetDocument, asDraft, documentSystemFields } from './sanity-document.factory';
+import {
+	onoffNationalityDocumentsMock,
+	onoffResourceTypeDocumentsMock,
+	onoffTagDocumentsMock,
+	tagDocumentId,
+} from './support-documents.projection';
+
+describe('documentos de soporte', () => {
+	it('derives one tag document per raw tag, preserving its prose', () => {
+		expect(onoffTagDocumentsMock).toHaveLength(onoffRawTagsMock.length);
+
+		onoffTagDocumentsMock.forEach((document, index) => {
+			const raw = onoffRawTagsMock[index];
+
+			expect(document.title).toBe(raw?.title);
+			expect(document.slug.current).toBe(raw?.slug);
+			expect(document.description).toBe(raw?.description);
+		});
+	});
+
+	// El `_id` no viaja en el raw —la query no lo proyecta—, así que se deriva del slug. Que sea único
+	// es lo que permite que una referencia resuelva contra un solo documento del dataset.
+	it('derives a unique id for every tag', () => {
+		const ids = onoffTagDocumentsMock.map((document) => document._id);
+
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	it('derives the resource type documents the author references', () => {
+		const slugs = (rawOnoffAuthor.resources ?? []).map((resource) => resource.resourceType.slug);
+
+		expect(onoffResourceTypeDocumentsMock.map((document) => document.slug.current)).toEqual(slugs);
+	});
+
+	// La query dereferencia la nacionalidad sin proyectarla, así que el raw ya trae el documento entero.
+	it('keeps the nationality document as the raw carries it', () => {
+		expect(onoffNationalityDocumentsMock[0]).toEqual(rawOnoffAuthor.nationality);
+	});
+});
+
+describe('factory de documentos', () => {
+	// Una fecha variable haría fallar al azar el caso de una obra sin `publishedAt`, que la query
+	// resuelve con `coalesce(publishedAt, _createdAt)`.
+	it('stamps a stable timestamp', () => {
+		expect(documentSystemFields('x')).toEqual(documentSystemFields('x'));
+	});
+
+	it('marks a draft with the path prefix Sanity uses', () => {
+		expect(asDraft({ _id: 'onoff-collection-geometrias' })._id).toBe('drafts.onoff-collection-geometrias');
+	});
+
+	// Es lo que permite que `asset->url` resuelva sin red: la url es un campo del documento de asset.
+	it('carries the url the raw transports for the asset', () => {
+		const asset = createFileAssetDocument({ ref: 'file-abc', url: 'https://cdn.example.org/onoff/geometria.ogg' });
+
+		expect(asset.url).toBe('https://cdn.example.org/onoff/geometria.ogg');
+		expect(asset._id).toBe('file-abc');
+		expect(asset.extension).toBe('ogg');
+	});
+});

--- a/src/mocks/onoff/document/support-documents.projection.spec.ts
+++ b/src/mocks/onoff/document/support-documents.projection.spec.ts
@@ -1,11 +1,10 @@
 import { onoffRawTagsMock } from '../../onoff-raw-tags.mock';
 import { rawOnoffAuthor } from '../../onoff-raw-author.mock';
-import { createFileAssetDocument, asDraft, documentSystemFields } from './sanity-document.factory';
+import { createAudioAssetDocument, asDraft, documentSystemFields } from './sanity-document.factory';
 import {
 	onoffNationalityDocumentsMock,
 	onoffResourceTypeDocumentsMock,
 	onoffTagDocumentsMock,
-	tagDocumentId,
 } from './support-documents.projection';
 
 describe('documentos de soporte', () => {
@@ -35,26 +34,29 @@ describe('documentos de soporte', () => {
 		expect(onoffResourceTypeDocumentsMock.map((document) => document.slug.current)).toEqual(slugs);
 	});
 
-	// La query dereferencia la nacionalidad sin proyectarla, así que el raw ya trae el documento entero.
-	it('keeps the nationality document as the raw carries it', () => {
-		expect(onoffNationalityDocumentsMock[0]).toEqual(rawOnoffAuthor.nationality);
+	it('carries the nationality as a document Sanity would store', () => {
+		const [nationality] = onoffNationalityDocumentsMock;
+
+		expect(nationality?._type).toBe('nationality');
+		expect(nationality?.country).toBe(rawOnoffAuthor.nationality.country);
+		expect(nationality?._id).toBeTruthy();
 	});
 });
 
 describe('factory de documentos', () => {
-	// Una fecha variable haría fallar al azar el caso de una obra sin `publishedAt`, que la query
-	// resuelve con `coalesce(publishedAt, _createdAt)`.
-	it('stamps a stable timestamp', () => {
-		expect(documentSystemFields('x')).toEqual(documentSystemFields('x'));
+	// Comparar dos llamadas entre sí no distingue una fecha fija de `new Date()`; que no sea la de hoy, sí.
+	it('stamps a timestamp that is not the current date', () => {
+		const stamped = new Date(documentSystemFields('x')._createdAt);
+
+		expect(stamped.getFullYear()).toBeLessThan(new Date().getFullYear());
 	});
 
 	it('marks a draft with the path prefix Sanity uses', () => {
 		expect(asDraft({ _id: 'onoff-collection-geometrias' })._id).toBe('drafts.onoff-collection-geometrias');
 	});
 
-	// Es lo que permite que `asset->url` resuelva sin red: la url es un campo del documento de asset.
 	it('carries the url the raw transports for the asset', () => {
-		const asset = createFileAssetDocument({ ref: 'file-abc', url: 'https://cdn.example.org/onoff/geometria.ogg' });
+		const asset = createAudioAssetDocument({ ref: 'file-abc', url: 'https://cdn.example.org/onoff/geometria.ogg' });
 
 		expect(asset.url).toBe('https://cdn.example.org/onoff/geometria.ogg');
 		expect(asset._id).toBe('file-abc');

--- a/src/mocks/onoff/document/support-documents.projection.ts
+++ b/src/mocks/onoff/document/support-documents.projection.ts
@@ -23,8 +23,8 @@ export function toTagDocument(raw: RawTag): Tag {
 	};
 }
 
-export function tagReference(raw: RawTag, key?: string) {
-	return documentReference(tagDocumentId(raw.slug), key);
+export function tagReference(slug: string) {
+	return { _key: slug, ...documentReference(tagDocumentId(slug)) };
 }
 
 export function resourceTypeDocumentId(slug: string): string {

--- a/src/mocks/onoff/document/support-documents.projection.ts
+++ b/src/mocks/onoff/document/support-documents.projection.ts
@@ -1,0 +1,56 @@
+import type { Nationality, ResourceType, Tag } from '@sanity-types';
+import { onoffRawTagsMock, type RawTag } from '../../onoff-raw-tags.mock';
+import { rawOnoffAuthor } from '../../onoff-raw-author.mock';
+import { documentReference, documentSystemFields, slugField } from './sanity-document.factory';
+
+// Los documentos que las queries dereferencian pero que ninguna entidad "posee": cada uno vive en su
+// propio documento de Sanity y varias entidades los referencian. Se derivan del canon crudo invirtiendo
+// la proyección que la query les aplica — el raw no transporta su `_id`, así que se deriva del slug.
+
+type RawResourceType = NonNullable<typeof rawOnoffAuthor.resources>[number]['resourceType'];
+
+export function tagDocumentId(slug: string): string {
+	return `tag-${slug}`;
+}
+
+export function toTagDocument(raw: RawTag): Tag {
+	return {
+		...documentSystemFields(tagDocumentId(raw.slug)),
+		_type: 'tag',
+		title: raw.title,
+		slug: slugField(raw.slug),
+		description: raw.description,
+	};
+}
+
+export function tagReference(raw: RawTag, key?: string) {
+	return documentReference(tagDocumentId(raw.slug), key);
+}
+
+export function resourceTypeDocumentId(slug: string): string {
+	return `resource-type-${slug}`;
+}
+
+export function toResourceTypeDocument(raw: RawResourceType): ResourceType {
+	return {
+		...documentSystemFields(resourceTypeDocumentId(raw.slug)),
+		_type: 'resourceType',
+		title: raw.title,
+		slug: slugField(raw.slug),
+		description: raw.description,
+	};
+}
+
+// La nacionalidad es el único caso en que el raw ya transporta el documento entero: la query la
+// dereferencia sin proyectar (`nationality->`), así que acá la inversión es la identidad.
+export function toNationalityDocument(raw: typeof rawOnoffAuthor.nationality): Nationality {
+	return raw;
+}
+
+export const onoffTagDocumentsMock: Tag[] = onoffRawTagsMock.map(toTagDocument);
+
+export const onoffResourceTypeDocumentsMock: ResourceType[] = (rawOnoffAuthor.resources ?? []).map((resource) =>
+	toResourceTypeDocument(resource.resourceType),
+);
+
+export const onoffNationalityDocumentsMock: Nationality[] = [toNationalityDocument(rawOnoffAuthor.nationality)];

--- a/src/mocks/onoff/literary-work/literary-work.document.projection.spec.ts
+++ b/src/mocks/onoff/literary-work/literary-work.document.projection.spec.ts
@@ -1,0 +1,50 @@
+import { onoffRawLiteraryWorksMock } from '../../onoff-raw-literary-works.mock';
+import {
+	onoffLiteraryWorkAssetDocumentsMock,
+	onoffLiteraryWorkDocumentsMock,
+} from './literary-work.document.projection';
+
+const [firstDocument] = onoffLiteraryWorkDocumentsMock;
+const [firstRaw] = onoffRawLiteraryWorksMock;
+
+describe('documento de literaryWork', () => {
+	// Es el bug que motiva la capa: los documentos sintéticos declaraban la portada como string.
+	it('keeps the cover image as the image object it is in the document', () => {
+		expect(firstDocument?.coverImage).toEqual(firstRaw?.coverImage);
+		expect(typeof firstDocument?.coverImage).not.toBe('string');
+	});
+
+	// La query los calcula; el documento no los tiene. Invertir una proyección es también descartar
+	// lo que ella agrega.
+	it('drops what the query computes', () => {
+		expect(firstDocument).not.toHaveProperty('sectionCount');
+		(firstDocument?.mediaSources ?? []).forEach((source) => expect(source).not.toHaveProperty('audioUrl'));
+	});
+
+	// Un campo ausente y uno en null no son lo mismo para GROQ, y el raw usa null donde el documento
+	// simplemente no trae la clave.
+	it('omits the keys the raw carries as null', () => {
+		const withoutNote = onoffLiteraryWorkDocumentsMock.find((document, index) => {
+			return onoffRawLiteraryWorksMock[index]?.editorialNote === null && document !== undefined;
+		});
+
+		expect(withoutNote).toBeDefined();
+		expect(withoutNote).not.toHaveProperty('editorialNote');
+	});
+
+	it('turns tags and authors into references', () => {
+		expect(firstDocument?.tags?.length).toBe(firstRaw?.tags.length);
+		firstDocument?.tags?.forEach((tag) => expect(tag._ref).toBeTruthy());
+		firstDocument?.authors.forEach((author) => expect(author._ref).toBeTruthy());
+	});
+
+	// Sin el documento de asset en el dataset, `asset->url` resuelve a null sin que nada falle.
+	it('emits an asset document for every space recording', () => {
+		const recordings = onoffRawLiteraryWorksMock.flatMap((work) =>
+			(work.mediaSources ?? []).filter((source) => source._type === 'spaceRecording'),
+		);
+
+		expect(onoffLiteraryWorkAssetDocumentsMock.length).toBe(recordings.length);
+		onoffLiteraryWorkAssetDocumentsMock.forEach((asset) => expect(asset.url).toBeTruthy());
+	});
+});

--- a/src/mocks/onoff/literary-work/literary-work.document.projection.spec.ts
+++ b/src/mocks/onoff/literary-work/literary-work.document.projection.spec.ts
@@ -1,4 +1,6 @@
+import type { LiteraryWork } from '@sanity-types';
 import { onoffRawLiteraryWorksMock } from '../../onoff-raw-literary-works.mock';
+import { onoffTagDocumentsMock } from '../document/support-documents.projection';
 import {
 	onoffLiteraryWorkAssetDocumentsMock,
 	onoffLiteraryWorkDocumentsMock,
@@ -7,43 +9,72 @@ import {
 const [firstDocument] = onoffLiteraryWorkDocumentsMock;
 const [firstRaw] = onoffRawLiteraryWorksMock;
 
+// El caso de los medios necesita la obra que los tiene: la primera del canon no declara ninguno, así
+// que un bucle sobre ella no correría y el caso pasaría vacío.
+const withMediaIndex = onoffRawLiteraryWorksMock.findIndex((work) => (work.mediaSources ?? []).length > 0);
+const documentWithMedia = onoffLiteraryWorkDocumentsMock[withMediaIndex];
+
 describe('documento de literaryWork', () => {
-	// Es el bug que motiva la capa: los documentos sintéticos declaraban la portada como string.
 	it('keeps the cover image as the image object it is in the document', () => {
 		expect(firstDocument?.coverImage).toEqual(firstRaw?.coverImage);
-		expect(typeof firstDocument?.coverImage).not.toBe('string');
+		expect(firstDocument?.coverImage).toMatchObject({ _type: 'image' });
 	});
 
-	// La query los calcula; el documento no los tiene. Invertir una proyección es también descartar
-	// lo que ella agrega.
-	it('drops what the query computes', () => {
+	// La guarda es el `@ts-expect-error`, no un `expect`: si el campo alguna vez admitiera un string, la
+	// directiva quedaría sin usar y `tsc` cortaría — el gate de typecheck cubre los spec.
+	it('rejects a cover image declared as a path', () => {
+		const document: LiteraryWork = {
+			...(firstDocument as LiteraryWork),
+			// @ts-expect-error la portada es un objeto de imagen en el documento, no una ruta
+			coverImage: 'uno.png',
+		};
+
+		expect(document._id).toBe(firstDocument?._id);
+	});
+
+	it('drops the section count the query computes', () => {
 		expect(firstDocument).not.toHaveProperty('sectionCount');
-		(firstDocument?.mediaSources ?? []).forEach((source) => expect(source).not.toHaveProperty('audioUrl'));
+	});
+
+	it('drops the resolved audio url from the media it carries', () => {
+		expect(documentWithMedia?.mediaSources?.length).toBeGreaterThan(0);
+		documentWithMedia?.mediaSources?.forEach((source) => expect(source).not.toHaveProperty('audioUrl'));
 	});
 
 	// Un campo ausente y uno en null no son lo mismo para GROQ, y el raw usa null donde el documento
 	// simplemente no trae la clave.
 	it('omits the keys the raw carries as null', () => {
-		const withoutNote = onoffLiteraryWorkDocumentsMock.find((document, index) => {
-			return onoffRawLiteraryWorksMock[index]?.editorialNote === null && document !== undefined;
+		const withoutNoteIndex = onoffRawLiteraryWorksMock.findIndex((work) => work.editorialNote === null);
+
+		expect(withoutNoteIndex).toBeGreaterThanOrEqual(0);
+		expect(onoffLiteraryWorkDocumentsMock[withoutNoteIndex]).not.toHaveProperty('editorialNote');
+	});
+
+	// Que la referencia exista no alcanza: si apunta a un `_id` que no está en el dataset, la query la
+	// resuelve a null sin fallar. Lo que hay que afirmar es que resuelve contra un documento real.
+	it('references tags that exist as documents', () => {
+		const tagIds = new Set(onoffTagDocumentsMock.map((tag) => tag._id));
+
+		onoffLiteraryWorkDocumentsMock.forEach((document) => {
+			expect(document.tags?.length).toBe(
+				onoffRawLiteraryWorksMock.find((raw) => raw._id === document._id)?.tags.length,
+			);
+			document.tags?.forEach((tag) => expect(tagIds).toContain(tag._ref));
 		});
-
-		expect(withoutNote).toBeDefined();
-		expect(withoutNote).not.toHaveProperty('editorialNote');
 	});
 
-	it('turns tags and authors into references', () => {
-		expect(firstDocument?.tags?.length).toBe(firstRaw?.tags.length);
-		firstDocument?.tags?.forEach((tag) => expect(tag._ref).toBeTruthy());
-		firstDocument?.authors.forEach((author) => expect(author._ref).toBeTruthy());
+	it('keeps every field the query projects, resources included', () => {
+		onoffLiteraryWorkDocumentsMock.forEach((document, index) => {
+			expect(document.resources ?? []).toHaveLength(onoffRawLiteraryWorksMock[index]?.resources.length ?? 0);
+		});
 	});
 
-	// Sin el documento de asset en el dataset, `asset->url` resuelve a null sin que nada falle.
 	it('emits an asset document for every space recording', () => {
 		const recordings = onoffRawLiteraryWorksMock.flatMap((work) =>
 			(work.mediaSources ?? []).filter((source) => source._type === 'spaceRecording'),
 		);
 
+		expect(recordings.length).toBeGreaterThan(0);
 		expect(onoffLiteraryWorkAssetDocumentsMock.length).toBe(recordings.length);
 		onoffLiteraryWorkAssetDocumentsMock.forEach((asset) => expect(asset.url).toBeTruthy());
 	});

--- a/src/mocks/onoff/literary-work/literary-work.document.projection.ts
+++ b/src/mocks/onoff/literary-work/literary-work.document.projection.ts
@@ -1,25 +1,20 @@
 import type { LiteraryWork, SanityFileAsset } from '@sanity-types';
 import { onoffRawLiteraryWorksMock } from '../../onoff-raw-literary-works.mock';
 import {
-	createFileAssetDocument,
+	createAudioAssetDocument,
 	documentReference,
 	documentSystemFields,
 	slugField,
+	withoutKey,
 } from '../document/sanity-document.factory';
-import { tagDocumentId } from '../document/support-documents.projection';
+import { resourceTypeDocumentId, tagReference } from '../document/support-documents.projection';
 
 type RawLiteraryWork = (typeof onoffRawLiteraryWorksMock)[number];
 type RawMediaSource = NonNullable<RawLiteraryWork['mediaSources']>[number];
 type DocumentMediaSource = NonNullable<LiteraryWork['mediaSources']>[number];
 
-// `sectionCount` y `audioUrl` no existen en el documento: los calcula la query. Invertir la proyección
-// es también descartar lo que ella agrega, no solo desanidar lo que aplana.
 function toDocumentMediaSource(raw: RawMediaSource): DocumentMediaSource {
-	const { ...source } = raw;
-	if ('audioUrl' in source) {
-		delete (source as { audioUrl?: unknown }).audioUrl;
-	}
-	return source as DocumentMediaSource;
+	return 'audioUrl' in raw ? withoutKey(raw, 'audioUrl') : raw;
 }
 
 // El raw transporta la url del audio ya resuelta, así que el documento de asset se puede reconstruir:
@@ -30,7 +25,7 @@ function assetDocumentsOf(raw: RawLiteraryWork): SanityFileAsset[] {
 			return [];
 		}
 		const ref = source.audioFile?.asset?._ref;
-		return ref && source.audioUrl ? [createFileAssetDocument({ ref, url: source.audioUrl })] : [];
+		return ref && source.audioUrl ? [createAudioAssetDocument({ ref, url: source.audioUrl })] : [];
 	});
 }
 
@@ -62,8 +57,15 @@ export function toLiteraryWorkDocument(raw: RawLiteraryWork): LiteraryWork {
 		...(raw.editorialNote ? { editorialNote: raw.editorialNote } : {}),
 		...(raw.totalReadingTime !== null ? { totalReadingTime: raw.totalReadingTime } : {}),
 		mediaSources: (raw.mediaSources ?? []).map(toDocumentMediaSource),
-		tags: raw.tags.map((tag) => ({ _key: tag.slug, ...documentReference(tagDocumentId(tag.slug)) })),
-		badLanguage: raw.badLanguage ?? undefined,
+		resources: raw.resources.map((resource, index) => ({
+			_type: 'resource' as const,
+			_key: `resource-${index}`,
+			title: resource.title,
+			url: resource.url,
+			resourceType: documentReference(resourceTypeDocumentId(resource.resourceType.slug)),
+		})),
+		tags: raw.tags.map((tag) => tagReference(tag.slug)),
+		badLanguage: raw.badLanguage,
 		originalPublication: raw.originalPublication,
 		publishedAt: raw.publishedAt,
 	};

--- a/src/mocks/onoff/literary-work/literary-work.document.projection.ts
+++ b/src/mocks/onoff/literary-work/literary-work.document.projection.ts
@@ -1,0 +1,75 @@
+import type { LiteraryWork, SanityFileAsset } from '@sanity-types';
+import { onoffRawLiteraryWorksMock } from '../../onoff-raw-literary-works.mock';
+import {
+	createFileAssetDocument,
+	documentReference,
+	documentSystemFields,
+	slugField,
+} from '../document/sanity-document.factory';
+import { tagDocumentId } from '../document/support-documents.projection';
+
+type RawLiteraryWork = (typeof onoffRawLiteraryWorksMock)[number];
+type RawMediaSource = NonNullable<RawLiteraryWork['mediaSources']>[number];
+type DocumentMediaSource = NonNullable<LiteraryWork['mediaSources']>[number];
+
+// `sectionCount` y `audioUrl` no existen en el documento: los calcula la query. Invertir la proyección
+// es también descartar lo que ella agrega, no solo desanidar lo que aplana.
+function toDocumentMediaSource(raw: RawMediaSource): DocumentMediaSource {
+	const { ...source } = raw;
+	if ('audioUrl' in source) {
+		delete (source as { audioUrl?: unknown }).audioUrl;
+	}
+	return source as DocumentMediaSource;
+}
+
+// El raw transporta la url del audio ya resuelta, así que el documento de asset se puede reconstruir:
+// sin él en el dataset, `asset->url` resolvería a null en silencio.
+function assetDocumentsOf(raw: RawLiteraryWork): SanityFileAsset[] {
+	return (raw.mediaSources ?? []).flatMap((source) => {
+		if (!('audioFile' in source) || !('audioUrl' in source)) {
+			return [];
+		}
+		const ref = source.audioFile?.asset?._ref;
+		return ref && source.audioUrl ? [createFileAssetDocument({ ref, url: source.audioUrl })] : [];
+	});
+}
+
+export function toLiteraryWorkDocument(raw: RawLiteraryWork): LiteraryWork {
+	return {
+		...documentSystemFields(raw._id),
+		_type: 'literaryWork',
+		title: raw.title,
+		slug: slugField(raw.slug),
+		authors: raw.authors.map((author) => ({ _key: author._id, ...documentReference(author._id) })),
+		...(raw.coverImage ? { coverImage: raw.coverImage } : {}),
+		content: raw.content.map((section) => ({
+			_type: 'section' as const,
+			_key: section._key,
+			...(section.title ? { title: section.title } : {}),
+			...(section.epigraphs.length > 0
+				? {
+						epigraphs: section.epigraphs.map((epigraph, index) => ({
+							_type: 'epigraph' as const,
+							_key: `epigraph-${index}`,
+							...(epigraph.text ? { text: epigraph.text } : {}),
+							...(epigraph.reference ? { reference: epigraph.reference } : {}),
+						})),
+					}
+				: {}),
+			body: section.body,
+			...(section.readingTime !== null ? { readingTime: section.readingTime } : {}),
+		})),
+		...(raw.editorialNote ? { editorialNote: raw.editorialNote } : {}),
+		...(raw.totalReadingTime !== null ? { totalReadingTime: raw.totalReadingTime } : {}),
+		mediaSources: (raw.mediaSources ?? []).map(toDocumentMediaSource),
+		tags: raw.tags.map((tag) => ({ _key: tag.slug, ...documentReference(tagDocumentId(tag.slug)) })),
+		badLanguage: raw.badLanguage ?? undefined,
+		originalPublication: raw.originalPublication,
+		publishedAt: raw.publishedAt,
+	};
+}
+
+export const onoffLiteraryWorkDocumentsMock: LiteraryWork[] = onoffRawLiteraryWorksMock.map(toLiteraryWorkDocument);
+
+export const onoffLiteraryWorkAssetDocumentsMock: SanityFileAsset[] =
+	onoffRawLiteraryWorksMock.flatMap(assetDocumentsOf);


### PR DESCRIPTION
Suma al corpus de Onoff la capa que le faltaba: los **documentos del content lake** que alimentan las queries. Con ella, un test que evalúa una query con `groq-js` deja de inventar su entrada.

```
documentos  →  (query GROQ)  →  raw  →  (ACL del repository)  →  dominio
```

## El bug que lo motiva

`collection.query.spec.ts` armaba sus documentos a mano y sin tipar, así que divergían de la forma real sin que nada avisara. Las obras declaraban `coverImage: 'uno.png'` —un string— cuando en el documento es un objeto de imagen con `asset`. Los tests pasaban porque GROQ proyecta el campo tal cual, pero la fixture afirmaba una forma que el content lake no produce.

**Verificado que la capa lo resuelve, no asumido:** poner `coverImage: 'uno.png'` sobre un documento tipado hace fallar el typecheck con el mensaje exacto. Queda como regresión permanente con un `@ts-expect-error`; si el campo alguna vez se aflojara, la directiva quedaría sin usar y `tsc` cortaría, porque el gate cubre los spec.

## Los documentos se derivan del raw, aunque el flujo real vaya al revés

El raw es lo que ya estaba escrito, así que invertir la proyección de la query evita duplicar contenido — el mismo criterio con el que el dominio se deriva del raw. Invertir es desanidar lo que la query aplana (el slug vuelve a ser objeto, las etiquetas y autores vuelven a ser referencias) y **descartar lo que la query agrega**: el conteo de secciones y la url del audio ya resuelta no existen en el documento.

Un detalle que la inversión hizo explícito: **los campos que el raw transporta en `null` quedan ausentes en el documento**, no en `null`. Para GROQ no es lo mismo — el `coalesce` de la query solo se comporta como en producción ante la clave ausente.

## Qué impide que la inversión mienta

`onoff-documents.mock.spec.ts` vuelve a aplicar `collectionBySlugQuery` y `literaryWorkBySlugQuery` sobre los documentos derivados y compara contra el canon crudo: las dos colecciones y las ocho obras. Si el resultado no lo reprodujera, los documentos estarían afirmando un content lake que no existe, y ningún otro test lo notaría.

Pasa en verde, y **se verificó falsable con dos mutaciones**: alterar un título rompe los casos de colección; omitir el documento de asset rompe tres.

## El modo de falla que `groq-js` no reporta

Si una referencia apunta a un `_id` que no está en el dataset, **`groq-js` la resuelve a `null` en silencio** — no lanza. Es el riesgo central de esta capa, y condiciona tres decisiones:

- El dataset se pide **entero** (`onoffDatasetMock`), no por subconjuntos.
- Cada proyección emite también los documentos de soporte que sus referencias necesitan: etiquetas, nacionalidades, tipos de recurso.
- El documento del **asset de audio** se reconstruye —el raw transporta la url ya resuelta, así que es derivable— y hay una guarda que afirma que `audioUrl` resuelve.

## Lo que queda afuera, y por qué

**No se toca el corpus raw existente.** Los `*.raw.mock.ts` se consumen de forma síncrona en cascada —`raw-collection.projection.ts` hace `.find()` sobre el agregador a nivel de módulo, y los specs de mapper arman overrides por spread—, así que convertirlos en promesas propagaría la asincronía a todo lo que los importa. Derivarlos exige generarlos en build-time con un gate de frescura, y eso vive en su propio issue.

**`storylist` no lleva capa de documentos:** es el agregado en baja.

## Correcciones al issue

Dos errores propios, encontrados al explorar el corpus: **"media" no es un tipo de documento** —es un objeto embebido, y lo que hace falta es el documento de asset—, y faltaban **`Nationality` y `ResourceType`**, que toda query de autor dereferencia. El issue se reescribió.

## Plan de pruebas

- **Tier local verde**: typecheck estricto, lint, stylelint, `check-agents` y la suite completa — **1542 pasando**, 3 skipped, 153 archivos.
- **El round-trip cubre las dos colecciones y las ocho obras**, comparando contra el canon crudo campo por campo.
- **Tres verificaciones por mutación**, ninguna asumida: título alterado, asset omitido y el recorte de portadas acortado en la query. Las tres revertidas.
- **El spec migrado conserva todos sus casos** y suma dos que el dataset real recién ahora habilita: la obra sin portada, que proyecta `null` en el abanico, y una colección sin `config`.
- **El caso de borradores se endureció**: lleva solo el borrador en el dataset, porque con la publicada al lado podía estar pasando por el orden en que la query las encuentra en vez de por el filtro.

## Pasada de review

La review encontró que varias aserciones de la capa nueva **no podían fallar** — comparar el sello de fecha contra sí mismo, resolver referencias contra una segunda derivación del mismo raw, recorrer un array vacío. Corregido: el sello se compara contra el año en curso, las referencias se resuelven contra los documentos que efectivamente entran al dataset, y los bucles corren sobre la obra que declara medios, con piso de longitud donde hacía falta.

Además:

- **El round-trip del listado compara el objeto entero** contra el canon de teasers, no solo los slugs, y las tres queries usan `toStrictEqual`.
- **Se fueron los escapes de tipo:** `withoutKey` concentra el recorte de una clave; antes había un `delete` sobre un objeto casteado y dos destructurings con variable muerta. Los fallbacks del canon vacío lanzan con mensaje en vez de producir un fixture roto en silencio.
- **Los escenarios de borde estrenan `_id` y slug propios**, así conviven con el canon: los dos casos que evaluaban sobre subconjuntos parciales pasan a componer sobre el dataset entero, que es lo que el README pide.
- **El orden esperado del listado se aproxima con `localeCompare('es')`**, no con el orden de unidades UTF-16, que divergiría del `order(title asc)` de GROQ ante el primer título acentuado.

Tier local verde tras la pasada: typecheck, lint, stylelint, `check-agents` y **1544 tests pasando**. La comparación completa del listado se verificó falsable acortando el recorte de portadas en la query.

Closes #2143.
