### PR TITLE
[#2112] - Actualizar la descripción del milestone como parte del checklist de release

### DIFF
--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -30,7 +30,7 @@ Ejemplo: `/release-workflow https://github.com/cuentoneta/cuentoneta/issues/<id>
 
 **Propósito:** reunir todo lo necesario para el release y detectar pasos manuales, sin commitear todavía.
 
-1. `gh issue view <issue-url> --json number,title,milestone` → número, título y **versión target** (del `milestone.title`).
+1. `gh issue view <issue-url> --json number,title,milestone` → número, título y **versión target** (del `milestone.title`). Retener también `milestone.number`: es el identificador con el que la Fase 4 actualiza la descripción del milestone, y no coincide con el número del issue ni con la versión.
 2. **Verificar el milestone (criterio de aceptación):** `gh issue list --milestone "<versión>" --state open`. No debe quedar ningún issue abierto **salvo el de release**. Si quedan otros, reportarlos y pausar — el release no está listo.
 3. **Rama:** `git checkout develop && git pull --ff-only`, luego `git checkout -b feat/<number>-<kebab>` (convención de `CLAUDE.md`).
 4. **Detectar y clasificar las migraciones de Sanity pendientes:** listar `cms/migrations/*/`. Para cada una, evaluar (por el issue que la introdujo y su commit) si ya se corrió contra producción. Las migraciones **mutan datos de producción**, así que **nunca** se corren automáticamente: se listan como **paso manual del usuario** (ver Fase 4). Si el usuario ya confirmó que una se ejecutó, anotarlo.
@@ -46,19 +46,25 @@ Ejemplo: `/release-workflow https://github.com/cuentoneta/cuentoneta/issues/<id>
 
 5. **Chequear versiones en documentación:** contrastar `docs/` (p. ej. `DEVELOPMENT_GUIDE.md`) contra `package.json` (`engines.node`, `packageManager`) y los saltos de versión mayor de la ventana. Solo requiere edición si hay un salto documentable (no por bumps minor/patch de Dependabot).
 6. **Reunir el contenido del CHANGELOG:** los issues cerrados del milestone + `git log --oneline <tag-anterior>..develop` para confirmar qué PRs mergearon desde el último tag. Incluir issues sin milestone que hayan shippeado en la ventana (hijos de epics); excluir los que pertenecen a un milestone futuro.
-7. Escribir `workspace/RELEASE.md` con: versión target, estado del milestone, migraciones de Sanity (pendientes / ya corridas), delta de documentación, y el **borrador de la entrada de CHANGELOG** (prosa + cambios agrupados por tema, replicando el formato de la sección anterior en `CHANGELOG.md`).
+7. **Redactar el borrador de la descripción del milestone.** La descripción es el único resumen de la versión que se lee desde la lista de hitos de GitHub; la entrada de CHANGELOG cuenta la misma historia pero vive en el repositorio. La que trae el milestone se escribió al abrirlo —antes de saber qué iba a entrar—, así que se reemplaza.
+
+   Se **deriva** de la prosa de la entrada de CHANGELOG del paso 6, condensada a un párrafo: los mismos temas, en el mismo orden, sin los cambios enumerados. Redactarla por separado es trabajo duplicado y la fuente de divergencia que la regla de la última sección prohíbe.
+
+8. Escribir `workspace/RELEASE.md` con: versión target, número del milestone, estado del milestone, migraciones de Sanity (pendientes / ya corridas), delta de documentación, el **borrador de la entrada de CHANGELOG** (prosa + cambios agrupados por tema, replicando el formato de la sección anterior en `CHANGELOG.md`) y el **borrador de la descripción del milestone**.
 
 **⏸ PAUSA — decisión vía `AskUserQuestion`.**
 
-- `question`: "El alcance del release y el borrador del CHANGELOG están en `workspace/RELEASE.md`. ¿Cómo seguimos?"
+- `question`: "El alcance del release, el borrador del CHANGELOG y el de la descripción del milestone están en `workspace/RELEASE.md`. ¿Cómo seguimos?"
 - `header`: `Release`
-- `options` (la recomendada primero): **Aprobar** — el alcance y el borrador quedan tal cual y se avanza a la Fase 2; **Dar feedback** — el orquestador pide el texto del feedback a continuación. La opción **"Other"** (automática) transporta el feedback directamente en un solo paso — la vía preferida cuando el usuario ya sabe qué cambiar (alcance, agrupación o prosa).
+- `options` (la recomendada primero): **Aprobar** — el alcance y ambos borradores quedan tal cual y se avanza a la Fase 2; **Dar feedback** — el orquestador pide el texto del feedback a continuación. La opción **"Other"** (automática) transporta el feedback directamente en un solo paso — la vía preferida cuando el usuario ya sabe qué cambiar (alcance, agrupación, prosa o descripción).
+
+Esta pausa es donde se aprueba el texto de la descripción; la Fase 4 lo aplica sin volver a preguntar.
 
 Ramificación tras la respuesta:
 
 - **Aprobar** → avanzar a la Fase 2.
 - **Dar feedback** → pedir el texto del feedback al usuario y tratarlo igual que Other.
-- **Other** (feedback) → ajustar `workspace/RELEASE.md` según lo indicado (alcance del release, o agrupación/prosa del CHANGELOG) y repetir la pausa, iterando hasta un "Aprobar".
+- **Other** (feedback) → ajustar `workspace/RELEASE.md` según lo indicado (alcance del release, agrupación/prosa del CHANGELOG, o descripción del milestone) y repetir la pausa, iterando hasta un "Aprobar". Un ajuste de la prosa del CHANGELOG arrastra la descripción, que se deriva de ella.
 
 ---
 
@@ -104,7 +110,7 @@ Ramificación tras la respuesta:
 
 - **Proceder** → avanzar a la Fase 4 (Ship + handoff manual).
 - **Dar feedback** → pedir el texto del feedback al usuario y tratarlo igual que Other.
-- **Other** (feedback) → aplicar el ajuste indicado sobre la verificación o el contenido preparado (con commit atómico si toca archivos versionados), re-verificar lo afectado y repetir la pausa.
+- **Other** (feedback) → aplicar el ajuste indicado sobre la verificación o el contenido preparado (con commit atómico si toca archivos versionados), re-verificar lo afectado y repetir la pausa. Si el ajuste toca la prosa del CHANGELOG, re-derivar la descripción del milestone en `workspace/RELEASE.md`: todavía no se aplicó, y es la última oportunidad de corregirla antes de que la Fase 4 la escriba.
 
 ---
 
@@ -117,7 +123,18 @@ Ramificación tras la respuesta:
    - Título: `[#<issue>] - <título del issue>`.
    - Cuerpo en español con **`Closes #<issue>`** (restricción dura: el keyword de cierre debe estar en el cuerpo, no basta el prefijo del título).
    - Incluir el bloque de pasos manuales (abajo) para que quede registrado en el PR.
-3. Presentar la URL del PR y el **bloque de handoff manual** al usuario:
+3. **Actualizar la descripción del milestone** con el texto aprobado en la Fase 1, usando el `milestone.number` recolectado en su paso 1:
+
+   ```bash
+   gh api -X PATCH repos/cuentoneta/cuentoneta/milestones/<número> -f description="<texto aprobado>"
+   ```
+
+   - **El texto es el aprobado, no uno nuevo.** Redactarlo acá otra vez reintroduce la divergencia con el CHANGELOG que la derivación de la Fase 1 existe para evitar.
+   - **Sobrescribe la descripción previa a propósito.** La que trae un milestone se escribió al abrirlo, cuando todavía no se sabía qué iba a entrar.
+   - **No lleva confirmación propia:** el texto ya pasó por la pausa de la Fase 1 y la de la Fase 3, que autoriza las acciones de ship igual que para el `gh pr create` del paso anterior. A cambio, la escritura no puede ser silenciosa: registrar en `workspace/RELEASE.md` el texto aplicado.
+   - Ocurre acá, y no en la Fase 2, porque no es un artefacto versionado: no viaja en el diff del PR. Aplicarla antes la expondría a quedar divergente si la pausa de la Fase 3 cambia la prosa, y dejaría descrito un release que todavía puede abortarse.
+
+4. Presentar la URL del PR y el **bloque de handoff manual** al usuario:
 
    ```
    Pasos manuales para completar la release:
@@ -144,9 +161,9 @@ Ramificación tras la respuesta:
       y las superficies que leen lo migrado sirviendo con la forma nueva.
    ```
 
-   Omitir el paso 3 si no hay migraciones pendientes o el usuario ya las corrió.
+   Omitir el paso 3 del bloque si no hay migraciones pendientes o el usuario ya las corrió.
 
-4. Presentar el resumen final (versión, rama, PR, commits, resultado de la verificación).
+5. Presentar el resumen final (versión, rama, PR, commits, resultado de la verificación, descripción del milestone aplicada).
 
 ---
 
@@ -158,3 +175,4 @@ Ramificación tras la respuesta:
 - Nunca mergear `develop → master` desde el skill: ese es el gatillo del release y lo hace el usuario.
 - Nunca abrir el PR sin `Closes #<issue>` en el cuerpo, ni antes de que pasen los gates de CI y la verificación.
 - El bump de versión va en **lockstep** (`package.json` + `cms/package.json`).
+- Nunca redactar la descripción del milestone por separado de la prosa del CHANGELOG: se deriva de ella, condensada. Dos textos escritos de cero para la misma versión divergen.

--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -46,11 +46,12 @@ Ejemplo: `/release-workflow https://github.com/cuentoneta/cuentoneta/issues/<id>
 
 5. **Chequear versiones en documentación:** contrastar `docs/` (p. ej. `DEVELOPMENT_GUIDE.md`) contra `package.json` (`engines.node`, `packageManager`) y los saltos de versión mayor de la ventana. Solo requiere edición si hay un salto documentable (no por bumps minor/patch de Dependabot).
 6. **Reunir el contenido del CHANGELOG:** los issues cerrados del milestone + `git log --oneline <tag-anterior>..develop` para confirmar qué PRs mergearon desde el último tag. Incluir issues sin milestone que hayan shippeado en la ventana (hijos de epics); excluir los que pertenecen a un milestone futuro.
-7. **Redactar el borrador de la descripción del milestone.** La descripción es el único resumen de la versión que se lee desde la lista de hitos de GitHub; la entrada de CHANGELOG cuenta la misma historia pero vive en el repositorio. La que trae el milestone se escribió al abrirlo —antes de saber qué iba a entrar—, así que se reemplaza.
+7. **Redactar el borrador de la entrada de CHANGELOG** con lo reunido en el paso anterior: prosa + cambios agrupados por tema, replicando el formato de la sección anterior en `CHANGELOG.md`.
+8. **Redactar el borrador de la descripción del milestone.** La descripción es el único resumen de la versión que se lee desde la lista de hitos de GitHub; la entrada de CHANGELOG cuenta la misma historia pero vive en el repositorio. La que trae el milestone se escribió al abrirlo —antes de saber qué iba a entrar—, así que se reemplaza.
 
-   Se **deriva** de la prosa de la entrada de CHANGELOG del paso 6, condensada a un párrafo: los mismos temas, en el mismo orden, sin los cambios enumerados. Redactarla por separado es trabajo duplicado y la fuente de divergencia que la regla de la última sección prohíbe.
+   Se **deriva** de la prosa redactada en el paso anterior, condensada a un párrafo: los mismos temas, en el mismo orden, sin los cambios enumerados. Redactarla por separado es trabajo duplicado y la fuente de divergencia que prohíbe **Restricciones (todas las fases)**.
 
-8. Escribir `workspace/RELEASE.md` con: versión target, número del milestone, estado del milestone, migraciones de Sanity (pendientes / ya corridas), delta de documentación, el **borrador de la entrada de CHANGELOG** (prosa + cambios agrupados por tema, replicando el formato de la sección anterior en `CHANGELOG.md`) y el **borrador de la descripción del milestone**.
+9. Escribir `workspace/RELEASE.md` con: versión target, número del milestone, estado del milestone, migraciones de Sanity (pendientes / ya corridas), delta de documentación y los dos borradores de los pasos 7 y 8.
 
 **⏸ PAUSA — decisión vía `AskUserQuestion`.**
 
@@ -104,7 +105,9 @@ Anotar los resultados en `workspace/RELEASE.md`. Si algo falla: diagnosticar, ar
 
 - `question`: "Verificación completa en `workspace/RELEASE.md`. ¿Cómo seguimos?"
 - `header`: `Verificación`
-- `options` (la recomendada primero): **Proceder** — abrir el PR de release (Fase 4); **Dar feedback** — el orquestador pide el texto del feedback a continuación. La opción **"Other"** (automática) transporta directamente el ajuste pedido.
+- `options` (la recomendada primero): **Proceder** — abrir el PR de release y aplicar al milestone la descripción aprobada en la Fase 1 (Fase 4); **Dar feedback** — el orquestador pide el texto del feedback a continuación. La opción **"Other"** (automática) transporta directamente el ajuste pedido.
+
+La opción nombra las dos escrituras hacia afuera de la Fase 4 porque es la única pausa que las autoriza: quien responde tiene que poder leer qué está aprobando.
 
 Ramificación tras la respuesta:
 
@@ -131,8 +134,9 @@ Ramificación tras la respuesta:
 
    - **El texto es el aprobado, no uno nuevo.** Redactarlo acá otra vez reintroduce la divergencia con el CHANGELOG que la derivación de la Fase 1 existe para evitar.
    - **Sobrescribe la descripción previa a propósito.** La que trae un milestone se escribió al abrirlo, cuando todavía no se sabía qué iba a entrar.
-   - **No lleva confirmación propia:** el texto ya pasó por la pausa de la Fase 1 y la de la Fase 3, que autoriza las acciones de ship igual que para el `gh pr create` del paso anterior. A cambio, la escritura no puede ser silenciosa: registrar en `workspace/RELEASE.md` el texto aplicado.
-   - Ocurre acá, y no en la Fase 2, porque no es un artefacto versionado: no viaja en el diff del PR. Aplicarla antes la expondría a quedar divergente si la pausa de la Fase 3 cambia la prosa, y dejaría descrito un release que todavía puede abortarse.
+   - **No lleva confirmación propia:** el texto ya pasó por la pausa de la Fase 1, y la de la Fase 3 autoriza esta escritura por su nombre. A cambio, no puede ser silenciosa: registrar en `workspace/RELEASE.md` la constancia de aplicación —el texto y el resultado del comando—, que es distinto del borrador que la Fase 1 ya asentó ahí.
+   - **Verificar el resultado, y no darlo por hecho.** Si el `PATCH` falla —token sin permiso sobre el repositorio, milestone inexistente o cerrado, 404—, reportarlo explícitamente y dejar la descripción **pendiente** en `workspace/RELEASE.md` y en el resumen final. Nunca reportarla como aplicada sin haber visto la respuesta.
+   - Ocurre acá, y no en la Fase 2, porque no es un artefacto versionado: no viaja en el diff del PR, y aplicarla antes la expondría a quedar divergente si la pausa de la Fase 3 cambia la prosa. La escritura precede igual al merge que dispara el release: si el release se aborta después, la descripción queda por revertir a mano.
 
 4. Presentar la URL del PR y el **bloque de handoff manual** al usuario:
 
@@ -163,7 +167,7 @@ Ramificación tras la respuesta:
 
    Omitir el paso 3 del bloque si no hay migraciones pendientes o el usuario ya las corrió.
 
-5. Presentar el resumen final (versión, rama, PR, commits, resultado de la verificación, descripción del milestone aplicada).
+5. Presentar el resumen final (versión, rama, PR, commits, resultado de la verificación, y el estado real de la descripción del milestone — aplicada o pendiente con su motivo).
 
 ---
 

--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -119,7 +119,7 @@ Ramificación tras la respuesta:
 
 ## Fase 4 — Ship + handoff manual
 
-**Propósito:** abrir el PR de release y entregar los pasos manuales que gatillan el release.
+**Propósito:** abrir el PR de release, aplicar la descripción del milestone y entregar los pasos manuales que gatillan el release.
 
 1. `git push -u origin feat/<number>-<kebab>`.
 2. Crear el PR con `gh pr create` (base **`develop`**, milestone de la versión):
@@ -129,8 +129,10 @@ Ramificación tras la respuesta:
 3. **Actualizar la descripción del milestone** con el texto aprobado en la Fase 1, usando el `milestone.number` recolectado en su paso 1:
 
    ```bash
-   gh api -X PATCH repos/cuentoneta/cuentoneta/milestones/<número> -f description="<texto aprobado>"
+   gh api -X PATCH repos/cuentoneta/cuentoneta/milestones/<número> -F description=@workspace/milestone-description.txt
    ```
+
+   El texto va **por archivo** (`-F …=@<ruta>`), no interpolado en la línea de comando: es prosa en español redactada por el agente, y una comilla, un `$` o un backtick mutilarían el valor sin que nada lo advierta.
 
    - **El texto es el aprobado, no uno nuevo.** Redactarlo acá otra vez reintroduce la divergencia con el CHANGELOG que la derivación de la Fase 1 existe para evitar.
    - **Sobrescribe la descripción previa a propósito.** La que trae un milestone se escribió al abrirlo, cuando todavía no se sabía qué iba a entrar.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -9,6 +9,7 @@ assignees: ''
 ## Tareas
 
 - [ ] Ajustar changelog.
+- [ ] Actualizar la descripción del milestone, condensando a un párrafo la prosa del changelog: es el único resumen de la versión que se lee desde la lista de hitos.
 - [ ] Actualizar versión en package.json.
 - [ ] Sanity: Determinar si hay migraciones de datos a ejecutar y **clasificarlas**, porque de eso depende cuándo corren:
   - **Independientes del código** (pueblan un campo que nadie lee, purgan huérfanos): el orden respecto del deploy es indiferente.


### PR DESCRIPTION
## Contexto

La descripción de un milestone es el único resumen de qué significó una versión que se lee desde la lista de hitos de GitHub. La entrada de CHANGELOG cuenta la misma historia, pero vive en el repositorio. Hasta ahora, actualizarla dependía de que alguien se acordara de pedirlo: el checklist de `release-workflow` no la contemplaba.

## Qué cambia

El skill `release-workflow` incorpora el paso, repartido entre dos fases:

- **Fase 1** redacta el **borrador** de la descripción, derivado de la prosa de la entrada de CHANGELOG y condensado a un párrafo, lo escribe en `workspace/RELEASE.md` y lo somete a la misma pausa de aprobación que ya cubre el alcance y el CHANGELOG. También retiene el `milestone.number`, que es el identificador que necesita la escritura.
- **Fase 4** lo **aplica** con `gh api -X PATCH …/milestones/<número>`, pasando el texto por archivo (`-F …=@<ruta>`) para que la prosa en español no se mutile en la línea de comando. Verifica el resultado: si el `PATCH` falla, la descripción queda **pendiente** y así se reporta — nunca se da por aplicada.
- **Restricciones** gana una regla dura: la descripción se deriva del CHANGELOG, nunca se redacta por separado.

La pausa que cierra la **Fase 3** nombra ahora las dos escrituras hacia afuera que autoriza (`Proceder` — abrir el PR *y* aplicar la descripción), porque es la única que las concede y quien responde tiene que poder leer qué aprueba. Y el **template del issue de release** —el checklist humano, que se sigue cuando el release no corre por el skill— suma la misma tarea: es el hueco simétrico del que cierra este PR.

## Decisiones de diseño

El issue dejaba dos detalles abiertos.

**En qué fase ocurre → Fase 4, no Fase 2.** La Fase 2 materializa artefactos versionados que viajan en el diff del PR; la descripción del milestone no está en ningún diff — es una escritura contra la API de GitHub, de la misma naturaleza que el `gh pr create` de la Fase 4. Además, la pausa que cierra la Fase 3 todavía admite feedback sobre la prosa del CHANGELOG de la que la descripción deriva: aplicarla antes la expone a quedar divergente. La derivación no se pierde: lo que se corre a la Fase 4 es la aplicación, no la redacción. La escritura precede igual al merge que dispara el release, y el skill lo dice en vez de prometer lo contrario: si el release se aborta después, la descripción queda por revertir a mano.

**Si requiere confirmación previa → no una propia.** El texto ya pasa por la pausa de la Fase 1, donde se aprueba, y por la de la Fase 3, que autoriza las acciones de ship igual que para el `gh pr create`. La confirmación previa que exigen las políticas cubre crear entidades nuevas — labels, issues —; acá se edita un campo de metadatos de un milestone existente con un `PATCH` reversible. A cambio, la escritura no puede ser silenciosa: queda registrada en `workspace/RELEASE.md` y en el resumen final de la fase.

## Plan de pruebas

El diff es solo documentación —dos archivos Markdown, sin superficie de runtime—, así que la verificación es por lectura contra los criterios de aceptación del issue, más los gates:

- Los cuatro criterios de aceptación se leen directamente del `SKILL.md` resultante. El primero está redactado sobre el supuesto de la Fase 2 y lo destraba el cuarto, como el propio issue anticipa.
- La numeración de la Fase 1 (que pasó de 7 a 9 pasos) y la de la Fase 4 (de 4 a 5) quedan consistentes, y ningún otro artefacto del repo referencia los pasos de este skill por número.
- Gates locales verdes: `check:agents`, `lint`, `stylelint`, `typecheck` y `test`. El relevante acá es `check:agents`, que verifica que la prosa nueva bajo `.claude/skills/**` no cite issues fuera de la allowlist de gobernanza.
- Los 14 checks del PR, verdes sobre el commit final.

Closes #2112.
