### PR TITLE
[#2188] - Generar release para versión 2.10.0 de La Cuentoneta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,68 @@ La lista de características futuras a implementar puede hallarse en la sección
 
 Los hitos futuros de desarrollo, en los cuales se detallan las funcionalidades a desarrollar y los cambios a implementar, pueden encontrarse en las secciones [milestones](https://github.com/cuentoneta/cuentoneta/milestones) y [projects](https://github.com/cuentoneta/cuentoneta/projects) del repositorio de Github del proyecto.
 
+## Versión 2.10.0 (2026-08-13)
+
+La versión 2.10.0 es la más grande de la serie 2.x, y tiene un solo hilo conductor: **el modelo de dominio nuevo deja de ser un plan y pasa a existir de punta a punta**, con el contenido real traspasado en los tres datasets.
+
+`Collection` nace completa —modelo, GROQ, repository con su ACL, services con errores tipados, controller con validación y provider— y estrena document type propio en el Studio (#1828, #1829, #1830, #1831, #1832, #2137). No es `Storylist` renombrada: nace en paralelo, con la forma correcta desde el principio —sin pestañas, la descripción en Markdown y agregando obras literarias en vez de historias— porque Sanity no admite patchear el tipo de un documento y, si de todos modos hay que crear documentos nuevos, conviene crearlos ya bien. El contenido cargado se traspasa con migraciones idempotentes y reversibles, que preservan la integridad referencial del origen en vez de sintetizarla (#2053).
+
+En paralelo avanza la **salida de Portable Text**. El corpus de cuentos migra a obras literarias en Markdown, publicadas y en borrador (#2128, #2133), la biografía de autor deja el formato viejo (#2051) y dos campos renombran su nombre de wire (#2066). El corte que faltaba —eliminar la infraestructura de Portable Text— queda para cuando `story` y `storylist` se den de baja como document types, que es su precondición real.
+
+El tercer frente es de **verificación**. El corpus de mocks de Onoff deja de escribirse a mano y pasa a **generarse evaluando las queries GROQ reales con `groq-js`** sobre documentos curados (#2155), con un gate de frescura que corta si el generado y su fuente divergen. Alrededor de eso se ordena el corpus entero: capa de documentos (#2143), carpetas por entidad (#2149, #2150), referencias de imagen puenteadas a assets locales (#2159), campañas derivadas de su propia capa (#2160) y el cruce del dominio contra el ACL sobre el raw (#2158, #2171). El resultado es que un cambio de mapeo ya no puede pasar desapercibido porque el mock y el código se movieron juntos.
+
+Del lado de **herramientas**, Angular sube a 22.1.1 y Nx a 23.1.1 (#2142). Rolldown pasa a ser el optimizador por defecto y recorta el bundle inicial un 23,6 % en crudo y un 29,9 % en transferencia; en el mismo movimiento el build y el dev server salen del envoltorio deprecado de la era webpack. Se incorporan las skills de estilo y auditoría de comentarios (#2164), se corre la primera auditoría sobre el código existente (#2170) y `scripts/` entra bajo los mismos controles de lint y de citas de issues que `src/` (#2169).
+
+### Cambios completos
+
+Ver el changelog completo en [2.10.0](https://github.com/cuentoneta/cuentoneta/releases/tag/2.10.0)
+
+### Cambios
+
+#### Dominio Collection
+
+- [#1828] - Crea el modelo de dominio Collection, rename-friendly hacia LiteraryWork.
+- [#1829] - Suma la query GROQ y el repository de Collection con su ACL.
+- [#1830] - Suma los services de lectura de Collection con errores tipados.
+- [#1831] - Suma el controller Hono de GET /collection/:slug con validación zod.
+- [#1832] - Suma el provider CollectionApi con su interfaz, implementación HTTP y doble.
+- [#2137] - Crea el document type Collection en el Studio.
+- [#2053] - Traspasa el contenido de Storylist a Collection en los tres datasets.
+- [#2141] - Migra el input de CollectionTeaserCard al tipo de dominio Collection.
+
+#### Salida de Portable Text
+
+- [#2128] - Migra el contenido de Story a LiteraryWork en Markdown.
+- [#2133] - Migra los cuentos en borrador a obras en borrador.
+- [#2051] - Migra la biografía de autor de blockContent a Markdown.
+- [#2066] - Renombra shortDescription a description en resourceType y tag.
+
+#### Corpus y verificación
+
+- [#2155] - Genera las fixtures raw del corpus evaluando las queries reales con groq-js.
+- [#2143] - Suma la capa de documentos al corpus de Onoff.
+- [#2149] - Agrupa el corpus de mocks de Onoff en carpetas por entidad.
+- [#2150] - Renombra la fixture cruda de storylist, que ocupaba el nombre de Collection.
+- [#2158] - Cruza el corpus de dominio contra el mapeo del ACL sobre el raw.
+- [#2159] - Puentea las referencias de imagen del corpus a los assets locales.
+- [#2160] - Genera el raw de las campañas de contenido desde su capa de documentos.
+- [#2171] - Consume la fixture generada de landing page en el spec del mapper.
+- [#2175] - Agrupa el generador del corpus en su carpeta y documenta por qué está partido.
+
+#### Tooling
+
+- [#2142] - Actualiza Angular a 22.1.1 y Nx a 23.1.1, con Rolldown por defecto.
+- [#2164] - Incorpora las skills aposd-comments-style y aposd-comment-audit al proyecto.
+- [#2170] - Audita los comentarios existentes de src/ y cms/.
+- [#2169] - Trae scripts/ bajo los mismos controles de lint y de citas de issues que src/.
+- [#2172] - Codifica el criterio de no declarar cantidades en los comentarios.
+
+#### Interfaz
+
+- [#2084] - Da de baja BioSummaryCard y el pie de la página de obra.
+- [#2180] - Restaura el renderizado del carousel en Storybook y su fidelidad responsive.
+- [#2148] - Corrige el rojo de e2e que dejaba el sync nocturno de datasets al revertir la biografía de autor.
+
 ## Versión 2.9.2 (2026-08-04)
 
 La versión 2.9.2 es un patch de dos frentes independientes.

--- a/cms/package.json
+++ b/cms/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/cms",
 	"private": true,
-	"version": "2.9.2",
+	"version": "2.10.0",
 	"description": "",
 	"main": "package.json",
 	"author": "Ramiro Olivencia <ramiro@olivencia.com.ar>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/app",
 	"type": "module",
-	"version": "2.9.2",
+	"version": "2.10.0",
 	"imports": {
 		"#tailwind-theme": "./src/tailwind.css"
 	},


### PR DESCRIPTION
Prepara el release de la versión **2.10.0**: bump de versión en lockstep y entrada de CHANGELOG.

## Alcance del hito

29 issues cerrados, agrupados en cinco frentes. El hilo conductor es que **el modelo de dominio nuevo deja de ser un plan y pasa a existir de punta a punta**, con el contenido real traspasado en los tres datasets: `Collection` completa —modelo, GROQ, repository con ACL, services, controller y provider— más su document type en el Studio y el traspaso del contenido cargado.

En paralelo avanzó la salida de Portable Text, el corpus de mocks pasó a generarse evaluando las queries GROQ reales con `groq-js`, y Angular subió a 22.1.1 con Rolldown por defecto (−23,6 % de bundle crudo).

## Verificación

| Comprobación | Resultado |
| --- | --- |
| `lint` · `typecheck` · `stylelint` | ✅ |
| `test` | ✅ 160 archivos · 1705 casos |
| `build` | ✅ y confirma `@cuentoneta/app@2.10.0` |
| `storybook` | ✅ |
| `studio-build` (typecheck + test + build) | ✅ 19 archivos · 185 casos |
| `check-agents` | ✅ |
| Dry-run de extracción de notas de `release.yml` | ✅ 61 líneas, bordes correctos |
| Lockstep de versión | ✅ `package.json` y `cms/package.json` en 2.10.0 |
| Issues citados ↔ shipped | ✅ 29 citados = 29 cerrados del milestone |

> **Corrección posterior al merge.** Este bloque decía que la migración iba **antes** del merge a `master`, y es al revés. Se ejecutó en ese orden y causó una caída: `master` todavía leía la biografía como Portable Text y el dato ya era Markdown, así que `/api/author/:slug` respondió 500 hasta que salió el deploy de 2.10.0. Producción quedó verificada sana después. El texto de abajo está corregido, y la corrección del flujo que lo indujo está en #2191.

## ⚠️ Migración acoplada — corre DESPUÉS del deploy

**La migración `author-biography-to-markdown` está acoplada a la forma que el código lee**, y ninguna de las dos formas del dato tolera el código de la otra. `master` trata la biografía como Portable Text hasta que este release despliega; el dato migrado es un string. Correrla **antes** del deploy deja al código viejo haciendo `.filter()` sobre un string y `/api/author/:slug` en 500 durante toda la ventana; correrla **después** la deja servida por el código que la entiende.

Al momento de abrir este PR quedaban 333 de 345 biografías en `blockContent`, 325 publicadas.

Hay además un efecto colateral que se cierra con la misma corrida: el workflow `sync-datasets` espeja `production` sobre `staging` y `development` cada noche, así que mientras producción tuviera el formato viejo, cada corrida revertía el dato migrado y dejaba `e2e` en rojo — lo que documentó #2148.

Verificación posterior, que tiene que dar **0**:

```bash
pnpm -C cms exec sanity documents query 'count(*[_type=="author" && defined(biography[0]._type)])' \
  --project-id s4dbqkc5 --dataset production --api-version v2021-06-07
```

## Pasos manuales para completar la release

1. Mergear este PR a `develop`.
2. Tras el merge, el workflow `prepare-release-pr` crea/actualiza el PR `develop → master` y dispara `ci.yml` sobre `develop` (el PR no gatilla checks por sí mismo por la anti-recursión del `GITHUB_TOKEN`; la señal de CI está en la corrida sobre `develop`). Revisarlo y mergearlo a `master` → dispara `release.yml` (tag 2.10.0 + GitHub Release + deploy de Sanity Studio). El deploy de la app lo cubre Vercel por integración Git nativa.
3. **Con el deploy ya en producción**, correr la migración acoplada:

   ```bash
   pnpm -C cms exec sanity migration run author-biography-to-markdown --project s4dbqkc5 --dataset production
   pnpm -C cms exec sanity migration run author-biography-to-markdown --project s4dbqkc5 --dataset production --no-dry-run --no-confirm
   ```

4. Verificar post-release: workflow Release verde (jobs `release` y `deploy-studio`), Release 2.10.0 publicado, Studio con el schema nuevo, y `/author/:slug` sirviendo la biografía en producción.

Closes #2188.

