### PR TITLE
[#2207] - Corregir la regresión del carousel y endurecer la escala de apilamiento

### DIFF
--- a/.claude/references/angular-components.md
+++ b/.claude/references/angular-components.md
@@ -345,7 +345,11 @@ Todo apilamiento sale de la escala del Design System, declarada como tokens `--z
 
 Un componente que eleva algo **dentro de sí** aísla su apilamiento con `isolate` en el elemento que contiene la elevación (`z-content`/`z-raised`). Confinado el contexto, el valor numérico deja de significar nada afuera de ese subárbol: dos componentes no relacionados pueden usar `z-raised` cada uno sin competir entre sí.
 
-Las capas globales son lo contrario: se usan **sin** aislar. Aislar la barra o la capa flotante las haría perder contra el contenido de página en vez de quedar por encima de todo. Por eso su franja (50-60) está **reservada** — ningún otro archivo puede declarar `z-nav`/`z-floating` salvo los que ya las declaran a nivel de aplicación.
+Las capas globales son lo contrario: se usan **sin** aislar. Aislar la barra o la capa flotante las haría perder contra el contenido de página en vez de quedar por encima de todo. Por eso su franja (50-60) está **reservada** — ningún otro archivo puede usarlas, ni como utilidad (`z-nav`) ni como declaración (`z-index: var(--z-index-nav)`), salvo los que ya las declaran a nivel de aplicación.
+
+**Sumar una capa nueva toca dos archivos si es global:** el token en el `@theme` y el conjunto de capas globales de `tools/z-index-scale.js`. Que una capa sea global es una decisión de diseño y no una consecuencia de su número, así que el helper la distingue por nombre; un token global agregado solo al tema pasaría por interno.
+
+**No hay capa "por debajo".** Las utilidades negativas (`-z-content`) se rechazan: mandar algo detrás se resuelve con el orden del documento dentro de un contexto confinado. Si aparece un caso real que no se pueda expresar así, se suma una capa a la escala en vez de un valor suelto.
 
 ### Cobertura por gate
 
@@ -362,7 +366,7 @@ Las dos reglas de lint reservan la franja global con la opción `allowGlobalLaye
 
 - Un nombre de clase computado en runtime (`'z-' + n`) es invisible a un escaneo estático.
 - Una asignación directa a `style.zIndex` también lo es.
-- Que el `isolate` esté en el ancestro correcto no lo decide ninguna regla de lint: lo mide el e2e de apilamiento, que discrimina el defecto por hit-test en un navegador real.
+- Que el `isolate` esté en el ancestro correcto no lo decide ninguna regla de lint: lo mide el e2e de apilamiento, que discrimina el defecto por hit-test en un navegador real. Ese e2e mira la barra de navegación; el orden **dentro** de un componente no lo cubre ningún gate, así que un cambio de capas internas se verifica en el navegador.
 - El **drawer** no participa de la escala: se apoya en `<dialog>.showModal()`, que promueve el elemento al top layer nativo del navegador — un mecanismo inmune al `z-index` de la página.
 
 ### Por qué el enforcement vive en lint

--- a/e2e/_utils/stacking.ts
+++ b/e2e/_utils/stacking.ts
@@ -81,8 +81,12 @@ export async function navStackingReport(page: Page): Promise<StackingReport> {
 						return 'nav';
 					}
 					// Nombra a quien tapa la barra: el mensaje de fallo señala al componente culpable en vez
-					// de decir solamente que alguien está encima.
-					const intruder = element.closest('[class*="cuentoneta-"], cuentoneta-header, [data-testid]');
+					// de decir solamente que alguien está encima. Los componentes se declaran por elemento,
+					// así que se sube hasta el ancestro cuyo tag lleva el prefijo del proyecto.
+					let intruder: Element | null = element;
+					while (intruder && !intruder.tagName.toLowerCase().startsWith('cuentoneta-')) {
+						intruder = intruder.parentElement;
+					}
 					return (intruder ?? element).tagName.toLowerCase();
 				}),
 			};

--- a/e2e/nav-stacking.spec.ts
+++ b/e2e/nav-stacking.spec.ts
@@ -12,16 +12,20 @@ import { test, expect } from '@playwright/test';
 import { NAV_OWNS_EVERY_SAMPLE, STACKING_VIEWPORTS, VIEWPORT_HEIGHT, navStackingReport } from './_utils/stacking';
 import { STABLE_SLUGS } from './_utils/seo-fixtures';
 
-// Las rutas con fixture estable, cada una con el elemento cuya presencia indica que la página pintó su
-// contenido. Sin esa espera, el hit-test podría correr sobre un esqueleto y no ejercer nada.
+// Las rutas con fixture estable, cada una con un elemento que **la propia página** aporta. El selector no
+// puede ser del shell —`cuentoneta-header` está presente aun con la ruta en esqueleto o en error—, porque
+// entonces el hit-test correría antes de que haya contenido con el que disputar la franja.
 //
 // `/read` no está acá: tiene su propio spec de regresión, que es el del defecto que originó todo esto y
 // nombra al hero como sospechoso. Sumarla también acá duplicaría su costo en el gate más frágil del repo.
 const ROUTES = Object.freeze([
-	{ name: 'home', path: '/home', ready: 'cuentoneta-header' },
-	{ name: 'story', path: `/story/${STABLE_SLUGS.story}`, ready: 'cuentoneta-header' },
-	{ name: 'author', path: `/author/${STABLE_SLUGS.author}`, ready: 'h1' },
-	{ name: 'storylist', path: `/storylist/${STABLE_SLUGS.storylist}`, ready: 'cuentoneta-header' },
+	{ name: 'home', path: '/home', ready: 'h1' },
+	{ name: 'story', path: `/story/${STABLE_SLUGS.story}`, ready: 'h1' },
+	// La ficha de autor sirve su `h1` vacío y lo completa en el cliente, así que no discrimina: se espera a
+	// las pestañas, que solo existen con el contenido de la página.
+	{ name: 'author', path: `/author/${STABLE_SLUGS.author}`, ready: 'cuentoneta-tabs' },
+	// La colección no declara `h1`; su título es un componente propio.
+	{ name: 'storylist', path: `/storylist/${STABLE_SLUGS.storylist}`, ready: 'cuentoneta-storylist-title' },
 ] as const);
 
 const statuses = new Map<string, number>();
@@ -50,7 +54,7 @@ for (const route of ROUTES) {
 		test(`${route.name} — nada se dibuja sobre la barra de navegación en el viewport ${viewport.name}`, async ({
 			page,
 		}) => {
-			// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de la ruta; repetirla acá sería el mismo fallo tres veces
+			// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de la ruta; repetirla acá sería el mismo fallo una vez por ancho
 			test.skip(statuses.get(route.name) !== 200, `"${route.path}" no responde 200 en el dataset`);
 
 			await page.setViewportSize({ width: viewport.width, height: VIEWPORT_HEIGHT });

--- a/src/app/components/carousel/carousel.component.html
+++ b/src/app/components/carousel/carousel.component.html
@@ -9,7 +9,9 @@
 		tabindex="0"
 	>
 		<!-- Diapositivas -->
-		<div class="slide-wrapper relative h-full w-full" #slideWrapper aria-live="polite" aria-atomic="false">
+		<!-- `isolate` confina el orden entre diapositivas: sin aislar competiría con los controles y los
+			 indicadores, que son sus hermanos y tienen que quedar por encima de la diapositiva activa. -->
+		<div class="slide-wrapper relative isolate h-full w-full" #slideWrapper aria-live="polite" aria-atomic="false">
 			@for (slide of slides(); track slide.slug; let i = $index) {
 				<!-- Diapositiva activa (entrando) -->
 				@if (i === activeIndex()) {

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -115,9 +115,9 @@
 		su franja está reservada a las capas que existen a nivel de aplicación.
 
 		A diferencia de `--color-*`, `--breakpoint-*` y `--radius-*`, esta namespace NO se limpia con
-		`initial`: Tailwind no trae defaults de z-index que reemplazar, y borrarla tampoco desactivaría los
-		números crudos — la utilidad `z` resuelve cualquier valor sin consultar el tema. De ahí que lo que
-		impide un valor fuera de la escala sea una regla de lint y no este archivo.
+		`initial`: no hay defaults de z-index que reemplazar, y limpiarla tampoco impediría un valor fuera de
+		la escala. Eso lo hacen las reglas de lint homónimas — ver angular-components.md, sección "Escala de
+		apilamiento".
 	*/
 	--z-index-content: 10;
 	--z-index-raised: 20;

--- a/tools/eslint/z-index-scale.js
+++ b/tools/eslint/z-index-scale.js
@@ -1,15 +1,9 @@
 /**
  * Exige que todo apilamiento salga de la escala del Design System: las utilidades `z-<capa>` del `@theme`
  * y `z-auto`, nunca un número crudo (`z-10`, `z-[999]`) ni una declaración `z-index` con un valor propio.
- *
- * Existe porque ningún gate de compilación puede avisar. Tailwind resuelve `z-10` sin consultar el tema,
- * así que el número compila para siempre; y una utilidad mal escrita (`z-nvv`) no emite CSS alguno **ni
- * falla el build**, de modo que el defecto viaja invisible hasta que alguien lo ve en pantalla.
- *
- * Con `allowGlobalLayersIn` la regla además reserva la franja alta: las capas globales —la barra fija y la
- * capa flotante anclada al body— quedan habilitadas solo en los archivos que las declaran. Sin esa
- * reserva, cualquier componente de página podría volver a elegir un valor que compita con la barra, que es
- * el modo de falla que la escala vino a cerrar.
+ * Con `allowGlobalLayersIn` reserva además la franja alta, habilitando las capas globales solo en los
+ * archivos que las declaran. Por qué ese enforcement no puede vivir en el tema, y qué cubre cada gate:
+ * `angular-components.md#escala-de-apilamiento-z-index`.
  *
  * Dos ramas según el archivo, porque las utilidades viven en dos formas distintas:
  * - `.html` (incluidas las plantillas inline, que el procesador de Angular extrae): escaneo del texto.
@@ -17,15 +11,23 @@
  *   inline. Saltea el valor de `template`, porque de esa plantilla ya se ocupa la otra rama — sin el
  *   salteo, una violación inline se reportaría dos veces.
  *
- * Puntos ciegos declarados: un nombre de clase computado en runtime (`'z-' + n`) y una asignación directa
- * a `style.zIndex` son invisibles para un escaneo estático. Hoy no existe ninguno en el repo. Que el
- * `isolate` esté en el ancestro correcto tampoco lo decide esta regla: eso lo mide el e2e de apilamiento.
+ * Puntos ciegos: un nombre de clase computado en runtime (`'z-' + n`) y una asignación directa a
+ * `style.zIndex` son invisibles para un escaneo estático, y que el `isolate` esté en el ancestro correcto
+ * no lo decide ninguna regla — eso lo mide el e2e de apilamiento.
  */
-import { isAllowedDeclarationValue, isAllowedUtility, isGlobalUtility, scaleTokens } from '../z-index-scale.js';
+import {
+	allowedTokensFor,
+	declaredLayer,
+	isAllowedDeclarationValue,
+	isAllowedUtility,
+	isGlobalUtility,
+} from '../z-index-scale.js';
 
-// Una utilidad de apilamiento con sus variantes: `z-nav`, `md:z-nav`, `hover:z-raised`, `z-[999]`. El
-// prefijo `-` (negativo) entra a propósito: `-z-content` no pertenece a la escala y tiene que reportarse.
-const UTILITY_PATTERN = /(?<![\w:-])(-?)z-((?:\[[^\]]*\])|[a-z0-9][\w.-]*)/g;
+// Una utilidad de apilamiento con sus variantes: `z-nav`, `md:z-nav`, `hover:z-raised`, `sm:hover:z-10`,
+// `z-[999]`. Las variantes se consumen en el patrón —no basta con excluirlas del lookbehind, que dejaría
+// pasar toda utilidad prefijada—. El `-` (negativo) entra a propósito: `-z-content` no pertenece a la
+// escala y tiene que reportarse.
+const UTILITY_PATTERN = /(?<![\w:-])((?:[\w-]+:)*)(-?)z-((?:\[[^\]]*\])|[a-z0-9][\w.-]*)/g;
 const DECLARATION_PATTERN = /(?<![\w-])z-index\s*:\s*([^;}"'`]+)/g;
 
 // `z-index` como utilidad no existe; la coincidencia proviene de una declaración CSS, que valida el otro
@@ -35,7 +37,7 @@ const NOT_A_UTILITY = new Set(['index']);
 function utilityViolations(text, allowGlobals) {
 	const violations = [];
 	for (const match of text.matchAll(UTILITY_PATTERN)) {
-		const [, negative, suffix] = match;
+		const [, , negative, suffix] = match;
 		if (NOT_A_UTILITY.has(suffix)) {
 			continue;
 		}
@@ -50,37 +52,45 @@ function utilityViolations(text, allowGlobals) {
 	return violations;
 }
 
-function declarationViolations(text) {
+function declarationViolations(text, allowGlobals) {
 	const violations = [];
 	for (const match of text.matchAll(DECLARATION_PATTERN)) {
-		if (!isAllowedDeclarationValue(match[1])) {
-			violations.push({
-				index: match.index,
-				length: match[0].length,
-				messageId: 'declaration',
-				value: match[1].trim(),
-			});
+		const value = match[1].trim();
+		const violation = { index: match.index, length: match[0].length, value, utility: value };
+		if (!isAllowedDeclarationValue(value)) {
+			violations.push({ ...violation, messageId: 'declaration' });
+			continue;
+		}
+		// La franja alta se reserva también en esta forma: de lo contrario, lo que `z-nav` prohíbe lo
+		// concedería la declaración equivalente.
+		if (!allowGlobals && isGlobalUtility(declaredLayer(value) ?? '')) {
+			violations.push({ ...violation, messageId: 'globalLayer' });
 		}
 	}
 	return violations;
 }
 
-/** Posición `{ line, column }` (1-based / 0-based, como las espera ESLint) del índice `index` del texto. */
-function positionAt(text, index) {
-	const upToIndex = text.slice(0, index);
-	const lines = upToIndex.split('\n');
-	return { line: lines.length, column: lines[lines.length - 1].length };
-}
-
-function reportInText(context, text, offset, node, allowGlobals) {
-	const violations = [...utilityViolations(text, allowGlobals), ...declarationViolations(text)];
+/**
+ * Reporta las violaciones de `text`, cuyo primer carácter está en `offset` dentro del archivo.
+ *
+ * La posición se traduce con `getLocFromIndex`, que cuenta sobre el archivo entero: derivarla del texto
+ * del nodo haría colapsar toda violación de un `.ts` a la primera línea, porque el índice es absoluto y
+ * el texto es un fragmento.
+ */
+function reportInText(context, sourceCode, text, offset, node, allowGlobals) {
+	const violations = [...utilityViolations(text, allowGlobals), ...declarationViolations(text, allowGlobals)];
 	for (const violation of violations) {
-		const start = positionAt(text, offset + violation.index);
-		const end = positionAt(text, offset + violation.index + violation.length);
 		context.report({
-			loc: { start, end },
+			loc: {
+				start: sourceCode.getLocFromIndex(offset + violation.index),
+				end: sourceCode.getLocFromIndex(offset + violation.index + violation.length),
+			},
 			messageId: violation.messageId,
-			data: { utility: violation.utility, value: violation.value, scale: scaleTokens().join(', ') },
+			data: {
+				utility: violation.utility,
+				value: violation.value,
+				scale: allowedTokensFor(allowGlobals).join(', '),
+			},
 			...(node ? { node } : {}),
 		});
 	}
@@ -123,7 +133,7 @@ export default {
 		if (context.filename.endsWith('.html')) {
 			return {
 				Program(program) {
-					reportInText(context, sourceCode.getText(), 0, program, allowGlobals);
+					reportInText(context, sourceCode, sourceCode.getText(), 0, program, allowGlobals);
 				},
 			};
 		}
@@ -143,7 +153,7 @@ export default {
 			if (isInlineTemplate(expression)) {
 				return;
 			}
-			reportInText(context, sourceCode.getText(node), node.range[0], node, allowGlobals);
+			reportInText(context, sourceCode, sourceCode.getText(node), node.range[0], node, allowGlobals);
 		};
 
 		return {

--- a/tools/eslint/z-index-scale.spec.ts
+++ b/tools/eslint/z-index-scale.spec.ts
@@ -2,8 +2,6 @@ import { RuleTester } from 'eslint';
 import tsParser from '@typescript-eslint/parser';
 import * as angular from 'angular-eslint';
 
-// REASON: la regla es un `.js` sin tipos propios; el RuleTester solo necesita el módulo.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import rule from './z-index-scale.js';
 
 const tsRuleTester = new RuleTester({ languageOptions: { parser: tsParser } });
@@ -24,6 +22,13 @@ tsRuleTester.run('z-index-scale (.ts)', rule, {
 		{ code: decorate('relative isolate z-content'), filename: 'a.ts' },
 		{ code: decorate('z-raised'), filename: 'a.ts' },
 		{ code: decorate('md:z-content hover:z-raised'), filename: 'a.ts' },
+		{ code: decorate('sm:hover:z-content'), filename: 'a.ts' },
+		// Plantilla inline con acento invertido, que es la forma real del repo: la cubre la rama de
+		// plantillas vía el procesador de Angular, así que acá no se reporta.
+		{
+			code: `import { Component } from '@angular/core';\n@Component({ selector: 'x', template: \`<div class="z-10"></div>\` })\nexport class Probe {}`,
+			filename: 'a.ts',
+		},
 		// `z-auto` es la utilidad nativa: no eleva nada.
 		{ code: decorate('z-auto'), filename: 'a.ts' },
 		// Una clase que apenas empieza igual no es una utilidad de apilamiento.
@@ -47,6 +52,12 @@ tsRuleTester.run('z-index-scale (.ts)', rule, {
 	],
 	invalid: [
 		{ code: decorate('z-10'), filename: 'a.ts', errors: [{ messageId: 'utility' }] },
+		// Con variante: el prefijo no exime, y la reserva de la franja alta tampoco se elude con él.
+		{ code: decorate('md:z-50'), filename: 'a.ts', errors: [{ messageId: 'utility' }] },
+		{ code: decorate('sm:hover:z-20'), filename: 'a.ts', errors: [{ messageId: 'utility' }] },
+		{ code: decorate('hover:z-[999]'), filename: 'a.ts', errors: [{ messageId: 'utility' }] },
+		{ code: decorate('md:-z-content'), filename: 'a.ts', errors: [{ messageId: 'utility' }] },
+		{ code: decorate('md:z-nav'), filename: 'a.ts', options: allowHeader, errors: [{ messageId: 'globalLayer' }] },
 		{ code: decorate('z-50'), filename: 'a.ts', errors: [{ messageId: 'utility' }] },
 		{ code: decorate('z-[999]'), filename: 'a.ts', errors: [{ messageId: 'utility' }] },
 		// Un negativo no pertenece a la escala aunque nombre una capa.
@@ -67,6 +78,31 @@ tsRuleTester.run('z-index-scale (.ts)', rule, {
 			code: `const styles = ['.overlay { z-index: var(--z-index-nope); }'];`,
 			filename: 'a.ts',
 			errors: [{ messageId: 'declaration' }],
+		},
+		// La reserva rige en las dos formas: lo que `z-nav` prohíbe no lo puede conceder la declaración.
+		{
+			code: `const styles = ['.overlay { z-index: var(--z-index-nav); }'];`,
+			filename: 'a.ts',
+			options: allowHeader,
+			errors: [{ messageId: 'globalLayer' }],
+		},
+		// Literales de plantilla: es la forma con que el repo escribe `styles`, y la que ejercita el
+		// visitor de `TemplateElement`.
+		{
+			code: 'const styles = [`.overlay { z-index: 3; }`];',
+			filename: 'a.ts',
+			errors: [{ messageId: 'declaration' }],
+		},
+		{ code: 'const classes = [`absolute z-10`];', filename: 'a.ts', errors: [{ messageId: 'utility' }] },
+		// La posición señala la violación, no el principio del archivo: es lo que vuelve accionable el
+		// mensaje en un componente largo.
+		{
+			code: `import { Component } from '@angular/core';\n\nconst first = 'z-10';\n\nconst second = 'z-20';`,
+			filename: 'a.ts',
+			errors: [
+				{ messageId: 'utility', line: 3, column: 16 },
+				{ messageId: 'utility', line: 5, column: 17 },
+			],
 		},
 		// La franja alta está reservada: en un archivo cualquiera, una capa global se rechaza aunque
 		// pertenezca a la escala.

--- a/tools/stylelint/z-index-scale.js
+++ b/tools/stylelint/z-index-scale.js
@@ -4,26 +4,33 @@
  * utilidades de la escala.
  *
  * Es la mitad de la cobertura que ESLint no puede dar: no lintea archivos `.css`, así que sin esta regla
- * las hojas de componente quedarían como la vía libre para un número crudo.
- *
- * `allowGlobalLayersIn` reserva la franja alta igual que su contraparte de ESLint: las capas globales solo
- * se habilitan en el archivo que declara una capa de la aplicación.
+ * las hojas de componente quedarían como la vía libre para un número crudo. `allowGlobalLayersIn` reserva
+ * la franja alta igual que su contraparte de ESLint. La escala y su rationale, en
+ * `angular-components.md#escala-de-apilamiento-z-index`.
  *
  * `src/tailwind.css` no necesita excepción: ahí los tokens son custom properties, no declaraciones
  * `z-index`, así que la regla no los mira.
  */
 import stylelint from 'stylelint';
 
-import { isAllowedDeclarationValue, isAllowedUtility, isGlobalUtility, scaleTokens } from '../z-index-scale.js';
+import {
+	declaredLayer,
+	isAllowedDeclarationValue,
+	isAllowedUtility,
+	isGlobalUtility,
+	allowedTokensFor,
+} from '../z-index-scale.js';
 
 const { createPlugin, utils } = stylelint;
 
 const ruleName = 'cuentoneta/z-index-scale';
 const messages = utils.ruleMessages(ruleName, {
-	rejectedDeclaration: (value) =>
-		`"z-index: ${value}" is outside the stacking scale. Reference a layer with var(--z-index-<layer>) (${scaleTokens().join(', ')}) — see angular-components.md#escala-de-apilamiento-z-index.`,
-	rejectedUtility: (utility) =>
-		`"${utility}" is not part of the stacking scale. Use one of its layers (${scaleTokens().join(', ')}) or z-auto — see angular-components.md#escala-de-apilamiento-z-index.`,
+	// El listado de capas sale de `allowedTokensFor`, no de la escala entera: ofrecerle una capa global a un
+	// archivo que no puede declararla sugeriría una salida que la regla rechaza en el paso siguiente.
+	rejectedDeclaration: (value, allowed) =>
+		`"z-index: ${value}" is outside the stacking scale. Reference a layer with var(--z-index-<layer>) (${allowed.join(', ')}) — see angular-components.md#escala-de-apilamiento-z-index.`,
+	rejectedUtility: (utility, allowed) =>
+		`"${utility}" is not part of the stacking scale. Use one of its layers (${allowed.join(', ')}) or z-auto — see angular-components.md#escala-de-apilamiento-z-index.`,
 	rejectedGlobalLayer: (utility) =>
 		`"${utility}" is a global layer, reserved for the fixed navigation bar and the floating layer. Raise with an internal layer and confine the component's stacking with isolate — see angular-components.md#escala-de-apilamiento-z-index.`,
 });
@@ -31,12 +38,23 @@ const meta = {
 	url: 'https://github.com/cuentoneta/cuentoneta/blob/develop/.claude/references/angular-components.md#escala-de-apilamiento-z-index',
 };
 
-const UTILITY_PATTERN = /(?:^|\s)(-?z-[^\s]+)/g;
+// Admite las variantes que preceden a la utilidad (`md:z-nav`, `sm:hover:z-10`): sin contemplarlas, toda
+// utilidad prefijada entraría sin que la regla la mire.
+const UTILITY_PATTERN = /(?:^|\s)((?:[\w-]+:)*-?z-[^\s]+)/g;
 
+/** La capa que nombra la utilidad, o `null` si el negativo la deja fuera de la escala por definición. */
 function utilitySuffix(utility) {
-	// Descarta la variante (`md:z-nav` → `z-nav`) para quedarse con la capa que nombra.
+	// Descarta la variante (`md:z-nav` → `z-nav`) para quedarse con la capa que nombra. El negativo se
+	// evalúa después de descartarla, porque `md:-z-content` no empieza con el guion.
 	const withoutVariants = utility.slice(utility.lastIndexOf(':') + 1);
-	return withoutVariants.startsWith('z-') ? withoutVariants.slice(2) : null;
+	// El guion del negativo se saca antes de leer la capa: `md:-z-content` la nombra igual, y descartarlo
+	// acá lo dejaría sin reportar en vez de rechazarlo.
+	const withoutSign = withoutVariants.startsWith('-') ? withoutVariants.slice(1) : withoutVariants;
+	return withoutSign.startsWith('z-') ? withoutSign.slice(2) : null;
+}
+
+function isNegative(utility) {
+	return utility.slice(utility.lastIndexOf(':') + 1).startsWith('-');
 }
 
 function checkApply(atRule, result, allowGlobals) {
@@ -45,8 +63,13 @@ function checkApply(atRule, result, allowGlobals) {
 		if (suffix === null) {
 			continue;
 		}
-		if (utility.startsWith('-') || !isAllowedUtility(suffix)) {
-			utils.report({ message: messages.rejectedUtility(utility), node: atRule, result, ruleName });
+		if (isNegative(utility) || !isAllowedUtility(suffix)) {
+			utils.report({
+				message: messages.rejectedUtility(utility, allowedTokensFor(allowGlobals)),
+				node: atRule,
+				result,
+				ruleName,
+			});
 			continue;
 		}
 		if (!allowGlobals && isGlobalUtility(suffix)) {
@@ -67,7 +90,18 @@ const ruleFunction = (primary, secondary) => (root, result) => {
 	root.walkDecls(/^z-index$/i, (declaration) => {
 		if (!isAllowedDeclarationValue(declaration.value)) {
 			utils.report({
-				message: messages.rejectedDeclaration(declaration.value),
+				message: messages.rejectedDeclaration(declaration.value, allowedTokensFor(allowGlobals)),
+				node: declaration,
+				result,
+				ruleName,
+			});
+			return;
+		}
+		// La franja alta se reserva también en esta forma: de lo contrario, lo que `z-nav` prohíbe lo
+		// concedería la declaración equivalente.
+		if (!allowGlobals && isGlobalUtility(declaredLayer(declaration.value) ?? '')) {
+			utils.report({
+				message: messages.rejectedGlobalLayer(declaration.value),
 				node: declaration,
 				result,
 				ruleName,

--- a/tools/stylelint/z-index-scale.spec.ts
+++ b/tools/stylelint/z-index-scale.spec.ts
@@ -11,7 +11,6 @@ const config = {
 	// El config no extiende los presets del repo a propósito: con esta regla como única activa, todo
 	// warning que llegue es suyo, y contarlos alcanza para afirmar.
 	// REASON: la forma de un config de Stylelint no vale tiparla acá; el spec solo lo pasa como dato.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
 
 async function warningsFor(code: string, codeFilename = 'src/app/components/probe/probe.component.css') {
@@ -38,6 +37,15 @@ describe('cuentoneta/z-index-scale', () => {
 		it('rejects a reference to a token outside the scale', async () => {
 			expect(await warningsFor('.a { z-index: var(--z-index-nope); }')).toHaveLength(1);
 		});
+
+		// La reserva rige en las dos formas: lo que `z-floating` prohíbe no lo puede conceder la declaración.
+		it('rejects a reference to a global layer outside the files that declare one', async () => {
+			expect(await warningsFor('.a { z-index: var(--z-index-nav); }')).toHaveLength(1);
+		});
+
+		it('accepts a reference to a global layer in the file that declares it', async () => {
+			expect(await warningsFor('.a { z-index: var(--z-index-floating); }', TOOLTIP_FILE)).toHaveLength(0);
+		});
 	});
 
 	describe('utilidades en @apply', () => {
@@ -55,6 +63,23 @@ describe('cuentoneta/z-index-scale', () => {
 
 		it('rejects a layer name that does not exist', async () => {
 			expect(await warningsFor('.a { @apply z-nvv; }')).toHaveLength(1);
+		});
+
+		// Con variante: el prefijo no exime, ni sirve para eludir la reserva de la franja alta.
+		it('accepts a layer of the scale with a variant', async () => {
+			expect(await warningsFor('.a { @apply md:z-content sm:hover:z-raised; }')).toHaveLength(0);
+		});
+
+		it('rejects a raw number behind a variant', async () => {
+			expect(await warningsFor('.a { @apply md:z-50; }')).toHaveLength(1);
+		});
+
+		it('rejects a negative behind a variant', async () => {
+			expect(await warningsFor('.a { @apply md:-z-content; }')).toHaveLength(1);
+		});
+
+		it('rejects a global layer behind a variant', async () => {
+			expect(await warningsFor('.a { @apply md:z-nav; }')).toHaveLength(1);
 		});
 
 		// La franja alta está reservada: la capa global se admite solo en el archivo que la declara.

--- a/tools/z-index-scale.js
+++ b/tools/z-index-scale.js
@@ -67,6 +67,14 @@ export function globalTokens() {
 	return scaleTokens().filter((token) => GLOBAL_LAYERS.has(token));
 }
 
+/**
+ * Las capas que un archivo puede usar. Es lo que va en el mensaje de error: ofrecer una capa global a un
+ * archivo que no puede declararla sugeriría una salida que la regla misma rechaza en el paso siguiente.
+ */
+export function allowedTokensFor(allowGlobals) {
+	return allowGlobals ? scaleTokens() : scaleTokens().filter((token) => !GLOBAL_LAYERS.has(token));
+}
+
 /** ¿`z-<suffix>` es una utilidad admitida — un token de la escala o la nativa `z-auto`? */
 export function isAllowedUtility(suffix) {
 	return NATIVE_UTILITIES.has(suffix) || zIndexScale().has(suffix);
@@ -78,14 +86,23 @@ export function isGlobalUtility(suffix) {
 }
 
 /**
+ * La capa que nombra el valor de una declaración `z-index`, o `null` si no referencia ninguna. Permite
+ * que la reserva de la franja alta rija también en esta forma: sin ella, lo que `z-nav` prohíbe lo
+ * concedería `z-index: var(--z-index-nav)`.
+ */
+export function declaredLayer(value) {
+	const reference = value.trim().match(/^var\(\s*--z-index-([a-z][a-z0-9-]*)\s*\)$/);
+	return reference === null ? null : reference[1];
+}
+
+/**
  * ¿El valor de una declaración `z-index` es admitido? Solo lo son una palabra clave de CSS y un
  * `var(--z-index-<token>)` cuyo token exista en la escala. Un número crudo nunca lo es.
  */
 export function isAllowedDeclarationValue(value) {
-	const normalized = value.trim();
-	if (CSS_WIDE_KEYWORDS.has(normalized.toLowerCase())) {
+	if (CSS_WIDE_KEYWORDS.has(value.trim().toLowerCase())) {
 		return true;
 	}
-	const reference = normalized.match(/^var\(\s*--z-index-([a-z][a-z0-9-]*)\s*\)$/);
-	return reference !== null && zIndexScale().has(reference[1]);
+	const layer = declaredLayer(value);
+	return layer !== null && zIndexScale().has(layer);
 }

--- a/tools/z-index-scale.spec.ts
+++ b/tools/z-index-scale.spec.ts
@@ -1,5 +1,9 @@
-// REASON: el helper es un `.js` sin tipos propios; el spec solo necesita sus exports.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// @vitest-environment node
+// Bajo `happy-dom`, la condición de exportación de Tailwind resuelve a su build de navegador, que no
+// expone el compilador.
+import { readFileSync } from 'node:fs';
+import { compile } from 'tailwindcss';
+
 import {
 	globalTokens,
 	isAllowedDeclarationValue,
@@ -51,6 +55,41 @@ describe('escala de apilamiento del Design System', () => {
 			expect(isAllowedUtility('10')).toBe(false);
 			expect(isAllowedUtility('50')).toBe(false);
 			expect(isAllowedUtility('nvv')).toBe(false);
+		});
+	});
+
+	// Que la escala genere utilidades es un detalle de implementación de Tailwind, no un contrato: la
+	// namespace `--z-index-*` la reconoce la versión instalada, y un bump que la renombrara dejaría a cada
+	// capa sin emitir CSS **sin romper el build**. Además, Tailwind descarta del CSS emitido los tokens del
+	// tema que ninguna utilidad usa, así que una capa consumida solo por `var()` desde una hoja de
+	// componente desaparecería sola. Compilar el tema real es lo único que ve las dos cosas.
+	describe('compilación del tema', () => {
+		async function compiledCss() {
+			const compiler = await compile(readFileSync('src/tailwind.css', 'utf-8'), {
+				base: process.cwd(),
+				loadStylesheet: async (id: string) => {
+					const path = id === 'tailwindcss' ? 'node_modules/tailwindcss/index.css' : id;
+					return { path, base: 'node_modules/tailwindcss', content: readFileSync(path, 'utf-8') };
+				},
+			});
+			return compiler.build(scaleTokens().map((token: string) => `z-${token}`));
+		}
+
+		it('emits a utility and its variable for every layer of the scale', async () => {
+			const css = await compiledCss();
+			for (const token of scaleTokens()) {
+				expect(css, `la capa "${token}" no emite su utilidad`).toContain(`.z-${token}`);
+				expect(css, `la capa "${token}" no emite su variable`).toContain(`--z-index-${token}:`);
+			}
+		});
+
+		// El valor emitido es el que ordena de verdad: si el token cambiara de número sin que nadie lo note,
+		// la escala seguiría compilando y el orden entre capas dejaría de ser el declarado.
+		it('emits each variable with the value the scale declares', async () => {
+			const css = await compiledCss();
+			for (const [token, value] of zIndexScale()) {
+				expect(css).toContain(`--z-index-${token}: ${value};`);
+			}
 		});
 	});
 


### PR DESCRIPTION
Correcciones a la escala de apilamiento que entró en #2214, a partir de la review posterior al merge. Una es una **regresión funcional que ya está en `develop`**; las otras tres dejaban a la escala prometiendo más de lo que verificaba.

Closes #2207

## La regresión

La migración del carousel cambió el orden de pintado sin que se notara. Antes las diapositivas ordenaban entre sí con valores por debajo del de los controles; al pasar a la escala quedaron en la capa elevada y los controles e indicadores en la de contenido, así que **la diapositiva activa —absoluta y a pantalla completa— se dibuja encima de ambos**. Los indicadores se renderizan siempre y son clickeables: el clic cae en el enlace de la campaña y navega en vez de cambiar de diapositiva.

El arreglo no reacomoda números: aplica la norma que este mismo trabajo introdujo. El contenedor de diapositivas es quien eleva y no confinaba nada, así que su orden interno competía con sus hermanos. Con el apilamiento aislado, ese orden queda adentro y los controles vuelven a estar encima sin depender de ningún valor.

**Medido en el navegador en los dos sentidos:** con el aislamiento, controles e indicadores responden al hit-test sobre su propio centro; sin él, a los tres los tapa la diapositiva activa.

## Los tres huecos del enforcement

| Qué prometía | Qué hacía |
| --- | --- |
| Cubrir `md:z-nav`, `hover:z-raised` | **Ninguna de las dos reglas veía una utilidad con variante.** El patrón excluía el `:` en vez de consumirlo: `md:z-50` entraba sin fricción y `md:z-nav` eludía la reserva de la franja alta. Los dos casos válidos con variante de los specs pasaban igual con la regla desactivada. |
| Señalar dónde está la violación | **La posición en TypeScript colapsaba siempre.** Se derivaba del texto del nodo con un índice absoluto del archivo, así que toda violación caía en la primera línea; en un componente largo el mensaje apuntaba al import. |
| Reservar la franja alta | **Regía solo en la forma utilidad.** Lo que `z-nav` prohibía lo concedía `z-index: var(--z-index-nav)`, mientras la referencia afirmaba lo contrario. |

Los tres estaban **fuera de la cobertura de sus propios specs**, que es por lo que sobrevivieron. Cada arreglo entra con los casos que lo fijan: utilidades con variante (válidas e inválidas, incluida la elusión de la reserva), dos violaciones en líneas distintas con línea y columna afirmadas, y la reserva en las dos formas.

## Lo demás

- **La escala se verifica contra el Tailwind real, no contra su promesa.** Que el tema genere utilidades es un detalle de implementación de la versión instalada, y Tailwind además descarta los tokens que ninguna utilidad usa — así que una capa consumida solo por referencia desde una hoja de componente podía desaparecer sola, sin romper el build. Un caso compila el tema y afirma que cada capa emite su utilidad y su variable, con el valor declarado.
- **El e2e espera contenido propio de cada ruta.** Tres de las cuatro esperaban a la barra de navegación, que la aporta el shell y está presente aun con la ruta en esqueleto: el hit-test podía correr antes de que hubiera contenido con el que disputar la franja. Los selectores nuevos salen de inspeccionar el HTML que sirve el servidor — la ficha de autor sirve su encabezado vacío y lo completa en el cliente, y la colección no declara ninguno.
- **La referencia dice lo que la escala sostiene:** la reserva vale para las dos formas, sumar una capa global toca dos archivos (el tema y el conjunto de capas globales, porque lo global es una decisión de diseño y no una consecuencia del número), los negativos se rechazan con su criterio, y el orden **dentro** de un componente no lo cubre ningún gate.
- Se van dos supresiones de lint que no suprimían nada —`tools/` está en el ignore de ESLint— y el rationale que estaba repetido cuatro veces, que ahora vive solo en la referencia.

## Verificación

- **Gates locales:** `typecheck`, `lint`, `stylelint`, `test` (1955) en verde sobre `develop` actualizado.
- **e2e de apilamiento:** 40 casos verdes en chromium y firefox con los selectores nuevos.
- **Los specs de `tools/`:** 78 casos, incluidos los que fallan sin cada uno de los tres arreglos.
