### PR TITLE
[#2182] - Restaurar el renderizado de la story de HeaderComponent

### DIFF
--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -410,7 +410,11 @@ export const Soft: Story = {
 
 Para dependencias de DI usá los decoradores `moduleMetadata({ imports, providers })` (imports/iconos por story) o `applicationConfig({ providers })` (providers de entorno).
 
-**Dónde va cada provider.** Al preview va lo que _cualquier_ componente puede necesitar sin configurarlo y cuya ausencia deja el canvas en la pantalla de error, no en un componente a medio pintar: hoy `LayoutService` —un token sin factory— y el router. A la story va lo propio del componente: sus iconos, sus imports de composición, y las animaciones del único componente que las declara. El set global vive en `src/testing/storybook-preview.provider.ts` y no en `.storybook/`, para que quede dentro del alcance de `lint` y de los aliases del proyecto.
+**Dónde va cada provider: el discriminante es la universalidad, no la gravedad.** Al preview va lo que _cualquier_ componente del catálogo podría necesitar sin declararlo — hoy `LayoutService`, un token sin factory, y el router. A la story va lo que depende de **ese** componente, por grave que sea su ausencia: los iconos que usa, sus imports de composición, y `provideAnimations()`, que hace falta solo en el único componente con `animations:` en el decorador.
+
+Que sin el provider el canvas quede en la pantalla de error **no decide dónde va**: es el umbral que separa un provider necesario de uno cosmético. Las animaciones lo cruzan —sin ellas el renderer aborta ante la propiedad sintética— y aun así son de la story, porque un provider global que solo un componente necesita le miente al lector sobre qué depende de qué.
+
+El set global vive en `src/testing/storybook-preview.provider.ts` y no en `.storybook/`, para que quede dentro del alcance de `lint`.
 
 El router se provee con `withDisabledInitialNavigation()`: sin eso arranca contra `iframe.html`, que no matchea ninguna ruta, y cada canvas con `routerLink` emite un `NG04002` ajeno al componente. Los `routerLink` resuelven su `href` igual.
 

--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -408,9 +408,15 @@ export const Soft: Story = {
 };
 ```
 
-Para dependencias de DI usá los decoradores `moduleMetadata({ imports, providers })` (imports/iconos por story) o `applicationConfig({ providers })` (servicios globales: Router, etc.).
+Para dependencias de DI usá los decoradores `moduleMetadata({ imports, providers })` (imports/iconos por story) o `applicationConfig({ providers })` (providers de entorno).
 
-`LayoutService` es la excepción: se provee **globalmente** en `.storybook/preview.js`, con el servicio real (`provideLayout()`), y ninguna story lo declara. Es un token sin factory, así que sin ese provider un componente que lo inyecte no renderiza — el canvas queda en `NG0201`. Storybook **acumula** los decoradores `applicationConfig`: los providers que declare una story se suman a los del preview, no los reemplazan.
+**Dónde va cada provider.** Al preview va lo que _cualquier_ componente puede necesitar sin configurarlo y cuya ausencia deja el canvas en la pantalla de error, no en un componente a medio pintar: hoy `LayoutService` —un token sin factory— y el router. A la story va lo propio del componente: sus iconos, sus imports de composición, y las animaciones del único componente que las declara. El set global vive en `src/testing/storybook-preview.provider.ts` y no en `.storybook/`, para que quede dentro del alcance de `lint` y de los aliases del proyecto.
+
+El router se provee con `withDisabledInitialNavigation()`: sin eso arranca contra `iframe.html`, que no matchea ninguna ruta, y cada canvas con `routerLink` emite un `NG04002` ajeno al componente. Los `routerLink` resuelven su `href` igual.
+
+Storybook **acumula** los decoradores `applicationConfig`: los providers que declare una story se suman a los del preview, no los reemplazan. Aun así, una story no repite lo que el preview ya da — dos fuentes para la misma dependencia se desincronizan.
+
+**El catálogo no tiene gate que lo verifique.** `storybook:build` compila sin ejecutar las stories, así que un provider faltante deja el canvas en la pantalla de error y CI pasa en verde. Un spec tampoco lo cubre: Angular Testing Library aporta `ActivatedRoute` por su cuenta, con lo que un caso que monte el componente pasa con y sin el provider en el preview. La única comprobación real es montar cada story en el navegador y mirar el canvas y la consola.
 
 Todo archivo de la app que el preview importe debe estar en el `include` de `.storybook/tsconfig.json`. Si tiene decoradores de Angular y queda fuera del programa, el compilador no lo procesa y el bundle del preview revienta con un `SyntaxError: Unexpected token 'export'` que **tumba el catálogo entero**, no una story.
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,11 +3,11 @@ import '../src/styles.css';
 import '../src/assets/css/typography.css';
 
 import { applicationConfig } from '@storybook/angular-vite';
-import { provideLayout } from '../src/app/providers/layout.provider';
+import { provideStorybookPreview } from '../src/testing/storybook-preview.provider';
 
-// `LayoutService` es un token sin factory: sin este provider, todo componente que lo inyecte cae en
-// NG0201. La convención completa está en `.claude/references/testing.md`.
-export const decorators = [applicationConfig({ providers: [provideLayout()] })];
+// El set y su porqué viven en el módulo importado, que además un spec puede montar.
+// La convención de qué va acá y qué en cada story está en `.claude/references/testing.md`.
+export const decorators = [applicationConfig({ providers: [provideStorybookPreview()] })];
 
 export const tags = ['autodocs'];
 

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -9,6 +9,7 @@
 	"exclude": ["../**/*.spec.ts"],
 	"include": [
 		"../src/app/providers/**/*.ts",
+		"../src/testing/**/*.ts",
 		"../src/**/*.stories.ts",
 		"../src/**/*.stories.js",
 		"../src/**/*.stories.jsx",

--- a/src/app/components/author-card-teaser/author-card-teaser.component.stories.ts
+++ b/src/app/components/author-card-teaser/author-card-teaser.component.stories.ts
@@ -1,12 +1,4 @@
-import {
-	applicationConfig,
-	argsToTemplate,
-	componentWrapperDecorator,
-	Meta,
-	moduleMetadata,
-	StoryObj,
-} from '@storybook/angular-vite';
-import { provideRouter } from '@angular/router';
+import { argsToTemplate, componentWrapperDecorator, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
 
 import { AuthorCardTeaserComponent } from './author-card-teaser.component';
 import { AuthorCardTeaserSkeletonComponent } from './author-card-teaser-skeleton.component';
@@ -21,11 +13,6 @@ const manyTags = onoffTagsMock.slice(0, 4);
 const meta: Meta<AuthorCardTeaserComponent> = {
 	component: AuthorCardTeaserComponent,
 	title: 'Componentes V3/AuthorCardTeaser',
-	decorators: [
-		applicationConfig({
-			providers: [provideRouter([])],
-		}),
-	],
 	parameters: {
 		docs: {
 			canvas: {

--- a/src/app/components/button/button.component.stories.ts
+++ b/src/app/components/button/button.component.stories.ts
@@ -1,5 +1,4 @@
 import { Meta, StoryObj, applicationConfig } from '@storybook/angular-vite';
-import { provideRouter } from '@angular/router';
 import { ButtonComponent } from './button.component';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { faBrandFacebook, faBrandTwitter, faBrandWhatsapp } from '@ng-icons/font-awesome/brands';
@@ -31,7 +30,7 @@ const meta: Meta<ButtonComponent> = {
 	},
 	decorators: [
 		applicationConfig({
-			providers: [provideRouter([]), provideIcons({ faBrandFacebook, faBrandTwitter, faBrandWhatsapp })],
+			providers: [provideIcons({ faBrandFacebook, faBrandTwitter, faBrandWhatsapp })],
 		}),
 	],
 };

--- a/src/app/components/carousel/carousel.component.stories.ts
+++ b/src/app/components/carousel/carousel.component.stories.ts
@@ -1,5 +1,4 @@
-import { applicationConfig, argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { provideRouter, withDisabledInitialNavigation } from '@angular/router';
+import { argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
 
 import { CarouselComponent } from './carousel.component';
 import { CarouselSkeletonComponent } from './carousel-skeleton.component';
@@ -9,14 +8,6 @@ import { ContentCampaign } from '@models/content-campaign.model';
 const meta: Meta<CarouselComponent> = {
 	component: CarouselComponent,
 	title: 'Componentes V3/Carousel',
-	decorators: [
-		applicationConfig({
-			// Sin desactivar la navegación inicial, el router arranca contra `iframe.html` y un set de
-			// rutas vacío, y el canvas emite un NG04002 que no dice nada del componente. Los routerLink
-			// de las diapositivas resuelven su href igual.
-			providers: [provideRouter([], withDisabledInitialNavigation())],
-		}),
-	],
 	parameters: {
 		// El carousel elige imagen y controles a partir del ancho de la ventana, no del contenedor: la
 		// única forma de catalogar sus dos formas es cambiar el viewport del canvas. El de 1600px es el

--- a/src/app/components/collection-teaser-card/collection-teaser-card.stories.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card.stories.ts
@@ -1,5 +1,4 @@
-import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { provideRouter } from '@angular/router';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
 
 import { CollectionTeaserCard } from './collection-teaser-card';
 import { CollectionTeaserCardSkeletonComponent } from './collection-teaser-card-skeleton';
@@ -12,9 +11,6 @@ const meta: Meta<CollectionTeaserCard> = {
 	component: CollectionTeaserCard,
 	title: 'Componentes V3/CollectionTeaserCard',
 	decorators: [
-		applicationConfig({
-			providers: [provideRouter([])],
-		}),
 		moduleMetadata({
 			imports: [CollectionTeaserCardSkeletonComponent],
 		}),

--- a/src/app/components/drawer/drawer.component.stories.ts
+++ b/src/app/components/drawer/drawer.component.stories.ts
@@ -1,5 +1,4 @@
-import { applicationConfig, moduleMetadata, Meta, StoryObj } from '@storybook/angular-vite';
-import { provideRouter } from '@angular/router';
+import { moduleMetadata, Meta, StoryObj } from '@storybook/angular-vite';
 
 import { DrawerComponent, DrawerDirection } from './drawer.component';
 import { DrawerHeaderDirective } from './drawer-header.directive';
@@ -123,7 +122,6 @@ export const ComposicionCollectionPage: Story = {
 		moduleMetadata({
 			imports: [CoverImageComponent, TagComponent, PortableTextParserComponent, NavigableCollectionTeaserComponent],
 		}),
-		applicationConfig({ providers: [provideRouter([])] }),
 	],
 	render: (args) => ({
 		props: {

--- a/src/app/components/header/header.component.stories.ts
+++ b/src/app/components/header/header.component.stories.ts
@@ -1,9 +1,27 @@
-import { Meta } from '@storybook/angular-vite';
+import { applicationConfig, Meta } from '@storybook/angular-vite';
+import { provideAnimations } from '@angular/platform-browser/animations';
 import { HeaderComponent } from './header.component';
 
 export default {
 	title: 'HeaderComponent',
 	component: HeaderComponent,
+	// Único componente de la app con animaciones declaradas: sin este provider, el renderer trata la
+	// propiedad sintética `[@toggle]` como desconocida y aborta el montaje.
+	decorators: [applicationConfig({ providers: [provideAnimations()] })],
+	parameters: {
+		docs: {
+			description: {
+				component: `<div><p>El <strong>HeaderComponent</strong> es el encabezado del sitio: logo, navegación principal y menú desplegable en viewports angostos. El input <code>isVisible</code> lo oculta al hacer scroll hacia abajo, con una transición de opacidad y desplazamiento.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		isVisible: {
+			control: { type: 'boolean' },
+			description: 'Muestra u oculta el encabezado; al ocultarse cierra el menú desplegable',
+			table: { defaultValue: { summary: 'true' } },
+		},
+	},
 } as Meta<HeaderComponent>;
 
 export const Primary = {

--- a/src/app/components/header/header.component.stories.ts
+++ b/src/app/components/header/header.component.stories.ts
@@ -1,11 +1,11 @@
-import { applicationConfig, Meta } from '@storybook/angular-vite';
+import { applicationConfig, Meta, StoryObj } from '@storybook/angular-vite';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { HeaderComponent } from './header.component';
 
 export default {
 	title: 'HeaderComponent',
 	component: HeaderComponent,
-	// Único componente de la app con animaciones declaradas: sin este provider, el renderer trata la
+	// El decorador de este componente declara animaciones: sin este provider, el renderer trata la
 	// propiedad sintética `[@toggle]` como desconocida y aborta el montaje.
 	decorators: [applicationConfig({ providers: [provideAnimations()] })],
 	parameters: {
@@ -19,14 +19,19 @@ export default {
 		isVisible: {
 			control: { type: 'boolean' },
 			description: 'Muestra u oculta el encabezado; al ocultarse cierra el menú desplegable',
-			table: { defaultValue: { summary: 'true' } },
+			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'true' } },
 		},
 	},
 } as Meta<HeaderComponent>;
 
-export const Primary = {
-	render: (args: HeaderComponent) => ({
-		props: args,
-	}),
-	args: {},
+export const Primary: StoryObj<HeaderComponent> = {
+	render: (args) => ({ props: args }),
+	args: { isVisible: true },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Encabezado visible, que es como se sirve en todas las páginas. Alterná el control para ver la transición de ocultamiento, la misma que dispara el scroll hacia abajo.</p><p><strong>Usos:</strong> todas las páginas del sitio, montado por el layout raíz.</p>`,
+			},
+		},
+	},
 };

--- a/src/app/components/literary-work-card-teaser/literary-work-card-teaser.component.stories.ts
+++ b/src/app/components/literary-work-card-teaser/literary-work-card-teaser.component.stories.ts
@@ -1,5 +1,4 @@
-import { applicationConfig, argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
-import { provideRouter } from '@angular/router';
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
 
 import { LiteraryWorkCardTeaserComponent } from './literary-work-card-teaser.component';
 import {
@@ -15,11 +14,6 @@ const meta: Meta<LiteraryWorkCardTeaserComponent> = {
 	component: LiteraryWorkCardTeaserComponent,
 	title: 'Componentes V3/LiteraryWorkCardTeaser',
 	tags: ['autodocs'],
-	decorators: [
-		applicationConfig({
-			providers: [provideRouter([])],
-		}),
-	],
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header.component.stories.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header.component.stories.ts
@@ -1,5 +1,4 @@
-import { applicationConfig, argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
-import { provideRouter } from '@angular/router';
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
 
 import { LiteraryWorkHeroHeaderComponent } from './literary-work-hero-header.component';
 import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
@@ -12,11 +11,6 @@ const meta: Meta<LiteraryWorkHeroHeaderComponent> = {
 	component: LiteraryWorkHeroHeaderComponent,
 	title: 'Componentes V3/LiteraryWorkHeroHeader',
 	tags: ['autodocs'],
-	decorators: [
-		applicationConfig({
-			providers: [provideRouter([])],
-		}),
-	],
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },

--- a/src/app/components/literary-work-home-card-teaser/literary-work-home-card-teaser.component.stories.ts
+++ b/src/app/components/literary-work-home-card-teaser/literary-work-home-card-teaser.component.stories.ts
@@ -1,5 +1,4 @@
-import { applicationConfig, argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { provideRouter } from '@angular/router';
+import { argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
 
 import { LiteraryWorkHomeCardTeaserComponent } from './literary-work-home-card-teaser.component';
 import { LiteraryWorkHomeCardTeaserSkeletonComponent } from './literary-work-home-card-teaser-skeleton.component';
@@ -9,11 +8,6 @@ import { corpusLiteraryWorkTeasers, literaryWorkSelectArgType } from '@mocks/ono
 const meta: Meta<LiteraryWorkHomeCardTeaserComponent> = {
 	component: LiteraryWorkHomeCardTeaserComponent,
 	title: 'Componentes V3/LiteraryWorkHomeCardTeaser',
-	decorators: [
-		applicationConfig({
-			providers: [provideRouter([])],
-		}),
-	],
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
@@ -1,12 +1,4 @@
-import {
-	applicationConfig,
-	argsToTemplate,
-	componentWrapperDecorator,
-	Meta,
-	moduleMetadata,
-	StoryObj,
-} from '@storybook/angular-vite';
-import { provideRouter } from '@angular/router';
+import { argsToTemplate, componentWrapperDecorator, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
 
 import { NavigableCollectionTeaserComponent } from './navigable-collection-teaser.component';
 import { NavigableCollectionTeaserSkeletonComponent } from './navigable-collection-teaser-skeleton.component';
@@ -15,11 +7,6 @@ import { storylistTeaserRepresentativeMock } from '@mocks/storylist.mock';
 const meta: Meta<NavigableCollectionTeaserComponent> = {
 	component: NavigableCollectionTeaserComponent,
 	title: 'Componentes V3/NavigableCollectionTeaser',
-	decorators: [
-		applicationConfig({
-			providers: [provideRouter([])],
-		}),
-	],
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },

--- a/src/app/components/reading-suggestions/reading-suggestions-list.component.stories.ts
+++ b/src/app/components/reading-suggestions/reading-suggestions-list.component.stories.ts
@@ -1,5 +1,4 @@
-import { applicationConfig, Meta, StoryObj } from '@storybook/angular-vite';
-import { provideRouter } from '@angular/router';
+import { Meta, StoryObj } from '@storybook/angular-vite';
 
 import { ReadingSuggestionsListComponent } from './reading-suggestions-list.component';
 import { corpusLiteraryWorkTeasers } from '@mocks/onoff-corpus.storybook';
@@ -9,11 +8,6 @@ import type { ReadingSuggestion } from './story-teaser-to-reading-suggestion.ada
 const meta: Meta<ReadingSuggestionsListComponent> = {
 	component: ReadingSuggestionsListComponent,
 	title: 'Componentes V3/ReadingSuggestionsList',
-	decorators: [
-		applicationConfig({
-			providers: [provideRouter([])],
-		}),
-	],
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },

--- a/src/testing/storybook-preview.provider.spec.ts
+++ b/src/testing/storybook-preview.provider.spec.ts
@@ -1,0 +1,25 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { provideStorybookPreview } from './storybook-preview.provider';
+import { LayoutService } from '../app/providers/layout.interface';
+
+// Afirma sobre el **injector**, no montando un componente: `render` de Angular Testing Library aporta
+// la ruta activa por su cuenta, así que un caso que monte un componente pasa con y sin estos
+// providers y no verificaría nada. Es la única comprobación automatizable del set que el catálogo da
+// a toda story — `storybook:build` compila sin ejecutarlas, así que un provider faltante deja el
+// canvas en la pantalla de error y CI pasa en verde.
+describe('provideStorybookPreview', () => {
+	beforeEach(() => {
+		TestBed.configureTestingModule({ providers: [provideStorybookPreview()] });
+	});
+
+	it('resuelve lo que un componente con enlaces necesita para montar', () => {
+		expect(TestBed.inject(ActivatedRoute)).toBeTruthy();
+		expect(TestBed.inject(Router)).toBeTruthy();
+	});
+
+	it('resuelve el servicio de layout, que no tiene factory propia', () => {
+		expect(TestBed.inject(LayoutService)).toBeTruthy();
+	});
+});

--- a/src/testing/storybook-preview.provider.ts
+++ b/src/testing/storybook-preview.provider.ts
@@ -8,8 +8,9 @@ import { provideLayout } from '../app/providers/layout.provider';
  * componente puede necesitar y cuya ausencia deja el canvas en la pantalla de error, no en un
  * componente a medio pintar.
  *
- * Vive acá y no en `.storybook/` para que un spec pueda montarlo: sin eso, "el preview alcanza"
- * no lo verifica ningún gate — `storybook:build` compila sin ejecutar y la suite no mira el preview.
+ * Vive acá y no en `.storybook/` para que su spec pueda afirmar sobre él: sin eso, "el preview
+ * alcanza" no lo verifica ningún gate — `storybook:build` compila sin ejecutar las stories, así que
+ * un provider faltante deja el canvas en la pantalla de error y la corrida pasa en verde igual.
  */
 export function provideStorybookPreview(): EnvironmentProviders {
 	return makeEnvironmentProviders([

--- a/src/testing/storybook-preview.provider.ts
+++ b/src/testing/storybook-preview.provider.ts
@@ -1,0 +1,23 @@
+import { makeEnvironmentProviders, type EnvironmentProviders } from '@angular/core';
+import { provideRouter, withDisabledInitialNavigation } from '@angular/router';
+
+import { provideLayout } from '../app/providers/layout.provider';
+
+/**
+ * Lo que el catálogo le da a toda story sin que ella lo declare: dependencias que cualquier
+ * componente puede necesitar y cuya ausencia deja el canvas en la pantalla de error, no en un
+ * componente a medio pintar.
+ *
+ * Vive acá y no en `.storybook/` para que un spec pueda montarlo: sin eso, "el preview alcanza"
+ * no lo verifica ningún gate — `storybook:build` compila sin ejecutar y la suite no mira el preview.
+ */
+export function provideStorybookPreview(): EnvironmentProviders {
+	return makeEnvironmentProviders([
+		// `LayoutService` es un token sin factory: quien lo inyecte no renderiza sin este provider.
+		provideLayout(),
+		// La navegación inicial va desactivada porque el router arrancaría contra `iframe.html`, que
+		// no matchea ninguna ruta, y el canvas emitiría un error de ruteo ajeno al componente. Los
+		// `routerLink` resuelven su `href` igual: lo que se apaga es la navegación, no el ruteo.
+		provideRouter([], withDisabledInitialNavigation()),
+	]);
+}


### PR DESCRIPTION
## Contexto

La story de `HeaderComponent` quedaba en la pantalla de error de Storybook con `NG0201: No provider found for ActivatedRoute`. Es el mismo modo de falla que tuvo el carousel, por otro token.

## Lo que el barrido encontró, más allá del issue

Antes de tocar nada se montaron **las 96 stories** del catálogo en el navegador, registrando pantalla de error y mensajes `NG0xxx` de consola. El resultado corrige la premisa del issue en un punto y la amplía en otro:

| | Antes | Después |
| --- | ---: | ---: |
| Stories con pantalla de error | 1 | **0** |
| `NG0201` (provider faltante) | 5 | **0** |
| `NG04002` (ruteo contra `iframe.html`) | 35 | **0** |
| Avisos `NG029xx` de `NgOptimizedImage` | 44 | 44 |

**El header era la única con pantalla de error**, así que "23 de 24 renderizan" se sostiene. Pero había dos clases de error invisibles a esa medición: el **footer** también inyecta `ActivatedRoute` sin declararlo —degrada en vez de tumbar el canvas—, y **35 stories emitían `NG04002`**, incluidas varias que sí proveían el router.

Los avisos de `NgOptimizedImage` que quedan son de otra clase —dimensiones y prioridad de imagen, no DI— y no bloquean el render. Quedan como candidatos a un trabajo aparte.

## Cambios

**El router pasa al preview**, con `withDisabledInitialNavigation()`. Once de los veinticuatro componentes lo necesitan, las diez declaraciones existentes eran idénticas, y la ausencia produce la misma falla que motivó globalizar el servicio de layout. La navegación desactivada es lo que elimina los 35 `NG04002`: el router arrancaba contra `iframe.html`, que no matchea ninguna ruta. Ese tratamiento existía solo en la story del carousel, donde se lo había descubierto.

**Las diez stories pierden su `provideRouter`**, junto con los decoradores e imports que quedan sin uso. Los providers propios de cada una —iconos del botón, imports de composición— se conservan.

**El header necesitaba un segundo provider que el issue no registraba:** es el único componente de la app con `animations:` declaradas, y sin `provideAnimations()` el renderer aborta al encontrar la propiedad sintética `[@toggle]`. Proveer el router destraba el `NG0201` y descubre ese error acto seguido. Ese sí es propio del componente y va en su story, que de paso gana la descripción de autodocs y el `argType` de su único input.

**El set global vive en `src/testing/storybook-preview.provider.ts`**, no en `.storybook/`, para quedar dentro del alcance de `lint` y de los aliases del proyecto.

## El test de regresión, en su segundo intento

El primero montaba los componentes con solo los providers del preview. Pasó — y **también pasaba con el router quitado**, porque Angular Testing Library aporta `ActivatedRoute` por su cuenta. Se descartó por no verificar nada.

El que quedó afirma sobre el **injector** en vez de renderizar: pide `ActivatedRoute`, `Router` y `LayoutService` a un `TestBed` configurado solo con el set global. Verificado falsificable — quitando el router del set, el caso cae con el mismo `NG0201` que motivó este trabajo.

Con eso el catálogo gana la única comprobación automatizable que puede tener del set de providers. Lo que **sigue sin gate** es el montaje de cada story: `storybook:build` compila sin ejecutarlas, así que un provider faltante en una story puntual pasa en verde. El barrido en navegador de este PR se corrió a mano; automatizarlo queda como candidato a issue de seguimiento.

## Verificación

El barrido posterior da **0 pantallas de error y 0 mensajes `NG0201`/`NG04002` en 96 stories**. La del header renderiza su `<header>`, el logo y sus cuatro enlaces resolviendo `href` (`/home`, `/story`, `/authors`, `/about`).

Gates locales en verde: `lint`, `typecheck`, `test` (161 archivos, 1707 casos), `check:agents` y `storybook:build`.

Closes #2182.
