### PR TITLE
[#2172] - Codificar el criterio de no declarar cantidades en los comentarios

### DIFF
--- a/.claude/skills/aposd-comment-audit/references/checks.md
+++ b/.claude/skills/aposd-comment-audit/references/checks.md
@@ -103,6 +103,18 @@ Acotación de este repo: los comentarios de sección de estilo `// Core` / `// M
 
 El cuerpo alterna un comentario / una sentencia. Eliminá la narración en bloque, y después evaluá si el bloque merece UN comentario de nivel más alto que enuncie qué logra como un todo.
 
+## C15 — Censo en el comentario (veredicto: REWRITE, o UPDATE si el número ya es falso)
+
+El comentario declara **cuántas cosas hay**: `// las doce imágenes del corpus`, `// las siete queries que la usan`, `// las ocho portadas`. El conteo es el dato que cambia sin que nadie vuelva a mirar el comentario, y ningún gate lo verifica.
+
+Distinguí **contar el contenido** de **enunciar una regla**. `// el parser exige exactamente cuatro segmentos` es correcto: cuatro es la especificación del parser, no un inventario. `// las ocho portadas` es un censo, aunque hoy sean ocho.
+
+Las **enumeraciones** entran acá igual, y rotan de dos formas a la vez —el número y la composición—, cada una por su lado.
+
+Veredicto: `REWRITE` si el conteo todavía es correcto (se saca igual, porque va a dejar de serlo), y `UPDATE` si ya es falso — ahí además engaña. En los dos casos **no se reemplaza un número por otro**: eso deja el mismo comentario esperando la próxima incorporación.
+
+La doctrina completa vive en [`aposd-comments-style`](../../aposd-comments-style/SKILL.md) → "Cantidades: la regla sí, el censo no".
+
 ## Qué explícitamente NO es un hallazgo
 
 - La ausencia de comentarios de implementación en métodos cortos y claros — ese es el estado ideal.

--- a/.claude/skills/aposd-comment-audit/references/checks.md
+++ b/.claude/skills/aposd-comment-audit/references/checks.md
@@ -16,7 +16,7 @@ for (const order of orders) {
 count++;
 ```
 
-Por qué: los comentarios al mismo nivel aportan cero información y se pudren al instante.
+Por qué: los comentarios al mismo nivel aportan cero información y quedan obsoletos al primer cambio.
 
 ## C2 — Eco de la firma (veredicto: DELETE, o REWRITE si hay un contrato real descubrible)
 
@@ -109,7 +109,7 @@ El comentario declara **cuántas cosas hay**: `// las doce imágenes del corpus`
 
 Distinguí **contar el contenido** de **enunciar una regla**. `// el parser exige exactamente cuatro segmentos` es correcto: cuatro es la especificación del parser, no un inventario. `// las ocho portadas` es un censo, aunque hoy sean ocho.
 
-Las **enumeraciones** entran acá igual, y rotan de dos formas a la vez —el número y la composición—, cada una por su lado.
+Las **enumeraciones** entran acá igual, y se desactualizan de dos formas a la vez —el número y la composición—, cada una por su lado.
 
 Veredicto: `REWRITE` si el conteo todavía es correcto (se saca igual, porque va a dejar de serlo), y `UPDATE` si ya es falso — ahí además engaña. En los dos casos **no se reemplaza un número por otro**: eso deja el mismo comentario esperando la próxima incorporación.
 

--- a/.claude/skills/aposd-comments-style/SKILL.md
+++ b/.claude/skills/aposd-comments-style/SKILL.md
@@ -79,7 +79,7 @@ Cuando una decisión de diseño atraviesa varios archivos, documentala **una sol
 6. **Filtración de implementación** en comentarios de interfaz.
 7. **Ritmo comentario-por-línea**: alternar un comentario / una sentencia a lo largo de un cuerpo.
 8. **Comentarios de disculpa/incertidumbre** en código entregado: `// esto es medio hacky pero funciona`. O lo arreglás, o documentás la restricción que fuerza el tradeoff.
-9. **Censos**: `// las doce imágenes del corpus`, `// las siete queries que la usan`. Contar el contenido se pudre — ver [Cantidades](#cantidades-la-regla-sí-el-censo-no).
+9. **Censos**: `// las doce imágenes del corpus`, `// las siete queries que la usan`. Contar el contenido queda obsoleto sin aviso — ver [Cantidades](#cantidades-la-regla-sí-el-censo-no).
 
 ## Mantener los comentarios al modificar código
 
@@ -113,7 +113,7 @@ Un comentario **no declara cuántas cosas hay**. El conteo es justo el dato que 
 
 No es "nunca un número". La distinción es entre **contar el contenido** y **enunciar una regla**:
 
-| ❌ Censo — se pudre                            | ✅ Regla — no se pudre                            |
+| ❌ Censo — caduca                              | ✅ Regla — no caduca                              |
 | ---------------------------------------------- | ------------------------------------------------- |
 | `// las doce imágenes del corpus`              | `// el parser exige exactamente cuatro segmentos` |
 | `// las ocho portadas comparten formato`       | `// la campaña ocupa un tamaño fijo por viewport` |
@@ -121,7 +121,7 @@ No es "nunca un número". La distinción es entre **contar el contenido** y **en
 
 "Cuatro" en la columna derecha es la especificación del parser de `_ref` de `@sanity/image-url`: no cambia porque el corpus crezca. "Doce" cambia, y cambia sin aviso.
 
-**Las enumeraciones tienen el mismo problema con un disfraz mejor.** Parecen auto-verificables —el número va seguido de la lista—, pero rotan de dos formas a la vez: el conteo y la composición, cada uno por su lado.
+**Las enumeraciones tienen el mismo problema con un disfraz mejor.** Parecen auto-verificables —el número va seguido de la lista—, pero se desactualizan de dos formas a la vez: el conteo y la composición, cada uno por su lado.
 
 Al corregir uno de estos, **no se reemplaza un número por otro**: eso deja el mismo comentario esperando la próxima incorporación. Lo que se saca es el conteo.
 

--- a/.claude/skills/aposd-comments-style/SKILL.md
+++ b/.claude/skills/aposd-comments-style/SKILL.md
@@ -79,6 +79,7 @@ Cuando una decisión de diseño atraviesa varios archivos, documentala **una sol
 6. **Filtración de implementación** en comentarios de interfaz.
 7. **Ritmo comentario-por-línea**: alternar un comentario / una sentencia a lo largo de un cuerpo.
 8. **Comentarios de disculpa/incertidumbre** en código entregado: `// esto es medio hacky pero funciona`. O lo arreglás, o documentás la restricción que fuerza el tradeoff.
+9. **Censos**: `// las doce imágenes del corpus`, `// las siete queries que la usan`. Contar el contenido se pudre — ver [Cantidades](#cantidades-la-regla-sí-el-censo-no).
 
 ## Mantener los comentarios al modificar código
 
@@ -105,6 +106,24 @@ Son casos del test del lector, pero con un giro propio: acá el comentario no re
 - **Navegación / estructura obvia.** ❌ `// la implementación HTTP vive en x.provider.ts` · ❌ `// API providers (patrón provideX)`. Los imports y los nombres de archivo ya lo muestran.
 - **Justificar una visibilidad que la convención ya fija.** ❌ `// public porque es la API imperativa` sobre un `input()`/`output()`/signal expuesta. Si el miembro **es** la API pública, su visibilidad ya la dicta `angular-components.md`; el modificador es autoexplicativo.
 - **Anotar un reemplazo canónico.** ❌ `// reemplaza ngOnDestroy` sobre un `effect((onCleanup) => …)`. El mapeo lifecycle hook → primitiva reactiva es la regla por defecto (`angular-components.md`).
+
+### Cantidades: la regla sí, el censo no
+
+Un comentario **no declara cuántas cosas hay**. El conteo es justo el dato que cambia sin que nadie vuelva a mirar el comentario, y no hay gate que lo verifique: comparar prosa contra la realidad del código es lo que ningún check estático hace.
+
+No es "nunca un número". La distinción es entre **contar el contenido** y **enunciar una regla**:
+
+| ❌ Censo — se pudre                            | ✅ Regla — no se pudre                            |
+| ---------------------------------------------- | ------------------------------------------------- |
+| `// las doce imágenes del corpus`              | `// el parser exige exactamente cuatro segmentos` |
+| `// las ocho portadas comparten formato`       | `// la campaña ocupa un tamaño fijo por viewport` |
+| `// idéntica en las siete queries que la usan` | `// idéntica en todas las queries que la usan`    |
+
+"Cuatro" en la columna derecha es la especificación del parser de `_ref` de `@sanity/image-url`: no cambia porque el corpus crezca. "Doce" cambia, y cambia sin aviso.
+
+**Las enumeraciones tienen el mismo problema con un disfraz mejor.** Parecen auto-verificables —el número va seguido de la lista—, pero rotan de dos formas a la vez: el conteo y la composición, cada uno por su lado.
+
+Al corregir uno de estos, **no se reemplaza un número por otro**: eso deja el mismo comentario esperando la próxima incorporación. Lo que se saca es el conteo.
 
 ### Comentarios de sección
 

--- a/src/mocks/onoff-raw-tags.mock.ts
+++ b/src/mocks/onoff-raw-tags.mock.ts
@@ -1,6 +1,6 @@
 import type { StoryBySlugQueryResult } from '@sanity-types';
 
-// El shape que devuelve la proyección `tags[] -> { … }`, idéntica en las siete queries que la usan.
+// El shape que devuelve la proyección `tags[] -> { … }`, idéntica en todas las queries que la usan.
 export type RawTag = NonNullable<StoryBySlugQueryResult>['tags'][number];
 
 // Tipo literario de la obra.

--- a/src/mocks/onoff/README.md
+++ b/src/mocks/onoff/README.md
@@ -43,7 +43,7 @@ documentos  →  (query GROQ)  →  raw  →  (ACL del repository)  →  dominio
 
 **`document/` no es una entidad**, como `media/`: aloja la factory de campos de sistema y los documentos que varias entidades referencian (etiquetas, nacionalidades, tipos de recurso).
 
-**Las carpetas no son independientes entre sí.** `literary-work/<slug>.literary-work.mock.ts` importa a su hermano de `story/`: la obra deriva de la story siete campos —slug, título, autor, portada, recursos, publicación original y fecha—. Esa relación existía antes, escondida por vivir las dos caras en el mismo archivo; separarlas la volvió visible en vez de crearla.
+**Las carpetas no son independientes entre sí.** `literary-work/<slug>.literary-work.mock.ts` importa a su hermano de `story/`: la obra deriva de la story todo lo que las dos caras comparten —metadata, autor, portada, recursos y datos de publicación—, y declara por su cuenta solo lo que es propio de `LiteraryWork`. Esa relación existía antes, escondida por vivir las dos caras en el mismo archivo; separarlas la volvió visible en vez de crearla.
 
 **`media/` no es una entidad**, es la excepción: la story y la obra literaria del mismo slug consumen _el mismo_ objeto de medios, y duplicarlo rompería la invariante de que ambas caras declaren exactamente los mismos. Ninguna de las dos puede reclamarlo, así que vive aparte. Es el criterio para la próxima pieza que se sume: si más de una entidad la consume y duplicarla rompería una invariante, va a carpeta propia; si solo la usa una, va con esa entidad.
 


### PR DESCRIPTION
Un comentario que declara **cuántas cosas hay** envejece sin que nadie lo mire, y no hay gate que pueda atraparlo: comparar prosa contra la realidad del código es justo lo que un check estático no hace. La auditoría de comentarios del stack de #2158/#2159/#2160 encontró uno que se volvió falso **dentro del propio stack** — lo escribió el primer PR con doce referencias de imagen y el segundo sumó cuatro banners.

Este PR escribe el criterio donde puede citarlo un revisor, y corrige los dos censos que quedaban en el repo.

## El criterio

No es "nunca un número". Es distinguir **contar el contenido** de **enunciar una regla**:

| ❌ Censo — caduca | ✅ Regla — no caduca |
| --- | --- |
| `// las doce imágenes del corpus` | `// el parser exige exactamente cuatro segmentos` |
| `// las ocho portadas comparten formato` | `// la campaña ocupa un tamaño fijo por viewport` |

"Cuatro" es la especificación del parser de `_ref` de `@sanity/image-url`: no cambia porque el corpus crezca. "Doce" cambia, y cambió.

Las **enumeraciones** entran igual, y son peores porque parecen auto-verificables: el número va seguido de la lista, así que da la impresión de poder chequearse de un vistazo. Se desactualizan por partida doble —el conteo y la composición—, cada una por su lado, y el segundo caso de abajo es exactamente eso.

## Los dos casos corregidos estaban mal, no solo expuestos

Verificados contra el código, no asumidos:

- `src/mocks/onoff-raw-tags.mock.ts` decía *"idéntica en las siete queries que la usan"*. Son **nueve** — conté los bloques `defineQuery` que contienen la proyección `tags[] ->`: `authorBySlugQuery`, `collectionBySlugQuery`, `collectionsQuery`, `landingPageContentQuery`, `literaryWorkBySlugQuery`, `literaryWorkSectionBySlugQuery`, `storyBySlugQuery`, `storylistTeasersQuery` y `storylistQuery`.
- `src/mocks/onoff/README.md` decía que la obra deriva de la story *"siete campos —slug, título, autor, portada, recursos, publicación original y fecha—"*. Son **ocho**, y la enumeración omitía `badLanguage`.

**Ninguno se arregla poniendo el número correcto.** Eso deja el mismo comentario esperando la próxima query o el próximo campo; lo que se saca es el conteo.

## Registro

De paso se corrige el mismo problema de registro en `checks.md`: el chequeo `C1` describía los comentarios reformulativos diciendo que "se pudren", un calco de _comment rot_ que en castellano queda entre lo literal y lo coloquial. Pasa a "quedan obsoletos".

## Dónde queda escrito

- `aposd-comments-style` gana la sección "Cantidades: la regla sí, el censo no" y el anti-patrón en la lista, que es la doctrina que se aplica **al escribir**.
- `aposd-comment-audit/references/checks.md` gana el chequeo `C15`, que es lo que se aplica **al auditar**, con dos veredictos según el estado del número: `REWRITE` si todavía es correcto —se saca igual, porque va a dejar de serlo— y `UPDATE` si ya es falso, que además engaña.

## Plan de pruebas

El cambio es documentación y dos comentarios; no toca comportamiento en runtime, así que no hay aserción nueva que verificar por mutación.

Gates corridos en local: `typecheck`, `lint`, `test` (1572 casos) y `check-agents`, que es el relevante acá — valida las rutas y las anclas que citan los dos archivos de skill, incluido el enlace nuevo entre ellos.

Closes #2172
