### PR TITLE
[#2218] - Un recurso de autor sin URL deja la ficha y sus obras sin cuerpo en SSR

### DIFF
--- a/.claude/references/sanity-acl.md
+++ b/.claude/references/sanity-acl.md
@@ -206,6 +206,16 @@ Patrones que se repiten:
   Sanity a la forma que el dominio espera. `biography` es la excepción deliberada: el schema la
   exige (`Rule.required()`), así que el mapper la pasa **sin** `?? ''` — un valor faltante es un
   bug de datos, no un estado válido a tolerar en silencio.
+- **Un `Rule.required()` del schema no es una garantía sobre el dato persistido.** Esa validación
+  rige la **edición** en el Studio, no el almacenamiento: un documento anterior a la regla, o
+  escrito por script o migración, la esquiva sin dejar ninguna señal. El typegen, en cambio, deriva
+  la nulabilidad del **schema declarado**, así que emite un tipo no-nullable en el que el mapper
+  confía por default. Cuando esa confianza puede fallar, el mapper decide explícitamente entre
+  **descartar** el dato (accesorio para el agregado) o **lanzar** (central para el agregado) — nunca
+  dejar pasar el hueco en silencio. `mapResources` es el caso descartar: filtra, con
+  `console.warn`, todo recurso cuyo `url` no sea un string no vacío, porque un recurso es
+  información accesoria de `Author`/`Story`/`LiteraryWork` y perder uno no invalida el agregado.
+  `biography` (arriba) es el caso lanzar: sin ella, `Author` pierde su contenido central.
 - **Composición:** un mapper grande delega en otros (`mapStoryContent` usa `mapAuthor`,
   `mapResources`, `mapTags`, `mapBlockContentToTextParagraphs`, `mapMediaSources`). `mapStoryContent`
   y `mapAuthor` propagan los **tags** del cuento y del autor vía `mapTags`; los mappers de teasers

--- a/cms/migrations/sanitize-resources-without-url/README.md
+++ b/cms/migrations/sanitize-resources-without-url/README.md
@@ -1,0 +1,111 @@
+# Sanear los recursos sin URL de autores y obras
+
+Un recurso web sin enlace no significa nada: la URL es su razón de ser. El schema lo declara con
+`Rule.required()`, pero esa regla valida la **edición** en el Studio y no lo ya almacenado, así que
+quedaron documentos —anteriores a la regla, o escritos por script— con el hueco abierto.
+
+En el autor el efecto era grave: el constructor de la Persona de schema.org leía `url.length` sobre
+un valor ausente, lanzaba, y como corre en una directiva declarada como `hostDirective` de la página,
+la excepción se llevaba puesto el render entero. La ficha y todas las obras de ese autor salían con
+`<main>` vacío en SSR. En la obra el mismo hueco solo produce un enlace sin destino.
+
+Esta migración cierra el hueco en los **datos**. Que la aplicación resista el caso lo garantiza el
+ACL, que descarta el recurso incompleto en la frontera: son dos defensas distintas y ninguna
+reemplaza a la otra, porque la validación del Studio no alcanza a lo escrito por script.
+
+## Censo
+
+Medido contra `production`, perspectiva `published`:
+
+| Tipo           | Documentos con un recurso sin `url` | Documentos con `resources` | Total |
+| -------------- | ----------------------------------: | -------------------------: | ----: |
+| `author`       |                              **17** |                        281 |   326 |
+| `story`        |                             **100** |                        254 |   613 |
+| `literaryWork` |                             **100** |                        254 |   617 |
+
+Los 100 de `story` y los 100 de `literaryWork` son el mismo contenido en documentos **distintos**:
+cada obra derivada lleva el id `lw-from-story-<uuid del cuento>` y copió el array `resources` con sus
+`_key` idénticos. Saltear uno de los dos tipos dejaría el espejo desalineado.
+
+## Disposición, por tipo
+
+**`author` — completar, salvo un caso.** El recurso se titula "Artículo de \<Nombre\> en Wikipedia", y
+cada artículo se verificó uno por uno contra la API de MediaWiki. Dieciséis existen y se enlazan; el
+único que no tiene destino es `anonimo`, donde "Anónimo" redirige a _Seudonimato y anonimato_, un
+artículo sobre el concepto y no sobre una persona. Ese recurso se borra.
+
+Un autor que no figure en la tabla y tenga un recurso sin URL **aborta la corrida**. La alternativa
+—saltearlo— dejaría que un caso nuevo pase en silencio por una migración que cree haberlo cubierto.
+
+**`story` / `literaryWork` — borrar.** Los 200 son un caso homogéneo: el recurso se titula siempre
+"Enlace a recurso original" y no nombra ningún destino averiguable, así que no hay nada que
+completar. Acá no hay tabla ni guard: la regla borra por predicado, con lo cual un documento nuevo
+con el mismo hueco queda cubierto por definición.
+
+## Por qué la disposición se indexa por slug y no por `_key`
+
+Los `_key` del censo salieron de `production`, y la migración corre en los tres datasets sin garantía
+de que coincidan. El recorrido localiza el recurso incompleto **por predicado** y lee su `_key` del
+documento; la tabla se indexa por `slug.current`. Los `_key` de abajo quedan solo como cruce de
+verificación del dry-run.
+
+| slug de autor       | `_key` del recurso en `production` |
+| ------------------- | ---------------------------------- |
+| algernon-blackwood  | `VEUjhZrri4M2SX1V33ljUjL5anwgG4VH` |
+| ambrose-bierce      | `euVmNg2UAgSDSklIMlIzlS8ACuM0VbSe` |
+| anonimo             | `hui5KatfYJHZ7Ff0VoM1M5fL3Jz7kaFL` |
+| don-juan-manuel     | `OPdclWAGjK50uSETGnzy7FQzOONNTHhS` |
+| eta-hoffmann        | `BxCiHvRrtSo0KEEGXMY8ChgQN2BZeY1F` |
+| frida-kahlo         | `Iw3Tt0myjnrAWcbOd4g4Jo6FunKGql9a` |
+| h-rider-haggard     | `gukTxVjBfZsXsO0AGegRQOqUETn72uK7` |
+| jean-ray            | `P6uqqsPxjwWK7fB7WY4F9qBTTmWFg2jj` |
+| khalil-gibran       | `SqUvLWdjHgmcrWCANgbEwFVSwFCyzHlf` |
+| kurt-vonnegut       | `UFCn3omoc6EwNk7Vn8oQXG7myYMfEI7f` |
+| leon-tolstoi        | `XOOUJmTjv7kzwWz7j7G4o2fIMo7D67Ey` |
+| margaret-st-clair   | `Kf9wsVxFfzs8ZkWrHVnN2uO6ALz0tluE` |
+| natalia-ginzburg    | `JNQexx7pKbMZyYTObTVP2gD6yiIXnhGH` |
+| nathaniel-hawthorne | `LF4x3z3mBtSXc9PJ7AwglB2CNuXIajxa` |
+| neil-gaiman         | `RgJICM6dXkX6mv6k6zSLvUtDABePLMR1` |
+| selma-lagerlof      | `74syWKDhiP84WQ0lrov0sZ8xVeDAxtek` |
+| the-monty-python    | `muYViD4uvID37VMXP7E4H7q2ILXypKGl` |
+
+El título del recurso de `the-monty-python` dice "The Monty Python", pero el artículo existe como
+_Monty Python_. La URL apunta al artículo real; corregir el título es trabajo editorial aparte.
+
+## Cómo se corre
+
+Dry-run por defecto, y **una corrida por dataset**: aplicarla en uno no la aplica a los otros.
+
+```bash
+pnpm exec sanity migration run sanitize-resources-without-url --dataset development
+pnpm exec sanity migration run sanitize-resources-without-url --dataset development --no-dry-run
+```
+
+Repetir para `staging` y `production`. El dry-run se contrasta contra los `_key` de la tabla.
+
+Es **independiente del código**: no renombra un campo ni cambia la forma de un valor, solo completa o
+quita un ítem que el código ya sabe leer. Los dos órdenes respecto del despliegue son seguros, así
+que conviene el que alivia antes — correr el saneamiento primero devuelve el cuerpo a las 37 páginas
+sin esperar al deploy.
+
+Lo que sí tiene orden obligatorio es la validación de forma de URL en el schema: va **después** de
+sanear, o el Studio marca en rojo los 217 documentos antes de que se los pueda corregir.
+
+Mientras `production` conserve el dato roto, la copia nocturna lo vuelve a plantar en los otros dos
+datasets. Sanear `production` primero hace que converjan solos en la copia siguiente, pero el orden
+de las copias no es una garantía: la migración se corre igual en cada uno.
+
+## Verificación
+
+Que la corrida reporte N mutaciones dice que **alcanzó** N documentos, no que escribió lo correcto.
+Se verifica consultando el resultado:
+
+```groq
+count(*[_type in ["author","story","literaryWork"] && count(resources[!defined(url)]) > 0])
+```
+
+Debe dar `0`. Y el smoke de indexado sobre las páginas que el defecto vaciaba:
+
+```bash
+BASE_URL=https://www.cuentoneta.ar SEO_SMOKE_SLUGS=/author/neil-gaiman,/story/wakefield pnpm seo:smoke
+```

--- a/cms/migrations/sanitize-resources-without-url/README.md
+++ b/cms/migrations/sanitize-resources-without-url/README.md
@@ -39,8 +39,25 @@ Un autor que no figure en la tabla y tenga un recurso sin URL **aborta la corrid
 
 **`story` / `literaryWork` — borrar.** Los 200 son un caso homogéneo: el recurso se titula siempre
 "Enlace a recurso original" y no nombra ningún destino averiguable, así que no hay nada que
-completar. Acá no hay tabla ni guard: la regla borra por predicado, con lo cual un documento nuevo
-con el mismo hueco queda cubierto por definición.
+completar. Acá no hay tabla —la regla borra por predicado, con lo cual un documento nuevo con el
+mismo hueco queda cubierto por definición—, pero sí un guard: si el título no es el del lote, la
+corrida **aborta**. Es la única operación destructiva de la migración, y su justificación se apoya en
+un hecho del dato, así que el código lo verifica en vez de darlo por cierto.
+
+**Dos URLs cargadas sin protocolo.** Un autor tiene dos perfiles guardados como `instagram.com/…` y
+`youtube.com/…`, sin esquema. No entran en el hueco que motiva la migración —tienen valor— pero la
+validación de forma que este cambio agrega al schema los rechazaría, y sanear a medias dejaría
+documentos en rojo por otro motivo. La migración les antepone `https://`.
+
+**Los `mailto:` se conservan.** Cinco autores tienen su dirección de contacto cargada como recurso.
+Son contenido válido, así que la validación del schema admite ese esquema además de `http`/`https`.
+
+## Borradores
+
+La corrida recorre también los borradores, donde una fila de recurso a medio completar es el estado
+normal apenas se agrega un ítem en el Studio. Un **autor en borrador** fuera de la tabla se saltea en
+vez de abortar: detener la corrida por una edición en curso impediría sanear el contenido publicado,
+que es lo que la migración viene a arreglar. El guard sigue vigente para todo lo publicado.
 
 ## Por qué la disposición se indexa por slug y no por `_key`
 

--- a/cms/migrations/sanitize-resources-without-url/index.spec.ts
+++ b/cms/migrations/sanitize-resources-without-url/index.spec.ts
@@ -56,7 +56,7 @@ describe('sanitize-resources-without-url', () => {
 			_id: 'story-1',
 			_type: 'story',
 			slug: { current: 'wakefield' },
-			resources: [{ _key: 'roto', url: null }],
+			resources: [{ _key: 'roto', url: null, title: 'Enlace a recurso original' }],
 		});
 
 		expect(patches).toMatchObject([{ path: ['resources', { _key: 'roto' }], op: { type: 'unset' } }]);
@@ -67,7 +67,7 @@ describe('sanitize-resources-without-url', () => {
 			_id: 'lw-from-story-1',
 			_type: 'literaryWork',
 			slug: { current: 'una-obra-cualquiera' },
-			resources: [{ _key: 'roto', url: null }],
+			resources: [{ _key: 'roto', url: null, title: 'Enlace a recurso original' }],
 		});
 
 		expect(patches).toMatchObject([{ path: ['resources', { _key: 'roto' }], op: { type: 'unset' } }]);
@@ -118,5 +118,80 @@ describe('sanitize-resources-without-url', () => {
 		expect(() => migrateDocument({ _id: 'author-10', _type: 'author', resources: [{ _key: 'roto' }] })).toThrow(
 			/no figura en la tabla de disposición/,
 		);
+	});
+
+	it('trata una url vacía igual que una ausente', () => {
+		const patches = migrateDocument({
+			_id: 'author-1',
+			_type: 'author',
+			slug: { current: 'neil-gaiman' },
+			resources: [{ _key: 'roto', url: '' }],
+		});
+
+		expect(patches).toMatchObject([{ path: ['resources', { _key: 'roto' }, 'url'] }]);
+	});
+
+	// Una fila a medio completar es el estado normal apenas se agrega un ítem en el Studio: abortar por
+	// eso detendría la corrida sobre el contenido publicado, que es lo que la migración viene a sanear.
+	it('saltea un autor en borrador fuera de la tabla, sin abortar', () => {
+		const doc = {
+			_id: 'drafts.author-11',
+			_type: 'author',
+			slug: { current: 'autor-a-medio-cargar' },
+			resources: [{ _key: 'roto' }],
+		};
+
+		expect(migrateDocument(doc)).toEqual([]);
+	});
+
+	it('aborta ante un autor con más recursos incompletos que los que la tabla puede completar', () => {
+		expect(() =>
+			migrateDocument({
+				_id: 'author-1',
+				_type: 'author',
+				slug: { current: 'neil-gaiman' },
+				resources: [{ _key: 'roto-1' }, { _key: 'roto-2' }],
+			}),
+		).toThrow(/la tabla asigna una sola/);
+	});
+
+	// La disposición de borrar se apoya en que el recurso no nombra ningún destino averiguable. Un
+	// título distinto es otro caso, y borrarlo sería destruir un dato que nadie evaluó.
+	it('aborta ante una obra con un recurso sin URL de título ajeno al lote', () => {
+		expect(() =>
+			migrateDocument({
+				_id: 'story-9',
+				_type: 'story',
+				slug: { current: 'una-obra' },
+				resources: [{ _key: 'roto', title: 'Entrevista al autor en un pódcast' }],
+			}),
+		).toThrow(/ajeno al lote/);
+	});
+
+	it('completa el protocolo de una URL cargada sin esquema', () => {
+		const patches = migrateDocument({
+			_id: 'author-12',
+			_type: 'author',
+			slug: { current: 'la-conspiracion-de-los-fuleros' },
+			resources: [{ _key: 'sin-esquema', url: 'instagram.com/conspiraciondelosfuleros', title: 'Perfil de Instagram' }],
+		});
+
+		expect(patches).toMatchObject([
+			{
+				path: ['resources', { _key: 'sin-esquema' }, 'url'],
+				op: { value: 'https://instagram.com/conspiraciondelosfuleros' },
+			},
+		]);
+	});
+
+	it('no toca una URL con esquema que no figura entre las conocidas', () => {
+		expect(
+			migrateDocument({
+				_id: 'author-13',
+				_type: 'author',
+				slug: { current: 'un-autor' },
+				resources: [{ _key: 'contacto', url: 'mailto:autor@example.com' }],
+			}),
+		).toEqual([]);
 	});
 });

--- a/cms/migrations/sanitize-resources-without-url/index.spec.ts
+++ b/cms/migrations/sanitize-resources-without-url/index.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import migration from './index';
+
+// La migración se define con `defineMigration`, que conserva el objeto tal cual: `migrate.document`
+// es la función pura que decide el patch de cada documento, y es lo único que hace falta ejercitar.
+type MigratedDocument = Parameters<NonNullable<NonNullable<typeof migration.migrate>['document']>>[0];
+
+interface TestDocument {
+	_id: string;
+	_type: string;
+	slug?: { current?: string };
+	resources?: { _key: string; url?: string | null; title?: string }[];
+}
+
+const migrateDocument = (doc: TestDocument) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as MigratedDocument);
+};
+
+const completeResource = { _key: 'sano', url: 'https://es.wikipedia.org/wiki/Julio_Cort%C3%A1zar' };
+
+describe('sanitize-resources-without-url', () => {
+	it('recorre los tres tipos que embeben recursos', () => {
+		expect(migration.documentTypes).toEqual(['author', 'story', 'literaryWork']);
+	});
+
+	it('completa la URL del recurso de un autor con artículo', () => {
+		const patches = migrateDocument({
+			_id: 'author-1',
+			_type: 'author',
+			slug: { current: 'neil-gaiman' },
+			resources: [{ _key: 'roto' }],
+		});
+
+		expect(patches).toMatchObject([
+			{ path: ['resources', { _key: 'roto' }, 'url'], op: { value: 'https://es.wikipedia.org/wiki/Neil_Gaiman' } },
+		]);
+	});
+
+	it('borra el recurso del autor que no tiene artículo al que apuntar', () => {
+		const patches = migrateDocument({
+			_id: 'author-2',
+			_type: 'author',
+			slug: { current: 'anonimo' },
+			resources: [{ _key: 'roto' }],
+		});
+
+		expect(patches).toMatchObject([{ path: ['resources', { _key: 'roto' }], op: { type: 'unset' } }]);
+	});
+
+	// El campo llega `null` en las obras y ausente en los autores; ambas formas son el mismo hueco.
+	it('trata una url nula igual que una ausente', () => {
+		const patches = migrateDocument({
+			_id: 'story-1',
+			_type: 'story',
+			slug: { current: 'wakefield' },
+			resources: [{ _key: 'roto', url: null }],
+		});
+
+		expect(patches).toMatchObject([{ path: ['resources', { _key: 'roto' }], op: { type: 'unset' } }]);
+	});
+
+	it('borra el recurso incompleto de una obra literaria, sin consultar tabla alguna', () => {
+		const patches = migrateDocument({
+			_id: 'lw-from-story-1',
+			_type: 'literaryWork',
+			slug: { current: 'una-obra-cualquiera' },
+			resources: [{ _key: 'roto', url: null }],
+		});
+
+		expect(patches).toMatchObject([{ path: ['resources', { _key: 'roto' }], op: { type: 'unset' } }]);
+	});
+
+	it('no toca los recursos sanos del mismo documento', () => {
+		const patches = migrateDocument({
+			_id: 'author-1',
+			_type: 'author',
+			slug: { current: 'neil-gaiman' },
+			resources: [completeResource, { _key: 'roto' }],
+		});
+
+		expect(patches).toHaveLength(1);
+		expect(patches).toMatchObject([{ path: ['resources', { _key: 'roto' }, 'url'] }]);
+	});
+
+	// Idempotencia: una segunda corrida no encuentra nada que sanear.
+	it('no produce mutación sobre un documento ya saneado', () => {
+		expect(
+			migrateDocument({
+				_id: 'author-1',
+				_type: 'author',
+				slug: { current: 'neil-gaiman' },
+				resources: [completeResource],
+			}),
+		).toEqual([]);
+	});
+
+	it('no produce mutación sobre un documento sin recursos', () => {
+		expect(migrateDocument({ _id: 'author-3', _type: 'author', slug: { current: 'julio-cortazar' } })).toEqual([]);
+	});
+
+	// El guard vive dentro de migrate.document, no solo en el filter: el filtro acota el recorrido,
+	// no garantiza la disposición.
+	it('aborta ante un autor con un recurso sin URL que no figura en la tabla', () => {
+		expect(() =>
+			migrateDocument({
+				_id: 'author-9',
+				_type: 'author',
+				slug: { current: 'autor-que-se-sumo-despues' },
+				resources: [{ _key: 'roto' }],
+			}),
+		).toThrow(/no figura en la tabla de disposición/);
+	});
+
+	it('aborta ante un autor sin slug', () => {
+		expect(() => migrateDocument({ _id: 'author-10', _type: 'author', resources: [{ _key: 'roto' }] })).toThrow(
+			/no figura en la tabla de disposición/,
+		);
+	});
+});

--- a/cms/migrations/sanitize-resources-without-url/index.ts
+++ b/cms/migrations/sanitize-resources-without-url/index.ts
@@ -1,0 +1,92 @@
+import { at, defineMigration, set, unset } from 'sanity/migrate';
+
+// `Rule.required()` sobre `url` valida la edición en el Studio, no lo ya almacenado: quedaron
+// documentos —anteriores a la regla, o escritos por script— con un recurso sin enlace. En el autor
+// eso reventaba el constructor de la Persona y dejaba su ficha y sus obras sin cuerpo en SSR; en la
+// obra renderiza un enlace sin destino. Esta migración cierra el hueco en los datos; que la
+// aplicación resista el caso lo garantiza el ACL.
+
+// El artículo de Wikipedia que cada recurso prometía, verificado uno por uno contra la API de
+// MediaWiki. Un autor ausente de este mapa pierde su recurso: es la disposición de quien no tiene
+// artículo al que apuntar.
+const AUTHOR_RESOURCE_URLS: Readonly<Record<string, string>> = {
+	'algernon-blackwood': 'https://es.wikipedia.org/wiki/Algernon_Blackwood',
+	'ambrose-bierce': 'https://es.wikipedia.org/wiki/Ambrose_Bierce',
+	'don-juan-manuel': 'https://es.wikipedia.org/wiki/Don_Juan_Manuel',
+	'eta-hoffmann': 'https://es.wikipedia.org/wiki/E._T._A._Hoffmann',
+	'frida-kahlo': 'https://es.wikipedia.org/wiki/Frida_Kahlo',
+	'h-rider-haggard': 'https://es.wikipedia.org/wiki/H._Rider_Haggard',
+	'jean-ray': 'https://es.wikipedia.org/wiki/Jean_Ray',
+	'khalil-gibran': 'https://es.wikipedia.org/wiki/Yibr%C3%A1n_Jalil_Yibr%C3%A1n',
+	'kurt-vonnegut': 'https://es.wikipedia.org/wiki/Kurt_Vonnegut',
+	'leon-tolstoi': 'https://es.wikipedia.org/wiki/Le%C3%B3n_Tolst%C3%B3i',
+	'margaret-st-clair': 'https://es.wikipedia.org/wiki/Margaret_St._Clair',
+	'natalia-ginzburg': 'https://es.wikipedia.org/wiki/Natalia_Ginzburg',
+	'nathaniel-hawthorne': 'https://es.wikipedia.org/wiki/Nathaniel_Hawthorne',
+	'neil-gaiman': 'https://es.wikipedia.org/wiki/Neil_Gaiman',
+	'selma-lagerlof': 'https://es.wikipedia.org/wiki/Selma_Lagerl%C3%B6f',
+	'the-monty-python': 'https://es.wikipedia.org/wiki/Monty_Python',
+};
+
+// El único autor cuyo recurso se borra en vez de completarse: "Anónimo" no nombra a una persona, y
+// el artículo al que redirige trata sobre el anonimato como concepto.
+const AUTHORS_WITHOUT_ARTICLE: readonly string[] = ['anonimo'];
+
+interface MigratedResource {
+	_key: string;
+	url?: string | null;
+}
+
+interface MigratedDocument {
+	_id: string;
+	_type: string;
+	slug?: { current?: string };
+	resources?: MigratedResource[];
+}
+
+function lacksUrl(resource: MigratedResource): boolean {
+	return typeof resource.url !== 'string' || resource.url.length === 0;
+}
+
+// El `_key` se lee del documento y la disposición se indexa por slug: los `_key` del censo salieron
+// de production y la migración corre en los tres datasets, donde no hay garantía de que coincidan.
+function migrateAuthor(document: MigratedDocument, incomplete: MigratedResource[]) {
+	const slug = document.slug?.current;
+
+	// Un autor que se sume después no debe pasar en silencio por una migración que cree haberlo
+	// cubierto: sin entrada en el mapa ni en la lista de excepciones, no hay disposición que aplicar.
+	if (!slug || (!(slug in AUTHOR_RESOURCE_URLS) && !AUTHORS_WITHOUT_ARTICLE.includes(slug))) {
+		throw new Error(
+			`El autor "${slug ?? document._id}" tiene un recurso sin URL y no figura en la tabla de disposición`,
+		);
+	}
+
+	const url = AUTHOR_RESOURCE_URLS[slug];
+	return incomplete.map((resource) =>
+		url
+			? at(['resources', { _key: resource._key }, 'url'], set(url))
+			: at(['resources', { _key: resource._key }], unset()),
+	);
+}
+
+// En la obra no hay tabla: el recurso se titula siempre "Enlace a recurso original" y no nombra
+// ningún destino averiguable, así que la única disposición posible es borrarlo. Al no enumerar
+// documentos, un caso nuevo con el mismo hueco queda cubierto por definición.
+function discardResources(incomplete: MigratedResource[]) {
+	return incomplete.map((resource) => at(['resources', { _key: resource._key }], unset()));
+}
+
+export default defineMigration({
+	title: 'Sanear los recursos sin URL de autores y obras',
+	documentTypes: ['author', 'story', 'literaryWork'],
+	migrate: {
+		document(document: MigratedDocument) {
+			const incomplete = (document.resources ?? []).filter(lacksUrl);
+			if (incomplete.length === 0) {
+				return [];
+			}
+
+			return document._type === 'author' ? migrateAuthor(document, incomplete) : discardResources(incomplete);
+		},
+	},
+});

--- a/cms/migrations/sanitize-resources-without-url/index.ts
+++ b/cms/migrations/sanitize-resources-without-url/index.ts
@@ -9,7 +9,7 @@ import { at, defineMigration, set, unset } from 'sanity/migrate';
 // El artículo de Wikipedia que cada recurso prometía, verificado uno por uno contra la API de
 // MediaWiki. Un autor ausente de este mapa pierde su recurso: es la disposición de quien no tiene
 // artículo al que apuntar.
-const AUTHOR_RESOURCE_URLS: Readonly<Record<string, string>> = {
+const AUTHOR_RESOURCE_URLS: Readonly<Partial<Record<string, string>>> = {
 	'algernon-blackwood': 'https://es.wikipedia.org/wiki/Algernon_Blackwood',
 	'ambrose-bierce': 'https://es.wikipedia.org/wiki/Ambrose_Bierce',
 	'don-juan-manuel': 'https://es.wikipedia.org/wiki/Don_Juan_Manuel',
@@ -32,9 +32,22 @@ const AUTHOR_RESOURCE_URLS: Readonly<Record<string, string>> = {
 // el artículo al que redirige trata sobre el anonimato como concepto.
 const AUTHORS_WITHOUT_ARTICLE: readonly string[] = ['anonimo'];
 
+// El título con el que se cargaron los recursos incompletos de las obras. La disposición de borrarlos
+// se apoya en que ese título no nombra ningún destino averiguable, así que la migración lo verifica
+// en vez de darlo por cierto: es su única operación destructiva.
+const WORK_RESOURCE_TITLE = 'Enlace a recurso original';
+
+// Dos perfiles cargados sin protocolo, que la validación de forma del schema rechazaría. Se indexan
+// por su URL literal porque es el dato que identifica al recurso, y no hay dos iguales.
+const SCHEMELESS_URL_FIXES: Readonly<Partial<Record<string, string>>> = {
+	'instagram.com/conspiraciondelosfuleros': 'https://instagram.com/conspiraciondelosfuleros',
+	'youtube.com/@conspiraciondelosfuleros7233': 'https://youtube.com/@conspiraciondelosfuleros7233',
+};
+
 interface MigratedResource {
 	_key: string;
 	url?: string | null;
+	title?: string;
 }
 
 interface MigratedDocument {
@@ -48,20 +61,35 @@ function lacksUrl(resource: MigratedResource): boolean {
 	return typeof resource.url !== 'string' || resource.url.length === 0;
 }
 
+function isDraft(document: MigratedDocument): boolean {
+	return document._id.startsWith('drafts.');
+}
+
 // El `_key` se lee del documento y la disposición se indexa por slug: los `_key` del censo salieron
 // de production y la migración corre en los tres datasets, donde no hay garantía de que coincidan.
 function migrateAuthor(document: MigratedDocument, incomplete: MigratedResource[]) {
-	const slug = document.slug?.current;
+	const slug = document.slug?.current ?? '';
+	const url = AUTHOR_RESOURCE_URLS[slug];
 
 	// Un autor que se sume después no debe pasar en silencio por una migración que cree haberlo
 	// cubierto: sin entrada en el mapa ni en la lista de excepciones, no hay disposición que aplicar.
-	if (!slug || (!(slug in AUTHOR_RESOURCE_URLS) && !AUTHORS_WITHOUT_ARTICLE.includes(slug))) {
+	// El borrador es la excepción: una fila de recurso a medio completar es el estado normal apenas se
+	// agrega un ítem en el Studio, y abortar por eso detendría la corrida sobre contenido publicado.
+	if (!url && !AUTHORS_WITHOUT_ARTICLE.includes(slug)) {
+		if (isDraft(document)) {
+			return [];
+		}
 		throw new Error(
-			`El autor "${slug ?? document._id}" tiene un recurso sin URL y no figura en la tabla de disposición`,
+			`El autor "${slug || document._id}" tiene un recurso sin URL y no figura en la tabla de disposición`,
 		);
 	}
 
-	const url = AUTHOR_RESOURCE_URLS[slug];
+	// La tabla asigna una URL por autor, así que dos recursos incompletos en el mismo documento
+	// quedarían apuntando ambos al mismo artículo. El censo dice que no pasa; esto lo afirma.
+	if (url && incomplete.length > 1) {
+		throw new Error(`El autor "${slug}" tiene ${incomplete.length} recursos sin URL y la tabla asigna una sola`);
+	}
+
 	return incomplete.map((resource) =>
 		url
 			? at(['resources', { _key: resource._key }, 'url'], set(url))
@@ -69,11 +97,27 @@ function migrateAuthor(document: MigratedDocument, incomplete: MigratedResource[
 	);
 }
 
-// En la obra no hay tabla: el recurso se titula siempre "Enlace a recurso original" y no nombra
-// ningún destino averiguable, así que la única disposición posible es borrarlo. Al no enumerar
-// documentos, un caso nuevo con el mismo hueco queda cubierto por definición.
-function discardResources(incomplete: MigratedResource[]) {
+// En la obra no hay tabla: el recurso no nombra ningún destino averiguable, así que la única
+// disposición posible es borrarlo. Al no enumerar documentos, un caso nuevo con el mismo hueco queda
+// cubierto por definición — siempre que sea el mismo caso, que es lo que verifica el título.
+function discardWorkResources(document: MigratedDocument, incomplete: MigratedResource[]) {
+	const unexpected = incomplete.find((resource) => resource.title !== WORK_RESOURCE_TITLE);
+	if (unexpected) {
+		throw new Error(
+			`La obra "${document.slug?.current ?? document._id}" tiene un recurso sin URL titulado "${unexpected.title}", ajeno al lote que esta migración borra`,
+		);
+	}
+
 	return incomplete.map((resource) => at(['resources', { _key: resource._key }], unset()));
+}
+
+// La validación de forma del schema rechaza una URL sin protocolo, y el saneamiento sería inútil si
+// dejara documentos que la incumplen por otro motivo que el hueco.
+function completeSchemelessUrls(resources: MigratedResource[]) {
+	return resources.flatMap((resource) => {
+		const fixed = typeof resource.url === 'string' ? SCHEMELESS_URL_FIXES[resource.url] : undefined;
+		return fixed ? [at(['resources', { _key: resource._key }, 'url'], set(fixed))] : [];
+	});
 }
 
 export default defineMigration({
@@ -81,12 +125,17 @@ export default defineMigration({
 	documentTypes: ['author', 'story', 'literaryWork'],
 	migrate: {
 		document(document: MigratedDocument) {
-			const incomplete = (document.resources ?? []).filter(lacksUrl);
+			const resources = document.resources ?? [];
+			const incomplete = resources.filter(lacksUrl);
+			const schemeless = completeSchemelessUrls(resources);
+
 			if (incomplete.length === 0) {
-				return [];
+				return schemeless;
 			}
 
-			return document._type === 'author' ? migrateAuthor(document, incomplete) : discardResources(incomplete);
+			const patches =
+				document._type === 'author' ? migrateAuthor(document, incomplete) : discardWorkResources(document, incomplete);
+			return [...patches, ...schemeless];
 		},
 	},
 });

--- a/cms/schemas/resourceType.ts
+++ b/cms/schemas/resourceType.ts
@@ -20,8 +20,11 @@ export const resource = defineType({
 		defineField({
 			name: 'url',
 			title: 'URL',
-			type: 'string',
-			validation: (Rule) => Rule.required(),
+			// Era un `string` con `required()`, que admitía cualquier texto: el recurso solo sirve si su
+			// valor es alcanzable. La regla rige sobre la edición y no sobre lo almacenado, así que
+			// sanear los documentos que ya la incumplían es un trabajo aparte y no algo que esto repare.
+			type: 'url',
+			validation: (Rule) => Rule.required().uri({ scheme: ['http', 'https'] }),
 		}),
 		defineField({
 			name: 'resourceType',

--- a/cms/schemas/resourceType.ts
+++ b/cms/schemas/resourceType.ts
@@ -20,11 +20,11 @@ export const resource = defineType({
 		defineField({
 			name: 'url',
 			title: 'URL',
-			// Era un `string` con `required()`, que admitía cualquier texto: el recurso solo sirve si su
-			// valor es alcanzable. La regla rige sobre la edición y no sobre lo almacenado, así que
-			// sanear los documentos que ya la incumplían es un trabajo aparte y no algo que esto repare.
 			type: 'url',
-			validation: (Rule) => Rule.required().uri({ scheme: ['http', 'https'] }),
+			// La regla rige sobre la edición y no sobre lo almacenado, así que sanear los documentos que
+			// ya la incumplían es un trabajo aparte y no algo que esto repare. `mailto` está admitido
+			// porque un recurso puede ser la dirección de contacto del autor, no solo una página.
+			validation: (Rule) => Rule.required().uri({ scheme: ['http', 'https', 'mailto'] }),
 		}),
 		defineField({
 			name: 'resourceType',

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -183,6 +183,7 @@ interface Story {
 - La historia debe tener al menos un párrafo de contenido
 - El tiempo de lectura debe ser un número positivo
 - El idioma debe ser un código ISO válido
+- `resources` nunca contiene un ítem con `url` ausente o vacía (ver [Resource](#resource-recurso-externo))
 
 **Ciclo de Vida:**
 
@@ -271,6 +272,7 @@ interface AttributedText {
 - `sectionCount` es el número real de secciones (derivado en la factory; en proyecciones parciales lo provee el mapper)
 - Las posiciones de sección son contiguas desde 0 en el agregado completo (`content[i].position === i`); las proyecciones parciales conservan el `position` de origen
 - `authors` exige al menos un autor (1..N) — la **obra anónima** referencia explícitamente al author "Anónimo" (slug `anonimo`, valor bien conocido del dominio; policy `isAnonymous` compara por slug, nunca por `_id`)
+- `resources` nunca contiene un ítem con `url` ausente o vacía (ver [Resource](#resource-recurso-externo))
 
 **Ciclo de Vida:**
 
@@ -328,7 +330,7 @@ interface AuthorNationality {
 - El nombre no puede estar vacío
 - Si `diedOn` está definido, debe ser posterior a `bornOn`
 - `AuthorNationality` siempre debe estar presente
-- `resources` nunca contiene un ítem con `url` ausente o vacía: el ACL descarta ese recurso en la frontera al mapear desde Sanity (ver [Resource](#resource-recurso-externo) más abajo), así que la garantía es del mapeo, no del schema
+- `resources` nunca contiene un ítem con `url` ausente o vacía (ver [Resource](#resource-recurso-externo))
 
 **Ciclo de Vida:**
 

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -328,6 +328,7 @@ interface AuthorNationality {
 - El nombre no puede estar vacío
 - Si `diedOn` está definido, debe ser posterior a `bornOn`
 - `AuthorNationality` siempre debe estar presente
+- `resources` nunca contiene un ítem con `url` ausente o vacía: el ACL descarta ese recurso en la frontera al mapear desde Sanity (ver [Resource](#resource-recurso-externo) más abajo), así que la garantía es del mapeo, no del schema
 
 **Ciclo de Vida:**
 
@@ -645,6 +646,8 @@ interface ResourceType {
 }
 ```
 
+> `url` es la razón de ser del recurso: sin un enlace válido, no hay nada que enlazar. El schema de Sanity la exige y valida su forma de URL, pero esa regla rige la **edición** en el Studio, no el dato ya persistido — un documento anterior a la regla, o escrito por script o migración, puede tenerla ausente o vacía sin que el Studio lo señale. El ACL cierra esa brecha en la frontera: `mapResources` descarta, con un `console.warn` para hacerlo visible en logs, todo recurso cuyo `url` no sea un string no vacío. Por eso `Author.resources`, `Story.resources` y `LiteraryWork.resources` nunca transportan un ítem incompleto — la garantía es del mapeo, no del schema.
+
 > El ícono que acompaña a un recurso en la interfaz lo resuelve el frontend a partir del `slug` del tipo, contra el mapa local de `@models/icon.model`. No viaja desde el CMS.
 
 > El nombre `description` no implica un mismo tipo en todo el modelo: en `ResourceType` y en [`Tag`](#tag-etiqueta) es texto plano, mientras que `Storylist.description` es Portable Text (`TextBlockContent[]`), `Media.description` es HTML saneado y `Collection.description` es Markdown saneado a HTML. Conviene mirar la interfaz antes de asumir el formato.
@@ -869,7 +872,7 @@ Frontend / API Client
 - `mapAuthorTeaser()` - Author reducido
 - etc.
 
-**Beneficio:** El cambio en Sanity no afecta el dominio si se mantienen los contratos.
+**Beneficio:** El cambio en Sanity no afecta el dominio si se mantienen los contratos. Esto incluye descartar en la frontera lo que el schema no puede garantizar sobre el dato ya persistido (ver [Resource](#resource-recurso-externo)), no solo traducir shapes.
 
 ---
 

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -16,6 +16,7 @@ import { rawOnoffAuthor, rawOnoffAuthorTeaser } from '@mocks/onoff-raw-author.mo
 import { onoffRawContentCampaignsMock, onoffRawLandingPageMock } from '@mocks/onoff-raw-landing-page.mock';
 import type { RotatingContent } from '@models/landing-page-content.model';
 import { onoffRawTagsMock } from '@mocks/onoff-raw-tags.mock';
+import { withoutUrl } from '@testing/resource-without-url';
 import { viewportElementSizes } from '@models/content-campaign.model';
 
 describe('mapTags (ACL)', () => {
@@ -103,15 +104,6 @@ describe('mapStoryNavigationTeaserWithAuthor (ACL)', () => {
 		expect(result[0].tags).toEqual([]);
 	});
 });
-
-type RawResource = (typeof rawOnoffAuthor)['resources'][number];
-
-// REASON: el typegen declara `url: string` porque lo deriva del `Rule.required()` del schema, así
-// que la forma que el dataset sí contiene —el recurso sin URL— no se puede expresar sin el cast.
-function withoutUrl(resource: RawResource): RawResource {
-	const { url, ...rest } = resource;
-	return rest as unknown as RawResource;
-}
 
 describe('mapResources (ACL)', () => {
 	it('maps a raw Sanity resource to the domain Resource model', () => {

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -151,6 +151,12 @@ describe('mapResources (ACL)', () => {
 
 		expect(mapResources([{ ...rawResource, url: null as unknown as string }])).toEqual([]);
 	});
+
+	it('drops a resource whose url is an empty string', () => {
+		const [rawResource] = rawOnoffAuthor.resources;
+
+		expect(mapResources([{ ...rawResource, url: '' }])).toEqual([]);
+	});
 });
 
 describe('mapContentCampaigns (ACL)', () => {

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -104,6 +104,15 @@ describe('mapStoryNavigationTeaserWithAuthor (ACL)', () => {
 	});
 });
 
+type RawResource = (typeof rawOnoffAuthor)['resources'][number];
+
+// REASON: el typegen declara `url: string` porque lo deriva del `Rule.required()` del schema, así
+// que la forma que el dataset sí contiene —el recurso sin URL— no se puede expresar sin el cast.
+function withoutUrl(resource: RawResource): RawResource {
+	const { url, ...rest } = resource;
+	return rest as unknown as RawResource;
+}
+
 describe('mapResources (ACL)', () => {
 	it('maps a raw Sanity resource to the domain Resource model', () => {
 		const [rawResource] = rawOnoffAuthor.resources;
@@ -134,6 +143,21 @@ describe('mapResources (ACL)', () => {
 		type RawResources = Parameters<typeof mapResources>[0];
 		expect(mapResources(null as unknown as RawResources)).toEqual([]);
 		expect(mapResources(undefined as unknown as RawResources)).toEqual([]);
+	});
+
+	it('drops a resource whose url is missing, keeping the complete ones', () => {
+		const [rawResource] = rawOnoffAuthor.resources;
+
+		const result = mapResources([rawResource, withoutUrl(rawResource)]);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].url).toBe(rawResource.url);
+	});
+
+	it('drops a resource whose url is null, the shape the dataset actually holds', () => {
+		const [rawResource] = rawOnoffAuthor.resources;
+
+		expect(mapResources([{ ...rawResource, url: null as unknown as string }])).toEqual([]);
 	});
 });
 

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -153,27 +153,23 @@ function hasUrl(resource: RawResource): boolean {
 }
 
 export function mapResources(resources: ResourcesSubQuery): Resource[] {
+	const discarded = resources?.filter((resource) => !hasUrl(resource)) ?? [];
+	if (discarded.length > 0) {
+		// Solo el título: el resto de los campos del recurso descartado son tan poco confiables como la
+		// URL que falta, y esta rama existe justamente para no lanzar.
+		console.warn('mapResources: se descartan recursos sin URL', { titles: discarded.map((r) => r.title) });
+	}
+
 	return (
-		resources
-			?.filter((resource) => {
-				if (hasUrl(resource)) {
-					return true;
-				}
-				console.warn('mapResources: se descarta un recurso sin URL', {
-					title: resource.title,
-					resourceType: resource.resourceType.slug,
-				});
-				return false;
-			})
-			.map((resource) => ({
-				title: resource.title,
-				url: resource.url,
-				resourceType: {
-					slug: resource.resourceType.slug,
-					title: resource.resourceType.title,
-					description: resource.resourceType.description,
-				},
-			})) ?? []
+		resources?.filter(hasUrl).map((resource) => ({
+			title: resource.title,
+			url: resource.url,
+			resourceType: {
+				slug: resource.resourceType.slug,
+				title: resource.resourceType.title,
+				description: resource.resourceType.description,
+			},
+		})) ?? []
 	);
 }
 

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -143,17 +143,37 @@ type ResourcesSubQuery = (
 	| NonNullable<LiteraryWorkBySlugQueryResult>
 	| StoriesByAuthorSlugQueryResult[0]
 )['resources'];
+type RawResource = NonNullable<ResourcesSubQuery>[number];
+
+// El typegen deriva `url: string` del `Rule.required()` del schema, pero esa regla valida la edición
+// en el Studio, no lo ya almacenado: hay documentos persistidos sin URL. El tipo miente, y sin este
+// guard la ausencia cruza la frontera y revienta al primer consumidor que la lea como string.
+function hasUrl(resource: RawResource): boolean {
+	return typeof resource.url === 'string' && resource.url.length > 0;
+}
+
 export function mapResources(resources: ResourcesSubQuery): Resource[] {
 	return (
-		resources?.map((resource) => ({
-			title: resource.title,
-			url: resource.url,
-			resourceType: {
-				slug: resource.resourceType.slug,
-				title: resource.resourceType.title,
-				description: resource.resourceType.description,
-			},
-		})) ?? []
+		resources
+			?.filter((resource) => {
+				if (hasUrl(resource)) {
+					return true;
+				}
+				console.warn('mapResources: se descarta un recurso sin URL', {
+					title: resource.title,
+					resourceType: resource.resourceType.slug,
+				});
+				return false;
+			})
+			.map((resource) => ({
+				title: resource.title,
+				url: resource.url,
+				resourceType: {
+					slug: resource.resourceType.slug,
+					title: resource.resourceType.title,
+					description: resource.resourceType.description,
+				},
+			})) ?? []
 	);
 }
 

--- a/src/app/pages/author/author-structured-data.directive.spec.ts
+++ b/src/app/pages/author/author-structured-data.directive.spec.ts
@@ -4,6 +4,7 @@ import { DOCUMENT } from '@angular/common';
 import { signal } from '@angular/core';
 
 import { authorMock } from '@mocks/author.mock';
+import { withoutUrl } from '@testing/resource-without-url';
 import { type AuthorProfile } from '@models/author.model';
 import { AuthorStructuredDataDirective } from './author-structured-data.directive';
 import { AUTHOR_HOST } from './author-host';
@@ -52,6 +53,21 @@ describe('AuthorStructuredDataDirective', () => {
 		expect(
 			JSON.parse(head.querySelector('script[data-schema-id="breadcrumb-author"]')?.textContent ?? '{}'),
 		).toMatchObject({ '@type': 'BreadcrumbList' });
+	});
+
+	it('should still emit both JSON-LD blocks when a resource has no url', () => {
+		const [resource] = authorMock.resources;
+		authorSignal.set({ ...authorMock, resources: [withoutUrl(resource)] });
+
+		instantiate();
+		TestBed.tick();
+
+		const head = TestBed.inject(DOCUMENT).head;
+		expect(JSON.parse(head.querySelector('script[data-schema-id="profile-page"]')?.textContent ?? '{}')).toMatchObject({
+			'@type': 'ProfilePage',
+			mainEntity: { '@type': 'Person', name: authorMock.name },
+		});
+		expect(head.querySelector('script[data-schema-id="breadcrumb-author"]')).not.toBeNull();
 	});
 
 	it('should remove both JSON-LD blocks when destroyed', () => {

--- a/src/app/pages/author/author.component.spec.ts
+++ b/src/app/pages/author/author.component.spec.ts
@@ -3,8 +3,9 @@ import { provideRouter } from '@angular/router';
 import { render, screen, within } from '@testing-library/angular';
 import AuthorComponent from './author.component';
 import { authorMock } from '@mocks/author.mock';
-import { provideAuthorApiMock } from '../../providers/author.mock';
+import { provideAuthorApiMock, StubAuthorApi } from '../../providers/author.mock';
 import { provideStoryApiMock } from '../../providers/story.mock';
+import { withoutUrl } from '@testing/resource-without-url';
 
 describe.skip('AuthorComponent', () => {
 	let component: AuthorComponent;
@@ -22,6 +23,23 @@ describe.skip('AuthorComponent', () => {
 
 	it('should create', () => {
 		expect(component).toBeTruthy();
+	});
+});
+
+// Reproduce el modo de falla del SSR: las directivas de SEO son hostDirectives de la página, así que
+// un throw en su effect derriba el render entero y la ficha sale sin cuerpo. El ErrorHandler de
+// test-setup relanza, con lo cual acá se manifiesta igual que en el servidor.
+describe('AuthorComponent — recurso sin URL', () => {
+	it('should keep its heading when a resource has no url', async () => {
+		const [resource] = authorMock.resources;
+		const author = { ...authorMock, resources: [withoutUrl(resource)] };
+
+		await render(AuthorComponent, {
+			inputs: { slug: author.slug, activeTab: 'about' },
+			providers: [provideRouter([]), provideAuthorApiMock(new StubAuthorApi(author)), provideStoryApiMock()],
+		});
+
+		expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(author.name);
 	});
 });
 

--- a/src/app/pages/story/story-structured-data.directive.spec.ts
+++ b/src/app/pages/story/story-structured-data.directive.spec.ts
@@ -4,6 +4,7 @@ import { DOCUMENT } from '@angular/common';
 import { signal } from '@angular/core';
 
 import { storyMock } from '@mocks/story.mock';
+import { withoutUrl } from '@testing/resource-without-url';
 import { type Story } from '@models/story.model';
 import { StoryStructuredDataDirective } from './story-structured-data.directive';
 import { STORY_HOST } from './story-host';
@@ -49,6 +50,24 @@ describe('StoryStructuredDataDirective', () => {
 		expect(
 			JSON.parse(head.querySelector('script[data-schema-id="breadcrumb-story"]')?.textContent ?? '{}'),
 		).toMatchObject({ '@type': 'BreadcrumbList' });
+	});
+
+	// La obra hereda la caída de su autor: el bloque de datos estructurados construye la Persona del
+	// autor para las señales E-E-A-T, así que un recurso incompleto en la ficha vaciaba también cada
+	// obra de ese autor.
+	it('should still emit both JSON-LD blocks when the author has a resource without url', () => {
+		const [resource] = storyMock.author.resources;
+		storySignal.set({ ...storyMock, author: { ...storyMock.author, resources: [withoutUrl(resource)] } });
+
+		instantiate();
+		TestBed.tick();
+
+		const head = TestBed.inject(DOCUMENT).head;
+		expect(JSON.parse(head.querySelector('script[data-schema-id="article"]')?.textContent ?? '{}')).toMatchObject({
+			'@type': 'Article',
+			author: { '@type': 'Person', name: storyMock.author.name },
+		});
+		expect(head.querySelector('script[data-schema-id="breadcrumb-story"]')).not.toBeNull();
 	});
 
 	it('should remove both JSON-LD blocks when destroyed', () => {

--- a/src/app/providers/author.mock.ts
+++ b/src/app/providers/author.mock.ts
@@ -8,12 +8,16 @@ import { authorMock, authorTeaserMock } from '@mocks/author.mock';
 import { AuthorApi } from './author-api.interface';
 
 export class StubAuthorApi implements AuthorApi {
+	// El autor entra por constructor para que un spec pueda servir una variante degradada del canon
+	// sin escribir su propia implementación de la interfaz.
+	constructor(private readonly author: AuthorProfile = authorMock) {}
+
 	public getAll(): Observable<AuthorTeaser[]> {
 		return of([authorTeaserMock]);
 	}
 
 	public getBySlug(): Observable<AuthorProfile> {
-		return of(authorMock);
+		return of(this.author);
 	}
 }
 

--- a/src/app/providers/author.mock.ts
+++ b/src/app/providers/author.mock.ts
@@ -8,8 +8,6 @@ import { authorMock, authorTeaserMock } from '@mocks/author.mock';
 import { AuthorApi } from './author-api.interface';
 
 export class StubAuthorApi implements AuthorApi {
-	// El autor entra por constructor para que un spec pueda servir una variante degradada del canon
-	// sin escribir su propia implementación de la interfaz.
 	constructor(private readonly author: AuthorProfile = authorMock) {}
 
 	public getAll(): Observable<AuthorTeaser[]> {

--- a/src/testing/resource-without-url.ts
+++ b/src/testing/resource-without-url.ts
@@ -1,0 +1,13 @@
+/**
+ * Deriva, a partir de un recurso del corpus, la variante incompleta que el dataset sí contiene: la
+ * que no trae URL. Sirve tanto para el recurso crudo de Sanity como para el del modelo de dominio.
+ *
+ * El cast es inevitable: el typegen declara `url: string` porque lo deriva del `Rule.required()` del
+ * schema, y esa regla valida la edición en el Studio, no lo ya almacenado. La forma existe en los
+ * datos y no en los tipos, así que solo se puede construir salteando al compilador — acotado acá,
+ * en vez de repetido en cada spec que la necesita.
+ */
+export function withoutUrl<T extends { url: string }>(resource: T): T {
+	const { url, ...rest } = resource;
+	return rest as unknown as T;
+}

--- a/src/testing/resource-without-url.ts
+++ b/src/testing/resource-without-url.ts
@@ -8,6 +8,7 @@
  * en vez de repetido en cada spec que la necesita.
  */
 export function withoutUrl<T extends { url: string }>(resource: T): T {
-	const { url, ...rest } = resource;
-	return rest as unknown as T;
+	const incomplete = { ...resource };
+	delete (incomplete as Partial<T>).url;
+	return incomplete;
 }

--- a/src/utils/schema-org.builders.spec.ts
+++ b/src/utils/schema-org.builders.spec.ts
@@ -1,6 +1,7 @@
 import { authorMock } from '@mocks/author.mock';
 
 import { assertValidJsonLd } from '@testing/json-ld-validation';
+import { withoutUrl } from '@testing/resource-without-url';
 import { buildBreadcrumbSchema, buildPersonSchema } from './schema-org.builders';
 
 describe('buildPersonSchema', () => {
@@ -22,6 +23,21 @@ describe('buildPersonSchema', () => {
 			name: 'François Onoff',
 			url: 'https://x/author/a',
 		});
+	});
+
+	it('should skip a resource without url instead of throwing', () => {
+		const [resource] = authorMock.resources;
+		const author = { ...authorMock, resources: [resource, withoutUrl(resource)] };
+
+		const schema = buildPersonSchema(author, 'https://x/author/a');
+
+		expect(schema.sameAs).toEqual([resource.url]);
+	});
+
+	it('should omit sameAs when the only resource has no url', () => {
+		const author = { ...authorMock, resources: [withoutUrl(authorMock.resources[0])] };
+
+		expect(buildPersonSchema(author, 'https://x/author/a')).not.toHaveProperty('sameAs');
 	});
 });
 

--- a/src/utils/schema-org.builders.spec.ts
+++ b/src/utils/schema-org.builders.spec.ts
@@ -34,6 +34,13 @@ describe('buildPersonSchema', () => {
 		expect(schema.sameAs).toEqual([resource.url]);
 	});
 
+	it('should skip a resource whose url is an empty string', () => {
+		const [resource] = authorMock.resources;
+		const author = { ...authorMock, resources: [{ ...resource, url: '' }] };
+
+		expect(buildPersonSchema(author, 'https://x/author/a')).not.toHaveProperty('sameAs');
+	});
+
 	it('should omit sameAs when the only resource has no url', () => {
 		const author = { ...authorMock, resources: [withoutUrl(authorMock.resources[0])] };
 

--- a/src/utils/schema-org.builders.ts
+++ b/src/utils/schema-org.builders.ts
@@ -13,7 +13,12 @@ export interface BreadcrumbItem {
  * nombre, URL de su perfil, imagen y `sameAs` con sus recursos web.
  */
 export function buildPersonSchema(author: Author, authorUrl: string): PersonLeaf {
-	const sameAs = author.resources.map((resource) => resource.url).filter((url) => url.length > 0);
+	// El ACL ya garantiza que todo recurso trae URL. Esto es defensa en profundidad para un `Author`
+	// que llegue por otra vía —rehidratado de un DTO, armado por un doble de test—, donde un valor
+	// ausente reventaría el render entero de la página en lugar de degradar este bloque.
+	const sameAs = author.resources
+		.map((resource) => resource.url)
+		.filter((url) => typeof url === 'string' && url.length > 0);
 	return {
 		'@type': 'Person',
 		name: author.name,


### PR DESCRIPTION
Treinta y siete páginas indexables servían un `<main>` vacío en producción —17 fichas de autor y las 20 obras de esos autores—: HTTP 200 con `ng-server-context="ssr"`, pero sin `<h1>`, sin texto y sin ningún bloque JSON-LD.

El constructor de la Persona de schema.org leía `url.length` sobre un recurso sin URL y lanzaba. Como corre en una directiva declarada como `hostDirective` de la página, la excepción no degradaba el bloque de datos estructurados: se llevaba puesto el render entero, y se propagaba de la ficha del autor a todas sus obras.

## La corrección va en la frontera

El tipo declaraba `url: string`, así que el código era correcto contra el tipo. Lo que falla es que el tipo no describe lo que Sanity devuelve, y la causa es general: **un campo con `Rule.required()` no garantiza nada sobre el dato ya persistido**, porque esa validación rige la edición en el Studio y no el almacenamiento. El typegen, en cambio, deriva la nulabilidad del schema declarado, así que emite un tipo no-nullable en el que el mapper confía.

Por eso el arreglo no es endurecer el `filter` del constructor: `mapResources` descarta el recurso incompleto en la frontera, con una advertencia en el log. Es la primitiva que comparten el autor, la obra y la obra literaria, así que la invariante *"`resources` contiene únicamente recursos completos"* queda declarada y hecha cumplir en un solo lugar, para los tres agregados. El `filter` del constructor se endurece igual, pero como red secundaria y no como remedio.

Descarta en vez de lanzar deliberadamente: que el mapper lance reproduciría la misma página en blanco que este cambio viene a eliminar. La biografía, que sí es contenido central del agregado, sigue siendo el caso opuesto — y ese criterio queda escrito en la referencia del ACL.

## El censo destapó 200 documentos más

El defecto estaba en una primitiva compartida, así que el censo se extendió a los otros dos tipos:

| Tipo | Documentos con un recurso sin `url` | Con `resources` | Total |
| --- | ---: | ---: | ---: |
| `author` | **17** | 281 | 326 |
| `story` | **100** | 254 | 613 |
| `literaryWork` | **100** | 254 | 617 |

Los 200 de obra no vacían ninguna página —el constructor de la Persona solo recorre `author.resources`— pero renderizan un enlace sin destino y son el mismo defecto latente. Los 100 de `literaryWork` son documentos propios (`lw-from-story-<uuid>`) con el contenido espejado del cuento, no una vista suya.

## El saneamiento

Una migración recorre los tres tipos, con disposición según lo que el dato permite:

- **Autores: completar, salvo uno.** El recurso nombra un artículo de Wikipedia, y los dieciséis que existen se verificaron uno por uno contra la API de MediaWiki. El único sin destino es `anonimo`: "Anónimo" no nombra a una persona y redirige a un artículo sobre el anonimato como concepto. Ese recurso se borra. Un autor con el hueco que no figure en la tabla **aborta la corrida**, en vez de pasar en silencio.
- **Obras: borrar.** Su recurso no nombra ningún destino averiguable, así que no hay URL que completar. Es la única operación destructiva del PR, y como su justificación se apoya en un hecho del dato —que el título es siempre el mismo—, el código lo verifica en vez de darlo por cierto: un título ajeno aborta.
- **Dos URLs sin protocolo.** Un autor tenía sus perfiles guardados como `instagram.com/…` y `youtube.com/…`. La migración les antepone el esquema.

La disposición se indexa por slug y el recurso se localiza por predicado, leyendo su `_key` del documento: los `_key` del censo son de `production` y la migración corre en los tres datasets. Un **autor en borrador** fuera de la tabla se saltea en vez de abortar — una fila a medio completar es el estado normal apenas se agrega un ítem en el Studio, y detener la corrida por una edición en curso impediría sanear lo publicado.

El campo `url` del schema pasa además de `string` con `required()` a `url` con validación de esquema, para que un enlace mal formado no vuelva a entrar por la vía de edición. Admite `mailto` además de `http`/`https`: cinco autores tienen su dirección de contacto cargada como recurso, y son contenido válido. Va después del saneamiento: al revés, el Studio marcaría en rojo los documentos que todavía incumplen antes de que se los pueda corregir.

El typegen no se regenera: Sanity extrae un campo `url` como `string`, igual que el `string` que reemplaza, así que ni `cms/schema.json` ni `src/sanity/types.ts` cambian.

Las dos tablas de disposición viven a nivel de módulo y no dentro de la función que las consume, a contramano de las Scope Rules: `migrate.document` corre una vez por documento, y bajarlas al scope las reconstruiría en cada uno. La excepción es deliberada.

## Plan de pruebas

Los tres niveles de regresión se verificaron **fallando contra el código anterior**, que es lo que los vuelve una regresión y no una descripción:

- **ACL** — `mapResources` descarta el recurso incompleto en sus tres formas: `url` ausente (la de los autores), `url: null` (la de las obras) y `url: ''`.
- **Constructor** — `buildPersonSchema` no lanza y `sameAs` trae solo la URL válida; si el único recurso es el incompleto, la clave no se emite.
- **Página** — la ficha de autor conserva su `<h1>` y emite sus dos bloques JSON-LD; la obra emite los suyos con el autor degradado, que es la vía por la que heredaron la caída 20 de las 37 páginas. Va en unit y no en e2e a propósito: las directivas de SEO son `hostDirectives` del componente y el `ErrorHandler` del setup relanza, así que reproduce el modo de falla del SSR — mientras que la suite e2e corre contra un dataset real, donde plantar un autor degradado sería contenido inválido que el saneamiento mismo borraría.
- **Migración** — 16 casos: las dos disposiciones de autor, las tres formas del hueco, el completado de protocolo, la idempotencia, el salteo del borrador y los cuatro abortos (autor fuera de tabla, autor sin slug, más incompletos que los que la tabla cubre, título ajeno al lote).

Gates locales en verde: `typecheck`, `lint`, `stylelint`, `check-agents`, `test` (1962 tests) y los del Studio (236 tests, `pnpm sanity:test` + `typecheck`).

Dry-run de la migración corrido contra `development`: 221 documentos alcanzados —203 borrados y 18 completados—, sin abortar.

**Pendiente tras el merge:** correr la migración en cada dataset y verificar con el smoke de indexado sobre las páginas afectadas. El procedimiento está en el README de la migración.

Closes #2218.
Closes #2219.
