### PR TITLE
[#2221] - La documentación todavía nombra a Jest como framework de tests unitarios

### DIFF
--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -369,9 +369,10 @@ El proyecto utiliza [git](https://git-scm.com) como herramienta de control de ve
 - En caso de que seas un colaborador externo, debes de dejar un mensaje en el issue que quieras tomar para que te lo puedan asignar, después es necesario que realices un _fork_ del repositorio y envíes tus
   cambios mediante un _pull request_ desde tu _fork_ al repositorio principal, generando el fork tal como se detalla
   en la sección previa [Clonar el repositorio](#clonar-el-repositorio).
-- Las ramas de trabajo se nomenclan de la siguiente manera: `<numero-de-incidencia>-<nombre-de-la-funcionalidad>`.
-  Por ejemplo: `469-implementar-nuevo-componente-story-card-component`. Para facilidad de la generación de las ramas
-  de trabajo, se recomienda hacer uso de la generación de ramas a partir de las incidencias de Github.
+- Las ramas de trabajo se nomenclan de la siguiente manera: `feat/<numero-de-incidencia>-<nombre-de-la-funcionalidad>`,
+  con el nombre en _kebab-case_. Por ejemplo: `feat/469-implementar-nuevo-componente-story-card-component`. Para
+  facilidad de la generación de las ramas de trabajo, se recomienda hacer uso de la generación de ramas a partir de
+  las incidencias de Github.
 - Todos los commits deben ser nomenclados de la siguiente manera, referenciando el commit de manera navegable desde
   la interfaz de Github: `[#numero-de-incidencia] - 
 <mensaje-del-commit>`. Por ejemplo: `[#469] - Crear componente PublicationCardComponent`.

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -18,7 +18,7 @@ el proyecto La Cuentoneta y cómo puedes contribuir al desarrollo del mismo.
 
 Las prácticas de nuestro proceso de desarrollo, más las herramientas utilizadas para el desarrollo y la gestión del
 mismo, están
-abiertas a propuestas para mejoras, cambios y reemplazos. En caso de que desees aportar sugerencias o propuestas de mejorar el proceso de desarrollo, puedes hacerla el canal **[**#🚐 | la-cuentoneta**][dc-channel]** en Discord o en sumar un issue de tipo **[💼 Proponer mejoras en la Gestión o el Proceso de Desarrollo del Proyecto](https://github.com/cuentoneta/cuentoneta/issues/new/choose)**.
+abiertas a propuestas para mejoras, cambios y reemplazos. En caso de que desees aportar sugerencias o propuestas de mejorar el proceso de desarrollo, puedes hacerla el canal **[**#🚐 | la-cuentoneta**][dc-channel]** en Discord o en sumar un issue de tipo **[💼 Proponer mejoras en la Gestión o el Proceso de Desarrollo del Proyecto][crear-issue-cuentoneta]**.
 
 ---
 
@@ -437,10 +437,7 @@ proyecto. La guía vive en [`docs/qa/TESTPLAN_GUIDE.md`](./qa/TESTPLAN_GUIDE.md)
 ---
 
 [dc-channel]: https://discord.com/channels/594363964499165194/1109220285841944586
-[github-issues-tutorial]: https://docs.github.com/es/issues/tracking-your-work-with-issues/creating-an-issue
 [crear-issue-cuentoneta]: https://github.com/cuentoneta/cuentoneta/issues/new/choose
-[feature-request-template]: https://github.com/cuentoneta/cuentoneta/issues/new?assignees=&labels=%F0%9F%8F%8E%EF%B8%8F+mejora&projects=&template=feature.yml
-[bug-report-template]: https://github.com/cuentoneta/cuentoneta/issues/new?assignees=&labels=%F0%9F%A6%9F+bug&projects=&template=bug_report.yml
 
 <!-- Enlaces a otros documentos -->
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -65,14 +65,19 @@ El tech stack actualmente utilizado para el desarrollo de La Cuentoneta es:
 - **<a href="https://pnpm.io/es/">pnpm</a>** como gestor de paquetes
 - **<a href="https://nx.dev/angular">Nx</a>** como gestor de monorepo y task runner
 
-Junto con Nx, el proyecto cuenta con ESLint y Prettier ya configuradas como dependencias.
+Junto con Nx, el proyecto cuenta con ESLint, Prettier y Stylelint ya configuradas como dependencias.
 
 ### Para el desarrollo de la plataforma web
 
 - **<a href="https://angular.dev">Angular 22</a>** con **<a href="https://angular.dev/guide/ssr">Server-Side rendering</a>** como framework de frontend
 - **<a href="https://www.typescriptlang.org/">TypeScript</a>**
-- **<a href="https://tailwindcss.com/docs/installation">Tailwind CSS</a>**
-- **<a href="https://storybook.js.org/docs/react/get-started/introduction">Storybook</a>** como herramienta de desarrollo de componentes.
+- **<a href="https://tailwindcss.com/docs/installation">Tailwind CSS v4</a>**
+- **<a href="https://storybook.js.org/docs/get-started/frameworks/angular">Storybook</a>** como herramienta de desarrollo de componentes.
+
+### Para el desarrollo de la API
+
+- **<a href="https://hono.dev/">Hono</a>** como framework del backend, cuyos endpoints viven en `src/api/`.
+- **<a href="https://zod.dev/">Zod</a>**, a través de <a href="https://hono.dev/docs/guides/validation">`@hono/zod-validator`</a>, para la validación de los parámetros de entrada.
 
 ### Para la gestión del contenido
 
@@ -215,7 +220,7 @@ Los tests de e2e corren contra el build SSR de producción (el `webServer` de Pl
 pnpm build && pnpm run test:e2e
 ```
 
-Esto iniciará una corrida de tests de integración y end-to-end utilizando Playwright, mostrando los resultados en consola y generando un reporte, el cual se encontrará en la carpeta `dist/.playwright/playwright-reports` al final de la corrida.
+Esto iniciará una corrida de tests de integración y end-to-end utilizando Playwright, mostrando los resultados en consola y generando un reporte, el cual se encontrará en la carpeta `dist/.playwright/playwright-report` al final de la corrida.
 
 ---
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -25,7 +25,7 @@ abiertas a propuestas para mejoras, cambios y reemplazos. En caso de que desees 
 ## Consideraciones Generales
 
 La Cuentoneta es un proyecto abierto tanto en el código como en su gestión, siendo pública y de libre acceso toda la
-información relacionada a su desarrollo y encontrándose la misma en línea con el [Código de Conducta](doc-code_of_conduct) y la declaración de [Misión, Visión y Valores](doc-mmv).
+información relacionada a su desarrollo y encontrándose la misma en línea con el [Código de Conducta][doc-code_of_conduct] y la declaración de [Misión, Visión y Valores][doc-mvv].
 
 Dada la naturaleza del proyecto, es importante que tengas en consideración que:
 
@@ -159,7 +159,7 @@ git clone https://github.com/<tu_nombre_de_usuario_en_github>/cuentoneta.git
 cd cuentoneta
 ```
 
-Posteriormente ejecuta el siguiente comando para instalar todas las dependencias listadas en el archivo [`package.json`](package.json). La ejecución de este comando también procederá a crear un archivo `.env`, el cual contiene las variables de entorno necesarias para el correcto funcionamiento del proyecto en el ambiente de desarrollo.
+Posteriormente ejecuta el siguiente comando para instalar todas las dependencias listadas en el archivo [`package.json`](../package.json). La ejecución de este comando también procederá a crear un archivo `.env`, el cual contiene las variables de entorno necesarias para el correcto funcionamiento del proyecto en el ambiente de desarrollo.
 
 ```bash
 pnpm install
@@ -431,20 +431,18 @@ a la hora de realizar el _triaging_ y análisis de la incidencia.
 
 Para características que requieran pruebas de integración, sean estas manuales o implementadas mediante Playwright, se
 encuentra disponible una guía y plantilla de cómo confeccionar un plan de pruebas para una funcionalidad determinada del
-proyecto. Puede accederse al template de planes de testing [en este enlace](#doc-test-plan).
+proyecto. La guía vive en [`docs/qa/TESTPLAN_GUIDE.md`](./qa/TESTPLAN_GUIDE.md) y la plantilla, en [`docs/qa/TEST_PLAN_TEMPLATE.md`](./qa/TEST_PLAN_TEMPLATE.md).
 
 ---
 
 [dc-channel]: https://discord.com/channels/594363964499165194/1109220285841944586
 [github-issues-tutorial]: https://docs.github.com/es/issues/tracking-your-work-with-issues/creating-an-issue
-[crear-issue-cuentoneta]: https://github.com/rolivencia/cuentoneta/issues/new/choose
-[feature-request-template]: https://github.com/rolivencia/cuentoneta/issues/new?assignees=&labels=%F0%9F%8F%8E%EF%B8%8F+mejora&projects=&template=feature.yml
-[bug-report-template]: https://github.com/rolivencia/cuentoneta/issues/new?assignees=&labels=%F0%9F%A6%9F+bug&projects=&template=bug_report.yml
+[crear-issue-cuentoneta]: https://github.com/cuentoneta/cuentoneta/issues/new/choose
+[feature-request-template]: https://github.com/cuentoneta/cuentoneta/issues/new?assignees=&labels=%F0%9F%8F%8E%EF%B8%8F+mejora&projects=&template=feature.yml
+[bug-report-template]: https://github.com/cuentoneta/cuentoneta/issues/new?assignees=&labels=%F0%9F%A6%9F+bug&projects=&template=bug_report.yml
 
 <!-- Enlaces a otros documentos -->
 
 [doc-mvv]: https://github.com/cuentoneta/cuentoneta/blob/develop/MVV.md
 [doc-code_of_conduct]: https://github.com/cuentoneta/cuentoneta/blob/develop/CODE_OF_CONDUCT.md
 [dc-fec]: https://discord.com/invite/frontendcafe
-[doc-test-plan]: https://github.com/cuentoneta/cuentoneta/blob/develop/docs/TEST_PLAN.md
-[doc-test-template]: https://github.com/cuentoneta/cuentoneta/blob/develop/docs/TEST_TEMPLATE.md

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -61,7 +61,7 @@ El tech stack actualmente utilizado para el desarrollo de La Cuentoneta es:
 ### Para la gestión de la base de código del proyecto
 
 - **<a href="https://git-scm.com/">Git</a>** como herramienta de control de versiones
-- **<a href="https://https://github.com">GitHub</a>** como host de la base de código
+- **<a href="https://github.com">GitHub</a>** como host de la base de código
 - **<a href="https://pnpm.io/es/">pnpm</a>** como gestor de paquetes
 - **<a href="https://nx.dev/angular">Nx</a>** como gestor de monorepo y task runner
 
@@ -81,7 +81,7 @@ Junto con Nx, el proyecto cuenta con ESLint, Prettier y Stylelint ya configurada
 
 ### Para la gestión del contenido
 
-- **<a href="https://www.sanity.io/docs">Sanity</a>** para persistencia de información de cuentos, autores y storylists.
+- **<a href="https://www.sanity.io/docs">Sanity</a>** para persistencia de la información de obras literarias, colecciones, autores, etiquetas y el contenido de la página de inicio.
 
 ### Para pruebas unitarias y de integración
 
@@ -201,7 +201,7 @@ Para ejecutar una corrida de tests unitarios, ejecutá el siguiente comando.
 pnpm run test
 ```
 
-Esto iniciará una corrida de tests unitarios utilizando Vitest, el cual se encargará de correr los tests unitarios de los componentes de Angular, mostrando los resultados en la consola. El script envuelve el target Nx `vitest:test`, inferido por el plugin `@nx/vitest`.
+Esto iniciará una corrida de tests unitarios utilizando Vitest, el cual se encargará de correr los tests unitarios de toda la aplicación —componentes de Angular, endpoints y servicios del backend, modelos de dominio y utilidades—, mostrando los resultados en la consola. El script envuelve el target Nx `vitest:test`, inferido por el plugin `@nx/vitest`.
 
 Para trabajar con los tests en modo _watch_ están disponibles estas dos variantes, que invocan Vitest directamente:
 
@@ -364,18 +364,16 @@ El proyecto utiliza [git](https://git-scm.com) como herramienta de control de ve
 
 ### Consideraciones al contribuir al repositorio
 
-- En caso de que seas un colaborador externo debes escribir un mensaje en la issue en el que desees trabajar, a fin de que te pueda ser asignado.
-- Aplica también para colaboradores externos la necesidad de realizar un _fork_ del repositorio para así posteriormente envar tus cambios mediante un _pull request_ desde tu _fork_ al repositorio principal. Para generar un _fork_, sigue los pasos detallados en la sección [Clonar el repositorio](#clonar-el-repositorio).
-- En caso de que seas un colaborador externo, debes de dejar un mensaje en el issue que quieras tomar para que te lo puedan asignar, después es necesario que realices un _fork_ del repositorio y envíes tus
-  cambios mediante un _pull request_ desde tu _fork_ al repositorio principal, generando el fork tal como se detalla
-  en la sección previa [Clonar el repositorio](#clonar-el-repositorio).
+- En caso de que seas un colaborador externo, debes dejar un mensaje en el issue que quieras tomar para que te lo
+  puedan asignar. Después es necesario que realices un _fork_ del repositorio y envíes tus cambios mediante un
+  _pull request_ desde tu _fork_ al repositorio principal, generando el fork tal como se detalla en la sección
+  [Clonar el repositorio](#clonar-el-repositorio).
 - Las ramas de trabajo se nomenclan de la siguiente manera: `feat/<numero-de-incidencia>-<nombre-de-la-funcionalidad>`,
-  con el nombre en _kebab-case_. Por ejemplo: `feat/469-implementar-nuevo-componente-story-card-component`. Para
-  facilidad de la generación de las ramas de trabajo, se recomienda hacer uso de la generación de ramas a partir de
-  las incidencias de Github.
+  con el nombre en _kebab-case_. Por ejemplo: `feat/469-implementar-nuevo-componente-story-card-component`. Si generás
+  la rama desde la incidencia en la interfaz de Github, tené en cuenta que el nombre que propone viene sin el prefijo
+  `feat/`: hay que agregárselo antes de empezar a trabajar.
 - Todos los commits deben ser nomenclados de la siguiente manera, referenciando el commit de manera navegable desde
-  la interfaz de Github: `[#numero-de-incidencia] - 
-<mensaje-del-commit>`. Por ejemplo: `[#469] - Crear componente PublicationCardComponent`.
+  la interfaz de Github: `[#numero-de-incidencia] - <mensaje-del-commit>`. Por ejemplo: `[#469] - Crear componente PublicationCardComponent`.
 - Las ramas de trabajo se crean a partir de la rama `develop` y se eliminan una vez integrados los cambios en la rama `develop`.
 - Las ramas de trabajo deben ser actualizadas con la rama `develop` antes de solicitar la integración de los cambios en la rama `develop`.
 - El código escrito en en el proyecto sigue las convenciones de [Angular](https://runebook.dev/es/docs/angular/guide/styleguide), [TypeScript](https://ts.dev/style/) y [RxJS](https://v10.angular.io/guide/rx-library#naming-conventions-for-observables) correspondientes para la escritura de código.

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -80,7 +80,7 @@ Junto con Nx, el proyecto cuenta con ESLint y Prettier ya configuradas como depe
 
 ### Para pruebas unitarias y de integración
 
-- **<a href="https://jestjs.io/docs/getting-started">Jest</a>** como framework de testing unitario, utilizando <a href="https://testing-library.com/docs/angular-testing-library/intro">Angular Testing Library</a> para la escritura de tests de componentes.
+- **<a href="https://vitest.dev/">Vitest</a>** como framework de testing unitario, utilizando <a href="https://testing-library.com/docs/angular-testing-library/intro">Angular Testing Library</a> para la escritura de tests de componentes.
 - **<a href="https://playwright.dev/">Playwright</a>** como framework de testing de integración y end-to-end
 
 ### Para generación y visualización de diagramas
@@ -196,7 +196,16 @@ Para ejecutar una corrida de tests unitarios, ejecutá el siguiente comando.
 pnpm run test
 ```
 
-Esto iniciará una corrida de tests unitarios utilizando Jest, el cual se encargará de correr los tests unitarios de los componentes de Angular, mostrando los resultados en la consola.
+Esto iniciará una corrida de tests unitarios utilizando Vitest, el cual se encargará de correr los tests unitarios de los componentes de Angular, mostrando los resultados en la consola. El script envuelve el target Nx `vitest:test`, inferido por el plugin `@nx/vitest`.
+
+Para trabajar con los tests en modo _watch_ están disponibles estas dos variantes, que invocan Vitest directamente:
+
+```bash
+pnpm run test:watch
+pnpm run test:ui
+```
+
+La segunda levanta además la interfaz web de Vitest.
 
 ##### Tests de integración y e2e
 

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -47,5 +47,4 @@ Los casos sin test asociado son la **cobertura faltante**: la lista de trabajo p
 ## Relacionados
 
 - Tablero de estado de QA — issue #1353.
-- Migración de Jest a Vitest — issue #1494.
 - Tests de integración pendientes — issues #948, #951, #1426.

--- a/docs/qa/TESTPLAN_GUIDE.md
+++ b/docs/qa/TESTPLAN_GUIDE.md
@@ -182,7 +182,7 @@ Esta documentación está escrita para que un agente de Claude Code pueda **asis
 7. **No inventar resultados**: dejar "Resultado obtenido" vacío hasta que las pruebas se ejecuten.
 8. **Señalar la cobertura faltante**: listar los casos sin test asociado como candidatos a automatizar.
 
-> Esta guía está pensada para exponerse también como archivo de referencia de Claude (`.claude/references/`) y/o alimentar un subagente asistente de QA. Ese cableado se aborda en la iniciativa de adopción de flujos de Claude (epic #1498).
+> El proyecto ya expone sus convenciones de testing como archivo de referencia de Claude, en `.claude/references/testing.md`, y las consumen sus agentes y skills. Esta guía es la contraparte de proceso de esa referencia: acá viven la estructura del plan de pruebas y sus plantillas.
 
 # 11. Herramientas del proyecto
 
@@ -193,8 +193,6 @@ Esta documentación está escrita para que un agente de Claude Code pueda **asis
 | **[Bruno](https://www.usebruno.com/)**                               | Pruebas de la API (`docs/api/`)           |
 | **[GitHub Issues](https://github.com/cuentoneta/cuentoneta/issues)** | Tracking de bugs y casos                  |
 | **GitHub Projects**                                                  | Tablero de estado de QA (ver issue #1353) |
-
-> **Nota sobre el runner:** el proyecto está migrando de Jest a **Vitest** (issue #1494). Mientras la migración no se complete, los tests unitarios corren en Jest; las convenciones de esta guía ya asumen Vitest como destino.
 
 Para el flujo general de desarrollo, ver la [Guía de Desarrollo](../DEVELOPMENT_GUIDE.md).
 


### PR DESCRIPTION
La documentación nombraba a Jest como el framework de tests unitarios del proyecto, y en dos lugares describía la migración a Vitest como si siguiera en curso. El proyecto corre Vitest desde hace tiempo, y el target de tests migró además al plugin inferido `@nx/vitest`: alguien que entrara por la guía de desarrollo instalaba expectativas equivocadas sobre cómo se corren y se escriben los tests.

## Qué cambia

**Los cuatro lugares del issue:**

- `docs/DEVELOPMENT_GUIDE.md` — Vitest reemplaza a Jest en el stack, y la descripción de `pnpm run test` precisa que envuelve el target Nx `vitest:test` (inferido por `@nx/vitest`), no un target `test`. Se suman `test:watch` y `test:ui`, que la guía no mencionaba.
- `docs/qa/README.md` y `docs/qa/TESTPLAN_GUIDE.md` — las dos notas de estado transitorio se **borran** en vez de corregirse: lo que sobra es la nota entera, no el nombre del runner. De los issues citados en la lista de `qa/README.md`, el de la migración era el único cerrado; los otros tres siguen abiertos y se conservan.

El barrido `jest|Jest|jest.config|ts-jest|jasmine|karma` sobre `docs/` ya no devuelve nada.

## Verificación del resto del stack

El issue pedía aprovechar y verificar que el stack descrito siguiera siendo el real. Lo estaba en Node, pnpm, Nx, Angular 22 con SSR, Sanity, Playwright y Bruno. No lo estaba en cinco puntos, corregidos acá:

| Lo que decía la guía | La realidad |
| --- | --- |
| El backend no figuraba en el stack | `src/api/` corre **Hono**, con validación por `@hono/zod-validator` + Zod |
| "Tailwind CSS", sin versión | Tailwind **v4** |
| Enlace de Storybook a su documentación de **React** | Proyecto Angular, sobre `@storybook/angular-vite` |
| "ESLint y Prettier ya configuradas" | También **Stylelint**, con gate de CI homónimo |
| Reporte de Playwright en `dist/.playwright/playwright-reports` | El preset de Nx lo emite en `playwright-report`, singular |

Y de paso, los enlaces rotos que la lectura completa dejó a la vista: el Código de Conducta con paréntesis donde va corchete, un label de referencia mal escrito, un ancla inexistente para los planes de prueba, dos labels apuntando a archivos que hoy viven en `docs/qa/` con otro nombre, un `package.json` relativo a `docs/`, y tres plantillas de issue nombrando todavía al repositorio personal previo a la organización.

Por último, la guía enunciaba la convención de ramas como `<numero>-<nombre>`, sin el prefijo `feat/` que fija `CLAUDE.md` y que usa la historia real de `develop`.

## Lo que la review sumó

Leer el documento entero dejó a la vista más de lo mismo, corregido en los dos últimos commits:

- Cuatro labels de referencia definidos y nunca usados sobrevivían a la poda de huérfanos. `crear-issue-cuentoneta` pasa a usarse donde su URL estaba escrito inline; los otros tres se van.
- El bullet que fija la convención de ramas seguía recomendando generarla desde la interfaz de GitHub, que produce justamente el nombre sin prefijo que ese bullet acababa de corregir. Ahora lo advierte.
- `https://https://github.com` en el enlace a GitHub del stack.
- La descripción de la corrida de tests reducía la suite a los componentes de Angular; cubre también el backend, los modelos de dominio y las utilidades.
- La de Sanity nombraba "cuentos, autores y storylists"; el Studio declara hoy obras literarias, colecciones, etiquetas y el contenido de la página de inicio, además de autores.
- Dos bullets consecutivos decían lo mismo sobre colaboradores externos, y el de la convención de commits tenía un salto de línea dentro del code span que lo renderizaba partido en dos.

## Fuera de alcance

- `tsconfig.editor.json` declara `"types": ["jest"]` —paquete que ya no está instalado, así que el editor reporta `TS2688`— y tanto ese archivo como `tsconfig.app.json` excluyen un `jest.config.ts` inexistente. Son residuos reales de la misma migración, pero de configuración de tooling y no de documentación → #2236.
- La imagen de cabecera con la que abren los documentos de `docs/` sigue apuntando al repositorio personal previo a la organización. Resuelve por redirección, así que no está rota: está desactualizada. Su `<picture>` además declara un `<source>` para modo oscuro que apunta al mismo asset que el `<img>`, así que la variante que promete no existe. Reapuntarla pide un cambio propio que tome todos los archivos de una vez → #2237.

## Plan de pruebas

Es un cambio solo de documentación (`docs/**`), sin efecto en runtime.

- **Exactitud factual**: cada afirmación nueva sobre el stack se verificó contra `package.json` (Vitest 4.1.10, Tailwind 4.3.3, Stylelint 16.26.1, Hono 4.12.32, `@hono/zod-validator` 0.9.0, Zod 4.4.3, Angular 22.1.1, `test` → `nx vitest:test`), contra los tipos de documento que declara `cms/schemas/`, y —para la ruta del reporte— contra el `nxE2EPreset` de `@nx/playwright`, que con la config en la raíz emite `dist/.playwright/playwright-report`.
- **Enlaces**: los 32 de `DEVELOPMENT_GUIDE.md` y los 41 de `docs/qa/` resuelven, sin anclas rotas ni rutas inexistentes; los externos nuevos devuelven 200; no quedan labels de referencia definidos-y-sin-usar ni usados-y-sin-definir.
- **Issues citados**: los dos borrados están cerrados; los cuatro que se conservan, abiertos (consultado contra la API).
- **Barrido**: `grep -rniE "jest|jasmine|karma" docs/` no devuelve nada.
- **Gates**: `lint`, `typecheck`, `stylelint`, `test` y `check-agents` corridos en local, todos en verde. El resto corre en la CI de este PR.

Closes #2221
