### PR TITLE
[#2202] - Aislar el hero de la página de lectura de la barra de navegación

### DIFF
--- a/e2e/_utils/seo-fixtures.ts
+++ b/e2e/_utils/seo-fixtures.ts
@@ -2,8 +2,8 @@ export const STABLE_SLUGS = Object.freeze({
 	story: 'el-aleph',
 	author: 'jorge-luis-borges',
 	storylist: 'verano-2022',
-	// Verificado contra los dos datasets que sirven a los e2e (development y staging): sin una obra que
-	// exista en ambos, todo caso de `/read` se saltea por su guarda de contenido y el verde no dice nada.
+	// Cada slug de acá tiene que existir en los dos datasets que sirven a los e2e (development en local,
+	// staging en CI): el que exista solo en uno deja sus casos salteados justo donde tenían que correr.
 	literaryWork: 'el-fin',
 } as const);
 

--- a/e2e/_utils/seo-fixtures.ts
+++ b/e2e/_utils/seo-fixtures.ts
@@ -2,7 +2,9 @@ export const STABLE_SLUGS = Object.freeze({
 	story: 'el-aleph',
 	author: 'jorge-luis-borges',
 	storylist: 'verano-2022',
-	literaryWork: 'el-odio',
+	// Verificado contra los dos datasets que sirven a los e2e (development y staging): sin una obra que
+	// exista en ambos, todo caso de `/read` se saltea por su guarda de contenido y el verde no dice nada.
+	literaryWork: 'el-fin',
 } as const);
 
 export const SITEWIDE_SCHEMA_IDS = Object.freeze(['organization', 'website'] as const);

--- a/e2e/read-hero-nav.spec.ts
+++ b/e2e/read-hero-nav.spec.ts
@@ -2,8 +2,8 @@
  * Test de regresión del solapamiento entre el hero de la obra y la barra de navegación fija.
  *
  * Es una aserción de apilamiento: no mira clases ni z-index declarados —eso mediría implementación y
- * pasaría igual con el defecto presente— sino quién responde a un click sobre la franja del nav una vez
- * que la página scrolleó. Si el hero se dibuja encima, es él quien responde.
+ * pasaría igual con el defecto presente— sino quién responde sobre la franja del nav una vez que la
+ * página scrolleó. Si el hero se dibuja encima, es él quien responde.
  */
 import { test, expect } from '@playwright/test';
 
@@ -13,45 +13,82 @@ const readPath = `/read/${STABLE_SLUGS.literaryWork}`;
 
 // El defecto se manifestó en los tres anchos del Design System, con distinto elemento del hero pisando
 // la barra en cada uno: se cubren los tres y no solo el más angosto.
-const VIEWPORTS = [
+const VIEWPORTS = Object.freeze([
 	{ name: 'desktop', width: 1440, height: 900 },
 	{ name: 'tablet', width: 768, height: 1024 },
 	{ name: 'mobile', width: 390, height: 844 },
-];
+] as const);
+
+let status: number;
+
+test.beforeAll(async ({ request }) => {
+	const response = await request.get(readPath);
+	status = response.status();
+});
+
+// Deliberadamente sin guarda de contenido: un dataset sin la obra de prueba es un problema de la
+// infraestructura de test, no un motivo para dejar de verificar. Sin este caso, los de abajo se
+// saltearían en silencio y el gate quedaría verde sin haber mirado nada — que es exactamente lo que
+// venía pasando con el slug anterior.
+test('read — el slug estable de la obra existe en el dataset', () => {
+	expect(status, `"/read/${STABLE_SLUGS.literaryWork}" no responde 200: los casos de /read no verifican nada`).toBe(
+		200,
+	);
+});
 
 for (const viewport of VIEWPORTS) {
-	test(`read — el hero no se dibuja sobre la barra de navegación en ${viewport.name}`, async ({ page, request }) => {
-		const response = await request.get(readPath);
-		// eslint-disable-next-line playwright/no-skipped-test -- skip condicional por contenido del dataset, no un test deshabilitado
-		test.skip(
-			response.status() === 404,
-			`No existe literaryWork con slug "${STABLE_SLUGS.literaryWork}" en el dataset`,
-		);
+	test(`read — el hero no se dibuja sobre la barra de navegación en ${viewport.name}`, async ({ page }) => {
+		// eslint-disable-next-line playwright/no-skipped-test -- la ausencia de la obra ya la reporta el caso de arriba; repetirla acá sería el mismo fallo cuatro veces
+		test.skip(status !== 200, `No existe literaryWork con slug "${STABLE_SLUGS.literaryWork}" en el dataset`);
 
 		await page.setViewportSize({ width: viewport.width, height: viewport.height });
 		await page.goto(readPath);
 		await expect(page.locator('cuentoneta-literary-work-hero-header')).toBeVisible();
 
+		// 100 px alcanza para que el hero se desplace bajo la barra y se queda corto del umbral con el que
+		// LayoutService la oculta: con la barra retraída no habría franja que disputar y el caso pasaría
+		// sin haber ejercido nada.
 		await page.evaluate(() => window.scrollTo(0, 100));
+
+		// Medido: Firefox responde el elemento raíz si el hit-test corre antes de componer el scroll, y el
+		// caso fallaría por esa carrera y no por el apilamiento. Se espera a que el punto resuelva a algún
+		// elemento del contenido — sea el nav o el hero, que es justamente lo que el caso discrimina.
+		await page.waitForFunction(() => {
+			const nav = document.querySelector('cuentoneta-header');
+			if (!nav) {
+				return false;
+			}
+			const { top, bottom, width } = nav.getBoundingClientRect();
+			const element = document.elementFromPoint(width / 2, (top + bottom) / 2);
+			return element !== null && element !== document.documentElement && element !== document.body;
+		});
 
 		// Se muestrea a lo ancho de la barra —logo, centro y zona de enlaces— porque cada viewport la
 		// solapa con una parte distinta del hero.
-		const intruders = await page.evaluate(() => {
+		const hits = await page.evaluate(() => {
 			const nav = document.querySelector('cuentoneta-header');
 			if (!nav) {
 				throw new Error('No se encontró la barra de navegación');
 			}
 			const { top, bottom, width } = nav.getBoundingClientRect();
 			const y = (top + bottom) / 2;
-			return [0.1, 0.3, 0.5, 0.7, 0.9]
-				.map((ratio) => {
-					const x = width * ratio;
-					const element = document.elementFromPoint(x, y);
-					return element?.closest('cuentoneta-literary-work-hero-header') ? Math.round(x) : undefined;
-				})
-				.filter((x) => x !== undefined);
+			return {
+				scrollY: window.scrollY,
+				navHeight: bottom - top,
+				owners: [0.1, 0.3, 0.5, 0.7, 0.9].map((ratio) => {
+					const element = document.elementFromPoint(width * ratio, y);
+					if (element?.closest('cuentoneta-literary-work-hero-header')) {
+						return 'hero';
+					}
+					return element?.closest('cuentoneta-header') ? 'nav' : 'otro';
+				}),
+			};
 		});
 
-		expect(intruders).toEqual([]);
+		// Control positivo: sin esto, "nadie del hero intercepta" se cumpliría igual con la página sin
+		// scrollear o con la barra retraída a alto cero, y el caso pasaría en vacío.
+		expect(hits.scrollY).toBeGreaterThan(0);
+		expect(hits.navHeight).toBeGreaterThan(0);
+		expect(hits.owners).toEqual(['nav', 'nav', 'nav', 'nav', 'nav']);
 	});
 }

--- a/e2e/read-hero-nav.spec.ts
+++ b/e2e/read-hero-nav.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Test de regresión del solapamiento entre el hero de la obra y la barra de navegación fija.
+ *
+ * Es una aserción de apilamiento: no mira clases ni z-index declarados —eso mediría implementación y
+ * pasaría igual con el defecto presente— sino quién responde a un click sobre la franja del nav una vez
+ * que la página scrolleó. Si el hero se dibuja encima, es él quien responde.
+ */
+import { test, expect } from '@playwright/test';
+
+import { STABLE_SLUGS } from './_utils/seo-fixtures';
+
+const readPath = `/read/${STABLE_SLUGS.literaryWork}`;
+
+// El defecto se manifestó en los tres anchos del Design System, con distinto elemento del hero pisando
+// la barra en cada uno: se cubren los tres y no solo el más angosto.
+const VIEWPORTS = [
+	{ name: 'desktop', width: 1440, height: 900 },
+	{ name: 'tablet', width: 768, height: 1024 },
+	{ name: 'mobile', width: 390, height: 844 },
+];
+
+for (const viewport of VIEWPORTS) {
+	test(`read — el hero no se dibuja sobre la barra de navegación en ${viewport.name}`, async ({ page, request }) => {
+		const response = await request.get(readPath);
+		// eslint-disable-next-line playwright/no-skipped-test -- skip condicional por contenido del dataset, no un test deshabilitado
+		test.skip(
+			response.status() === 404,
+			`No existe literaryWork con slug "${STABLE_SLUGS.literaryWork}" en el dataset`,
+		);
+
+		await page.setViewportSize({ width: viewport.width, height: viewport.height });
+		await page.goto(readPath);
+		await expect(page.locator('cuentoneta-literary-work-hero-header')).toBeVisible();
+
+		await page.evaluate(() => window.scrollTo(0, 100));
+
+		// Se muestrea a lo ancho de la barra —logo, centro y zona de enlaces— porque cada viewport la
+		// solapa con una parte distinta del hero.
+		const intruders = await page.evaluate(() => {
+			const nav = document.querySelector('cuentoneta-header');
+			if (!nav) {
+				throw new Error('No se encontró la barra de navegación');
+			}
+			const { top, bottom, width } = nav.getBoundingClientRect();
+			const y = (top + bottom) / 2;
+			return [0.1, 0.3, 0.5, 0.7, 0.9]
+				.map((ratio) => {
+					const x = width * ratio;
+					const element = document.elementFromPoint(x, y);
+					return element?.closest('cuentoneta-literary-work-hero-header') ? Math.round(x) : undefined;
+				})
+				.filter((x) => x !== undefined);
+		});
+
+		expect(intruders).toEqual([]);
+	});
+}

--- a/e2e/read-hero-nav.spec.ts
+++ b/e2e/read-hero-nav.spec.ts
@@ -7,16 +7,21 @@
  */
 import { test, expect } from '@playwright/test';
 
+import { VIEWPORT_WIDTHS_NUMERIC } from '@utils/screen.utils';
+
 import { STABLE_SLUGS } from './_utils/seo-fixtures';
 
 const readPath = `/read/${STABLE_SLUGS.literaryWork}`;
 
-// El defecto se manifestó en los tres anchos del Design System, con distinto elemento del hero pisando
-// la barra en cada uno: se cubren los tres y no solo el más angosto.
+const VIEWPORT_HEIGHT = 900;
+
+// El apilamiento no depende del ancho —ni el hero ni la barra declaran prefijos responsive—, pero la
+// geometría sí: al angostarse, el hero pisa la franja de la barra con otro de sus hijos. Se toma el punto
+// más ancho de cada banda del Design System, el mismo criterio con que `WindowLayoutService` las clasifica.
 const VIEWPORTS = Object.freeze([
-	{ name: 'desktop', width: 1440, height: 900 },
-	{ name: 'tablet', width: 768, height: 1024 },
-	{ name: 'mobile', width: 390, height: 844 },
+	{ name: 'xs', width: VIEWPORT_WIDTHS_NUMERIC.sm - 1 },
+	{ name: 'sm', width: VIEWPORT_WIDTHS_NUMERIC.md - 1 },
+	{ name: 'lg', width: VIEWPORT_WIDTHS_NUMERIC.xl - 1 },
 ] as const);
 
 let status: number;
@@ -37,11 +42,11 @@ test('read — el slug estable de la obra existe en el dataset', () => {
 });
 
 for (const viewport of VIEWPORTS) {
-	test(`read — el hero no se dibuja sobre la barra de navegación en ${viewport.name}`, async ({ page }) => {
+	test(`read — el hero no se dibuja sobre la barra de navegación en el viewport ${viewport.name}`, async ({ page }) => {
 		// eslint-disable-next-line playwright/no-skipped-test -- la ausencia de la obra ya la reporta el caso de arriba; repetirla acá sería el mismo fallo cuatro veces
 		test.skip(status !== 200, `No existe literaryWork con slug "${STABLE_SLUGS.literaryWork}" en el dataset`);
 
-		await page.setViewportSize({ width: viewport.width, height: viewport.height });
+		await page.setViewportSize({ width: viewport.width, height: VIEWPORT_HEIGHT });
 		await page.goto(readPath);
 		await expect(page.locator('cuentoneta-literary-work-hero-header')).toBeVisible();
 

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -15,7 +15,9 @@ type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 @Component({
 	selector: 'cuentoneta-header',
 	host: {
-		class: 'fixed top-0 z-10 w-full items-center justify-center border-b-1 border-neutral-200 md:m-auto',
+		// La barra se dibuja sobre el contenido de cualquier ruta: su z-index queda por encima del rango
+		// que usan los componentes de página, para que ninguno tenga que conocerla para no taparla.
+		class: 'fixed top-0 z-50 w-full items-center justify-center border-b-1 border-neutral-200 md:m-auto',
 	},
 	template: `
 		<header

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header-skeleton.component.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header-skeleton.component.ts
@@ -11,7 +11,8 @@ import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton
 @Component({
 	selector: 'cuentoneta-literary-work-hero-header-skeleton',
 	imports: [SkeletonComponent, CoverImageSkeletonComponent],
-	host: { class: 'relative block overflow-hidden bg-neutral-900' },
+	// Aísla su apilamiento por el mismo motivo que el hero real, que este esqueleto replica.
+	host: { class: 'relative isolate block overflow-hidden bg-neutral-900' },
 	template: `
 		<div class="relative z-10 px-6 pt-28 pb-10">
 			<div class="mx-auto flex w-full max-w-180 items-center gap-8">

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header.component.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header.component.ts
@@ -30,7 +30,10 @@ import { LiteraryWorkHeroHeaderSkeletonComponent } from './literary-work-hero-he
 		TagsListComponent,
 		LiteraryWorkHeroHeaderSkeletonComponent,
 	],
-	host: { class: 'relative block overflow-hidden bg-neutral-900' },
+	// `isolate` confina el apilamiento interno: el contenido se eleva con z-10 para quedar sobre el fondo
+	// difuminado y su velo, y sin aislar ese z-10 sube al contexto raíz, donde compite con la barra de
+	// navegación fija y le gana por orden de documento.
+	host: { class: 'relative isolate block overflow-hidden bg-neutral-900' },
 	template: `
 		@if (literaryWork(); as literaryWork) {
 			@if (backgroundImageUrl(); as backgroundImageUrl) {


### PR DESCRIPTION
El hero de la obra se dibujaba por encima de la barra de navegación fija: al scrollear en `/read/:slug`, la portada, el título y el avatar del autor tapaban el logo y los enlaces.

Closes #2202

## Qué pasaba

Los dos componentes competían en el **mismo contexto de apilamiento** —el raíz— con el mismo `z-index`:

- `HeaderComponent` declaraba `fixed top-0 z-10` en su host.
- `LiteraryWorkHeroHeaderComponent` declaraba `relative` **sin** `z-index`, así que no creaba contexto propio, y adentro elevaba su capa de contenido con `relative z-10` para dejarla sobre la portada difuminada y su velo.

Ese `z-10` interno no quedaba confinado al hero: subía al contexto raíz, empataba con el del header, y el empate lo resolvía el orden del documento a favor del hero.

## Qué cambia

**`isolate` en el host del hero.** Devuelve ese `z-10` al lugar donde significa algo —ordenar contenido contra fondo, dentro del hero— en vez de escalar números hasta que el síntoma desaparezca. El esqueleto del hero repite el mismo patrón y por eso recibe el mismo tratamiento: sin él, el solapamiento vuelve mientras la obra carga.

**La barra sube a `z-50`.** No hace falta para este caso, pero deja de depender de que cada componente de página conozca su valor para no taparla.

## TDD

El test se escribió primero y se lo vio fallar: en los tres anchos, con los cinco puntos de muestreo interceptados por el hero. Después del fix, verde en los tres anchos y en los dos navegadores de la suite.

Los tres anchos salen de `VIEWPORT_WIDTHS_NUMERIC` (`@utils/screen.utils`, la misma fuente que espeja `--breakpoint-*` en `src/tailwind.css` y que usa `WindowLayoutService`): el punto más ancho de cada banda, y los casos nombrados por su token. El apilamiento no depende del ancho —ni el hero ni la barra declaran prefijos responsive—, pero la geometría sí: al angostarse, el hero pisa la franja de la barra con otro de sus hijos.

`e2e/read-hero-nav.spec.ts` afirma **quién responde** sobre la franja del nav una vez que la página scrolleó, muestreando cinco puntos a lo ancho. Es la única forma de que discrimine: una aserción sobre el `z-index` declarado pasaría igual con el defecto presente, porque los dos valores conviven sin conflicto aparente hasta que se resuelve el apilamiento. No se agrega spec unitario por la misma razón — en un DOM sin las utilidades de Tailwind cargadas, lo único afirmable sería la clase, que es implementación.

## Un hallazgo aparte

`STABLE_SLUGS.literaryWork` era `el-odio`, que **no existe en ninguno de los dos datasets** que sirven a los e2e (verificado contra `development` y `staging`: 617 obras cada uno, ninguna con ese slug). La guarda de contenido salteaba entonces todos los casos de `/read` también en CI, así que el test de este PR habría nacido verde sin haber corrido nunca. Pasa a `el-fin`, que existe en ambos; con eso vuelven a correr de verdad los cuatro casos de indexado de `e2e/seo/read.spec.ts`, que hoy también se salteaban.

## Verificación

- **e2e:** rojo antes del fix, verde después, en los anchos `xs` (767), `sm` (959) y `lg` (1535) × chromium y firefox.
- **Barrido de otras rutas:** con el header ya en `z-50`, ningún elemento intercepta la franja del nav en `/home`, `/story/:slug` ni `/authors`.
- **Gates locales:** `test` (1833), `lint`, `stylelint`, `typecheck`, `build`, `storybook` y los e2e de `/read` en verde.

## Alcance

Solo el solapamiento. El rediseño de la página de lectura y de su hero es de 2.11.0 en adelante y este PR no lo anticipa.

