### PR TITLE
[#2191] - Fijar en el flujo de release cuándo corre una migración según su acoplamiento al código

### DIFF
--- a/.claude/references/sanity-migrations.md
+++ b/.claude/references/sanity-migrations.md
@@ -50,7 +50,37 @@ Las que llevan rich text a Markdown consumen [`resources/portable-text-to-markdo
 
 Que una corrida reporte N mutaciones dice que **alcanzó** N documentos, no que no perdió contenido —ni, al aplicar, que haya escrito algo: el contador cuenta lo que la migración emite, no lo que el servidor termina aplicando—. La verificación de fidelidad se hace comparando el texto de origen contra el que produce el pipeline real, y la de idempotencia mirando si el contenido cambió, no contando mutaciones.
 
-## Rename de un campo requerido: patrón expand/contract
+## Orden de despliegue: clasificar antes de correr
+
+Antes de correr una migración contra un dataset hay que saber a qué clase pertenece, porque de eso depende cuándo puede correr:
+
+- **Independiente del código.** Puebla un campo que todavía nadie lee, purga propiedades huérfanas, corrige valores sin cambiar su forma. El orden respecto del despliegue es indiferente.
+- **Acoplada al código.** Cambia **lo que el código lee**: el nombre de un campo o la **forma de su valor**. Ningún orden simple es seguro, y el patrón para las dos es el mismo — **ampliar** lo que el lector acepta, migrar, y recién entonces **contraer**.
+
+El error a evitar es tratar una acoplada como si fuera independiente y elegir el orden por conveniencia: las dos secuencias simples rompen, solo que en momentos distintos.
+
+### Cambio de forma del valor
+
+Cuando la migración cambia la **forma** de un valor que el código ya lee —de un array de bloques a un string, por ejemplo— y el mapper no tolera más que una, los dos órdenes dejan un intervalo roto:
+
+| Orden                      | Estado intermedio         | Qué falla                                                                        |
+| -------------------------- | ------------------------- | -------------------------------------------------------------------------------- |
+| Migrar y después desplegar | código viejo + dato nuevo | El mapper viejo aplica sobre el valor una operación que su forma nueva no admite |
+| Desplegar y después migrar | código nuevo + dato viejo | El mapper nuevo aplica sobre el valor una operación que su forma vieja no admite |
+
+A diferencia del rename, acá la falla es **ruidosa**: el mapper lanza y el endpoint responde 500, así que el síntoma aparece de inmediato en toda superficie que lea ese campo — no solo en la que lo renderiza.
+
+El patrón que sí deja una ventana segura:
+
+1. **Ampliar:** desplegar un lector que acepte **ambas** formas (`Array.isArray(valor) ? convertir(valor) : valor`). Es el único estado en el que las dos versiones del dato se sirven por igual.
+2. **Migrar** el dataset.
+3. **Contraer:** quitar la tolerancia una vez verificado que no queda ningún documento con la forma vieja.
+
+**Saltearse el paso 1 no elimina la ventana: elige cuál de las dos caídas tener.** Si se decide asumirla —porque el campo es de baja exposición o la ventana es corta—, la decisión se toma explícitamente y se verifica el resultado apenas termina, en vez de descubrirla por un reporte.
+
+Un agravante propio de este repo: mientras `production` conserve la forma vieja, el sync nocturno de datasets la reintroduce en `staging` y `development`, así que el intervalo roto **se reabre cada noche** en los datasets de trabajo aunque el código nuevo ya esté desplegado ahí.
+
+### Rename de un campo requerido
 
 Cuando la migración renombra un campo **requerido** y el código lo lee sin fallback, una migración única de `set` + `unset` no tiene ningún orden de despliegue seguro: migrar antes de desplegar deja el código ya corriendo leyendo un campo que todavía no existe; desplegar antes de migrar deja la proyección nueva devolviendo `null` para los documentos no migrados. No hay ventana en la que ambas versiones —código y dato— coincidan.
 

--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -33,7 +33,17 @@ Ejemplo: `/release-workflow https://github.com/cuentoneta/cuentoneta/issues/<id>
 1. `gh issue view <issue-url> --json number,title,milestone` → número, título y **versión target** (del `milestone.title`).
 2. **Verificar el milestone (criterio de aceptación):** `gh issue list --milestone "<versión>" --state open`. No debe quedar ningún issue abierto **salvo el de release**. Si quedan otros, reportarlos y pausar — el release no está listo.
 3. **Rama:** `git checkout develop && git pull --ff-only`, luego `git checkout -b feat/<number>-<kebab>` (convención de `CLAUDE.md`).
-4. **Detectar migraciones de Sanity pendientes:** listar `cms/migrations/*/`. Para cada una, evaluar (por el issue que la introdujo y su commit) si ya se corrió contra producción. Las migraciones **mutan datos de producción**, así que **nunca** se corren automáticamente: se listan como **paso manual del usuario** (ver Fase 4). Si el usuario ya confirmó que una se ejecutó, anotarlo.
+4. **Detectar y clasificar las migraciones de Sanity pendientes:** listar `cms/migrations/*/`. Para cada una, evaluar (por el issue que la introdujo y su commit) si ya se corrió contra producción. Las migraciones **mutan datos de producción**, así que **nunca** se corren automáticamente: se listan como **paso manual del usuario** (ver Fase 4). Si el usuario ya confirmó que una se ejecutó, anotarlo.
+
+   **La clasificación no es opcional, porque de ella depende cuándo puede correr** (criterio completo en [`sanity-migrations.md`](../../references/sanity-migrations.md) → "Orden de despliegue"):
+
+   - **Independiente del código** — puebla un campo que nadie lee todavía, purga huérfanos, corrige valores sin cambiar su forma. El orden respecto del deploy es indiferente.
+   - **Acoplada al código** — cambia el nombre de un campo o la **forma de su valor**. Ninguna de las dos secuencias simples es segura: migrar antes deja el código viejo con el dato nuevo, y desplegar antes deja el código nuevo con el dato viejo.
+
+   El docblock de la propia migración suele declarar su acoplamiento y su orden de despliegue. **Si contradice a este skill, gana el docblock:** conoce el acoplamiento concreto, y este documento solo puede generalizar.
+
+   Registrar la clase de cada una en `workspace/RELEASE.md`, junto a su estado por dataset.
+
 5. **Chequear versiones en documentación:** contrastar `docs/` (p. ej. `DEVELOPMENT_GUIDE.md`) contra `package.json` (`engines.node`, `packageManager`) y los saltos de versión mayor de la ventana. Solo requiere edición si hay un salto documentable (no por bumps minor/patch de Dependabot).
 6. **Reunir el contenido del CHANGELOG:** los issues cerrados del milestone + `git log --oneline <tag-anterior>..develop` para confirmar qué PRs mergearon desde el último tag. Incluir issues sin milestone que hayan shippeado en la ventana (hijos de epics); excluir los que pertenecen a un milestone futuro.
 7. Escribir `workspace/RELEASE.md` con: versión target, estado del milestone, migraciones de Sanity (pendientes / ya corridas), delta de documentación, y el **borrador de la entrada de CHANGELOG** (prosa + cambios agrupados por tema, replicando el formato de la sección anterior en `CHANGELOG.md`).
@@ -111,12 +121,8 @@ Ramificación tras la respuesta:
 
    ```
    Pasos manuales para completar la release:
-   1. Correr las migraciones de Sanity pendientes contra producción (si aplica):
-        cd cms
-        pnpm exec sanity migration run <nombre> --project <id> --dataset production          # dry-run
-        pnpm exec sanity migration run <nombre> --project <id> --dataset production --no-dry-run
-   2. Mergear este PR a `develop` (el issue de release debe tener label `release`).
-   3. Tras el merge, el workflow `prepare-release-pr` crea/actualiza el PR `develop → master`
+   1. Mergear este PR a `develop` (el issue de release debe tener label `release`).
+   2. Tras el merge, el workflow `prepare-release-pr` crea/actualiza el PR `develop → master`
       con los pasos manuales y dispara `ci.yml` sobre `develop` (el PR no gatilla checks por sí
       mismo por la anti-recursión del `GITHUB_TOKEN`; la señal de CI está en la corrida sobre
       `develop`). Revisarlo y mergearlo a `master`
@@ -124,11 +130,21 @@ Ramificación tras la respuesta:
       El deploy de la app lo cubre Vercel por integración Git nativa.
       Si el milestone no estaba completo, el Action hace skip con warning; re-disparar
       con workflow_dispatch + force si corresponde.
+   3. Correr las migraciones de Sanity pendientes contra producción, en el momento que
+      corresponda a su clase (ver Fase 1):
+        pnpm -C cms exec sanity migration run <nombre> --project <id> --dataset production
+        pnpm -C cms exec sanity migration run <nombre> --project <id> --dataset production --no-dry-run --no-confirm
+      - Independiente del código: en cualquier momento de esta secuencia.
+      - Acoplada al código: NO hay orden simple seguro. Con un lector tolerante ya
+        desplegado, corre acá. Sin él, la ventana rota existe igual y hay que elegir
+        cuál asumir — decidirlo explícitamente y verificar apenas termina, en vez de
+        descubrirla por un reporte.
    4. Verificar post-release: workflow Release verde (jobs `release` y `deploy-studio`),
-      Release <x> publicado, Studio con el schema nuevo, app en producción sin regresiones.
+      Release <x> publicado, Studio con el schema nuevo, app en producción sin regresiones,
+      y las superficies que leen lo migrado sirviendo con la forma nueva.
    ```
 
-   Omitir el paso 1 si no hay migraciones pendientes o el usuario ya las corrió.
+   Omitir el paso 3 si no hay migraciones pendientes o el usuario ya las corrió.
 
 4. Presentar el resumen final (versión, rama, PR, commits, resultado de la verificación).
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -10,7 +10,9 @@ assignees: ''
 
 - [ ] Ajustar changelog.
 - [ ] Actualizar versión en package.json.
-- [ ] Sanity: Determinar si hay scripts de actualización de datos a ejecutar.
+- [ ] Sanity: Determinar si hay migraciones de datos a ejecutar y **clasificarlas**, porque de eso depende cuándo corren:
+  - **Independientes del código** (pueblan un campo que nadie lee, purgan huérfanos): el orden respecto del deploy es indiferente.
+  - **Acopladas al código** (cambian el nombre de un campo o la forma de su valor): ninguna secuencia simple es segura. Anotar para cada una en qué momento corre y, si no hay un lector tolerante a ambas formas, qué ventana se asume.
 - [ ] Chequear si deben actualizarse en la documentación del proyecto las versiones de herramientas o dependencias
 
 `(Agregar otras tareas particulares de la versión, en caso de que sea necesario)`


### PR DESCRIPTION
## Contexto

Durante el release 2.10.0 se corrió `author-biography-to-markdown` contra `production` antes de que el código que lee la biografía como Markdown llegara a `master`. `/api/author/:slug` respondió 500 y las fichas de autor quedaron sin biografía hasta que salió el deploy.

La migración era correcta y el dry-run también: emitió exactamente los parches censados, sin construcciones no soportadas. **El error fue de secuencia**, y el flujo lo inducía: el bloque de handoff del skill numeraba las migraciones como paso 1, antes de mergear a `master`, sin distinguir de qué clase eran.

## Una corrección al enunciado del issue

El issue planteaba que una migración acoplada "corre después del deploy". **Es insuficiente.** Con un cambio de forma del valor los dos órdenes rompen:

| Orden | Estado intermedio | Qué falla |
| --- | --- | --- |
| Migrar y después desplegar | código viejo + dato nuevo | El mapper viejo aplica una operación que la forma nueva no admite |
| Desplegar y después migrar | código nuevo + dato viejo | El mapper nuevo aplica una operación que la forma vieja no admite |

Las dos caras se vivieron acá: la primera en producción, y la segunda cada noche que el sync de datasets revertía el dato mientras el código nuevo ya corría en `staging`, dejando `e2e` en rojo.

Es exactamente lo que la doctrina ya decía para el rename de un campo requerido —"no hay ventana en la que ambas versiones coincidan"—, solo que enunciado como caso aislado. **El patrón correcto es el análogo de expand/contract: un lector tolerante a ambas formas durante la transición.**

## Cambios

**`sanity-migrations.md`** abre ahora clasificando por acoplamiento —independiente del código contra acoplada— y suma el caso del cambio de forma con su patrón de tres pasos: ampliar lo que el lector acepta, migrar, contraer. Queda dicho que saltearse la tolerancia no elimina la ventana sino que elige cuál de las dos caídas tener, y que el sync nocturno la reabre en los datasets de trabajo mientras producción conserve la forma vieja. La sección de rename pasa a ser el caso particular dentro de ese marco.

**`release-workflow`** deja de prescribir un orden fijo. La Fase 1 clasifica cada migración pendiente y registra su clase junto al estado por dataset; el handoff mueve el paso después del deploy y, para las acopladas, dice lo que realmente ocurre en vez de dar una secuencia falsamente segura. Se suma una regla de precedencia: **si el docblock de una migración contradice al skill, gana el docblock**, que conoce el acoplamiento concreto.

**La plantilla de release** pide clasificar las migraciones y anotar cuándo corre cada una.

## Verificación

`check-agents` en verde, que es el gate que este diff activa de lleno —toca `.claude/skills/` y `.claude/references/`—, más `lint` y `typecheck` por política. El diff no toca `src/`, `cms/` ni `scripts/`: es cambio de documentación, exento del requisito de tests.

Los tres archivos se escribieron **sin citar issues**, como exige la Sección 3 de `coding-agent-policies.md` para la prosa de `.claude/**`: las reglas enuncian la conducta vigente y el porqué histórico vive acá.

## Lo que no entra

Tocar `author-biography-to-markdown`, que corrió correctamente y ya está aplicada en los tres datasets, y hacer tolerante alguna lectura concreta: no hay ninguna conversión de formato en vuelo hoy. Cuando la haya, el patrón está escrito.

Closes #2191.
