### PR TITLE
[#2205] - Acota la búsqueda de Obra literaria a los campos de primer nivel

### DIFF
--- a/cms/structure/content-type-items.ts
+++ b/cms/structure/content-type-items.ts
@@ -1,15 +1,22 @@
+import { BookIcon } from '@sanity/icons/Book';
 import { createBulkActionsTable } from 'sanity-plugin-bulk-actions-table';
 import type { StructureBuilder, StructureResolverContext } from 'sanity/structure';
 import { filteredDocumentListItems } from 'sanity-plugin-singleton-management';
 
 import { landingPageListItem } from './landing-page-list-item';
 
-// Los tipos de documento no-singleton, planos (sin carpeta intermedia), con overrides: story usa la tabla
-// de acciones masivas y landingPage el pane con badge de activa.
+// Los tipos de documento no-singleton, planos (sin carpeta intermedia), con overrides: story y
+// literaryWork usan la tabla de acciones masivas y landingPage el pane con badge de activa.
 export const contentTypeItems = (S: StructureBuilder, context: StructureResolverContext) =>
 	filteredDocumentListItems({ S, context }).map((collection) => {
 		if (collection.getId() === 'story') {
 			return createBulkActionsTable({ type: 'story', S, context, title: 'Cuentos' });
+		}
+		// La tabla trae su propio buscador, que solo mira los campos string de primer nivel: buscar el
+		// título de una obra deja de matchear dentro del cuerpo de sus secciones, como sí pasa en el
+		// pane nativo.
+		if (collection.getId() === 'literaryWork') {
+			return createBulkActionsTable({ type: 'literaryWork', S, context, title: 'Obras literarias', icon: BookIcon });
 		}
 		if (collection.getId() === 'landingPage') {
 			return landingPageListItem(S);


### PR DESCRIPTION
## Qué cambia

El ítem **Obra literaria** del árbol de Contenido pasa a renderizarse con la tabla de acciones masivas —el mismo pane que ya usa Cuentos—, en lugar del pane de lista nativo.

## Por qué

Buscar el título de una obra en la lista devolvía también las obras que solo mencionan el término dentro del texto. El pane nativo arma su filtro GROQ con un `||` sobre **todos** los paths string del tipo, y ahí entran `content[].body` y `content[].epigraphs[].text`.

No hay forma soportada de acotar esos paths en el pane nativo, verificado sobre `sanity@5.31.1`:

- `__experimental_search`, la vieja manera de declarar los paths buscables, ya no existe en Studio 5. Lo único experimental que sobrevive es `__experimental_omnisearch_visibility`, que oculta el tipo entero de la búsqueda global.
- Los pesos por campo (`options: { search: { weight } }`) no aplican en esta superficie: el pane pide la búsqueda con `skipSortByScore`, ordena por el criterio de la lista y el peso nunca entra en juego. Solo sirven para la búsqueda global (⌘K) y los inputs de referencia.

La tabla, en cambio, tiene buscador propio y arma el filtro únicamente con los campos string de **primer nivel** del tipo, así que el texto de las secciones deja de matchear.

## Consecuencias asumidas

- El pane pasa de lista a tabla, con el mismo UX que Cuentos.
- Siguen matcheando `title`, `editorialNote`, `originalPublication` y el slug, por ser de primer nivel. Lo que se elimina es el ruido del cuerpo de las obras.
- El ítem conserva el icono del schema y pasa a llamarse "Obras literarias", en plural, en línea con "Cuentos".

## Verificación

- `pnpm sanity:typecheck`, `pnpm sanity:test` (21 archivos, 220 tests) y `pnpm exec sanity build` en verde.
- `pnpm lint` en verde (queda el warning preexistente de `e2e/seo/sitemap.spec.ts`).
- Pendiente de verificación manual en el Studio: buscar en la lista un término presente solo en el cuerpo de una obra y confirmar que no aparece.

Closes #2205
