### PR TITLE
[#2196] - Chequear el documento del sitemap en el smoke de indexado

### DIFF
--- a/scripts/seo-smoke.helpers.spec.ts
+++ b/scripts/seo-smoke.helpers.spec.ts
@@ -1,5 +1,6 @@
 import {
 	checkSitewideAbsoluteUrls,
+	collectSitemapViolations,
 	expectationsFor,
 	parseSitemap,
 	sample,
@@ -144,5 +145,64 @@ describe('expectationsFor', () => {
 describe('slugOf', () => {
 	it('toma el último segmento del path', () => {
 		expect(slugOf('/story/el-aleph')).toBe('el-aleph');
+	});
+});
+
+describe('collectSitemapViolations', () => {
+	const urlEntry = (path: string, lastmod?: string) =>
+		`<url><loc>https://www.cuentoneta.ar${path}</loc>${lastmod ? `<lastmod>${lastmod}</lastmod>` : ''}</url>`;
+
+	const sitemapOf = (entries: string[]) => `<?xml version="1.0" encoding="UTF-8"?><urlset>${entries.join('')}</urlset>`;
+
+	// Fechas dispersas: una por entrada, ninguna concentrada.
+	const spread = (count: number) =>
+		Array.from({ length: count }, (_, index) =>
+			urlEntry(`/story/obra-${index}`, `2025-01-${`${index + 1}`.padStart(2, '0')}`),
+		);
+
+	it('no reporta nada para un sitemap con fechas dispersas y en secuencia', () => {
+		const report = collectSitemapViolations(sitemapOf([urlEntry('/'), ...spread(9)]));
+
+		expect(report.violations).toEqual([]);
+		expect(report.urls).toBe(10);
+		expect(report.dated).toBe(9);
+		expect(report.distinctDates).toBe(9);
+	});
+
+	// La proporción del caso es la que servía producción cuando el `lastmod` derivaba de la fecha de
+	// escritura: el chequeo no sirve de nada si no marca ese estado.
+	it('reporta una fecha concentrada en casi la mitad del corpus', () => {
+		const clustered = Array.from({ length: 48 }, (_, index) => urlEntry(`/story/lote-${index}`, '2026-06-29'));
+
+		const report = collectSitemapViolations(sitemapOf([...clustered, ...spread(52)]));
+
+		expect(report.largestCluster).toEqual({ date: '2026-06-29', share: 0.48 });
+		expect(report.violations).toHaveLength(1);
+		expect(report.violations[0]).toContain('escritura en lote');
+	});
+
+	it('reporta la fecha emitida antes de la ubicación', () => {
+		const inverted = '<url><lastmod>2025-01-01</lastmod><loc>https://www.cuentoneta.ar/story/a</loc></url>';
+
+		const report = collectSitemapViolations(sitemapOf([inverted, ...spread(9)]));
+
+		expect(report.violations).toHaveLength(1);
+		expect(report.violations[0]).toContain('secuencia');
+	});
+
+	it('reporta los elementos que los buscadores ignoran', () => {
+		const withIgnored =
+			'<url><loc>https://www.cuentoneta.ar/story/a</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>';
+
+		const report = collectSitemapViolations(sitemapOf([withIgnored, ...spread(9)]));
+
+		expect(report.violations.filter((violation) => violation.includes('ignoran'))).toHaveLength(2);
+	});
+
+	it('reporta un sitemap sin entradas', () => {
+		const report = collectSitemapViolations(sitemapOf([]));
+
+		expect(report.violations).toEqual(['El sitemap no expone ninguna entrada <url>.']);
+		expect(report.largestCluster).toBeNull();
 	});
 });

--- a/scripts/seo-smoke.helpers.ts
+++ b/scripts/seo-smoke.helpers.ts
@@ -6,6 +6,7 @@
 import type { IndexableHtmlExpectations } from '../e2e/_utils/seo-invariants';
 import { parseHtml, parseJsonLdBlocks } from '../e2e/_utils/seo';
 import { SCHEMA_IDS, SITEWIDE_SCHEMA_IDS } from '../e2e/_utils/seo-fixtures';
+import { childElementSequences } from '../src/testing/sitemap-xml';
 
 export function slugOf(path: string): string {
 	return path.split('/').filter(Boolean).pop() ?? '';
@@ -96,6 +97,78 @@ export function expectationsFor(path: string): IndexableHtmlExpectations | null 
 		};
 	}
 	return null;
+}
+
+// Cuando una fecha se repite en más de esta proporción del sitemap, ya no está describiendo cuándo
+// cambió cada página: está describiendo cuándo se corrió una operación en lote. El valor separa los
+// dos estados medidos —un corpus contaminado por una escritura masiva llegó a concentrar la mitad de
+// las fechas en una sola, y uno derivado de fechas de origen no pasó de unas pocas centésimas—, con
+// margen para un día de alta editorial legítimo.
+const LASTMOD_CLUSTER_LIMIT = 0.25;
+
+const IGNORED_ELEMENTS = ['changefreq', 'priority'];
+
+export interface SitemapReport {
+	urls: number;
+	dated: number;
+	distinctDates: number;
+	largestCluster: { date: string; share: number } | null;
+	violations: string[];
+}
+
+function largestCluster(dates: readonly string[]): { date: string; share: number } | null {
+	const counts = new Map<string, number>();
+	dates.forEach((date) => counts.set(date, (counts.get(date) ?? 0) + 1));
+	const ranked = [...counts.entries()].sort(([, a], [, b]) => b - a);
+	const [top] = ranked;
+	return top ? { date: top[0], share: top[1] / dates.length } : null;
+}
+
+/**
+ * Invariantes del documento del sitemap: la secuencia de elementos que exige su esquema y que la
+ * fecha de modificación siga siendo una señal y no el rastro de la última escritura masiva.
+ *
+ * Lo segundo no se puede verificar en un test: necesita el corpus real de un despliegue, que es
+ * justamente lo que este smoke tiene a mano.
+ */
+export function collectSitemapViolations(xml: string): SitemapReport {
+	const sequences = childElementSequences(xml);
+	const dates = parseHtml(xml)
+		.querySelectorAll('lastmod')
+		.map((element) => element.text.trim());
+	const cluster = largestCluster(dates);
+	const violations: string[] = [];
+
+	if (sequences.length === 0) {
+		violations.push('El sitemap no expone ninguna entrada <url>.');
+	}
+
+	const outOfOrder = sequences.filter(
+		(sequence) => sequence.join(',') !== 'loc,lastmod' && sequence.join(',') !== 'loc',
+	);
+	if (outOfOrder.length > 0) {
+		violations.push(
+			`Hay entradas que no respetan la secuencia del esquema (loc → lastmod). Primera encontrada: ${outOfOrder[0]?.join(' → ')}.`,
+		);
+	}
+
+	IGNORED_ELEMENTS.filter((element) => xml.includes(`<${element}>`)).forEach((element) =>
+		violations.push(`El sitemap emite <${element}>, que los buscadores ignoran.`),
+	);
+
+	if (cluster && cluster.share > LASTMOD_CLUSTER_LIMIT) {
+		violations.push(
+			`El ${Math.round(cluster.share * 100)}% de las fechas es ${cluster.date}: el lastmod está reflejando una escritura en lote, no cambios de contenido.`,
+		);
+	}
+
+	return {
+		urls: parseHtml(xml).querySelectorAll('loc').length,
+		dated: dates.length,
+		distinctDates: new Set(dates).size,
+		largestCluster: cluster,
+		violations,
+	};
 }
 
 /**

--- a/scripts/seo-smoke.ts
+++ b/scripts/seo-smoke.ts
@@ -7,6 +7,10 @@
  * corrida (cobertura rotativa). Los patrones de `<title>`/`<h1>` se derivan del slug de cada URL.
  * Si el sitemap no está disponible, el baseline igual se ejerce (la muestra se omite con un aviso).
  *
+ * Del propio `/sitemap.xml` chequea además la secuencia de elementos que exige su esquema y la
+ * dispersión del `lastmod`: una fecha repetida en medio corpus delata una escritura en lote, y eso
+ * solo se ve contra el corpus real de un despliegue.
+ *
  * Uso:
  *   BASE_URL=https://www.cuentoneta.ar pnpm seo:smoke
  *   SEO_SMOKE_SAMPLE=5 pnpm seo:smoke                            # N aleatorios por tipo (default 3)
@@ -19,7 +23,13 @@
  */
 import { collectIndexableHtmlViolations, type IndexableHtmlExpectations } from '../e2e/_utils/seo-invariants';
 import { STABLE_SLUGS, SITEWIDE_SCHEMA_IDS } from '../e2e/_utils/seo-fixtures';
-import { checkSitewideAbsoluteUrls, expectationsFor, parseSitemap, selectByType } from './seo-smoke.helpers';
+import {
+	checkSitewideAbsoluteUrls,
+	collectSitemapViolations,
+	expectationsFor,
+	parseSitemap,
+	selectByType,
+} from './seo-smoke.helpers';
 
 const BASE_URL = process.env['BASE_URL'] ?? 'http://localhost:4000';
 const FULL = process.argv.includes('--full') || process.env['SEO_SMOKE_FULL'] === 'true';
@@ -92,12 +102,27 @@ async function reportPath(path: string): Promise<boolean> {
 	return expectations ? reportExpectations(expectations) : false;
 }
 
-async function sampledPaths(baseline: readonly string[]): Promise<string[]> {
-	const response = await fetch(`${BASE_URL}/sitemap.xml`, { headers: proxyHeaders });
-	if (!response.ok) {
-		throw new Error(`GET /sitemap.xml devolvió HTTP ${response.status}`);
+// El documento del sitemap se reporta con la misma descarga que alimenta la muestra: pedirlo dos
+// veces daría dos versiones distintas si el caché de borde expira en el medio.
+function reportSitemapDocument(xml: string): boolean {
+	const report = collectSitemapViolations(xml);
+	const cluster = report.largestCluster;
+	const clusterLabel = cluster ? `, mayor concentración ${Math.round(cluster.share * 100)}% en ${cluster.date}` : '';
+
+	console.log(
+		`\nSitemap: ${report.urls} URLs, ${report.dated} con fecha, ${report.distinctDates} fechas distintas${clusterLabel}`,
+	);
+	if (report.violations.length === 0) {
+		console.log('✅ /sitemap.xml');
+		return false;
 	}
-	const paths = parseSitemap(await response.text());
+	console.log('❌ /sitemap.xml');
+	report.violations.forEach((violation) => console.log(`     - ${violation}`));
+	return true;
+}
+
+function sampledPaths(baseline: readonly string[], xml: string): string[] {
+	const paths = parseSitemap(xml);
 	const excluded = new Set(baseline);
 	return ['/story/', '/author/', '/storylist/']
 		.flatMap((prefix) => selectByType(paths, prefix, SAMPLE_SIZE, FULL))
@@ -115,20 +140,27 @@ async function reportBaseline(baseline: readonly string[]): Promise<boolean> {
 }
 
 /**
- * La muestra sí depende del sitemap, así que su falla se reporta pero **no** tumba el baseline: que
- * el sitemap no esté disponible no dice nada sobre las rutas que ya se ejercieron.
+ * Reporta el documento del sitemap y las páginas que muestrea de él. Todo esto depende del sitemap,
+ * así que su falla se reporta pero **no** tumba el baseline: que el sitemap no esté disponible no
+ * dice nada sobre las rutas que ya se ejercieron.
  */
-async function reportSample(baseline: readonly string[]): Promise<boolean> {
+async function reportSitemap(baseline: readonly string[]): Promise<boolean> {
 	try {
-		const sample = await sampledPaths(baseline);
+		const response = await fetch(`${BASE_URL}/sitemap.xml`, { headers: proxyHeaders });
+		if (!response.ok) {
+			throw new Error(`GET /sitemap.xml devolvió HTTP ${response.status}`);
+		}
+		const xml = await response.text();
+
+		let failed = reportSitemapDocument(xml);
+		const sample = sampledPaths(baseline, xml);
 		console.log(`\nMuestra del sitemap (${FULL ? 'full' : `${SAMPLE_SIZE}/tipo`}):\n  ${sample.join('\n  ')}\n`);
-		let failed = false;
 		for (const path of sample) {
 			failed = (await reportPath(path)) || failed;
 		}
 		return failed;
 	} catch (error) {
-		console.log(`⚠️ sitemap no disponible, se omite la muestra aleatoria: ${messageOf(error)}`);
+		console.log(`⚠️ sitemap no disponible, se omiten sus chequeos y la muestra aleatoria: ${messageOf(error)}`);
 		return true;
 	}
 }
@@ -146,7 +178,7 @@ async function run(): Promise<void> {
 	let failed = await reportBaseline(baseline);
 	// Con slugs explícitos no hay muestra que tomar: el llamador ya dijo qué quiere ejercer.
 	if (SLUGS_OVERRIDE.length === 0) {
-		failed = (await reportSample(baseline)) || failed;
+		failed = (await reportSitemap(baseline)) || failed;
 	}
 
 	if (failed) {


### PR DESCRIPTION
## Contexto

La corrección de la señal de `lastmod` dejó una verificación sin lugar donde vivir: **la dispersión de las fechas no se puede afirmar en un test**. Necesita el corpus real de un despliegue, y ni el gate `test` —que afirma sobre entradas construidas a mano— ni el gate `e2e` —que afirma un piso sobre el dataset de staging— pueden verla.

Es el defecto que más caro sale, porque no rompe nada: el sitemap sigue siendo válido, sigue teniendo todas sus URLs, y simplemente deja de ser una señal en la que Google confíe. Un backfill futuro puede reintroducirlo sin que ningún gate se entere.

## Cambios

`pnpm seo:smoke` ya descargaba el `/sitemap.xml` para muestrear páginas, así que el chequeo del **documento** entra sin pedir red de más — y se reporta desde esa **misma** descarga, no una segunda: pedirlo dos veces daría dos versiones distintas si el caché de borde de 6 h expira en el medio.

Reporta el conteo de URLs, cuántas llevan fecha, cuántas fechas distintas hay y en qué proporción está la mayor concentración. Y marca como violación:

- una secuencia de elementos fuera del orden que exige el esquema de sitemaps.org;
- la presencia de `changefreq` o `priority`;
- una fecha repetida en más de un cuarto del corpus.

## El umbral, y por qué no es el que puse primero

Lo elegí en la mitad del corpus y **el ensayo contra producción lo desmintió**: el despliegue servía una concentración del **48%**, justo por debajo, así que el chequeo no habría marcado exactamente el estado que motivó todo esto.

El valor salió entonces de las dos mediciones reales: derivando de la fecha de escritura, una sola fecha llegó a cubrir **48%** del sitemap; derivando de fechas de origen, la mayor concentración no pasó de **3,4%**. Un cuarto separa los dos con margen para un día de alta editorial legítimo. El caso del spec fija esa proporción exacta, para que un umbral que deje de marcarla falle.

## Verificación

Ensayado contra el despliegue real de producción, que todavía servía el formato anterior:

```
Sitemap: 968 URLs, 965 con fecha, 14 fechas distintas, mayor concentración 48% en 2026-06-29
❌ /sitemap.xml
     - Hay entradas que no respetan la secuencia del esquema (loc → lastmod). Primera encontrada: loc → changefreq → priority.
     - El sitemap emite <changefreq>, que los buscadores ignoran.
     - El sitemap emite <priority>, que los buscadores ignoran.
     - El 48% de las fechas es 2026-06-29: el lastmod está reflejando una escritura en lote, no cambios de contenido.
```

Las cuatro violaciones son las que el cambio anterior corrige, así que este chequeo debería quedar en verde una vez desplegado.

Gates locales en verde: `lint`, `typecheck` y `test` (163 archivos, 1733 casos).

## Alcance

No se convierte en gate de CI: el smoke es una herramienta manual de diagnóstico contra un despliegue real, y CI no tiene uno.

Closes #2196.
