### PR TITLE
[#2053] - Traspasar el contenido de Storylist a Collection

### DIFF
--- a/cms/migrations/draft-storylist-to-collection/README.md
+++ b/cms/migrations/draft-storylist-to-collection/README.md
@@ -1,0 +1,66 @@
+# `draft-storylist-to-collection`
+
+Crea una colección **en borrador** por cada storylist en borrador que esté completa. Comparte el núcleo de armado con [`storylist-to-collection`](../storylist-to-collection/README.md), que documenta el mapeo campo por campo, la fuerza de las referencias y el procedimiento. Acá va **solo lo que cambia**.
+
+## Qué admite el filtro, y por qué
+
+```
+_id in path('drafts.**') && defined(title) && defined(slug.current) && count(description) > 0 && count(stories) > 0
+```
+
+El principio es que **el filtro admite exactamente lo que el destino declara requerido**, y el destino son dos capas:
+
+- El **schema del Studio** exige `title`, `slug` y `description`.
+- La **factory del dominio** exige además al menos una obra: `createCollection` rechaza una colección sin obras literarias, y `createCollectionTeaser` rechaza un contador menor a uno.
+
+Sin esa última condición la migración escribiría un documento que el dominio **nunca puede construir**: la falla no aparecería al migrar sino al mapear, lejos de donde se corrige.
+
+No es una lista de casos observados. Si alguna de las dos capas cambia lo que exige, el filtro cambia con ella.
+
+Semántica de GROQ que conviene tener presente: un campo ausente hace que `count(...)` devuelva `null`, y `null > 0` es falso, así que ausente y vacío se excluyen por igual. El spec lo **ejecuta** con el motor real en vez de comparar el filtro como texto.
+
+## El corte medido
+
+De 9 storylists en borrador, el filtro admite **3**:
+
+| Colección                                     | Obras | Referencias colgantes tras reapuntar |
+| --------------------------------------------- | ----: | -----------------------------------: |
+| Cuentos originales                            |    15 |                                    0 |
+| Cuentos cortos para el verano #6: Chéjov/Vela |     3 |                                    0 |
+| Semanario - 50/2025                           |     6 |                                    0 |
+
+Las **6 excluidas**: cinco por no tener descripción y una —"3 cuentos: Lermo Balbi"— por no tener obras. Ninguna se excluye por título ni por slug.
+
+Entre las excluidas por descripción está **"Los días siguientes y otros relatos"**, que además es el único caso asimétrico del corpus: 16 de sus referencias apuntan a cuentos que existen solo como borradores incompletos, sin obra migrada en ninguna forma. Cae por el filtro general, sin nombrarla y sin ninguna condición ad-hoc, que es la propiedad deseable.
+
+Vale explicitar por qué no se la migra con esas referencias colgantes, ahora que la fuerza se preserva del origen. La asimetría es real: en el **origen**, la referencia débil apunta a un cuento que existe como borrador, el editor lo ve en el Studio y publicarlo cierra el agujero. En el **destino** apuntaría a un documento que no existe en ninguna forma y que ninguna acción del Studio crea: la promesa de `_strengthenOnPublish` sería incumplible. Un agujero sin camino de reparación es peor que una exclusión visible — la exclusión se ve en el censo, el agujero no se ve en ningún lado.
+
+### La columna de colgantes del censo no es un extra
+
+Hoy da cero para las tres admitidas. Si algún día da distinto de cero, se completa editorialmente el cuento y se vuelve a correr `draft-story-to-literary-work`; **nunca** se migra la colección con agujeros.
+
+Es la única defensa ante el escenario concreto: si alguien le carga una descripción y obras a "Los días siguientes" y vuelve a correr la migración, entra con sus 16 colgantes. Por eso el censo es un paso obligatorio del procedimiento.
+
+## Nada se publica
+
+El identificador derivado conserva el prefijo de path del origen y lo reaplica **encabezando**, así que una storylist inédita produce una colección inédita. Las queries del sitio excluyen borradores: nada de esto llega a una página.
+
+**Dos de las tres admitidas tienen versión publicada** (Chéjov/Vela y Semanario 50/2025), así que producen el borrador de su **misma** colección: ambos identificadores derivan del mismo uuid. No nace una colección distinta ni se toca la publicada.
+
+En el Studio esos dos van a aparecer como **cambios sin publicar que nadie hizo**. Es esperado, no un error. Antes de publicar uno conviene comparar ambas versiones: publicarlo reemplazaría el contenido de la versión publicada, incluidas las correcciones editoriales posteriores a la migración.
+
+## Consecuencia editorial de las referencias débiles
+
+"Cuentos originales" migra con 14 referencias débiles a obras que existen solo como borradores. Es fiel al origen y no rompe nada mientras la colección esté en borrador, porque el sitio no lee borradores. Pero **al publicarla, esas obras no publicadas desaparecen del listado sin ningún error**. Conviene saberlo antes de publicar.
+
+## Cuidado con el limpiador de borradores
+
+`scripts/remove-all-unpublished-drafts.ts` borra **todos** los borradores del dataset: correrlo después de esta migración se lleva puestas las colecciones que crea.
+
+## Revertir
+
+```bash
+pnpm -C cms exec sanity migration run revert-draft-storylist-to-collection --project s4dbqkc5 --dataset <ds> --no-dry-run --no-confirm
+```
+
+Es la que corresponde para reintentar **este** lote. La reversión amplia alcanza las dos formas del identificador y se llevaría también las colecciones publicadas, que son sobre las que se construye la página nueva.

--- a/cms/migrations/draft-storylist-to-collection/index.spec.ts
+++ b/cms/migrations/draft-storylist-to-collection/index.spec.ts
@@ -1,0 +1,111 @@
+import { evaluate, parse } from 'groq-js';
+import { describe, expect, it } from 'vitest';
+
+import type { PortableTextBlock } from '../../../resources/portable-text-to-markdown/portable-text-to-markdown';
+import { type StorylistDocument } from '../storylist-to-collection/build-collection-document';
+import migration from './index';
+
+const migrateDocument = (doc: StorylistDocument) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never);
+};
+
+const paragraph = (text: string): PortableTextBlock => ({
+	_type: 'block',
+	_key: 'b1',
+	style: 'normal',
+	markDefs: [],
+	children: [{ _type: 'span', _key: 's1', text, marks: [] }],
+});
+
+const draftStorylist = (overrides: Partial<StorylistDocument> = {}): StorylistDocument => ({
+	_id: 'drafts.storylist-1',
+	title: 'Cuentos originales',
+	slug: { _type: 'slug', current: 'cuentos-originales' },
+	description: [paragraph('Prosa editorial.')],
+	stories: [{ _type: 'reference', _ref: 'story-a', _key: 'k1' }],
+	...overrides,
+});
+
+describe('migración de storylists en borrador a colecciones en borrador', () => {
+	it('alcanza solo a las storylists', () => {
+		expect(migration.documentTypes).toEqual(['storylist']);
+	});
+
+	// El filtro se ejecuta con el mismo motor que GROQ, no se compara como texto: una aserción textual
+	// pasa igual con un filtro roto mientras el literal coincida, y no distingue `count(x) > 0` de
+	// `count(x) >= 0` ni dice qué hace ante un campo ausente, que es el caso frecuente en un borrador.
+	describe('el filtro decide qué entra', () => {
+		const admitido = {
+			_id: 'drafts.ok',
+			_type: 'storylist',
+			title: 'T',
+			slug: { current: 't' },
+			description: [{}],
+			stories: [{}],
+		};
+
+		const matching = async (...docs: Record<string, unknown>[]) => {
+			const result = await evaluate(parse(`*[${migration.filter}]._id`), { dataset: docs });
+			return (await result.get()) as string[];
+		};
+
+		it('admite un borrador completo', async () => {
+			expect(await matching(admitido)).toEqual(['drafts.ok']);
+		});
+
+		it('deja fuera una storylist publicada', async () => {
+			expect(await matching({ ...admitido, _id: 'publicada' })).toEqual([]);
+		});
+
+		it('deja fuera un borrador sin descripción, esté ausente o vacía', async () => {
+			const sinCampo = { ...admitido, _id: 'drafts.sin-campo', description: undefined };
+			const vacia = { ...admitido, _id: 'drafts.vacia', description: [] };
+
+			expect(await matching(sinCampo, vacia)).toEqual([]);
+		});
+
+		// La condición no sale del schema del Studio, que declara las obras opcionales, sino de la factory
+		// del dominio, que exige al menos una. Sin ella se escribiría un documento que el dominio nunca
+		// puede construir, y la falla aparecería al mapear en vez de en la migración.
+		it('deja fuera un borrador sin obras, esté ausente o vacío', async () => {
+			const sinCampo = { ...admitido, _id: 'drafts.sin-obras', stories: undefined };
+			const vacio = { ...admitido, _id: 'drafts.obras-vacias', stories: [] };
+
+			expect(await matching(sinCampo, vacio)).toEqual([]);
+		});
+
+		it('deja fuera un borrador sin título o sin slug', async () => {
+			const sinTitulo = { ...admitido, _id: 'drafts.sin-titulo', title: undefined };
+			const sinSlug = { ...admitido, _id: 'drafts.sin-slug', slug: undefined };
+
+			expect(await matching(sinTitulo, sinSlug)).toEqual([]);
+		});
+	});
+
+	it('crea la colección en borrador sin tocar la storylist de origen', () => {
+		const [mutation] = migrateDocument(draftStorylist()) as {
+			type: string;
+			document: { _id: string; _type: string };
+		}[];
+
+		expect(mutation?.type).toBe('createIfNotExists');
+		expect(mutation?.document._id).toBe('drafts.collection-from-storylist-storylist-1');
+		expect(mutation?.document._type).toBe('collection');
+	});
+
+	// Lo que impide que la corrida publique contenido inédito.
+	it('deriva un identificador que Sanity lee como borrador', () => {
+		const [mutation] = migrateDocument(draftStorylist()) as { document: { _id: string } }[];
+
+		expect(mutation?.document._id.startsWith('drafts.')).toBe(true);
+	});
+
+	// Defensa en profundidad: el filtro no debería entregar una storylist así, pero si lo hiciera —otro
+	// filtro en la invocación, un cambio en el runner— la corrida se detiene en vez de escribir una
+	// colección degradada que fallaría recién al leerse.
+	it('propaga el error del mapeo ante un borrador incompleto', () => {
+		expect(() => migrateDocument(draftStorylist({ title: undefined }))).toThrow(/no tiene título/);
+	});
+});

--- a/cms/migrations/draft-storylist-to-collection/index.ts
+++ b/cms/migrations/draft-storylist-to-collection/index.ts
@@ -1,0 +1,37 @@
+import { createIfNotExists, defineMigration } from 'sanity/migrate';
+
+import { buildCollectionDocument, type StorylistDocument } from '../storylist-to-collection/build-collection-document';
+
+/**
+ * Crea una colección **en borrador** por cada storylist en borrador que esté completa.
+ *
+ * **Nada se publica.** El identificador derivado conserva el prefijo de path del origen, así que una
+ * storylist inédita produce una colección inédita, y las queries del sitio excluyen borradores: nada de
+ * esto llega a una página.
+ *
+ * **Una storylist con versión publicada y borrador produce el borrador de su misma colección**, porque
+ * ambos identificadores derivan del mismo uuid. No nace una colección distinta ni se toca la publicada.
+ * En el Studio esos borradores aparecen como cambios sin publicar que nadie hizo: es esperado.
+ *
+ * **Los borradores incompletos se excluyen en el filtro, no en el código.** Uno a medio escribir es un
+ * estado legítimo, no un error del dataset, así que no corresponde ni abortar la corrida entera ni
+ * saltearlo desde el mapeo: la exclusión declarativa queda a la vista en el diff y el censo dice qué
+ * quedó afuera. El armado sigue lanzando como defensa en profundidad.
+ *
+ * **El filtro admite exactamente lo que el destino declara requerido**, y el destino son dos capas: el
+ * schema del Studio exige título, slug y descripción; la factory del dominio exige además al menos una
+ * obra. Sin esa última condición la migración escribiría un documento que el dominio nunca puede
+ * construir, y la falla aparecería al mapear en vez de acá. No es una lista de casos observados: si
+ * alguna de las dos capas cambia lo que exige, el filtro cambia con ella.
+ */
+export default defineMigration({
+	title: 'Crear una colección en borrador por cada storylist en borrador',
+	documentTypes: ['storylist'],
+	filter:
+		"_id in path('drafts.**') && defined(title) && defined(slug.current) && count(description) > 0 && count(stories) > 0",
+	migrate: {
+		document(doc: StorylistDocument) {
+			return [createIfNotExists(buildCollectionDocument(doc))];
+		},
+	},
+});

--- a/cms/migrations/revert-draft-storylist-to-collection/index.spec.ts
+++ b/cms/migrations/revert-draft-storylist-to-collection/index.spec.ts
@@ -1,0 +1,51 @@
+import { evaluate, parse } from 'groq-js';
+import { describe, expect, it } from 'vitest';
+
+import migration from './index';
+
+const migrateDocument = (doc: { _id: string }) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never);
+};
+
+describe('reversión acotada de colecciones en borrador', () => {
+	it('alcanza solo a las colecciones', () => {
+		expect(migration.documentTypes).toEqual(['collection']);
+	});
+
+	describe('el filtro decide qué entra', () => {
+		const matching = async (...docs: Record<string, unknown>[]) => {
+			const result = await evaluate(parse(`*[${migration.filter}]._id`), { dataset: docs });
+			return (await result.get()) as string[];
+		};
+
+		it('admite una colección migrada en borrador', async () => {
+			const borrador = { _id: 'drafts.collection-from-storylist-abc', _type: 'collection' };
+
+			expect(await matching(borrador)).toEqual([borrador._id]);
+		});
+
+		// Es la razón de existir de esta reversión: la amplia se llevaría el corpus publicado.
+		it('deja fuera una colección migrada publicada', async () => {
+			expect(await matching({ _id: 'collection-from-storylist-abc', _type: 'collection' })).toEqual([]);
+		});
+
+		it('deja fuera un borrador ajeno a la migración', async () => {
+			expect(await matching({ _id: 'drafts.coleccion-escrita-a-mano', _type: 'collection' })).toEqual([]);
+		});
+	});
+
+	it('borra la colección en borrador que nació de la migración', () => {
+		const [mutation] = migrateDocument({ _id: 'drafts.collection-from-storylist-abc' }) as { type: string }[];
+
+		expect(mutation?.type).toBe('delete');
+	});
+
+	// Las dos condiciones tienen que darse: el prefijo de path solo no alcanza, y el de la migración solo
+	// alcanzaría también a las publicadas.
+	it('no borra una colección migrada publicada ni un borrador ajeno', () => {
+		expect(migrateDocument({ _id: 'collection-from-storylist-abc' })).toEqual([]);
+		expect(migrateDocument({ _id: 'drafts.coleccion-escrita-a-mano' })).toEqual([]);
+	});
+});

--- a/cms/migrations/revert-draft-storylist-to-collection/index.ts
+++ b/cms/migrations/revert-draft-storylist-to-collection/index.ts
@@ -1,0 +1,35 @@
+import { defineMigration, del } from 'sanity/migrate';
+
+import { DRAFTS_PATH_PREFIX } from '../story-to-literary-work/build-literary-work-document';
+import { isMigratedCollectionId, MIGRATED_ID_PREFIX } from '../storylist-to-collection/build-collection-document';
+
+interface CollectionDocument {
+	_id: string;
+}
+
+/**
+ * Deshace **solo** la creación de colecciones en borrador, dejando intactas las publicadas.
+ *
+ * `revert-storylist-to-collection` alcanza las dos formas del identificador a la vez, así que usarla
+ * para descartar el lote de borradores se llevaría también las colecciones publicadas —que son sobre
+ * las que se construye la página nueva, y que pueden haber recibido correcciones editoriales que
+ * `createIfNotExists` protege deliberadamente—. Esta es la que se usa de verdad al reintentar.
+ *
+ * El guard exige **las dos** condiciones y no solo el prefijo de path: un documento cualquiera bajo
+ * `drafts.` no es una colección migrada, y el predicado compartido es lo que distingue una de otra.
+ *
+ * No restaura nada en las storylists, porque la migración de ida no las tocó.
+ */
+export default defineMigration({
+	title: 'Revertir la creación de colecciones en borrador a partir de storylists en borrador',
+	documentTypes: ['collection'],
+	filter: `string::startsWith(_id, "${DRAFTS_PATH_PREFIX}${MIGRATED_ID_PREFIX}")`,
+	migrate: {
+		document(doc: CollectionDocument) {
+			if (!doc._id.startsWith(DRAFTS_PATH_PREFIX) || !isMigratedCollectionId(doc._id)) {
+				return [];
+			}
+			return [del(doc._id)];
+		},
+	},
+});

--- a/cms/migrations/revert-storylist-to-collection/index.spec.ts
+++ b/cms/migrations/revert-storylist-to-collection/index.spec.ts
@@ -1,0 +1,54 @@
+import { evaluate, parse } from 'groq-js';
+import { describe, expect, it } from 'vitest';
+
+import migration from './index';
+
+const migrateDocument = (doc: { _id: string }) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never);
+};
+
+describe('reversión amplia de colecciones migradas', () => {
+	it('alcanza solo a las colecciones', () => {
+		expect(migration.documentTypes).toEqual(['collection']);
+	});
+
+	describe('el filtro decide qué entra', () => {
+		const matching = async (...docs: Record<string, unknown>[]) => {
+			const result = await evaluate(parse(`*[${migration.filter}]._id`), { dataset: docs });
+			return (await result.get()) as string[];
+		};
+
+		it('alcanza las dos formas del identificador derivado', async () => {
+			const publicada = { _id: 'collection-from-storylist-abc', _type: 'collection' };
+			const borrador = { _id: 'drafts.collection-from-storylist-abc', _type: 'collection' };
+
+			expect(await matching(publicada, borrador)).toEqual([publicada._id, borrador._id]);
+		});
+
+		it('deja fuera una colección ajena a la migración', async () => {
+			const aMano = { _id: 'coleccion-escrita-a-mano', _type: 'collection' };
+			const borradorAMano = { _id: 'drafts.coleccion-escrita-a-mano', _type: 'collection' };
+
+			expect(await matching(aMano, borradorAMano)).toEqual([]);
+		});
+	});
+
+	it('borra la colección migrada, publicada o en borrador', () => {
+		const publicada = migrateDocument({ _id: 'collection-from-storylist-abc' }) as { type: string; id: string }[];
+		const borrador = migrateDocument({ _id: 'drafts.collection-from-storylist-abc' }) as {
+			type: string;
+			id: string;
+		}[];
+
+		expect(publicada[0]?.type).toBe('delete');
+		expect(borrador[0]?.type).toBe('delete');
+	});
+
+	// El guard revalida porque el filtro es una optimización del runner, no la garantía: es lo que
+	// protege una colección creada a mano en el Studio.
+	it('no emite mutación ante una colección ajena a la migración', () => {
+		expect(migrateDocument({ _id: 'coleccion-escrita-a-mano' })).toEqual([]);
+	});
+});

--- a/cms/migrations/revert-storylist-to-collection/index.ts
+++ b/cms/migrations/revert-storylist-to-collection/index.ts
@@ -1,0 +1,36 @@
+import { defineMigration, del } from 'sanity/migrate';
+
+import { DRAFTS_PATH_PREFIX } from '../story-to-literary-work/build-literary-work-document';
+import { isMigratedCollectionId, MIGRATED_ID_PREFIX } from '../storylist-to-collection/build-collection-document';
+
+interface CollectionDocument {
+	_id: string;
+}
+
+/**
+ * Deshace la creación de colecciones a partir de storylists, en sus **dos** formas: las publicadas y
+ * las que nacieron de un borrador. Es el mazazo; para reintentar solo el lote de borradores está la
+ * reversión acotada, que no se lleva puesto el corpus publicado.
+ *
+ * **El predicado se importa, no se reescribe.** Una segunda noción de "colección migrada" podría
+ * divergir y borrar una colección creada a mano en el Studio.
+ *
+ * **El filtro enumera las dos formas** porque el prefijo de path antecede al de la migración y GROQ no
+ * ofrece recortarlo dentro del filtro. Usa `string::startsWith` y no `match`: el `match` de GROQ compara
+ * por tokens, así que un patrón con comodín es más ancho de lo que aparenta.
+ *
+ * El guard revalida sobre cada documento porque el filtro es una optimización del runner, no la
+ * garantía.
+ *
+ * No restaura nada en las storylists, porque la migración de ida no las tocó.
+ */
+export default defineMigration({
+	title: 'Revertir la creación de colecciones a partir de storylists',
+	documentTypes: ['collection'],
+	filter: `string::startsWith(_id, "${MIGRATED_ID_PREFIX}") || string::startsWith(_id, "${DRAFTS_PATH_PREFIX}${MIGRATED_ID_PREFIX}")`,
+	migrate: {
+		document(doc: CollectionDocument) {
+			return isMigratedCollectionId(doc._id) ? [del(doc._id)] : [];
+		},
+	},
+});

--- a/cms/migrations/storylist-to-collection/README.md
+++ b/cms/migrations/storylist-to-collection/README.md
@@ -55,6 +55,23 @@ count(*[_type == "storylist" && count(tabs) > 0])
 
 Resultado: **cero** en `production`, `staging` y `development`. Por eso no se exporta nada antes de descartar el campo.
 
+### Qué construcciones trae la prosa
+
+Medido sobre el corpus, para que el contraste de fidelidad sepa qué buscar:
+
+```groq
+{
+  "estilos": array::unique(*[_type == "storylist"].description[].style),
+  "listItems": array::unique(*[_type == "storylist"].description[].listItem),
+  "marcas": array::unique(*[_type == "storylist"].description[].children[].marks[]),
+  "tiposMarkDef": array::unique(*[_type == "storylist"].description[].markDefs[]._type)
+}
+```
+
+Un único estilo de bloque (`normal`), un único tipo de ítem de lista (`bullet`), decoradores `strong` y `em`, y `link` como único tipo de markDef. Sin encabezados, sin `code`, sin listas numeradas: todo cae dentro de lo que el conversor traduce, así que la corrida no se detiene por `UnsupportedPortableTextError`.
+
+**Las listas de viñetas no son un caso de borde:** las traen 8 de las 36 descripciones. `florilegio-50-2025` es la muestra útil para el contraste —un párrafo introductorio y seis ítems, con negritas, enlaces y una cursiva—, porque ejercita todo el inventario de una sola vez.
+
 ## Aborta en vez de degradar
 
 Ante un dato del que no se puede derivar una colección válida —sin título, sin slug, sin descripción, con miembros sin `_key`, o con una referencia que apunta a un borrador— el núcleo lanza `UnmigratableStorylistError` y la corrida se detiene identificando el documento.

--- a/cms/migrations/storylist-to-collection/README.md
+++ b/cms/migrations/storylist-to-collection/README.md
@@ -1,0 +1,99 @@
+# `storylist-to-collection`
+
+Crea una colección publicada por cada storylist publicada. No renombra ni modifica el origen: emite un documento nuevo al lado, con la forma del tipo `collection`.
+
+`storylist` no se toca en ningún momento, así que la página vieja sigue sirviéndose durante toda la convivencia y la reversión es un borrado limpio.
+
+## Prerequisito
+
+**`story-to-literary-work` tiene que estar aplicada con `--no-dry-run` en el mismo dataset.** El reapuntado deriva el identificador de cada obra a partir del de su cuento; si la obra no existe y la referencia es fuerte, el content lake rechaza la transacción entera al escribir.
+
+El dry-run **no** lo detecta: imprime mutaciones sin llegar al servidor. Por eso el censo previo es un paso obligatorio del procedimiento, no una sugerencia.
+
+## Por qué una migración y no un renombre
+
+Sanity no admite patchear `_type`. Renombrar el tipo obligaría igual a crear documentos nuevos y dar de baja los viejos, así que conviene crearlos ya con la forma correcta —sin pestañas, con la descripción en Markdown y agregando obras literarias— en vez de arrastrar la forma vieja y corregirla después.
+
+## Mapeo campo por campo
+
+| Campo destino                                     | Origen        | Regla                                                                                                     |
+| ------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------- |
+| `_id`                                             | `_id`         | Derivado: `collection-from-storylist-<uuid>`, conservando el prefijo de path del origen y **encabezando** |
+| `_type`                                           | —             | `collection`                                                                                              |
+| `title`, `slug`                                   | iguales       | Uno a uno; aborta si falta cualquiera                                                                     |
+| `description`                                     | `description` | Portable Text convertido a Markdown; aborta si queda vacía                                                |
+| `literaryWorks`                                   | `stories`     | Cada referencia reapuntada a su obra migrada, con el `_key` de origen y su fuerza preservada              |
+| `featuredImage`, `tags`, `config`, `mediaSources` | iguales       | Viajan sin transformar; la clave se **omite** cuando el origen no la trae, nunca se escribe vacía         |
+| `tabs`                                            | —             | **No se lee ni se escribe**: no existe en el tipo destino                                                 |
+| `count`                                           | —             | No existe en el schema; se deriva en el mapper como longitud del array                                    |
+
+### El identificador derivado
+
+Sostiene cuatro cosas a la vez sin agregar ningún campo al schema: la **correspondencia** entre cada colección y su storylist, la **idempotencia** (con `createIfNotExists`, re-migrar es un no-op del lado del servidor), la **reversión** (la inversa filtra por el prefijo) y que **nada se publique por accidente**.
+
+Lo último merece su propia línea: Sanity lee `drafts.` como borrador solo cuando **encabeza** el `_id`. Concatenarlo detrás del prefijo de la migración produciría un documento publicado con nombre de borrador, y contenido inédito quedaría en línea sin que nada lo señale.
+
+Se descartó un campo `migratedFrom` en el schema: sería un campo permanente del dominio nuevo para un problema transitorio, y por sí solo no daría idempotencia.
+
+### La fuerza de las referencias
+
+La regla tiene dos mitades, y las dos importan:
+
+1. **`_weak` se copia del miembro de origen cuando está, y no se agrega cuando no está.** La migración no introduce debilidad ni la quita: la integridad referencial de la colección es un espejo exacto de la de su storylist. Sintetizar debilidad donde el origen no la tiene taparía un dataset a medio migrar; quitarla haría que el content lake rechazara la escritura, porque una referencia fuerte exige que el destino exista.
+
+2. **`_strengthenOnPublish` se retraduce, no se copia.** La forma en el corpus lleva **el tipo del documento destino**, y el destino cambió: se emite `{ type: 'literaryWork', template: { id: 'literaryWork' } }`. Copiarla tal cual dejaría una referencia a un `literaryWork` prometiéndole al Studio fortalecerla contra un `story`.
+
+Un caso que la regla **no** cubre, dicho explícitamente: una referencia fuerte cuya obra publicada no existe porque el prerequisito no se cumplió. Eso no es debilidad que inventar, es una violación del prerequisito, y la corrida debe fallar ruidosamente al escribir.
+
+### Las pestañas se descartan sin perder contenido
+
+El tipo destino no tiene `tabs`, y el corpus no tiene ninguna cargada. Medido en los tres datasets:
+
+```groq
+count(*[_type == "storylist" && count(tabs) > 0])
+```
+
+Resultado: **cero** en `production`, `staging` y `development`. Por eso no se exporta nada antes de descartar el campo.
+
+## Aborta en vez de degradar
+
+Ante un dato del que no se puede derivar una colección válida —sin título, sin slug, sin descripción, con miembros sin `_key`, o con una referencia que apunta a un borrador— el núcleo lanza `UnmigratableStorylistError` y la corrida se detiene identificando el documento.
+
+En el ámbito publicado esa es la única respuesta correcta: una storylist publicada incompleta es un error del dataset, no un estado legítimo. La migración de borradores toma la decisión opuesta, por la razón opuesta; su README lo explica.
+
+## Procedimiento
+
+Cada fase corre **por dataset**, y ningún gate de CI detecta uno sin migrar.
+
+1. **Censar.** Storylists publicadas y en borrador, cuántas tienen pestañas, y —para las que el filtro admite— cuántas referencias quedarían **colgantes** tras el reapuntado. Cualquier valor distinto de cero en esa última columna se resuelve completando la migración de obras, **nunca** migrando con agujeros.
+2. **Dry-run**, redirigido a archivo.
+3. **Contrastar la fidelidad** de las descripciones sobre una muestra con nombre propio. No alcanza con contar mutaciones: que el dry-run reporte 27 dice que alcanzó 27 documentos, no que no perdió nada.
+4. **Aplicar**, primero las publicadas y después los borradores.
+5. **Verificar** por GROQ: que ninguna referencia haya cambiado de fuerza, que ningún `_strengthenOnPublish` diga `story`, y que ninguna colección publicada tenga referencias sin resolver.
+6. **Repetir** para probar la idempotencia, verificando en el **contenido** y no en el contador de la CLI.
+7. **Probar la reversión acotada** y volver a aplicar el lote de borradores.
+
+```bash
+pnpm -C cms exec sanity documents query '<groq>' --project-id s4dbqkc5 --dataset <ds> --api-version v2021-06-07
+pnpm -C cms exec sanity migration run storylist-to-collection --project s4dbqkc5 --dataset <ds>
+pnpm -C cms exec sanity migration run storylist-to-collection --project s4dbqkc5 --dataset <ds> --no-dry-run --no-confirm
+```
+
+Dos banderas que no son opcionales:
+
+- **`--api-version v2021-06-07` en las consultas del censo.** La versión que la CLI elige sola usa perspectiva `published` y **los borradores no aparecen**, sin ninguna advertencia.
+- **`--no-confirm` al aplicar.** Sin ella la CLI pide confirmación interactiva y la corrida queda esperando.
+
+El contador de la CLI cuenta mutaciones **emitidas**, no aplicadas: una segunda corrida vuelve a reportar 27 aunque no escriba nada. La idempotencia se comprueba en que `_updatedAt` no avanza y en que una edición manual posterior sobrevive.
+
+`development` se borra y reimporta desde `production` por `sync-datasets.yml`: conviene ejecutar la secuencia completa de una sentada.
+
+## Revertir
+
+```bash
+pnpm -C cms exec sanity migration run revert-storylist-to-collection --project s4dbqkc5 --dataset <ds> --no-dry-run --no-confirm
+```
+
+Borra solo lo que la ida creó, comprobado documento por documento con el mismo predicado que deriva el identificador —no con una segunda noción de "colección migrada", que podría divergir y borrar una creada a mano en el Studio—. Alcanza **también** a las colecciones en borrador.
+
+Para reintentar solo el lote de borradores está `revert-draft-storylist-to-collection`, que no se lleva puestas las publicadas.

--- a/cms/migrations/storylist-to-collection/build-collection-document.spec.ts
+++ b/cms/migrations/storylist-to-collection/build-collection-document.spec.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PortableTextBlock } from '../../../resources/portable-text-to-markdown/portable-text-to-markdown';
+import {
+	buildCollectionDocument,
+	collectionIdFor,
+	isMigratedCollectionId,
+	UnmigratableStorylistError,
+	type StorylistDocument,
+} from './build-collection-document';
+
+const paragraph = (text: string, key = 'b1'): PortableTextBlock => ({
+	_type: 'block',
+	_key: key,
+	style: 'normal',
+	markDefs: [],
+	children: [{ _type: 'span', _key: `${key}-s1`, text, marks: [] }],
+});
+
+const storylist = (overrides: Partial<StorylistDocument> = {}): StorylistDocument => ({
+	_id: 'storylist-1',
+	title: 'Geometrías del desvelo',
+	slug: { _type: 'slug', current: 'geometrias-del-desvelo' },
+	description: [paragraph('Prosa editorial de la colección.')],
+	stories: [{ _type: 'reference', _ref: 'story-a', _key: 'k1' }],
+	...overrides,
+});
+
+const reference = (
+	overrides: Partial<{ _ref: string; _key: string; _weak: boolean; _strengthenOnPublish: unknown }>,
+) => ({ _type: 'reference' as const, _ref: 'story-a', _key: 'k1', ...overrides });
+
+describe('collectionIdFor', () => {
+	// Las colecciones ya creadas dependen de que esta rama no se mueva: con `createIfNotExists`, un id
+	// distinto las duplicaría en vez de reconocerlas.
+	it('deriva el id de la colección del id de su storylist', () => {
+		expect(collectionIdFor('abc-123')).toBe('collection-from-storylist-abc-123');
+	});
+
+	it('antepone el prefijo de borrador al derivar el id de un borrador', () => {
+		expect(collectionIdFor('drafts.abc-123')).toBe('drafts.collection-from-storylist-abc-123');
+	});
+
+	// Concatenar sin separar el path deja un documento publicado con nombre de borrador.
+	it('no deja el prefijo de borrador en medio del id', () => {
+		expect(collectionIdFor('drafts.abc-123')).not.toBe('collection-from-storylist-drafts.abc-123');
+		expect(collectionIdFor('drafts.abc-123').startsWith('drafts.')).toBe(true);
+	});
+});
+
+describe('isMigratedCollectionId', () => {
+	it('reconoce las dos formas del id derivado', () => {
+		expect(isMigratedCollectionId('collection-from-storylist-abc')).toBe(true);
+		expect(isMigratedCollectionId('drafts.collection-from-storylist-abc')).toBe(true);
+	});
+
+	// El predicado es lo que protege una colección creada a mano en el Studio de la reversión.
+	it('no reconoce una colección ajena a la migración', () => {
+		expect(isMigratedCollectionId('coleccion-escrita-a-mano')).toBe(false);
+		expect(isMigratedCollectionId('drafts.coleccion-escrita-a-mano')).toBe(false);
+		expect(isMigratedCollectionId('lw-from-story-abc')).toBe(false);
+	});
+});
+
+describe('buildCollectionDocument', () => {
+	it('deriva la identidad y el tipo del documento destino', () => {
+		const result = buildCollectionDocument(storylist());
+
+		expect(result._id).toBe('collection-from-storylist-storylist-1');
+		expect(result._type).toBe('collection');
+	});
+
+	it('copia título y slug tal cual', () => {
+		const result = buildCollectionDocument(storylist());
+
+		expect(result.title).toBe('Geometrías del desvelo');
+		expect(result.slug).toEqual({ _type: 'slug', current: 'geometrias-del-desvelo' });
+	});
+
+	it('convierte la descripción a Markdown preservando marcas y enlaces', () => {
+		const description: PortableTextBlock[] = [
+			{
+				_type: 'block',
+				_key: 'b1',
+				style: 'normal',
+				markDefs: [{ _key: 'l1', _type: 'link', href: 'https://ejemplo.test' }],
+				children: [
+					{ _type: 'span', _key: 's1', text: 'Una obra ', marks: [] },
+					{ _type: 'span', _key: 's2', text: 'destacada', marks: ['strong'] },
+					{ _type: 'span', _key: 's3', text: ' y ', marks: [] },
+					{ _type: 'span', _key: 's4', text: 'matizada', marks: ['em'] },
+					{ _type: 'span', _key: 's5', text: ', con enlace', marks: ['l1'] },
+				],
+			},
+			paragraph('Segundo párrafo.', 'b2'),
+		];
+
+		const result = buildCollectionDocument(storylist({ description }));
+
+		expect(result.description).toContain('**destacada**');
+		expect(result.description).toContain('*matizada*');
+		expect(result.description).toContain('](https://ejemplo.test)');
+		expect(result.description).toContain('Segundo párrafo.');
+	});
+
+	// El reapuntado usa la misma derivación que creó las obras: una segunda noción de cómo se llama la
+	// obra migrada produciría referencias rotas en silencio.
+	it('reapunta cada historia a su obra migrada, en orden y con el _key de origen', () => {
+		const result = buildCollectionDocument(
+			storylist({
+				stories: [reference({ _ref: 'story-a', _key: 'k1' }), reference({ _ref: 'story-b', _key: 'k2' })],
+			}),
+		);
+
+		expect(result.literaryWorks).toEqual([
+			{ _type: 'reference', _ref: 'lw-from-story-story-a', _key: 'k1' },
+			{ _type: 'reference', _ref: 'lw-from-story-story-b', _key: 'k2' },
+		]);
+	});
+
+	it('omite literaryWorks cuando la storylist no tiene historias', () => {
+		expect(buildCollectionDocument(storylist({ stories: [] }))).not.toHaveProperty('literaryWorks');
+		expect(buildCollectionDocument(storylist({ stories: undefined }))).not.toHaveProperty('literaryWorks');
+	});
+
+	// El campo no existe en el tipo destino. La aserción explícita evita que su ausencia se lea como un
+	// olvido del mapeo.
+	it('no traslada las pestañas del tipo de origen', () => {
+		const withTabs = { ...storylist(), tabs: [{ _key: 't1', title: 'Pestaña' }] } as StorylistDocument;
+
+		expect(buildCollectionDocument(withTabs)).not.toHaveProperty('tabs');
+	});
+
+	it('copia los campos que viajan sin transformar y omite los ausentes', () => {
+		const featuredImage = { _type: 'image', asset: { _ref: 'image-abc' } };
+		const config = { showAuthors: false };
+		const tags = [reference({ _ref: 'tag-a', _key: 'tk1' })];
+
+		const withAll = buildCollectionDocument(storylist({ featuredImage, config, tags }));
+		const withNone = buildCollectionDocument(storylist());
+
+		expect(withAll).toMatchObject({ featuredImage, config, tags });
+		expect(withNone).not.toHaveProperty('featuredImage');
+		expect(withNone).not.toHaveProperty('config');
+		expect(withNone).not.toHaveProperty('tags');
+	});
+
+	it('omite los arrays que llegan vacíos en vez de escribirlos', () => {
+		const result = buildCollectionDocument(storylist({ tags: [], mediaSources: [] }));
+
+		expect(result).not.toHaveProperty('tags');
+		expect(result).not.toHaveProperty('mediaSources');
+	});
+});
+
+// La integridad referencial de la colección es un espejo exacto de la de su storylist: la migración no
+// introduce debilidad ni la quita.
+describe('buildCollectionDocument — debilidad de las referencias', () => {
+	it('deja fuerte una referencia que el origen tiene fuerte', () => {
+		const [work] = buildCollectionDocument(storylist()).literaryWorks as Record<string, unknown>[];
+
+		expect(work).not.toHaveProperty('_weak');
+		expect(work).not.toHaveProperty('_strengthenOnPublish');
+	});
+
+	it('conserva la debilidad que el origen declara', () => {
+		const stories = [reference({ _weak: true })];
+
+		const [work] = buildCollectionDocument(storylist({ stories })).literaryWorks as Record<string, unknown>[];
+
+		expect(work._weak).toBe(true);
+	});
+
+	// El tipo del destino cambió: copiar la marca tal cual prometería fortalecer contra un `story` una
+	// referencia que apunta a un `literaryWork`.
+	it('retraduce _strengthenOnPublish al tipo del destino', () => {
+		const stories = [reference({ _weak: true, _strengthenOnPublish: { type: 'story', template: { id: 'story' } } })];
+
+		const [work] = buildCollectionDocument(storylist({ stories })).literaryWorks as Record<string, unknown>[];
+
+		expect(work._strengthenOnPublish).toEqual({ type: 'literaryWork', template: { id: 'literaryWork' } });
+	});
+
+	it('no agrega _strengthenOnPublish cuando el origen no lo trae', () => {
+		const stories = [reference({ _weak: true })];
+
+		const [work] = buildCollectionDocument(storylist({ stories })).literaryWorks as Record<string, unknown>[];
+
+		expect(work).not.toHaveProperty('_strengthenOnPublish');
+	});
+});
+
+describe('buildCollectionDocument — datos que detienen la corrida', () => {
+	it.each([
+		['sin título', { title: undefined }, 'no tiene título'],
+		['sin slug', { slug: undefined }, 'no tiene slug'],
+		['sin descripción', { description: undefined }, 'no tiene descripción'],
+		['con descripción vacía', { description: [] }, 'no tiene descripción'],
+		['con una historia sin _key', { stories: [{ _type: 'reference' as const, _ref: 'story-a' }] }, 'sin _key'],
+		['con un tag sin _key', { tags: [{ _type: 'reference' as const, _ref: 'tag-a' }] }, 'sin _key'],
+		['con un recurso sin _key', { mediaSources: [{ _type: 'audioRecording' }] }, 'sin _key'],
+	])('aborta con una storylist %s', (_caso, overrides, expected) => {
+		expect(() => buildCollectionDocument(storylist(overrides as Partial<StorylistDocument>))).toThrow(expected);
+	});
+
+	it('identifica la storylist en el mensaje y usa el error tipado', () => {
+		expect(() => buildCollectionDocument(storylist({ title: undefined }))).toThrow(UnmigratableStorylistError);
+		expect(() => buildCollectionDocument(storylist({ title: undefined }))).toThrow('storylist-1');
+	});
+
+	// Sin el guard, la derivación trataría el `_ref` como un id de borrador y produciría un destino con
+	// `drafts.` adelante, que no es una referencia válida. Ningún `_ref` del corpus lo tiene: el guard
+	// convierte una corrupción silenciosa en una detención.
+	it('aborta ante una referencia que apunta a un borrador', () => {
+		const stories = [reference({ _ref: 'drafts.story-a' })];
+
+		expect(() => buildCollectionDocument(storylist({ stories }))).toThrow('apunta a un borrador');
+	});
+
+	it('propaga el error del conversor ante Portable Text no soportado', () => {
+		const description = [
+			{ _type: 'block', _key: 'b1', style: 'h1', markDefs: [], children: [] },
+		] as PortableTextBlock[];
+
+		expect(() => buildCollectionDocument(storylist({ description }))).toThrow();
+	});
+});

--- a/cms/migrations/storylist-to-collection/build-collection-document.ts
+++ b/cms/migrations/storylist-to-collection/build-collection-document.ts
@@ -1,0 +1,189 @@
+/**
+ * Núcleo puro de la migración de `storylist` a `collection`: dado el documento crudo de una storylist,
+ * arma el documento de la colección equivalente, con su descripción en Markdown y sus obras
+ * reapuntadas a las que dejó la migración de `story` a `literaryWork`.
+ *
+ * Sin I/O ni cliente de Sanity, para poder testearlo sin red ni credenciales. La migración le delega
+ * el mapeo entero y se queda solo con la mutación.
+ *
+ * Los tipos del documento se declaran acá y no se importan del typegen: el typegen describe el
+ * **schema**, y lo que la migración lee es el documento crudo tal como Sanity lo devuelve.
+ */
+import {
+	portableTextToMarkdown,
+	type PortableTextBlock,
+} from '../../../resources/portable-text-to-markdown/portable-text-to-markdown';
+import { DRAFTS_PATH_PREFIX, literaryWorkIdFor } from '../story-to-literary-work/build-literary-work-document';
+
+interface SanityReference {
+	_type: 'reference';
+	_ref: string;
+	_key?: string;
+	// El Studio marca así una referencia a un documento todavía inédito, y las fortalece al publicarlo.
+	_weak?: boolean;
+	_strengthenOnPublish?: unknown;
+}
+
+export interface StorylistDocument {
+	_id: string;
+	title?: string;
+	slug?: { _type: 'slug'; current: string };
+	description?: PortableTextBlock[];
+	featuredImage?: unknown;
+	tags?: SanityReference[];
+	config?: { showAuthors?: boolean };
+	stories?: SanityReference[];
+	mediaSources?: unknown[];
+	// `tabs` no se declara: el tipo destino no lo tiene y la migración no lo lee.
+}
+
+/**
+ * El documento destino. Declara `_id` y `_type` porque la mutación de creación los exige, y el resto
+ * abierto porque el mapeo copia campos del origen sin reinterpretarlos.
+ */
+export type CollectionDocument = { _id: string; _type: 'collection' } & Record<string, unknown>;
+
+/** Se lanza ante un dato del que no se puede derivar una colección válida. Detiene la corrida. */
+export class UnmigratableStorylistError extends Error {
+	constructor(message: string, storylistId: string) {
+		super(`${message} (storylist "${storylistId}")`);
+		this.name = 'UnmigratableStorylistError';
+	}
+}
+
+/**
+ * El `_id` de la colección se deriva del de su storylist de origen. Sostiene tres cosas a la vez: la
+ * correspondencia entre ambas, la idempotencia (con `createIfNotExists`, re-migrar es un no-op) y la
+ * reversión (la migración inversa filtra por este prefijo). Por eso vive acá, como fuente única que
+ * ambas migraciones comparten: una reversión con su propia noción de "documento migrado" podría
+ * borrar una colección nacida en el Studio.
+ */
+export const MIGRATED_ID_PREFIX = 'collection-from-storylist-';
+
+/**
+ * El prefijo de path va **antes** que el de la migración, por la misma razón que en la migración de
+ * obras: Sanity lee `drafts.` como borrador solo cuando encabeza el `_id`, así que concatenarlo detrás
+ * del origen publicaría contenido inédito sin que nada lo señale.
+ *
+ * La forma se repite en vez de extraerse a un módulo compartido: unificarla obligaría a modificar la
+ * migración de obras, ya aplicada en los tres datasets, cuyo valor es ser el registro fiel de lo que
+ * corrió. Lo que sí se importa es la constante del prefijo, para no tener dos definiciones de cómo
+ * marca Sanity un borrador.
+ */
+export function collectionIdFor(storylistId: string): string {
+	if (storylistId.startsWith(DRAFTS_PATH_PREFIX)) {
+		return `${DRAFTS_PATH_PREFIX}${MIGRATED_ID_PREFIX}${storylistId.slice(DRAFTS_PATH_PREFIX.length)}`;
+	}
+	return `${MIGRATED_ID_PREFIX}${storylistId}`;
+}
+
+export function isMigratedCollectionId(id: string): boolean {
+	const withoutPath = id.startsWith(DRAFTS_PATH_PREFIX) ? id.slice(DRAFTS_PATH_PREFIX.length) : id;
+	return withoutPath.startsWith(MIGRATED_ID_PREFIX);
+}
+
+function toRequiredMarkdown(blocks: PortableTextBlock[] | undefined, storylistId: string): string {
+	if (!blocks?.length) {
+		throw new UnmigratableStorylistError('La storylist no tiene descripción', storylistId);
+	}
+	const markdown = portableTextToMarkdown(blocks);
+	if (markdown.trim() === '') {
+		throw new UnmigratableStorylistError('La descripción quedó vacía al convertirla a Markdown', storylistId);
+	}
+	return markdown;
+}
+
+/**
+ * Reapunta una historia a su obra migrada, preservando la integridad referencial del origen.
+ *
+ * **La debilidad se copia del origen y nunca se sintetiza.** Una referencia débil dice que el destino
+ * todavía no está publicado; el content lake rechaza una referencia fuerte a un documento inexistente,
+ * así que copiarla es lo que permite migrar una colección cuyas obras siguen inéditas. Debilitar una
+ * que el origen tiene fuerte sería lo contrario: taparía un dataset a medio migrar.
+ *
+ * **`_strengthenOnPublish` se retraduce en vez de copiarse**, que es donde difiere de la migración de
+ * obras: allá el tipo del destino no cambiaba, acá sí. Copiarla tal cual dejaría una referencia a un
+ * `literaryWork` prometiéndole al Studio fortalecerla contra un `story`.
+ *
+ * El `_key` se preserva del miembro de origen y no se deriva del `_ref`: una misma obra puede aparecer
+ * dos veces en la colección, y derivarlo produciría claves duplicadas que Sanity rechaza.
+ */
+function buildLiteraryWorkReference(story: SanityReference, index: number, storylistId: string): SanityReference {
+	if (story._ref.startsWith(DRAFTS_PATH_PREFIX)) {
+		throw new UnmigratableStorylistError(`La referencia ${index} de "stories" apunta a un borrador`, storylistId);
+	}
+	return {
+		_type: 'reference',
+		_ref: literaryWorkIdFor(story._ref),
+		_key: story._key,
+		...(story._weak !== undefined ? { _weak: story._weak } : {}),
+		...(story._strengthenOnPublish !== undefined
+			? { _strengthenOnPublish: { type: 'literaryWork', template: { id: 'literaryWork' } } }
+			: {}),
+	};
+}
+
+function assertKeyed(items: unknown[] | undefined, field: string, storylistId: string): void {
+	const missing = (items ?? []).some((item) => !(item as { _key?: string })?._key);
+	if (missing) {
+		throw new UnmigratableStorylistError(`Hay miembros de "${field}" sin _key`, storylistId);
+	}
+}
+
+/** Una storylist que ya pasó las validaciones: title y slug dejan de ser opcionales para el llamador. */
+type MigratableStorylist = StorylistDocument & { title: string; slug: { current: string } };
+
+/** Lo que la colección no puede construirse sin ello: sin esto el documento nacería inválido. */
+function assertMigratable(storylist: StorylistDocument): asserts storylist is MigratableStorylist {
+	if (!storylist.title) {
+		throw new UnmigratableStorylistError('La storylist no tiene título', storylist._id);
+	}
+	if (!storylist.slug?.current) {
+		throw new UnmigratableStorylistError('La storylist no tiene slug', storylist._id);
+	}
+	assertKeyed(storylist.stories, 'stories', storylist._id);
+	assertKeyed(storylist.tags, 'tags', storylist._id);
+	assertKeyed(storylist.mediaSources, 'mediaSources', storylist._id);
+}
+
+/**
+ * Los campos que viajan sin transformar. Se omiten cuando el origen no los trae, en vez de escribirse
+ * vacíos: un array vacío y un campo ausente no se leen igual en las queries, y `undefined` no es un
+ * valor válido en un documento de Sanity.
+ */
+function optionalFields(storylist: StorylistDocument): Partial<CollectionDocument> {
+	return {
+		...(storylist.featuredImage !== undefined ? { featuredImage: storylist.featuredImage } : {}),
+		...(storylist.config !== undefined ? { config: storylist.config } : {}),
+		...(storylist.tags?.length ? { tags: storylist.tags } : {}),
+		...(storylist.mediaSources?.length ? { mediaSources: storylist.mediaSources } : {}),
+	};
+}
+
+/**
+ * Arma el documento `collection` equivalente a una `storylist`.
+ *
+ * Lanza `UnmigratableStorylistError` ante un dato que no permite construir una colección válida, en
+ * vez de escribir un documento degradado: el repository construye el agregado con factories que
+ * validan, así que un documento inválido fallaría recién al leerse, lejos de acá.
+ *
+ * No toca la storylist de origen: emite un documento nuevo al lado. Por eso la reversión es un borrado
+ * limpio y la página vieja sigue sirviéndose durante toda la convivencia.
+ */
+export function buildCollectionDocument(storylist: StorylistDocument): CollectionDocument {
+	assertMigratable(storylist);
+
+	const literaryWorks = (storylist.stories ?? []).map((story, index) =>
+		buildLiteraryWorkReference(story, index, storylist._id),
+	);
+
+	return {
+		_id: collectionIdFor(storylist._id),
+		_type: 'collection',
+		title: storylist.title,
+		slug: { _type: 'slug', current: storylist.slug.current },
+		description: toRequiredMarkdown(storylist.description, storylist._id),
+		...(literaryWorks.length > 0 ? { literaryWorks } : {}),
+		...optionalFields(storylist),
+	};
+}

--- a/cms/migrations/storylist-to-collection/index.spec.ts
+++ b/cms/migrations/storylist-to-collection/index.spec.ts
@@ -1,0 +1,93 @@
+import { evaluate, parse } from 'groq-js';
+import { describe, expect, it } from 'vitest';
+
+import type { PortableTextBlock } from '../../../resources/portable-text-to-markdown/portable-text-to-markdown';
+import { type StorylistDocument } from './build-collection-document';
+import migration from './index';
+
+// `defineMigration` conserva el objeto tal cual, así que `migrate.document` es una función pura y es
+// lo único que hace falta ejercitar: decide qué mutación emite cada storylist.
+const migrateDocument = (doc: StorylistDocument) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never);
+};
+
+const paragraph = (text: string): PortableTextBlock => ({
+	_type: 'block',
+	_key: 'b1',
+	style: 'normal',
+	markDefs: [],
+	children: [{ _type: 'span', _key: 's1', text, marks: [] }],
+});
+
+const publishedStorylist = (overrides: Partial<StorylistDocument> = {}): StorylistDocument => ({
+	_id: 'storylist-1',
+	title: 'Geometrías del desvelo',
+	slug: { _type: 'slug', current: 'geometrias-del-desvelo' },
+	description: [paragraph('Prosa editorial.')],
+	stories: [{ _type: 'reference', _ref: 'story-a', _key: 'k1' }],
+	...overrides,
+});
+
+describe('migración de storylists publicadas a colecciones', () => {
+	it('alcanza solo a las storylists', () => {
+		expect(migration.documentTypes).toEqual(['storylist']);
+	});
+
+	// El filtro se ejecuta con el mismo motor que GROQ, no se compara como texto: una aserción textual
+	// pasa igual con un filtro roto mientras el literal coincida.
+	describe('el filtro decide qué entra', () => {
+		const matching = async (...docs: Record<string, unknown>[]) => {
+			const result = await evaluate(parse(`*[${migration.filter}]._id`), { dataset: docs });
+			return (await result.get()) as string[];
+		};
+
+		it('admite una storylist publicada', async () => {
+			expect(await matching({ _id: 'publicada', _type: 'storylist' })).toEqual(['publicada']);
+		});
+
+		// El ámbito de borradores tiene su propia migración, con la postura opuesta ante un dato incompleto.
+		it('deja fuera un borrador', async () => {
+			expect(await matching({ _id: 'drafts.borrador', _type: 'storylist' })).toEqual([]);
+		});
+	});
+
+	it('emite una única mutación de creación por storylist', () => {
+		expect(migrateDocument(publishedStorylist())).toHaveLength(1);
+	});
+
+	// La mutación apunta a OTRO documento: itera storylists y crea colecciones. La storylist queda
+	// intacta. Y es `createIfNotExists` y no `createOrReplace`: repetir la corrida no debe pisar lo que
+	// alguien haya editado a mano en la colección después de migrarla.
+	it('crea la colección sin tocar la storylist de origen', () => {
+		const [mutation] = migrateDocument(publishedStorylist()) as {
+			type: string;
+			document: { _id: string; _type: string };
+		}[];
+
+		expect(mutation?.type).toBe('createIfNotExists');
+		expect(mutation?.document._id).toBe('collection-from-storylist-storylist-1');
+		expect(mutation?.document._type).toBe('collection');
+	});
+
+	it('lleva la descripción convertida y las obras reapuntadas', () => {
+		const [mutation] = migrateDocument(publishedStorylist()) as { document: Record<string, unknown> }[];
+		const works = mutation?.document['literaryWorks'] as Record<string, unknown>[];
+
+		expect(mutation?.document['description']).toBe('Prosa editorial.');
+		expect(works[0]?.['_ref']).toBe('lw-from-story-story-a');
+	});
+
+	// En este ámbito abortar es la conducta deseada: una storylist publicada incompleta es un error del
+	// dataset, y saltearla dejaría el corpus a medio migrar sin señal.
+	it('propaga el error del mapeo ante una storylist incompleta', () => {
+		expect(() => migrateDocument(publishedStorylist({ description: undefined }))).toThrow(/no tiene descripción/);
+	});
+
+	it('propaga el error del conversor ante una construcción no soportada', () => {
+		const exotico = { ...paragraph('Texto'), style: 'inventado' };
+
+		expect(() => migrateDocument(publishedStorylist({ description: [exotico] }))).toThrow(/Estilo no soportado/);
+	});
+});

--- a/cms/migrations/storylist-to-collection/index.ts
+++ b/cms/migrations/storylist-to-collection/index.ts
@@ -1,0 +1,37 @@
+import { createIfNotExists, defineMigration } from 'sanity/migrate';
+
+import { buildCollectionDocument, type StorylistDocument } from './build-collection-document';
+
+/**
+ * Crea una colección publicada por cada storylist publicada, con su descripción convertida desde
+ * Portable Text y sus obras reapuntadas a las que dejó la migración de cuentos.
+ *
+ * **No toca la storylist de origen:** itera un tipo y emite la mutación sobre otro documento. Por eso
+ * la reversión es un borrado limpio, y la página vieja sigue sirviéndose durante toda la convivencia.
+ *
+ * **La idempotencia viene de `createIfNotExists` sobre un identificador derivado.** Se descarta
+ * `createOrReplace`, que refrescaría el contenido en cada corrida pisando las correcciones editoriales
+ * hechas en el Studio después de migrar. El contador de la CLI cuenta mutaciones **emitidas**, no
+ * aplicadas: una segunda corrida vuelve a reportar el total, y la idempotencia se comprueba en el
+ * contenido, no en ese número.
+ *
+ * **Aborta ante lo que no puede traducir**, y esa postura es específica de este ámbito: una storylist
+ * publicada sin descripción o sin slug es un error del dataset, no un estado legítimo, y saltearla en
+ * silencio dejaría el corpus a medio migrar sin que nada lo señale. La migración de borradores toma la
+ * decisión opuesta, por la razón opuesta.
+ *
+ * **Prerequisito:** la migración de cuentos a obras tiene que estar aplicada en el mismo dataset. El
+ * reapuntado deriva el identificador de cada obra; si la obra no existe y la referencia es fuerte, el
+ * content lake rechaza la transacción al escribir. El dry-run no lo detecta: imprime mutaciones sin
+ * llegar al servidor.
+ */
+export default defineMigration({
+	title: 'Crear una colección por cada storylist publicada',
+	documentTypes: ['storylist'],
+	filter: "!(_id in path('drafts.**'))",
+	migrate: {
+		document(doc: StorylistDocument) {
+			return [createIfNotExists(buildCollectionDocument(doc))];
+		},
+	},
+});

--- a/cms/schemas/collection.spec.ts
+++ b/cms/schemas/collection.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import collection from './collection';
+
+// El tipo nace de un traspaso desde `storylist`, y las tres diferencias que lo separan de su origen
+// son decisiones de dominio, no detalles de forma: sin pestañas, la descripción en Markdown y las
+// obras literarias en lugar de las historias. Un cambio que las revierta rompe la migración que
+// construye estos documentos y el ACL que los lee, así que se afirman acá y no en ningún otro lado.
+// El resto de los campos no se re-declara: un test que enumere el schema entero solo duplica su fuente.
+
+type SchemaField = { name: string; type: string; validation?: unknown; of?: Array<Record<string, unknown>> };
+
+const fields = collection.fields as unknown as SchemaField[];
+const fieldNamed = (name: string) => fields.find((field) => field.name === name);
+
+describe('schema collection', () => {
+	it('does not declare the tabs of its origin type', () => {
+		expect(fieldNamed('tabs')).toBeUndefined();
+	});
+
+	it('takes the description as Markdown and requires it', () => {
+		const description = fieldNamed('description');
+
+		expect(description?.type).toBe('markdown');
+		expect(description?.validation).toBeDefined();
+	});
+
+	it('aggregates literary works instead of stories', () => {
+		const literaryWorks = fieldNamed('literaryWorks');
+
+		expect(literaryWorks?.type).toBe('array');
+		expect(literaryWorks?.of?.[0]).toMatchObject({ type: 'reference', to: [{ type: 'literaryWork' }] });
+		expect(fieldNamed('stories')).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Contexto

`Collection` no es `Storylist` renombrado: es el objeto de dominio nuevo que lo reemplaza, y Sanity no admite patchear `_type`. Este PR trae las migraciones que crean una colección por cada storylist —publicada o en borrador— reapuntando sus obras a las que dejó la migración de cuentos. `storylist` queda intacto y se da de baja más adelante.

El document type ya estaba en `develop`, entregado por #2137 con la forma que este trabajo asume: sin pestañas, la descripción en Markdown y agregando obras literarias en vez de historias.

## Cambios

**El schema gana un spec.** Llegó sin uno, y su forma no es incidental: las tres decisiones que lo separan de `storylist` son las que la migración asume al construir cada documento. Nada las verificaba.

**Un núcleo puro y cuatro migraciones.** El núcleo no tiene cliente de Sanity, así que se ejercita sin red ni credenciales. Deriva el identificador de la colección del de su storylist —lo que sostiene a la vez la correspondencia, la idempotencia y la reversión— y separa el prefijo de borrador para reaplicarlo encabezando: dejarlo en medio produciría un documento publicado con nombre de borrador.

**Dos migraciones de ida, no una con filtro.** Las dos posturas ante un dato incompleto son incompatibles. Para una storylist publicada, tener descripción no es un criterio de admisión sino una invariante que el dataset ya garantiza: violarla debe detener la corrida. Para un borrador, la misma condición es el discriminador legítimo entre lista y a medio escribir, y debe excluir en silencio. Un filtro único convertiría una storylist publicada rota en un documento salteado sin aviso.

**Dos reversiones.** La amplia alcanza las dos formas del identificador; usarla para reintentar el lote de borradores se llevaría las colecciones publicadas, que son sobre las que se construye la página nueva. La acotada es la que se usa al reintentar.

## Corrección respecto del plan original

El plan anotó como condicional que «si la factory llega a existir con una invariante de al menos una obra, hay que sumar esa condición al filtro de borradores». La condición se cumplió: #1828 shippeó `createCollection` rechazando una colección sin obras literarias, y `createCollectionTeaser` rechazando un contador menor a uno.

Sin esa condición la migración escribiría un documento que el dominio **nunca puede construir**, y la falla aparecería al mapear en vez de al migrar. Con ella, el corte de borradores pasa de 4 a **3**: "3 cuentos: Lermo Balbi" queda excluida por no tener obras.

## Verificación

Censo re-corrido hoy sobre los tres datasets, idénticos entre sí y a lo que el plan midió: 27 storylists publicadas, 9 en borrador, **cero** con pestañas, 615 obras publicadas, ninguna colección creada aún. Las 27 publicadas están impecables —sin descripciones faltantes, sin referencias débiles, sin colgantes, sin miembros sin `_key`— y los borradores admitidos tienen cero referencias colgantes.

Dry-run sobre `development`: **27** documentos publicados y **3** en borrador, los tres con el prefijo de borrador encabezando, y exactamente los tres que el censo anticipaba.

Las aserciones se verificaron falsificables: mutar el schema en sus tres decisiones, quitarle al filtro la condición de obras y quitarle a la reversión acotada su acotamiento rompen cada uno su caso.

Gates locales en verde: `sanity:typecheck`, `sanity:test` (19 archivos, 185 casos), `sanity:build`, `lint` y `check:agents`.

## Aplicado en los tres datasets

| | development | staging | production |
| --- | ---: | ---: | ---: |
| Colecciones publicadas | 27 | 27 | 27 |
| En borrador | 3 | 3 | 3 |
| Referencias débiles | 14 | 14 | 14 |
| `_strengthenOnPublish` con `story` | 0 | 0 | 0 |
| Publicadas con referencias colgantes | 0 | 0 | 0 |

Cada dataset se censó antes de escribir: cero colecciones previas y cero referencias colgantes. Las 14 referencias débiles son exactamente las que el origen tiene débiles, así que la integridad referencial quedó como espejo exacto.

En `development` se ejercitó además el ciclo completo: **idempotencia** —la segunda corrida reportó 27 mutaciones y no reescribió nada, ningún `_updatedAt` avanzó— y **reversión acotada**, que borró los 3 borradores dejando las 27 publicadas intactas, tras lo cual se reaplicó el lote.

El origen quedó sin tocar: en `production` la storylist más reciente tiene `_updatedAt` del 3 de agosto, nueve días antes de que se crearan las colecciones.

**Nada cambia para el visitante.** `storylist` sigue sirviendo la home y la página vieja, la query de colección excluye borradores, y aunque el provider está registrado ningún componente lo inyecta todavía.

## Nota operativa

`sync-datasets.yml` reimporta `development` desde `production`. Como `production` ya tiene las colecciones, el próximo sync se las lleva; las 3 en borrador desaparecerían de `development`, porque los borradores no viajan en el import. Se vuelven a aplicar en un comando.

Closes #2053.
