### PR TITLE
[#2130] - Revisar el texto centrado que la migración a Markdown deja como párrafo plano

### DIFF
--- a/cms/migrations/restore-centered-block-semantics/README.md
+++ b/cms/migrations/restore-centered-block-semantics/README.md
@@ -59,6 +59,8 @@ pnpm exec sanity documents query --api-version v2021-06-07 --dataset production 
 
 `--api-version v2021-06-07` **no es opcional**: la versión que la CLI elige sola consulta con perspectiva de publicados y los borradores no aparecen, sin advertencia. El censo tiene que poder afirmar que no hay ninguno.
 
+**Si aparece un borrador, publicalo o descartalo antes de correr.** El filtro los incluye, y uno cuyo texto haya divergido aborta la corrida entera — posiblemente con documentos anteriores ya escritos, porque la migración no es transaccional entre documentos.
+
 ### 2. Ensayo
 
 ```bash

--- a/cms/migrations/restore-centered-block-semantics/README.md
+++ b/cms/migrations/restore-centered-block-semantics/README.md
@@ -1,0 +1,86 @@
+# `restore-centered-block-semantics`
+
+Reexpresa en Markdown semántico los pasajes de tres obras donde el Portable Text original usaba **alineación centrada** para cargar significado. Markdown no tiene alineación, así que la migración a obras dejó esos pasajes como prosa corriente.
+
+No toca ningún otro documento ni ningún otro pasaje: la tabla de correcciones enumera los tres identificadores y ancla cada corrección en un texto exacto.
+
+## Qué corrige, obra por obra
+
+### _La liga de los pelirrojos_ — los dos avisos impresos
+
+El relato transcribe dos carteles: el que convoca a la Liga y el que anuncia su disolución. En el original cada uno venía **enmarcado por filas de asteriscos centradas**, que no son un corte de escena sino el borde del papel. La migración a Markdown tradujo esas filas a reglas horizontales, junto con los cortes de escena reales del corpus, y dejó el encabezado en negrita.
+
+Ambos pasan a ser **cita**, que es la construcción que Markdown tiene para "esto es un texto dentro de otro texto". Como la cita ya hace de marco, las dos reglas que lo rodeaban se van con ella.
+
+> Esta obra no tiene cortes de escena propios: sus cuatro reglas eran los dos marcos. Aun así el motor solo consume **las dos reglas contiguas al ancla**, porque la construcción es indistinguible y otra obra sí podría tener ambas cosas.
+
+### _Carta a Chichita_ — la firma
+
+El original centraba la firma al pie de la carta. Pasa a **énfasis**, que la distingue del cuerpo sin inventar una estructura que la carta no tiene. El texto que la precede —"Un beso de tu"— ya declara qué es, así que la marca es tipográfica y no informativa.
+
+### _Amor a lo lejos_ — el encabezado de parte pegado
+
+No es una pérdida de centrado sino un defecto visible: el encabezado de la última parte quedó **sin separación** del texto que lo sigue, así que renderiza corrido, a diferencia de las tres partes anteriores. En el origen los dos fragmentos vivían en un mismo bloque de Portable Text con la marca en uno solo de sus tramos, y la migración lo serializó fielmente. Se separa en dos párrafos.
+
+### _Sombras sobre vidrio esmerilado_ — no se toca
+
+Su envío poético quedó como texto en negrita y cursiva en línea propia, que ya lo separa del cuerpo. Queda fuera de la tabla y, por lo tanto, fuera del filtro.
+
+## Orden de despliegue: **independiente del código**
+
+No cambia el nombre ni la forma de ningún campo. El cuerpo de cada sección sigue siendo Markdown antes y después, y el pipeline ya renderiza cita, énfasis y párrafos. **Puede correr en cualquier momento respecto de un despliegue.**
+
+La única dependencia con el código es que la cita sobreviva al saneamiento del pipeline. Está verificada y cubierta por un caso del spec de `markdown-pipeline.utils`: si alguien acotara la lista blanca y la cita cayera, ese caso se pone rojo antes de que estos pasajes pierdan su texto.
+
+## Idempotencia y fail-fast
+
+El motor distingue **tres** resultados por corrección, y esa distinción es el diseño:
+
+| Resultado   | Cuándo                                           | Qué hace                      |
+| ----------- | ------------------------------------------------ | ----------------------------- |
+| Aplicada    | Aparece la forma de origen                       | Transforma                    |
+| Ya aplicada | Aparece la forma de destino                      | No emite patch                |
+| Ausente     | No aparece ninguna de las dos **en esa sección** | Se resuelve a nivel documento |
+
+Ausente no lanza en el motor porque una corrección vive en una sola sección: quien puede concluir que falta es quien ve el documento entero, y ahí sí **aborta la corrida** nombrando documento y corrección. Sí lanzan de inmediato la **ocurrencia múltiple** —elegir la primera reescribiría un pasaje que nadie miró— y el **ancla presente sin su marco**, que es una inconsistencia que ninguna otra sección puede desmentir.
+
+Como la migración emite patches y no creaciones, una segunda corrida no emite ninguna mutación y **el contador de la CLI sirve como señal de idempotencia** — a diferencia de las migraciones basadas en `createIfNotExists`, donde el contador vuelve a reportar el total.
+
+## Procedimiento
+
+El sync de datasets es `production → staging + development` (borrado e importación nocturnos), así que alcanza con aplicar contra producción: el espejo propaga. Hasta que corra, los otros dos conservan el texto viejo, lo que es inocuo porque ninguna prueba end-to-end afirma sobre esta prosa.
+
+### 1. Censo previo
+
+```bash
+pnpm exec sanity documents query --api-version v2021-06-07 --dataset production \
+  '*[_id in ["lw-from-story-bd3bbc87-71bd-4374-9cf8-417e915669c7","lw-from-story-e1138575-5c25-41c4-9bd2-4793642ceb62","lw-from-story-666dac9b-9086-4db9-a17c-d38f6f09532c"]]{_id, "secciones": count(content)}'
+```
+
+`--api-version v2021-06-07` **no es opcional**: la versión que la CLI elige sola consulta con perspectiva de publicados y los borradores no aparecen, sin advertencia. El censo tiene que poder afirmar que no hay ninguno.
+
+### 2. Ensayo
+
+```bash
+pnpm exec sanity migration run restore-centered-block-semantics --dataset production > dry-run.txt
+```
+
+Contrastar los patches impresos **carácter a carácter** contra el resultado buscado: las dos citas con `>` en su línea intermedia, las reglas del marco ausentes, la firma en cursiva al cierre y la separación del encabezado de parte. El ensayo imprime las mutaciones que la migración emite y **no llega al servidor**, así que no valida nada del content lake: este contraste es un paso, no una sugerencia.
+
+### 3. Aplicación
+
+```bash
+pnpm exec sanity migration run restore-centered-block-semantics --dataset production --no-dry-run --no-confirm
+```
+
+### 4. Verificación
+
+Sobre el cuerpo de las tres obras: contiene la cita del aviso de apertura; no contiene la secuencia regla-encabezado del marco; termina en la firma en cursiva; y contiene el encabezado de parte separado del texto que lo sigue.
+
+Después, **un segundo ensayo debe reportar cero mutaciones**.
+
+Por último, la comprobación visual en la página de lectura de las tres obras, teniendo en cuenta que la caché de borde sirve contenido revalidándolo en segundo plano: la fuente se verifica por consulta y recién después la página.
+
+## Reversión
+
+**No se escribe migración inversa.** El cambio es una corrección editorial de texto, no la creación de documentos: el historial de Sanity conserva la versión previa de los tres, y una inversa mecánica reintroduciría prosa que ya se decidió descartar.

--- a/cms/migrations/restore-centered-block-semantics/apply-corrections.spec.ts
+++ b/cms/migrations/restore-centered-block-semantics/apply-corrections.spec.ts
@@ -70,6 +70,19 @@ describe('applyCorrection — replace-literal', () => {
 
 		expect(() => applyCorrection(body, literalCorrection)).toThrow(UncorrectableLiteraryWorkError);
 	});
+
+	// Una entrada así vuelve a coincidir consigo misma en la segunda corrida: se aplicaría de nuevo y
+	// el contador dejaría de ser señal de idempotencia.
+	it('throws when the replacement contains the searched text', () => {
+		const notIdempotent: Correction = {
+			id: 'no-idempotente',
+			kind: CORRECTION_KINDS.replaceLiteral,
+			search: 'José',
+			replacement: '*José*',
+		};
+
+		expect(() => applyCorrection('Un beso de tu\n\nJosé', notIdempotent)).toThrow(UncorrectableLiteraryWorkError);
+	});
 });
 
 describe('applyCorrection — quote-ruled-block', () => {
@@ -94,6 +107,30 @@ describe('applyCorrection — quote-ruled-block', () => {
 		expect(result.body.startsWith('Primera escena.\n\n---\n\n')).toBe(true);
 		expect(result.body.endsWith('\n\n---\n\nÚltima escena.')).toBe(true);
 		expect(result.body).toContain(`> ${ANCHOR}`);
+	});
+
+	// El mismo texto del ancla puede aparecer citado dentro de un párrafo. Localizarlo como subcadena
+	// citaría ese párrafo y borraría los cortes de escena que lo rodean, dejando el aviso sin corregir
+	// y sin ninguna señal, porque el estado sería el de una corrección aplicada.
+	it('ignores the anchor text mentioned inside a paragraph', () => {
+		const body = [
+			'Escena uno.',
+			'',
+			'---',
+			'',
+			`Se acordó de ${ANCHOR} que había leído.`,
+			'',
+			'---',
+			'',
+			framedBody,
+		].join('\n');
+
+		const result = applyCorrection(body, quoteCorrection);
+
+		expect(result.body).toContain(`Se acordó de ${ANCHOR} que había leído.`);
+		expect(result.body).toContain(`> ${ANCHOR}`);
+		expect(result.body).toContain('> El cuerpo del aviso.');
+		expect(result.body.startsWith('Escena uno.\n\n---\n\n')).toBe(true);
 	});
 
 	it('preserves the quoted text verbatim, escapes included', () => {
@@ -140,13 +177,21 @@ describe('applyCorrection — quote-ruled-block', () => {
 
 		expect(() => applyCorrection(body, quoteCorrection)).toThrow(UncorrectableLiteraryWorkError);
 	});
+
+	// Dos líneas ancla consecutivas comparten el salto que las separa. Contar por partición las lee
+	// como una sola y el guard de ambigüedad no llega a activarse.
+	it('throws when two anchor lines are adjacent', () => {
+		const body = ['Leyó:', '', '---', '', ANCHOR, ANCHOR, '', '---', '', 'Fin.'].join('\n');
+
+		expect(() => applyCorrection(body, quoteCorrection)).toThrow(UncorrectableLiteraryWorkError);
+	});
 });
 
 describe('UncorrectableLiteraryWorkError', () => {
 	it('names the correction that could not be applied', () => {
 		const body = ['Leyó:', '', ANCHOR, '', 'El cuerpo.'].join('\n');
 
-		expect(() => applyCorrection(body, quoteCorrection)).toThrow(/aviso/);
+		expect(() => applyCorrection(body, quoteCorrection)).toThrow(/corrección "aviso"/);
 	});
 });
 

--- a/cms/migrations/restore-centered-block-semantics/apply-corrections.spec.ts
+++ b/cms/migrations/restore-centered-block-semantics/apply-corrections.spec.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	applyCorrection,
+	applySectionCorrections,
+	CORRECTION_STATUSES,
+	UncorrectableLiteraryWorkError,
+} from './apply-corrections';
+import { CORRECTION_KINDS, type Correction } from './corrections';
+
+// Fixtures sintéticas con la forma relevada, nunca el texto de las obras: un spec anclado en prosa de
+// producción quedaría atado a un texto que esta misma migración modifica.
+const ANCHOR = '**UN AVISO**';
+
+const quoteCorrection: Correction = {
+	id: 'aviso',
+	kind: CORRECTION_KINDS.quoteRuledBlock,
+	anchor: ANCHOR,
+};
+
+const literalCorrection: Correction = {
+	id: 'firma',
+	kind: CORRECTION_KINDS.replaceLiteral,
+	search: 'Un beso de tu\n\nJosé',
+	replacement: 'Un beso de tu\n\n*José*',
+};
+
+const framedBody = [
+	'Tomó el papel y leyó:',
+	'',
+	'---',
+	'',
+	ANCHOR,
+	'',
+	'El cuerpo del aviso.',
+	'',
+	'---',
+	'',
+	'—¿Qué significa esto?',
+].join('\n');
+
+describe('applyCorrection — replace-literal', () => {
+	it('applies the replacement and leaves the rest of the body untouched', () => {
+		const body = `Antes.\n\nUn beso de tu\n\nJosé\n\nDespués.`;
+
+		const result = applyCorrection(body, literalCorrection);
+
+		expect(result.status).toBe(CORRECTION_STATUSES.applied);
+		expect(result.body).toBe(`Antes.\n\nUn beso de tu\n\n*José*\n\nDespués.`);
+	});
+
+	it('reports an already corrected body without changing it', () => {
+		const body = `Un beso de tu\n\n*José*`;
+
+		const result = applyCorrection(body, literalCorrection);
+
+		expect(result.status).toBe(CORRECTION_STATUSES.already);
+		expect(result.body).toBe(body);
+	});
+
+	// Ausente no lanza: la corrección puede vivir en otra sección del mismo documento.
+	it('reports absence instead of throwing', () => {
+		const result = applyCorrection('Un cuerpo sin nada de esto.', literalCorrection);
+
+		expect(result.status).toBe(CORRECTION_STATUSES.absent);
+	});
+
+	it('throws when the searched text appears more than once', () => {
+		const body = `Un beso de tu\n\nJosé\n\nY otra vez: Un beso de tu\n\nJosé`;
+
+		expect(() => applyCorrection(body, literalCorrection)).toThrow(UncorrectableLiteraryWorkError);
+	});
+});
+
+describe('applyCorrection — quote-ruled-block', () => {
+	it('turns the framed block into a quote and drops its rules', () => {
+		const result = applyCorrection(framedBody, quoteCorrection);
+
+		expect(result.status).toBe(CORRECTION_STATUSES.applied);
+		expect(result.body).toBe(
+			['Tomó el papel y leyó:', '', `> ${ANCHOR}`, '>', '> El cuerpo del aviso.', '', '—¿Qué significa esto?'].join(
+				'\n',
+			),
+		);
+	});
+
+	// El caso central: el cuerpo de una obra tiene separadores de escena que son la misma construcción
+	// que el marco del aviso. Solo se consumen los dos contiguos al ancla.
+	it('leaves the other rules of the body untouched', () => {
+		const body = ['Primera escena.', '', '---', '', framedBody, '', '---', '', 'Última escena.'].join('\n');
+
+		const result = applyCorrection(body, quoteCorrection);
+
+		expect(result.body.startsWith('Primera escena.\n\n---\n\n')).toBe(true);
+		expect(result.body.endsWith('\n\n---\n\nÚltima escena.')).toBe(true);
+		expect(result.body).toContain(`> ${ANCHOR}`);
+	});
+
+	it('preserves the quoted text verbatim, escapes included', () => {
+		const body = ['Leyó:', '', '---', '', ANCHOR, '', 'Un 50\\% y un \\*asterisco\\*.', '', '---', '', 'Fin.'].join(
+			'\n',
+		);
+
+		const result = applyCorrection(body, quoteCorrection);
+
+		expect(result.body).toContain('> Un 50\\% y un \\*asterisco\\*.');
+	});
+
+	it('reports an already quoted block without changing it', () => {
+		const quoted = applyCorrection(framedBody, quoteCorrection).body;
+
+		const result = applyCorrection(quoted, quoteCorrection);
+
+		expect(result.status).toBe(CORRECTION_STATUSES.already);
+		expect(result.body).toBe(quoted);
+	});
+
+	it('reports absence when the anchor is nowhere', () => {
+		const result = applyCorrection('Un cuerpo sin ancla.', quoteCorrection);
+
+		expect(result.status).toBe(CORRECTION_STATUSES.absent);
+	});
+
+	// El ancla presente sin su marco es una inconsistencia del documento, no una ausencia: ninguna otra
+	// sección puede desmentirla, así que lanza.
+	it('throws when the opening rule is missing', () => {
+		const body = ['Leyó:', '', ANCHOR, '', 'El cuerpo del aviso.', '', '---', '', 'Fin.'].join('\n');
+
+		expect(() => applyCorrection(body, quoteCorrection)).toThrow(UncorrectableLiteraryWorkError);
+	});
+
+	it('throws when the closing rule is missing', () => {
+		const body = ['Leyó:', '', '---', '', ANCHOR, '', 'El cuerpo del aviso.'].join('\n');
+
+		expect(() => applyCorrection(body, quoteCorrection)).toThrow(UncorrectableLiteraryWorkError);
+	});
+
+	it('throws when the anchor appears twice', () => {
+		const body = [framedBody, '', framedBody].join('\n');
+
+		expect(() => applyCorrection(body, quoteCorrection)).toThrow(UncorrectableLiteraryWorkError);
+	});
+});
+
+describe('UncorrectableLiteraryWorkError', () => {
+	it('names the correction that could not be applied', () => {
+		const body = ['Leyó:', '', ANCHOR, '', 'El cuerpo.'].join('\n');
+
+		expect(() => applyCorrection(body, quoteCorrection)).toThrow(/aviso/);
+	});
+});
+
+describe('applySectionCorrections', () => {
+	it('folds every correction over the body and reports each status', () => {
+		const body = [framedBody, '', 'Un beso de tu', '', 'José'].join('\n');
+
+		const result = applySectionCorrections(body, [quoteCorrection, literalCorrection]);
+
+		expect(result.statuses).toEqual({ aviso: CORRECTION_STATUSES.applied, firma: CORRECTION_STATUSES.applied });
+		expect(result.body).toContain(`> ${ANCHOR}`);
+		expect(result.body).toContain('*José*');
+	});
+
+	it('is idempotent: a second fold reports every correction as already applied', () => {
+		const body = [framedBody, '', 'Un beso de tu', '', 'José'].join('\n');
+		const once = applySectionCorrections(body, [quoteCorrection, literalCorrection]).body;
+
+		const twice = applySectionCorrections(once, [quoteCorrection, literalCorrection]);
+
+		expect(twice.statuses).toEqual({ aviso: CORRECTION_STATUSES.already, firma: CORRECTION_STATUSES.already });
+		expect(twice.body).toBe(once);
+	});
+});

--- a/cms/migrations/restore-centered-block-semantics/apply-corrections.ts
+++ b/cms/migrations/restore-centered-block-semantics/apply-corrections.ts
@@ -33,19 +33,24 @@ export interface SectionCorrectionsResult {
 	statuses: Readonly<Record<string, CorrectionStatus>>;
 }
 
-const RULE_BLOCK = '\n\n---\n\n';
 const QUOTE_PREFIX = '> ';
 
 /** Se lanza ante un cuerpo del que no se puede derivar la corrección. Detiene la corrida. */
 export class UncorrectableLiteraryWorkError extends Error {
-	constructor(message: string, correctionId: string) {
-		super(`${message} (corrección "${correctionId}")`);
+	constructor(message: string, correctionId?: string) {
+		super(correctionId ? `${message} (corrección "${correctionId}")` : message);
 		this.name = 'UncorrectableLiteraryWorkError';
 	}
 }
 
+// Avanza de a un carácter y no por `split`, que cuenta 1 ante dos ocurrencias solapadas: dos líneas
+// ancla consecutivas comparten el salto que las separa, y ésa es justamente la ambigüedad a detectar.
 function countOccurrences(haystack: string, needle: string): number {
-	return haystack.split(needle).length - 1;
+	let count = 0;
+	for (let at = haystack.indexOf(needle); at !== -1; at = haystack.indexOf(needle, at + 1)) {
+		count += 1;
+	}
+	return count;
 }
 
 /** Cita un tramo preservándolo verbatim: sin reflow ni reescapes, que reescribirían la obra. */
@@ -57,6 +62,16 @@ function quote(text: string): string {
 }
 
 function applyReplaceLiteral(body: string, search: string, replacement: string, id: string): CorrectionResult {
+	// Un reemplazo que contiene al buscado vuelve a coincidir en la segunda corrida, así que se
+	// aplicaría de nuevo y la idempotencia dejaría de valer. Es un error de la tabla, no del documento,
+	// y conviene que salte en el ensayo y no cuando alguien lea el contador.
+	if (replacement.includes(search)) {
+		throw new UncorrectableLiteraryWorkError(
+			'El texto de reemplazo contiene al buscado, así que no sería idempotente',
+			id,
+		);
+	}
+
 	const found = countOccurrences(body, search);
 	if (found > 1) {
 		throw new UncorrectableLiteraryWorkError(`El texto buscado aparece ${found} veces`, id);
@@ -80,7 +95,13 @@ function applyReplaceLiteral(body: string, search: string, replacement: string, 
  * son la misma construcción y no deben tocarse.
  */
 function applyQuoteRuledBlock(body: string, anchor: string, id: string): CorrectionResult {
-	const bare = countOccurrences(body, `\n${anchor}\n`);
+	const RULE_BLOCK = '\n\n---\n\n';
+	// El ancla se busca como **línea completa**, no como subcadena: si el mismo texto aparece embebido
+	// en un párrafo, tomarlo por posición citaría ese párrafo y borraría los cortes de escena que lo
+	// rodean, dejando intacto el pasaje que había que corregir. Por eso se cuenta y se localiza con el
+	// mismo patrón.
+	const anchorLine = `\n${anchor}\n`;
+	const bare = countOccurrences(body, anchorLine);
 	const quoted = countOccurrences(body, `\n${QUOTE_PREFIX}${anchor}\n`);
 	if (bare + quoted > 1) {
 		throw new UncorrectableLiteraryWorkError(`El ancla aparece ${bare + quoted} veces`, id);
@@ -94,7 +115,7 @@ function applyQuoteRuledBlock(body: string, anchor: string, id: string): Correct
 
 	// El ancla está pero el marco no: es una inconsistencia del documento, no una ausencia. Lanza acá
 	// porque ninguna otra sección puede desmentirla.
-	const anchorAt = body.indexOf(anchor);
+	const anchorAt = body.indexOf(anchorLine) + 1;
 	const openingAt = body.lastIndexOf(RULE_BLOCK, anchorAt);
 	const closingAt = body.indexOf(RULE_BLOCK, anchorAt);
 	if (openingAt === -1 || closingAt === -1) {

--- a/cms/migrations/restore-centered-block-semantics/apply-corrections.ts
+++ b/cms/migrations/restore-centered-block-semantics/apply-corrections.ts
@@ -1,0 +1,127 @@
+/**
+ * Motor puro de la migración: aplica una corrección editorial al cuerpo Markdown de una sección.
+ *
+ * Sin I/O ni cliente de Sanity, para poder testearlo sin red ni credenciales. La migración le delega
+ * la transformación y se queda con la mutación.
+ *
+ * Distingue **tres** resultados, y esa distinción es el punto: la idempotencia exige que una segunda
+ * corrida no vuelva a tocar nada, y el fail-fast exige que un texto que ya no coincide detenga la
+ * corrida. Confundir "ya está aplicada" con "no la encuentro" haría que una edición hecha en el
+ * Studio entre el relevamiento y la corrida pasara inadvertida.
+ *
+ * Que no aparezca no se decide acá: una corrección vive en una sola sección, así que ausente en ésta
+ * puede ser presente en la siguiente. Quien tiene el documento entero a la vista es quien puede
+ * concluir que falta, y por eso `absent` se devuelve en vez de lanzarse.
+ */
+import { CORRECTION_KINDS, type Correction } from './corrections';
+
+export const CORRECTION_STATUSES = Object.freeze({
+	applied: 'applied',
+	already: 'already',
+	absent: 'absent',
+} as const);
+
+export type CorrectionStatus = (typeof CORRECTION_STATUSES)[keyof typeof CORRECTION_STATUSES];
+
+export interface CorrectionResult {
+	status: CorrectionStatus;
+	body: string;
+}
+
+export interface SectionCorrectionsResult {
+	body: string;
+	statuses: Readonly<Record<string, CorrectionStatus>>;
+}
+
+const RULE_BLOCK = '\n\n---\n\n';
+const QUOTE_PREFIX = '> ';
+
+/** Se lanza ante un cuerpo del que no se puede derivar la corrección. Detiene la corrida. */
+export class UncorrectableLiteraryWorkError extends Error {
+	constructor(message: string, correctionId: string) {
+		super(`${message} (corrección "${correctionId}")`);
+		this.name = 'UncorrectableLiteraryWorkError';
+	}
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+	return haystack.split(needle).length - 1;
+}
+
+/** Cita un tramo preservándolo verbatim: sin reflow ni reescapes, que reescribirían la obra. */
+function quote(text: string): string {
+	return text
+		.split('\n')
+		.map((line) => (line === '' ? '>' : `${QUOTE_PREFIX}${line}`))
+		.join('\n');
+}
+
+function applyReplaceLiteral(body: string, search: string, replacement: string, id: string): CorrectionResult {
+	const found = countOccurrences(body, search);
+	if (found > 1) {
+		throw new UncorrectableLiteraryWorkError(`El texto buscado aparece ${found} veces`, id);
+	}
+	if (found === 1) {
+		return { status: CORRECTION_STATUSES.applied, body: body.replace(search, replacement) };
+	}
+
+	const alreadyThere = countOccurrences(body, replacement);
+	if (alreadyThere > 1) {
+		throw new UncorrectableLiteraryWorkError(`El texto ya corregido aparece ${alreadyThere} veces`, id);
+	}
+	return alreadyThere === 1
+		? { status: CORRECTION_STATUSES.already, body }
+		: { status: CORRECTION_STATUSES.absent, body };
+}
+
+/**
+ * Reemplaza el tramo entre las dos reglas **contiguas al ancla** por ese mismo tramo citado. Mirar
+ * solo esas dos es lo que deja intactos los separadores de escena reales del resto del cuerpo, que
+ * son la misma construcción y no deben tocarse.
+ */
+function applyQuoteRuledBlock(body: string, anchor: string, id: string): CorrectionResult {
+	const bare = countOccurrences(body, `\n${anchor}\n`);
+	const quoted = countOccurrences(body, `\n${QUOTE_PREFIX}${anchor}\n`);
+	if (bare + quoted > 1) {
+		throw new UncorrectableLiteraryWorkError(`El ancla aparece ${bare + quoted} veces`, id);
+	}
+	if (quoted === 1) {
+		return { status: CORRECTION_STATUSES.already, body };
+	}
+	if (bare === 0) {
+		return { status: CORRECTION_STATUSES.absent, body };
+	}
+
+	// El ancla está pero el marco no: es una inconsistencia del documento, no una ausencia. Lanza acá
+	// porque ninguna otra sección puede desmentirla.
+	const anchorAt = body.indexOf(anchor);
+	const openingAt = body.lastIndexOf(RULE_BLOCK, anchorAt);
+	const closingAt = body.indexOf(RULE_BLOCK, anchorAt);
+	if (openingAt === -1 || closingAt === -1) {
+		throw new UncorrectableLiteraryWorkError('El ancla no está enmarcada por dos reglas horizontales', id);
+	}
+
+	const inner = body.slice(openingAt + RULE_BLOCK.length, closingAt);
+	const head = body.slice(0, openingAt);
+	const tail = body.slice(closingAt + RULE_BLOCK.length);
+	return { status: CORRECTION_STATUSES.applied, body: `${head}\n\n${quote(inner)}\n\n${tail}` };
+}
+
+export function applyCorrection(body: string, correction: Correction): CorrectionResult {
+	if (correction.kind === CORRECTION_KINDS.replaceLiteral) {
+		return applyReplaceLiteral(body, correction.search, correction.replacement, correction.id);
+	}
+	return applyQuoteRuledBlock(body, correction.anchor, correction.id);
+}
+
+/** Pliega las correcciones sobre un cuerpo, devolviendo el resultado y el estado de cada una. */
+export function applySectionCorrections(body: string, corrections: readonly Correction[]): SectionCorrectionsResult {
+	const statuses: Record<string, CorrectionStatus> = {};
+	const corrected = corrections.reduce((current, correction) => {
+		const result = applyCorrection(current, correction);
+		statuses[correction.id] = result.status;
+		return result.body;
+	}, body);
+
+	return { body: corrected, statuses };
+}

--- a/cms/migrations/restore-centered-block-semantics/corrections.ts
+++ b/cms/migrations/restore-centered-block-semantics/corrections.ts
@@ -23,6 +23,11 @@ export const CORRECTION_KINDS = Object.freeze({
 export type CorrectionKind = (typeof CORRECTION_KINDS)[keyof typeof CORRECTION_KINDS];
 
 interface QuoteRuledBlockCorrection {
+	/**
+	 * Clave de resolución, no solo texto para el mensaje de error: es con lo que la migración lleva la
+	 * cuenta de qué correcciones encontró. Dos iguales en un mismo documento colapsan, y una que no se
+	 * aplicó pasaría por aplicada. Un caso del spec fija la unicidad.
+	 */
 	id: string;
 	kind: typeof CORRECTION_KINDS.quoteRuledBlock;
 	/**
@@ -34,9 +39,16 @@ interface QuoteRuledBlockCorrection {
 }
 
 interface ReplaceLiteralCorrection {
+	/** Misma condición que arriba: es clave de resolución. */
 	id: string;
 	kind: typeof CORRECTION_KINDS.replaceLiteral;
+	/**
+	 * Se busca por subcadena, sin noción de palabra: un texto que sea prefijo de otro más largo
+	 * coincide dentro de él. Toda entrada nueva tiene que terminar en un límite de línea o de fin de
+	 * cuerpo, o incluir suficiente contexto como para no ser ambigua.
+	 */
 	search: string;
+	/** No puede contener a `search`: volvería a coincidir en la segunda corrida y no sería idempotente. */
 	replacement: string;
 }
 

--- a/cms/migrations/restore-centered-block-semantics/corrections.ts
+++ b/cms/migrations/restore-centered-block-semantics/corrections.ts
@@ -1,0 +1,80 @@
+/**
+ * Dato editorial de la migración: qué pasaje de qué obra se reexpresa y en qué.
+ *
+ * Vive separado del motor porque se revisa distinto. El motor se lee buscando errores de lógica; esta
+ * tabla se lee carácter por carácter contra el documento real, que es donde una diferencia mínima
+ * —una tilde, un espacio— pasa desapercibida y convierte la corrección en un aborto de la corrida.
+ *
+ * Se indexa por `_id` publicado. El `_id` es inmutable; el slug lo edita cualquiera desde el Studio,
+ * y un slug reusado apuntaría a otra obra.
+ */
+
+export const CORRECTION_KINDS = Object.freeze({
+	/**
+	 * Un bloque enmarcado por dos reglas horizontales que pasa a ser cita. En el original el marco eran
+	 * filas de asteriscos centradas —el borde del aviso impreso, no un corte de escena—, así que la
+	 * cita lo reemplaza en vez de sumarse a él.
+	 */
+	quoteRuledBlock: 'quote-ruled-block',
+	/** Par literal buscar/reemplazar, para pasajes lo bastante cortos como para transcribirlos. */
+	replaceLiteral: 'replace-literal',
+} as const);
+
+export type CorrectionKind = (typeof CORRECTION_KINDS)[keyof typeof CORRECTION_KINDS];
+
+interface QuoteRuledBlockCorrection {
+	id: string;
+	kind: typeof CORRECTION_KINDS.quoteRuledBlock;
+	/**
+	 * La línea que abre el bloque. El cuerpo del aviso **no** se transcribe: el motor lo toma verbatim
+	 * del propio documento, porque son cientos de caracteres de prosa y copiarlos sería reescribir la
+	 * obra desde un archivo de configuración.
+	 */
+	anchor: string;
+}
+
+interface ReplaceLiteralCorrection {
+	id: string;
+	kind: typeof CORRECTION_KINDS.replaceLiteral;
+	search: string;
+	replacement: string;
+}
+
+export type Correction = QuoteRuledBlockCorrection | ReplaceLiteralCorrection;
+
+export const CORRECTIONS_BY_DOCUMENT_ID: Readonly<Record<string, readonly Correction[]>> = Object.freeze({
+	// La liga de los pelirrojos — los dos carteles que el relato cita como impresos.
+	'lw-from-story-bd3bbc87-71bd-4374-9cf8-417e915669c7': Object.freeze([
+		Object.freeze({
+			id: 'cartel-apertura',
+			kind: CORRECTION_KINDS.quoteRuledBlock,
+			anchor: '**A LA LIGA DE LOS PELIRROJOS**',
+		}),
+		Object.freeze({
+			id: 'cartel-disolucion',
+			kind: CORRECTION_KINDS.quoteRuledBlock,
+			anchor: '**LA LIGA DE LOS PELIRROJOS HA SIDO DISUELTA**',
+		}),
+	]),
+	// Carta a Chichita — la firma, que el original centraba al pie de la carta.
+	'lw-from-story-e1138575-5c25-41c4-9bd2-4793642ceb62': Object.freeze([
+		Object.freeze({
+			id: 'firma',
+			kind: CORRECTION_KINDS.replaceLiteral,
+			search: 'Un beso de tu\n\nJosé',
+			replacement: 'Un beso de tu\n\n*José*',
+		}),
+	]),
+	// Amor a lo lejos — el encabezado de parte quedó pegado al texto que lo sigue, así que renderiza
+	// corrido, a diferencia de las tres partes anteriores.
+	'lw-from-story-666dac9b-9086-4db9-a17c-d38f6f09532c': Object.freeze([
+		Object.freeze({
+			id: 'parte-final',
+			kind: CORRECTION_KINDS.replaceLiteral,
+			search: '**Parte final**Abrí',
+			replacement: '**Parte final**\n\nAbrí',
+		}),
+	]),
+});
+
+export const TARGET_DOCUMENT_IDS: readonly string[] = Object.freeze(Object.keys(CORRECTIONS_BY_DOCUMENT_ID));

--- a/cms/migrations/restore-centered-block-semantics/index.spec.ts
+++ b/cms/migrations/restore-centered-block-semantics/index.spec.ts
@@ -1,0 +1,167 @@
+import { evaluate, parse } from 'groq-js';
+import { describe, expect, it } from 'vitest';
+
+import { UncorrectableLiteraryWorkError } from './apply-corrections';
+import migration from './index';
+
+interface LiteraryWorkDocument {
+	_id: string;
+	content?: { _key?: string; body?: unknown }[];
+}
+
+interface BodyPatch {
+	op: { type: string; value: string };
+	path: (string | { _key: string })[];
+}
+
+// `defineMigration` conserva el objeto tal cual, así que `migrate.document` es una función pura y es
+// lo único que hace falta ejercitar: decide qué patches emite cada obra.
+const migrateDocument = (doc: LiteraryWorkDocument) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never) as unknown as BodyPatch[];
+};
+
+const LIGA_ID = 'lw-from-story-bd3bbc87-71bd-4374-9cf8-417e915669c7';
+const CARTA_ID = 'lw-from-story-e1138575-5c25-41c4-9bd2-4793642ceb62';
+const AMOR_ID = 'lw-from-story-666dac9b-9086-4db9-a17c-d38f6f09532c';
+const SOMBRAS_ID = 'lw-from-story-187a0eab-11ce-4b91-96c2-b2403d35cc05';
+
+const work = (id: string, body: string): LiteraryWorkDocument => ({
+	_id: id,
+	content: [{ _key: 'section-0', body }],
+});
+
+const bodyOf = (patches: BodyPatch[]) => patches[0].op.value;
+
+// Los cuerpos reproducen la FORMA relevada —marco, ancla, separadores de escena vecinos— con prosa de
+// relleno. No se copia el texto de las obras: ataría el spec a un texto que esta migración modifica.
+const ligaBody = [
+	'Primera escena.',
+	'',
+	'---',
+	'',
+	'Tomé el periódico de sus manos y leí:',
+	'',
+	'---',
+	'',
+	'**A LA LIGA DE LOS PELIRROJOS**',
+	'',
+	'El cuerpo del primer aviso.',
+	'',
+	'---',
+	'',
+	'En ella se leía esto:',
+	'',
+	'---',
+	'',
+	'**LA LIGA DE LOS PELIRROJOS HA SIDO DISUELTA**',
+	'',
+	'**9 de octubre de 1890**',
+	'',
+	'---',
+	'',
+	'Examinamos el anuncio.',
+	'',
+	'---',
+	'',
+	'Última escena.',
+].join('\n');
+
+const cartaBody = 'Cuerpo de la carta.\n\nUn beso de tu\n\nJosé';
+const amorBody = '**Parte I**\n\nPrimera parte.\n\n**Parte final**Abrí los ojos.\n\nSigue el desenlace.';
+
+describe('migración de los pasajes centrados a Markdown semántico', () => {
+	it('alcanza solo a las obras', () => {
+		expect(migration.documentTypes).toEqual(['literaryWork']);
+	});
+
+	// El filtro se ejecuta con el mismo motor que GROQ, no se compara como texto: una aserción textual
+	// pasa igual con un filtro roto mientras el literal coincida.
+	describe('el filtro decide qué entra', () => {
+		const matching = async (...docs: Record<string, unknown>[]) => {
+			const result = await evaluate(parse(`*[${migration.filter}]._id`), { dataset: docs });
+			return (await result.get()) as string[];
+		};
+
+		it('admite las tres obras a corregir y sus borradores', async () => {
+			const ids = await matching(
+				{ _id: LIGA_ID },
+				{ _id: CARTA_ID },
+				{ _id: AMOR_ID },
+				{ _id: `drafts.${LIGA_ID}` },
+				{ _id: `drafts.${CARTA_ID}` },
+				{ _id: `drafts.${AMOR_ID}` },
+			);
+
+			expect(ids).toHaveLength(6);
+		});
+
+		it('deja fuera la obra que se decidió no tocar y cualquier otra', async () => {
+			const ids = await matching({ _id: SOMBRAS_ID }, { _id: `drafts.${SOMBRAS_ID}` }, { _id: 'lw-cualquiera' });
+
+			expect(ids).toEqual([]);
+		});
+	});
+
+	it('no muta una obra fuera de la tabla', () => {
+		expect(migrateDocument(work('lw-cualquiera', 'Prosa.'))).toEqual([]);
+	});
+
+	// El patch se ancla por `_key` y no por índice: un índice se corre si alguien reordena las secciones
+	// entre el dry-run y la corrida real.
+	it('ancla el patch en la _key de la sección', () => {
+		const [patch] = migrateDocument(work(CARTA_ID, cartaBody));
+
+		expect(patch.path).toEqual(['content', { _key: 'section-0' }, 'body']);
+	});
+
+	it('cita los dos avisos y deja intactos los separadores de escena', () => {
+		const corrected = bodyOf(migrateDocument(work(LIGA_ID, ligaBody)));
+
+		expect(corrected).toContain('> **A LA LIGA DE LOS PELIRROJOS**');
+		expect(corrected).toContain('> **LA LIGA DE LOS PELIRROJOS HA SIDO DISUELTA**');
+		expect(corrected).toContain('>\n> **9 de octubre de 1890**');
+		expect(corrected.startsWith('Primera escena.\n\n---\n\n')).toBe(true);
+		expect(corrected.endsWith('\n\n---\n\nÚltima escena.')).toBe(true);
+	});
+
+	it('pone la firma en énfasis al cierre de la carta', () => {
+		const corrected = bodyOf(migrateDocument(work(CARTA_ID, cartaBody)));
+
+		expect(corrected.endsWith('Un beso de tu\n\n*José*')).toBe(true);
+	});
+
+	it('separa el encabezado de parte del texto que lo sigue, sin tocar los anteriores', () => {
+		const corrected = bodyOf(migrateDocument(work(AMOR_ID, amorBody)));
+
+		expect(corrected).toContain('**Parte final**\n\nAbrí los ojos.');
+		expect(corrected).toContain('**Parte I**\n\nPrimera parte.');
+	});
+
+	it('corrige el borrador igual que su publicado', () => {
+		const corrected = bodyOf(migrateDocument(work(`drafts.${CARTA_ID}`, cartaBody)));
+
+		expect(corrected.endsWith('*José*')).toBe(true);
+	});
+
+	// La idempotencia es observable en el contador de la CLI porque la migración emite patches: una
+	// segunda corrida sobre el resultado no emite ninguna mutación.
+	it('no emite mutación alguna sobre una obra ya corregida', () => {
+		const corrected = bodyOf(migrateDocument(work(LIGA_ID, ligaBody)));
+
+		expect(migrateDocument(work(LIGA_ID, corrected))).toEqual([]);
+	});
+
+	it('aborta cuando el pasaje ya no está en el documento', () => {
+		expect(() => migrateDocument(work(CARTA_ID, 'Una carta que alguien reescribió.'))).toThrow(
+			UncorrectableLiteraryWorkError,
+		);
+	});
+
+	it('aborta cuando una sección no tiene _key, porque el patch no podría anclarse', () => {
+		expect(() => migrateDocument({ _id: CARTA_ID, content: [{ body: cartaBody }] })).toThrow(
+			UncorrectableLiteraryWorkError,
+		);
+	});
+});

--- a/cms/migrations/restore-centered-block-semantics/index.spec.ts
+++ b/cms/migrations/restore-centered-block-semantics/index.spec.ts
@@ -2,6 +2,7 @@ import { evaluate, parse } from 'groq-js';
 import { describe, expect, it } from 'vitest';
 
 import { UncorrectableLiteraryWorkError } from './apply-corrections';
+import { CORRECTIONS_BY_DOCUMENT_ID } from './corrections';
 import migration from './index';
 
 interface LiteraryWorkDocument {
@@ -85,16 +86,11 @@ describe('migración de los pasajes centrados a Markdown semántico', () => {
 		};
 
 		it('admite las tres obras a corregir y sus borradores', async () => {
-			const ids = await matching(
-				{ _id: LIGA_ID },
-				{ _id: CARTA_ID },
-				{ _id: AMOR_ID },
-				{ _id: `drafts.${LIGA_ID}` },
-				{ _id: `drafts.${CARTA_ID}` },
-				{ _id: `drafts.${AMOR_ID}` },
-			);
+			const expected = [LIGA_ID, CARTA_ID, AMOR_ID].flatMap((id) => [id, `drafts.${id}`]);
 
-			expect(ids).toHaveLength(6);
+			const ids = await matching(...expected.map((_id) => ({ _id })), { _id: 'lw-ajena' });
+
+			expect([...ids].sort()).toEqual([...expected].sort());
 		});
 
 		it('deja fuera la obra que se decidió no tocar y cualquier otra', async () => {
@@ -153,6 +149,30 @@ describe('migración de los pasajes centrados a Markdown semántico', () => {
 		expect(migrateDocument(work(LIGA_ID, corrected))).toEqual([]);
 	});
 
+	// La corrección vive en una sola sección, y por eso el motor no puede concluir que falta: ausente
+	// en la primera puede ser presente en la segunda. Sin este caso, evaluar la comprobación por
+	// sección en vez de por documento dejaría el resto del spec en verde.
+	it('encuentra la corrección en cualquiera de las secciones y parcha solo la que cambió', () => {
+		const patches = migrateDocument({
+			_id: CARTA_ID,
+			content: [
+				{ _key: 'section-0', body: 'Un prólogo sin firma.' },
+				{ _key: 'section-1', body: cartaBody },
+			],
+		});
+
+		expect(patches).toHaveLength(1);
+		expect(patches[0].path).toEqual(['content', { _key: 'section-1' }, 'body']);
+	});
+
+	// Resolución parcial: una corrección aplicada no habilita a la otra. Sin este caso, el filtro sobre
+	// varias correcciones nunca se ejercita, porque las demás obras tienen una sola.
+	it('aborta cuando solo uno de los dos avisos está presente, sin emitir el patch del otro', () => {
+		const soloApertura = ligaBody.split('En ella se leía esto:')[0];
+
+		expect(() => migrateDocument(work(LIGA_ID, soloApertura))).toThrow(/cartel-disolucion/);
+	});
+
 	it('aborta cuando el pasaje ya no está en el documento', () => {
 		expect(() => migrateDocument(work(CARTA_ID, 'Una carta que alguien reescribió.'))).toThrow(
 			UncorrectableLiteraryWorkError,
@@ -163,5 +183,34 @@ describe('migración de los pasajes centrados a Markdown semántico', () => {
 		expect(() => migrateDocument({ _id: CARTA_ID, content: [{ body: cartaBody }] })).toThrow(
 			UncorrectableLiteraryWorkError,
 		);
+	});
+
+	// Saltear un cuerpo con otra forma haría que el síntoma llegara como "el documento no contiene el
+	// pasaje", que apunta al lugar equivocado.
+	it('aborta cuando el cuerpo de una sección no es texto', () => {
+		expect(() =>
+			migrateDocument({ _id: CARTA_ID, content: [{ _key: 'section-0', body: [{ _type: 'block' }] }] }),
+		).toThrow(/no es texto/);
+	});
+});
+
+// La tabla es dato transcripto de documentos reales: un identificador con un typo no lo delata ningún
+// guard —el filtro no matchea, la migración no corre, y la corrida reporta cero mutaciones, que es
+// indistinguible de una segunda corrida idempotente—.
+describe('la tabla de correcciones', () => {
+	it('apunta a las tres obras relevadas, con la cantidad de correcciones de cada una', () => {
+		expect(
+			Object.fromEntries(
+				Object.entries(CORRECTIONS_BY_DOCUMENT_ID).map(([id, corrections]) => [id, corrections.length]),
+			),
+		).toEqual({ [LIGA_ID]: 2, [CARTA_ID]: 1, [AMOR_ID]: 1 });
+	});
+
+	// El identificador es la clave con la que la migración lleva la cuenta de qué encontró: dos iguales
+	// colapsan y una corrección no aplicada pasaría por aplicada.
+	it('no repite identificadores dentro de un mismo documento', () => {
+		Object.values(CORRECTIONS_BY_DOCUMENT_ID).forEach((corrections) => {
+			expect(new Set(corrections.map(({ id }) => id)).size).toBe(corrections.length);
+		});
 	});
 });

--- a/cms/migrations/restore-centered-block-semantics/index.ts
+++ b/cms/migrations/restore-centered-block-semantics/index.ts
@@ -9,6 +9,8 @@ const DRAFTS_PATH_PREFIX = 'drafts.';
 // lo que la migración recibe es el documento crudo tal como Sanity lo devuelve.
 interface LiteraryWorkDocument {
 	_id: string;
+	// `body` va como `unknown` a propósito: el documento llega crudo del content lake, no tipado por el
+	// typegen, y que su forma sea la esperada es justamente lo que la migración comprueba.
 	content?: { _key?: string; body?: unknown }[];
 }
 
@@ -25,14 +27,13 @@ function assertEveryCorrectionResolved(
 	resolved: ReadonlySet<string>,
 	documentId: string,
 ): void {
-	corrections
-		.filter((correction) => !resolved.has(correction.id))
-		.forEach((correction) => {
-			throw new UncorrectableLiteraryWorkError(
-				`El documento "${documentId}" no contiene el pasaje a corregir en ninguna de sus secciones`,
-				correction.id,
-			);
-		});
+	const missing = corrections.find((correction) => !resolved.has(correction.id));
+	if (missing) {
+		throw new UncorrectableLiteraryWorkError(
+			`El documento "${documentId}" no contiene el pasaje a corregir en ninguna de sus secciones`,
+			missing.id,
+		);
+	}
 }
 
 /**
@@ -72,10 +73,16 @@ export default defineMigration({
 				if (!section._key) {
 					throw new UncorrectableLiteraryWorkError(
 						`Una sección de "${doc._id}" no tiene _key, así que el patch no puede anclarse`,
-						'—',
 					);
 				}
-				const body = typeof section.body === 'string' ? section.body : '';
+				// Un cuerpo con otra forma no se saltea: el síntoma llegaría como "el documento no
+				// contiene el pasaje", que apunta al lugar equivocado. Ausente sí es legítimo.
+				if (section.body !== undefined && typeof section.body !== 'string') {
+					throw new UncorrectableLiteraryWorkError(
+						`La sección "${section._key}" de "${doc._id}" tiene un cuerpo que no es texto`,
+					);
+				}
+				const body = section.body ?? '';
 				const { body: corrected, statuses } = applySectionCorrections(body, corrections);
 
 				Object.entries(statuses)

--- a/cms/migrations/restore-centered-block-semantics/index.ts
+++ b/cms/migrations/restore-centered-block-semantics/index.ts
@@ -1,0 +1,92 @@
+import { at, defineMigration, set } from 'sanity/migrate';
+
+import { applySectionCorrections, CORRECTION_STATUSES, UncorrectableLiteraryWorkError } from './apply-corrections';
+import { CORRECTIONS_BY_DOCUMENT_ID, TARGET_DOCUMENT_IDS, type Correction } from './corrections';
+
+const DRAFTS_PATH_PREFIX = 'drafts.';
+
+// El shape mínimo que la migración lee. No se importan los tipos del typegen: describen el schema, y
+// lo que la migración recibe es el documento crudo tal como Sanity lo devuelve.
+interface LiteraryWorkDocument {
+	_id: string;
+	content?: { _key?: string; body?: unknown }[];
+}
+
+function publishedIdOf(id: string): string {
+	return id.startsWith(DRAFTS_PATH_PREFIX) ? id.slice(DRAFTS_PATH_PREFIX.length) : id;
+}
+
+/**
+ * Comprueba, con el documento entero a la vista, que ninguna corrección haya quedado sin encontrar.
+ * El motor no puede concluirlo: ve una sección por vez, y ausente en una puede ser presente en otra.
+ */
+function assertEveryCorrectionResolved(
+	corrections: readonly Correction[],
+	resolved: ReadonlySet<string>,
+	documentId: string,
+): void {
+	corrections
+		.filter((correction) => !resolved.has(correction.id))
+		.forEach((correction) => {
+			throw new UncorrectableLiteraryWorkError(
+				`El documento "${documentId}" no contiene el pasaje a corregir en ninguna de sus secciones`,
+				correction.id,
+			);
+		});
+}
+
+/**
+ * Reexpresa en Markdown semántico los pasajes de tres obras donde el Portable Text original usaba
+ * alineación centrada para cargar significado: dos avisos impresos que pasan a ser cita, una firma
+ * que pasa a énfasis y un encabezado de parte que había quedado pegado al texto que lo sigue.
+ *
+ * **Orden de despliegue: independiente del código.** No cambia el nombre ni la forma de ningún campo
+ * —el cuerpo sigue siendo Markdown antes y después— y el pipeline ya renderiza cita, énfasis y
+ * párrafos. Puede correr en cualquier momento respecto de un despliegue.
+ *
+ * **Las reglas que enmarcan los avisos no son separadores de escena.** En el original eran filas de
+ * asteriscos centradas, o sea el borde del papel impreso, y por eso la cita las reemplaza en vez de
+ * sumarse a ellas. Los separadores de escena reales del mismo cuerpo son la misma construcción y no
+ * se tocan: el motor solo consume las dos reglas contiguas al ancla.
+ *
+ * **Aborta ante un cuerpo que ya no coincide con el relevamiento**, en vez de pasar de largo. Una
+ * edición hecha en el Studio entre el relevamiento y la corrida es exactamente lo que hay que ver.
+ *
+ * **Idempotente y observable:** emite patches, no creaciones, así que una segunda corrida no emite
+ * ninguna mutación y el contador de la CLI sirve como señal.
+ */
+export default defineMigration({
+	title: 'Reexpresar en Markdown semántico los pasajes que el original centraba',
+	documentTypes: ['literaryWork'],
+	filter: `_id in [${TARGET_DOCUMENT_IDS.flatMap((id) => [`"${id}"`, `"${DRAFTS_PATH_PREFIX}${id}"`]).join(', ')}]`,
+	migrate: {
+		document(doc: LiteraryWorkDocument) {
+			// El guard vive acá y no solo en el filtro: el filtro acota el recorrido, no garantiza el alcance.
+			const corrections = CORRECTIONS_BY_DOCUMENT_ID[publishedIdOf(doc._id)];
+			if (!corrections) {
+				return [];
+			}
+
+			const resolved = new Set<string>();
+			const patches = (doc.content ?? []).flatMap((section) => {
+				if (!section._key) {
+					throw new UncorrectableLiteraryWorkError(
+						`Una sección de "${doc._id}" no tiene _key, así que el patch no puede anclarse`,
+						'—',
+					);
+				}
+				const body = typeof section.body === 'string' ? section.body : '';
+				const { body: corrected, statuses } = applySectionCorrections(body, corrections);
+
+				Object.entries(statuses)
+					.filter(([, status]) => status !== CORRECTION_STATUSES.absent)
+					.forEach(([id]) => resolved.add(id));
+
+				return corrected === body ? [] : [at(`content[_key=="${section._key}"].body`, set(corrected))];
+			});
+
+			assertEveryCorrectionResolved(corrections, resolved, doc._id);
+			return patches;
+		},
+	},
+});

--- a/src/utils/markdown-pipeline.utils.spec.ts
+++ b/src/utils/markdown-pipeline.utils.spec.ts
@@ -9,6 +9,20 @@ describe('markdownToSanitizedHtml', () => {
 		expect(html).toContain('<p>Un párrafo con <strong>negrita</strong>.</p>');
 	});
 
+	// La cita es lo que reexpresa un pasaje que el original marcaba con alineación, que Markdown no
+	// tiene. Si alguien acotara la allow-list y `blockquote` cayera, ese pasaje se descartaría al
+	// renderizar y la obra quedaría peor que sin la marca.
+	it('preserves blockquotes and emphasis', () => {
+		const html = markdownToSanitizedHtml(
+			createMarkdown('> **UN AVISO**\n>\n> El cuerpo del aviso.\n\nUn beso de tu\n\n*José*'),
+		);
+
+		expect(html).toContain('<blockquote>');
+		expect(html).toContain('<p><strong>UN AVISO</strong></p>');
+		expect(html).toContain('<p>El cuerpo del aviso.</p>');
+		expect(html).toContain('<p><em>José</em></p>');
+	});
+
 	// Batería XSS: cada payload mezcla prosa benigna (así la salida no es vacía y no lanza por el
 	// invariante de SanitizedHtml) con un constructo peligroso que la allow-list debe neutralizar.
 	// `forbidden` reconoce el constructo peligroso *como tag o atributo*, no como texto: una obra


### PR DESCRIPTION
## Contexto

La migración de cuentos a obras llevó el contenido de Portable Text a Markdown, que no tiene alineación. El issue registraba cinco pasajes donde el centrado del original **imitaba algo del mundo de la obra** y quedaría como párrafo plano, más un hallazgo de calidad de datos.

## Lo que el relevamiento contra producción corrigió del issue

Antes de decidir nada se leyeron los cuatro documentos migrados. **La premisa quedó desactualizada en la mayoría de los casos**: la migración conservó más de lo esperado.

| Pasaje | Lo que el issue esperaba | Lo que hay |
| --- | --- | --- |
| Los tres bloques de *La liga de los pelirrojos* | Párrafo plano | Enmarcados por reglas horizontales, encabezado en negrita |
| El envío de *Sombras sobre vidrio esmerilado* | Párrafo plano | `***Envío***` en línea propia |
| La firma de *Carta a Chichita* | Párrafo plano | Párrafo plano ✓ |
| El bloque de *Amor a lo lejos* | Dos bloques fusionados, conviene separarlos | **Peor**: sin separación alguna, renderiza corrido |

Dos hallazgos que cambiaron el planteo:

**Las reglas que enmarcan los carteles no son cortes de escena.** En el origen eran filas de asteriscos centradas: el borde del papel impreso. La migración las tradujo a reglas junto con los cortes de escena reales del corpus.

**El bloque de *Amor a lo lejos* no es un matiz perdido sino un defecto visible.** `**Parte final**Abrí los ojos.` no tiene separación, mientras que las tres partes anteriores sí. Se verificó que **no es un bug de la migración**: el origen tenía los dos tramos en un mismo bloque de Portable Text y la serialización fue fiel.

## Las decisiones

| Obra | Decisión |
| --- | --- |
| *La liga de los pelirrojos* | Los dos avisos pasan a **cita**; como la cita hace de marco, las reglas se van con ella |
| *Carta a Chichita* | La firma pasa a **énfasis** |
| *Amor a lo lejos* | El encabezado de parte se **separa** del texto que lo sigue |
| *Sombras sobre vidrio esmerilado* | **Sin cambios** |

## Por qué una migración y no patches

El cuerpo de *La liga* pesa unos 50 KB en un solo campo de texto. Un `set` directo obliga a reescribir la cadena entera, y un error de transcripción se llevaría puesto el cuento sin que ningún diff lo delate. La migración hace reemplazos quirúrgicos, tiene ensayo, es idempotente y queda revisable.

Dentro de ella, la **tabla editorial vive separada del motor** porque se revisan distinto: el motor se lee buscando errores de lógica, y la tabla se lee carácter por carácter contra el documento real. Y los carteles **no transcriben el aviso** —son cientos de caracteres de prosa—: la corrección ancla en la línea del encabezado y el motor toma el cuerpo verbatim del propio documento.

## Idempotencia y fail-fast

El motor distingue **tres** resultados, no dos. La idempotencia pide que una segunda corrida no toque nada; el fail-fast pide que un texto que ya no coincide detenga todo. Confundir "ya aplicada" con "no la encuentro" haría que una edición hecha en el Studio entre el relevamiento y la corrida pasara inadvertida.

Ausente **no lanza en el motor**: una corrección vive en una sola sección, así que quien puede concluir que falta es quien ve el documento entero. Sí lanzan la ocurrencia múltiple —elegir la primera reescribiría un pasaje que nadie miró— y el ancla presente sin su marco.

Como emite patches y no creaciones, una segunda corrida no emite mutación alguna y el contador de la CLI sirve como señal, a diferencia de las migraciones basadas en creación.

## Verificación

**La dependencia con el código se verificó ejecutando el pipeline**, no leyéndolo: la cita pertenece al esquema por defecto del saneamiento y lo atraviesa intacta. No hay que ampliar ninguna lista blanca, que es justamente lo que el issue dejaba fuera de alcance. Queda cubierto por un caso nuevo del spec del pipeline —que cubría encabezado, negrita, enlaces, imágenes y la batería de vectores XSS, pero ni cita ni énfasis—, verificado falsificable: quitando ambos de la lista blanca cae ese caso y ningún otro.

**El motor se ensayó contra el texto real de producción**, no solo contra fixtures. Los dos avisos quedan citados con su cuerpo verbatim, la prosa que los rodea intacta, y el delta de longitud se explica carácter por carácter. Ahí quedó a la vista que esta obra no tiene cortes de escena propios —sus cuatro reglas eran los dos marcos—, así que el caso que fija no consumir los ajenos se sostiene sobre el spec y no sobre el corpus; también se verificó falsificable, tomando la primera regla del cuerpo en vez de la contigua.

**La review encontró que el motor podía reescribir el pasaje equivocado sin emitir ninguna señal.** El ancla se contaba con un patrón —la línea completa— pero se localizaba con otro —el texto suelto—, así que si el mismo texto aparecía antes embebido en un párrafo, el motor citaba ese párrafo, borraba los dos cortes de escena que lo rodeaban y dejaba el aviso sin corregir, devolviendo el estado de una corrección aplicada. Los cuatro anclas de hoy no lo disparan, pero eso es un hecho sobre los datos y no sobre el motor, que queda versionado para las correcciones que vengan. Corregido, con su caso verificado falsificable, y el ensayo contra el texto real da idéntico que antes del arreglo.

Con eso, la afirmación de que el motor solo consume las dos reglas contiguas al ancla pasa a ser cierta: antes describía la intención, no lo que el código garantizaba.

También aparecieron **dos aserciones que pasaban sin verificar lo que decían**. Ninguna fixture tenía más de una sección, así que evaluar la comprobación por sección en vez de por documento —el diseño que este PR defiende— dejaba el spec entero en verde; y el caso de aborto usaba la obra de una sola corrección, así que la resolución parcial nunca se ejercitaba. Los dos casos nuevos se verificaron falsificables.

El resto son endurecimientos del motor y de la tabla: el conteo por partición leía dos ocurrencias solapadas como una y esquivaba el guard de ambigüedad; un reemplazo que contuviera al buscado rompería la idempotencia en silencio; el identificador de corrección es la clave con la que se lleva la cuenta de lo encontrado y nada fijaba su unicidad; y un cuerpo de sección con otra forma se salteaba, haciendo que el síntoma apuntara al lugar equivocado.

Gates locales en verde: `lint`, `typecheck`, el type-check del Studio, `test` (1734 casos) y los tests del Studio (220 casos).

## Lo que este PR no hace

**No corre la migración.** Mutar producción es paso manual, y el procedimiento —censo, ensayo, aplicación, verificación y segundo ensayo— está en el README de la migración.

**No estila la prosa.** Hoy la página de lectura no tiene reglas de tipografía para el HTML inyectado, así que la cita se ve igual que un párrafo mientras que las reglas que se van sí se ven: en el interín, el cambio quita la única marca visible que distingue los carteles. Es una pérdida real y acotada —esa página está en `noindex`, es el walking skeleton, y la página pública de cuento no lee estos documentos—, y se trata aparte para no meter una decisión de diseño en un PR de contenido.

Closes #2130.
