### PR TITLE
[#2180] - Restaurar el renderizado del carousel en Storybook y su fidelidad responsive

### DIFF
--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -409,6 +409,8 @@ export const Soft: Story = {
 
 Para dependencias de DI usá los decoradores `moduleMetadata({ imports, providers })` (imports/iconos por story) o `applicationConfig({ providers })` (servicios globales: Router, etc.).
 
+`LayoutService` es la excepción: se provee **globalmente** en `.storybook/preview.js`, con el servicio real (`provideLayout()`), y ninguna story lo declara. Es un token sin factory, así que sin ese provider un componente que lo inyecte no renderiza — el canvas queda en `NG0201`. Storybook **acumula** los decoradores `applicationConfig`: los providers que declare una story se suman a los del preview, no los reemplazan.
+
 **Siempre** actualizá las stories cuando cambien inputs, estados visuales o la API pública del componente.
 
 ### Documentación de la descripción (`description`)

--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -411,6 +411,8 @@ Para dependencias de DI usá los decoradores `moduleMetadata({ imports, provider
 
 `LayoutService` es la excepción: se provee **globalmente** en `.storybook/preview.js`, con el servicio real (`provideLayout()`), y ninguna story lo declara. Es un token sin factory, así que sin ese provider un componente que lo inyecte no renderiza — el canvas queda en `NG0201`. Storybook **acumula** los decoradores `applicationConfig`: los providers que declare una story se suman a los del preview, no los reemplazan.
 
+Todo archivo de la app que el preview importe debe estar en el `include` de `.storybook/tsconfig.json`. Si tiene decoradores de Angular y queda fuera del programa, el compilador no lo procesa y el bundle del preview revienta con un `SyntaxError: Unexpected token 'export'` que **tumba el catálogo entero**, no una story.
+
 **Siempre** actualizá las stories cuando cambien inputs, estados visuales o la API pública del componente.
 
 ### Documentación de la descripción (`description`)

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,11 +5,8 @@ import '../src/assets/css/typography.css';
 import { applicationConfig } from '@storybook/angular-vite';
 import { provideLayout } from '../src/app/providers/layout.provider';
 
-// `LayoutService` es un token sin factory, así que un componente que lo inyecte no renderiza sin
-// este provider — falla el inject() del constructor y el canvas queda en NG0201, no en un error de
-// la story. Va el servicio real y no el doble: el canvas es un navegador de verdad, así que el
-// catálogo responde al ancho como el sitio. Storybook acumula los `applicationConfig`, de modo que
-// los providers propios de cada story siguen vigentes.
+// `LayoutService` es un token sin factory: sin este provider, todo componente que lo inyecte cae en
+// NG0201. La convención completa está en `.claude/references/testing.md`.
 export const decorators = [applicationConfig({ providers: [provideLayout()] })];
 
 export const tags = ['autodocs'];

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,16 @@
 import '../src/styles.css';
 import '../src/assets/css/typography.css';
 
+import { applicationConfig } from '@storybook/angular-vite';
+import { provideLayout } from '../src/app/providers/layout.provider';
+
+// `LayoutService` es un token sin factory, así que un componente que lo inyecte no renderiza sin
+// este provider — falla el inject() del constructor y el canvas queda en NG0201, no en un error de
+// la story. Va el servicio real y no el doble: el canvas es un navegador de verdad, así que el
+// catálogo responde al ancho como el sitio. Storybook acumula los `applicationConfig`, de modo que
+// los providers propios de cada story siguen vigentes.
+export const decorators = [applicationConfig({ providers: [provideLayout()] })];
+
 export const tags = ['autodocs'];
 
 export const parameters = {

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -8,6 +8,7 @@
 
 	"exclude": ["../**/*.spec.ts"],
 	"include": [
+		"../src/app/providers/**/*.ts",
 		"../src/**/*.stories.ts",
 		"../src/**/*.stories.js",
 		"../src/**/*.stories.jsx",

--- a/src/app/components/carousel/carousel-skeleton.component.spec.ts
+++ b/src/app/components/carousel/carousel-skeleton.component.spec.ts
@@ -1,5 +1,5 @@
 // Librería de pruebas
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 
 // Componentes
 import { CarouselSkeletonComponent } from './carousel-skeleton.component';
@@ -14,8 +14,7 @@ describe('CarouselSkeletonComponent', () => {
 	// el mismo breakpoint que la del componente real (`carousel.component.html`). Cuando no coinciden,
 	// el contenido salta al reemplazar al esqueleto en la franja entre ambos breakpoints.
 	it('should switch aspect ratio at the same breakpoint as the carousel', async () => {
-		const { container } = await render(CarouselSkeletonComponent);
-		const skeleton = container.querySelector('cuentoneta-skeleton');
-		expect(skeleton).toHaveClass('aspect-[540/220]', 'sm:aspect-[1240/360]');
+		await render(CarouselSkeletonComponent);
+		expect(screen.getByRole('status')).toHaveClass('aspect-[540/220]', 'sm:aspect-[1240/360]');
 	});
 });

--- a/src/app/components/carousel/carousel-skeleton.component.spec.ts
+++ b/src/app/components/carousel/carousel-skeleton.component.spec.ts
@@ -10,9 +10,12 @@ describe('CarouselSkeletonComponent', () => {
 		expect(container).toBeInTheDocument();
 	});
 
-	it('should render skeleton loader', async () => {
-		await render(CarouselSkeletonComponent);
-		// El componente se renderiza correctamente si no lanza errores
-		expect(true).toBe(true);
+	// El esqueleto reserva el lugar del carousel, así que su relación de aspecto tiene que cambiar en
+	// el mismo breakpoint que la del componente real (`carousel.component.html`). Cuando no coinciden,
+	// el contenido salta al reemplazar al esqueleto en la franja entre ambos breakpoints.
+	it('should switch aspect ratio at the same breakpoint as the carousel', async () => {
+		const { container } = await render(CarouselSkeletonComponent);
+		const skeleton = container.querySelector('cuentoneta-skeleton');
+		expect(skeleton).toHaveClass('aspect-[540/220]', 'sm:aspect-[1240/360]');
 	});
 });

--- a/src/app/components/carousel/carousel-skeleton.component.ts
+++ b/src/app/components/carousel/carousel-skeleton.component.ts
@@ -11,7 +11,7 @@ import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 	template: `<div class="slider">
 		<cuentoneta-skeleton
 			appearance="square"
-			class="grid aspect-[540/220] w-full justify-self-center rounded-[16px] bg-neutral-200 object-cover md:aspect-[1240/360]"
+			class="grid aspect-[540/220] w-full justify-self-center rounded-[16px] bg-neutral-200 object-cover sm:aspect-[1240/360]"
 		/>
 	</div>`,
 })

--- a/src/app/components/carousel/carousel.component.html
+++ b/src/app/components/carousel/carousel.component.html
@@ -18,13 +18,13 @@
 						[class.slide-in-right]="direction() === 'right'"
 						class="slide active absolute inset-0 h-full w-full transition-transform ease-in-out"
 					>
-						<a [routerLink]="slide.url" [class]="viewportSpecificClasses[viewport()]">
+						<a [routerLink]="slide.url" [class]="viewportSpecificClasses[viewport()]" class="block h-full w-full">
 							<img
 								[ngSrc]="slide.contents[viewport()].imageUrl"
 								[width]="slide.contents[viewport()].imageWidth"
 								[height]="slide.contents[viewport()].imageHeight"
 								[alt]="'Imagen de la campaña de contenido ' + slide.title"
-								class="rounded-xl"
+								class="h-full w-full rounded-xl object-cover"
 								priority
 							/>
 						</a>
@@ -38,13 +38,13 @@
 						[class.slide-out-right]="direction() === 'right'"
 						class="slide previous absolute inset-0 h-full w-full transition-transform ease-in-out"
 					>
-						<a [routerLink]="slide.url" [class]="viewportSpecificClasses[viewport()]">
+						<a [routerLink]="slide.url" [class]="viewportSpecificClasses[viewport()]" class="block h-full w-full">
 							<img
 								[ngSrc]="slide.contents[viewport()].imageUrl"
 								[width]="slide.contents[viewport()].imageWidth"
 								[height]="slide.contents[viewport()].imageHeight"
 								[alt]="'Imagen de la campaña de contenido ' + slide.title"
-								class="rounded-xl"
+								class="h-full w-full rounded-xl object-cover"
 							/>
 						</a>
 					</div>

--- a/src/app/components/carousel/carousel.component.spec.ts
+++ b/src/app/components/carousel/carousel.component.spec.ts
@@ -50,6 +50,14 @@ describe('CarouselComponent', () => {
 		});
 	});
 
+	// El esqueleto reserva el lugar de este contenedor mientras carga, así que ambos tienen que cambiar
+	// de relación de aspecto en el mismo breakpoint. La aserción espejo vive en el spec del esqueleto:
+	// con una sola de las dos, una deriva de este lado dejaría el desalineamiento sin señal.
+	it('should declare the aspect ratios its skeleton mirrors', async () => {
+		await setup();
+		expect(screen.getByRole('region')).toHaveClass('aspect-[540/220]', 'sm:aspect-[1240/360]');
+	});
+
 	// El contenedor de la diapositiva se estira al ancho disponible; sin que el enlace y la imagen
 	// ocupen esa área, la imagen queda anclada arriba a la izquierda y los controles e indicadores
 	// —posicionados contra los bordes del contenedor— dejan de alinearse con lo que se ve. happy-dom

--- a/src/app/components/carousel/carousel.component.spec.ts
+++ b/src/app/components/carousel/carousel.component.spec.ts
@@ -50,6 +50,34 @@ describe('CarouselComponent', () => {
 		});
 	});
 
+	// El contenedor de la diapositiva se estira al ancho disponible; sin que el enlace y la imagen
+	// ocupen esa área, la imagen queda anclada arriba a la izquierda y los controles e indicadores
+	// —posicionados contra los bordes del contenedor— dejan de alinearse con lo que se ve. happy-dom
+	// no computa layout, así que lo verificable es el contrato de clases.
+	it('should stretch the slide link over the container area', async () => {
+		await setup();
+		screen.getAllByRole('link').forEach((link) => {
+			expect(link).toHaveClass('block', 'h-full', 'w-full');
+		});
+	});
+
+	it('should stretch the slide image over the container area', async () => {
+		await setup();
+		screen.getAllByRole('img').forEach((image) => {
+			expect(image).toHaveClass('h-full', 'w-full', 'object-cover');
+		});
+	});
+
+	// Estirar la imagen no puede costar sus dimensiones intrínsecas: son las que reservan el espacio
+	// antes de que cargue y las que NgOptimizedImage exige para no advertir.
+	it('should keep the intrinsic dimensions of the slide image', async () => {
+		await setup('md');
+		const [image] = screen.getAllByRole('img');
+		const { md } = contentCampaignMock[0].contents;
+		expect(image).toHaveAttribute('width', String(md.imageWidth));
+		expect(image).toHaveAttribute('height', String(md.imageHeight));
+	});
+
 	// Pruebas de navegación
 	it('should navigate to next slide', async () => {
 		const { fixture } = await setup();

--- a/src/app/components/carousel/carousel.component.stories.ts
+++ b/src/app/components/carousel/carousel.component.stories.ts
@@ -1,5 +1,5 @@
 import { applicationConfig, argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withDisabledInitialNavigation } from '@angular/router';
 
 import { CarouselComponent } from './carousel.component';
 import { CarouselSkeletonComponent } from './carousel-skeleton.component';
@@ -11,10 +11,23 @@ const meta: Meta<CarouselComponent> = {
 	title: 'Componentes V3/Carousel',
 	decorators: [
 		applicationConfig({
-			providers: [provideRouter([])],
+			// Sin desactivar la navegación inicial, el router arranca contra `iframe.html` y un set de
+			// rutas vacío, y el canvas emite un NG04002 que no dice nada del componente. Los routerLink
+			// de las diapositivas resuelven su href igual.
+			providers: [provideRouter([], withDisabledInitialNavigation())],
 		}),
 	],
 	parameters: {
+		// El carousel elige imagen y controles a partir del ancho de la ventana, no del contenedor: la
+		// única forma de catalogar sus dos formas es cambiar el viewport del canvas. El de 1600px es el
+		// que muestra el comportamiento por encima del ancho intrínseco de la imagen.
+		viewport: {
+			options: {
+				movil: { name: 'Móvil', styles: { width: '375px', height: '812px' }, type: 'mobile' },
+				escritorio: { name: 'Escritorio', styles: { width: '1240px', height: '800px' }, type: 'desktop' },
+				panoramico: { name: 'Panorámico', styles: { width: '1600px', height: '900px' }, type: 'desktop' },
+			},
+		},
 		docs: {
 			canvas: {
 				sourceState: 'shown',
@@ -208,39 +221,52 @@ export const Interactive: Story = {
 	},
 };
 
-export const DesktopAndMobile: Story = {
-	name: 'Escritorio y móvil',
-	render: (args) => ({
-		props: args,
-		template: `
-			<div class="flex flex-col gap-8 p-4">
-				<div>
-					<h3 class="text-lg font-semibold text-neutral-700 mb-3">Desktop (960px)</h3>
-					<div style="width: 1240px; max-width: 100%; justify-self: center;">
-						<cuentoneta-carousel [slides]="slides" [transitionDuration]="transitionDuration" />
-					</div>
-				</div>
-
-				<div>
-					<h3 class="text-lg font-semibold text-neutral-700 mb-3">Mobile (375px)</h3>
-					<div style="width: 375px; justify-self: center;">
-						<cuentoneta-carousel [slides]="slides" [transitionDuration]="transitionDuration" />
-					</div>
-				</div>
-			</div>
-		`,
-	}),
+export const Movil: Story = {
+	name: 'Móvil',
+	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
+	globals: { viewport: { value: 'movil' } },
 	args: {
 		slides: contentCampaignMock,
 		transitionDuration: 600,
 	},
 	parameters: {
-		layout: 'fullscreen',
 		docs: {
-			// El render envuelve al carousel en un andamiaje comparativo desktop/mobile; ocultamos el código para no exponerlo como uso copiable.
-			canvas: { sourceState: 'none' },
 			description: {
-				story: `<p>Comparativa del carousel en vista desktop (960px) y mobile (375px) para visualizar las diferencias de diseño responsivo.</p><p><strong>Usos:</strong> referencia de comportamiento responsive entre breakpoints.</p>`,
+				story: `<p>Carousel en un viewport de 375px: sirve la imagen <code>xs</code> y oculta los controles de navegación, que solo aparecen de <code>sm</code> para arriba.</p><p><strong>Usos:</strong> referencia del comportamiento en móvil.</p>`,
+			},
+		},
+	},
+};
+
+export const Escritorio: Story = {
+	name: 'Escritorio',
+	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
+	globals: { viewport: { value: 'escritorio' } },
+	args: {
+		slides: contentCampaignMock,
+		transitionDuration: 600,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Carousel en un viewport de 1240px, el ancho intrínseco de la imagen <code>md</code>, con controles de navegación.</p><p><strong>Usos:</strong> referencia del comportamiento en escritorio, que es como se ve hoy en Home.</p>`,
+			},
+		},
+	},
+};
+
+export const Panoramico: Story = {
+	name: 'Panorámico',
+	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
+	globals: { viewport: { value: 'panoramico' } },
+	args: {
+		slides: contentCampaignMock,
+		transitionDuration: 600,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Carousel en un viewport de 1600px, por encima del ancho intrínseco de la imagen: la diapositiva ocupa el área del contenedor y los controles e indicadores quedan alineados con lo que se ve.</p><p><strong>Usos:</strong> verificación de que el componente se sostiene en contenedores más anchos que su imagen.</p>`,
 			},
 		},
 	},

--- a/src/app/components/carousel/carousel.component.stories.ts
+++ b/src/app/components/carousel/carousel.component.stories.ts
@@ -239,7 +239,6 @@ export const Movil: Story = {
 };
 
 export const Escritorio: Story = {
-	name: 'Escritorio',
 	render: (args) => ({ props: args, template: `<cuentoneta-carousel ${argsToTemplate(args)} />` }),
 	globals: { viewport: { value: 'escritorio' } },
 	args: {

--- a/src/app/providers/layout.provider.spec.ts
+++ b/src/app/providers/layout.provider.spec.ts
@@ -1,4 +1,4 @@
-import { fn, spyOn, type Mock } from '@test-utils';
+import { advanceTimersByTime, fn, spyOn, useFakeTimers, useRealTimers, type Mock } from '@test-utils';
 import { TestBed } from '@angular/core/testing';
 import { WindowLayoutService } from './layout.provider';
 import { Direction, type LayoutService } from './layout.interface';
@@ -22,7 +22,11 @@ describe('WindowLayoutService', () => {
 		dispatchEvent: Mock;
 	};
 
+	// Los timers falsos se instalan antes de construir el servicio para que el estrangulado de sus
+	// observables quede bajo control del test y no del reloj real.
 	beforeEach(() => {
+		useFakeTimers();
+
 		mockWindow = {
 			scrollY: 0,
 			innerWidth: 1920,
@@ -44,37 +48,48 @@ describe('WindowLayoutService', () => {
 		service = TestBed.inject(WindowLayoutService);
 	});
 
+	afterEach(() => {
+		useRealTimers();
+	});
+
 	it('should be created', () => {
 		expect(service).toBeTruthy();
 	});
 
-	// Redimensionar o rotar cambia qué contenido corresponde servir, y quien lo consulta —el carousel,
-	// por caso— no tiene otra fuente. Antes esto solo se recalculaba de rebote dentro de
-	// `isHeaderVisible$`, que además exige que el usuario haya scrolleado.
-	//
-	// Los eventos viajan estrangulados, así que hay que dejar pasar la ventana del throttle para leer
-	// el tamaño final: es la misma espera que impone una ráfaga real de redimensionado.
+	// El viewport es la única fuente que tiene quien decide qué contenido servir —el carousel, por
+	// caso—, así que un cambio de tamaño que no lo actualice deja servido el contenido del ancho
+	// anterior. Los eventos viajan estrangulados: hay que agotar la ventana para leer el tamaño final.
 	describe('recálculo del viewport ante un cambio de tamaño', () => {
-		// El throttle corre sobre el scheduler real, montado al construirse el servicio: adelantar
-		// timers falsos desde acá no lo alcanza, así que la espera es real.
-		const afterThrottleWindow = () => new Promise((resolve) => setTimeout(resolve, 150));
+		const throttleWindow = 150;
 
-		it('recalculates the viewport on resize, with no scrolling involved', async () => {
+		it('recalculates the viewport on resize, with no scrolling involved', () => {
 			expect(service.isActual('xl')).toBe(true);
 
 			mockWindow.innerWidth = 500;
 			mockWindow.dispatchEvent(new Event('resize'));
-			await afterThrottleWindow();
+			advanceTimersByTime(throttleWindow);
 
 			expect(service.isActual('xs')).toBe(true);
 		});
 
-		it('recalculates the viewport on orientation change', async () => {
+		it('recalculates the viewport on orientation change', () => {
 			mockWindow.innerWidth = 500;
 			mockWindow.dispatchEvent(new Event('orientationchange'));
-			await afterThrottleWindow();
+			advanceTimersByTime(throttleWindow);
 
 			expect(service.isActual('xs')).toBe(true);
+		});
+
+		// Arrastrar el borde de la ventana emite una ráfaga entera: lo que vale es dónde terminó, no
+		// dónde empezó.
+		it('keeps the last width of a burst of resize events', () => {
+			mockWindow.innerWidth = 500;
+			mockWindow.dispatchEvent(new Event('resize'));
+			mockWindow.innerWidth = 1024;
+			mockWindow.dispatchEvent(new Event('resize'));
+			advanceTimersByTime(throttleWindow);
+
+			expect(service.isActual('md')).toBe(true);
 		});
 	});
 

--- a/src/app/providers/layout.provider.spec.ts
+++ b/src/app/providers/layout.provider.spec.ts
@@ -48,6 +48,36 @@ describe('WindowLayoutService', () => {
 		expect(service).toBeTruthy();
 	});
 
+	// Redimensionar o rotar cambia qué contenido corresponde servir, y quien lo consulta —el carousel,
+	// por caso— no tiene otra fuente. Antes esto solo se recalculaba de rebote dentro de
+	// `isHeaderVisible$`, que además exige que el usuario haya scrolleado.
+	//
+	// Los eventos viajan estrangulados, así que hay que dejar pasar la ventana del throttle para leer
+	// el tamaño final: es la misma espera que impone una ráfaga real de redimensionado.
+	describe('recálculo del viewport ante un cambio de tamaño', () => {
+		// El throttle corre sobre el scheduler real, montado al construirse el servicio: adelantar
+		// timers falsos desde acá no lo alcanza, así que la espera es real.
+		const afterThrottleWindow = () => new Promise((resolve) => setTimeout(resolve, 150));
+
+		it('recalculates the viewport on resize, with no scrolling involved', async () => {
+			expect(service.isActual('xl')).toBe(true);
+
+			mockWindow.innerWidth = 500;
+			mockWindow.dispatchEvent(new Event('resize'));
+			await afterThrottleWindow();
+
+			expect(service.isActual('xs')).toBe(true);
+		});
+
+		it('recalculates the viewport on orientation change', async () => {
+			mockWindow.innerWidth = 500;
+			mockWindow.dispatchEvent(new Event('orientationchange'));
+			await afterThrottleWindow();
+
+			expect(service.isActual('xs')).toBe(true);
+		});
+	});
+
 	describe('userHasScrolled$', () => {
 		it('should emit Direction.Up when scrolling up', () =>
 			new Promise<void>((resolve) => {

--- a/src/app/providers/layout.provider.ts
+++ b/src/app/providers/layout.provider.ts
@@ -48,10 +48,13 @@ export class WindowLayoutService implements LayoutService {
 	 * o se recalcula el tamaño de pantalla asignado al navegador en el dispositivo.
 	 * @private
 	 */
+	// `trailing` es lo que hace que el último tamaño de una ráfaga llegue: arrastrar el borde de la
+	// ventana emite decenas de eventos, y solo con `leading` el viewport quedaría fijado en el ancho
+	// del primer instante del arrastre.
 	private readonly _viewportHasChanged$ = merge(
 		fromEvent(this.window, 'resize').pipe(startWith(null)),
 		fromEvent(this.window, 'orientationchange').pipe(startWith(null)),
-	).pipe(takeUntilDestroyed(), throttleTime(100));
+	).pipe(takeUntilDestroyed(), throttleTime(100, undefined, { leading: true, trailing: true }));
 
 	public readonly isHeaderVisible = toSignal(this.isHeaderVisible$, { initialValue: true });
 
@@ -77,6 +80,12 @@ export class WindowLayoutService implements LayoutService {
 
 	constructor() {
 		this.setViewport();
+
+		// El otro consumidor de `viewportHasChanged$` es `isHeaderVisible$`, que lo combina con
+		// `userHasScrolled$` — y ese exige dos eventos de scroll por encima de 400px. Sin esta
+		// suscripción propia, redimensionar la ventana o rotar el dispositivo no recalcula el viewport
+		// hasta que además se scrollea, y el componente sigue sirviendo el contenido del ancho anterior.
+		this.viewportHasChanged$.pipe(takeUntilDestroyed()).subscribe(() => this.setViewport());
 	}
 
 	/**

--- a/src/app/providers/layout.provider.ts
+++ b/src/app/providers/layout.provider.ts
@@ -46,15 +46,20 @@ export class WindowLayoutService implements LayoutService {
 	/**
 	 * Observable que se dispara cuando ocurre un cambio de orientación de pantalla
 	 * o se recalcula el tamaño de pantalla asignado al navegador en el dispositivo.
+	 *
+	 * `trailing` es lo que hace llegar el último tamaño de una ráfaga: arrastrar el borde de la ventana
+	 * emite decenas de eventos, y solo con `leading` el viewport quedaría fijado en el ancho del primer
+	 * instante del arrastre.
 	 * @private
 	 */
-	// `trailing` es lo que hace que el último tamaño de una ráfaga llegue: arrastrar el borde de la
-	// ventana emite decenas de eventos, y solo con `leading` el viewport quedaría fijado en el ancho
-	// del primer instante del arrastre.
 	private readonly _viewportHasChanged$ = merge(
 		fromEvent(this.window, 'resize').pipe(startWith(null)),
 		fromEvent(this.window, 'orientationchange').pipe(startWith(null)),
 	).pipe(takeUntilDestroyed(), throttleTime(100, undefined, { leading: true, trailing: true }));
+
+	// Única fuente de recálculo del viewport. Va antes de `isHeaderVisible` a propósito: los inicializadores
+	// de campo corren en orden, y quien decide la visibilidad del header lee el viewport ya sincronizado.
+	private readonly viewportResync = this._viewportHasChanged$.subscribe(() => this.setViewport());
 
 	public readonly isHeaderVisible = toSignal(this.isHeaderVisible$, { initialValue: true });
 
@@ -68,24 +73,12 @@ export class WindowLayoutService implements LayoutService {
 
 	private get isHeaderVisible$() {
 		return combineLatest([this.viewportHasChanged$, this.userHasScrolled$]).pipe(
-			map(([hasChanged, direction]) => {
-				if (hasChanged) {
-					this.setViewport();
-				}
-
-				return this.biggerThan('xs') || direction === Direction.Up;
-			}),
+			map(([, direction]) => this.biggerThan('xs') || direction === Direction.Up),
 		);
 	}
 
 	constructor() {
 		this.setViewport();
-
-		// El otro consumidor de `viewportHasChanged$` es `isHeaderVisible$`, que lo combina con
-		// `userHasScrolled$` — y ese exige dos eventos de scroll por encima de 400px. Sin esta
-		// suscripción propia, redimensionar la ventana o rotar el dispositivo no recalcula el viewport
-		// hasta que además se scrollea, y el componente sigue sirviendo el contenido del ancho anterior.
-		this.viewportHasChanged$.pipe(takeUntilDestroyed()).subscribe(() => this.setViewport());
 	}
 
 	/**


### PR DESCRIPTION
## Qué resuelve

Las siete stories de `CarouselComponent` no renderizaban: el canvas mostraba la pantalla de error de Storybook con `NG0201: No provider found for InjectionToken LayoutService`. El componente inyecta `LayoutService` para derivar el viewport, el token no declara `factory`, y el catálogo no lo proveía por ningún lado.

Con el bloqueo levantado quedaron a la vista tres defectos que el error tapaba, y que se arreglan acá.

## Cambios

**1. `LayoutService` se provee globalmente en `.storybook/preview.js`,** con el servicio real y no con el doble: el canvas es un navegador de verdad, así que el catálogo responde al ancho igual que el sitio. Va en el preview y no en el meta de la story para que el próximo componente que dependa del viewport no vuelva a caer por lo mismo — `story.component.ts` ya inyecta el mismo token. Storybook acumula los decoradores `applicationConfig`, de modo que los providers propios de cada story siguen vigentes.

Eso obligó a sumar `src/app/providers/**` al `include` de `.storybook/tsconfig.json`: un archivo con decoradores de Angular importado desde el preview y ausente del programa de TypeScript no se compila, y el bundle revienta con un `SyntaxError` que deja el catálogo entero en blanco. Queda documentado en `.claude/references/testing.md`.

**2. La diapositiva ocupa el área de su contenedor.** La `<section>` declara la relación de aspecto y se estira al ancho disponible, pero la imagen conservaba sus dimensiones intrínsecas: por encima de 1240px quedaba anclada arriba a la izquierda, con los controles y los indicadores —posicionados contra los bordes de la sección— desalineados de lo que se ve. Se conservan `ngSrc` y las dimensiones intrínsecas, que son las que reservan el espacio antes de la carga.

**3. Cobertura por viewport real, en reemplazo de «Escritorio y móvil».** Esa story prometía una comparativa que no podía dar: renderizaba dos `div` de ancho fijo, pero el componente elige imagen y controles a partir del ancho de la ventana, no del contenedor, así que el panel rotulado como móvil mostraba la imagen de escritorio encogida. Las tres stories nuevas —`Móvil` (375px), `Escritorio` (1240px) y `Panorámico` (1600px)— cambian el viewport del canvas, que es lo único que el componente observa. El viewport no necesita addon: desde Storybook 9 vive en el core.

**4. El viewport se recalcula ante un cambio de tamaño de ventana.** Es un defecto de la aplicación, no del catálogo, y salió a la luz al verificar el punto anterior: la story `Móvil` quedaba vacía. El único recálculo vivía dentro de la política de visibilidad del header, que combina el cambio de tamaño con el scroll y exige que el usuario haya scrolleado dos veces por encima de 400px; hasta entonces, redimensionar la ventana o rotar el dispositivo dejaba el viewport en el valor del montaje. El estrangulado pasa además a emitir al final de la ráfaga: con solo el primer evento, arrastrar el borde de la ventana fijaba el ancho del instante inicial del arrastre.

**5. El esqueleto del carousel cambia de relación de aspecto en el mismo breakpoint que el contenido** que reemplaza (`sm`, no `md`). Entre 640 y 768px reservaba un alto distinto del que después ocupa, y el contenido saltaba al aparecer — justo lo que la story `Estados` existe para revelar.

## Plan de pruebas

**Automatizado.** Los once gates en verde. Casos nuevos:

- `carousel.component.spec.ts` — el enlace y la imagen de la diapositiva declaran las clases que las hacen ocupar el área del contenedor; la imagen conserva sus dimensiones intrínsecas; el contenedor declara las relaciones de aspecto que el esqueleto refleja.
- `carousel-skeleton.component.spec.ts` — el esqueleto cambia de relación de aspecto en el mismo breakpoint que el contenedor real. Reemplaza a un caso que afirmaba `expect(true).toBe(true)`.
- `layout.provider.spec.ts` — el viewport se recalcula ante `resize` y ante `orientationchange` sin scroll de por medio, y en una ráfaga de eventos gana el último ancho. Los tres fallan si se quita el `trailing`, verificado quitándolo.

Las aserciones sobre clases son una red de seguridad, no una medición: `happy-dom` no computa layout. La evidencia de que la imagen efectivamente llena el contenedor la aporta la story `Panorámico`.

**Manual, en el navegador** (Storybook real):

- Las nueve stories del carousel renderizan, sin errores de Angular en la consola del canvas. El `NG04002` de la navegación inicial desapareció.
- A 1600px la imagen llena el contenedor, con controles e indicadores alineados con lo que se ve.
- La story `Móvil` sirve la imagen `xs` (540×220) en una caja de 343×140 —misma relación de aspecto, sin recorte— y sin controles de navegación. Antes del arreglo del viewport esta story quedaba **vacía**.
- Barrido del catálogo montando una story por componente y detectando la pantalla de error de Storybook: **23 de 24 renderizan**. El único roto es `HeaderComponent`, por un `NG0201` de `ActivatedRoute` ajeno a este PR y anterior a él, que quedó en #2182.

Closes #2180
