### PR TITLE
[#2232] - La barra de navegación oculta sigue siendo enfocable con teclado y clickeable

### DIFF
--- a/e2e/nav-hidden.spec.ts
+++ b/e2e/nav-hidden.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * La barra de navegación oculta no recibe foco ni clics.
+ *
+ * El estado oculto colapsa el alto y pinta transparente, y ninguna de las dos cosas quita nada del árbol:
+ * sin un mecanismo que lo excluya, el contenido se derrama fuera de la caja de alto cero y sigue siendo
+ * enfocable y clickeable. Las dos consecuencias que se afirman acá —el hit-test y la política de foco—
+ * solo existen en un navegador real; el spec unitario alcanza únicamente el atributo que las declara.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+import { STACKING_VIEWPORTS, VIEWPORT_HEIGHT } from './_utils/stacking';
+import { STABLE_SLUGS } from './_utils/seo-fixtures';
+
+// El único ancho donde la barra llega a ocultarse: `WindowLayoutService` la mantiene visible en cuanto el
+// viewport supera `xs`.
+const VIEWPORT_WIDTH = STACKING_VIEWPORTS[0].width;
+
+// Una obra y no la home, para que un clic que active el enlace de marca sea distinguible del estado previo.
+const ROUTE = `/story/${STABLE_SLUGS.story}`;
+
+const NAV_SELECTOR = 'cuentoneta-header';
+const HEADER_SELECTOR = `${NAV_SELECTOR} header`;
+const BRAND_LINK = `${NAV_SELECTOR} a[aria-label="La Cuentoneta — Inicio"]`;
+
+// El servicio deriva la dirección de a pares de eventos de scroll por encima de 400px, así que el estado
+// oculto no se alcanza con un salto único: se scrollea de a tramos hasta que la barra se retrae.
+const SCROLL_STEP = 300;
+
+// La clase con que el componente expresa el estado oculto: es la señal de que la barra ya se retrajo,
+// disponible tanto con el defecto presente como con él corregido.
+const HIDDEN_CLASS = 'h-0';
+
+let status = 0;
+
+test.beforeAll(async ({ request }) => {
+	status = (await request.get(ROUTE)).status();
+});
+
+// Guarda como caso propio, no como `skip` silencioso: un dataset sin el fixture es un problema de la
+// infraestructura de test, no un motivo para que el gate quede verde sin haber mirado nada.
+test('la ruta existe en el dataset', () => {
+	expect(status, `"${ROUTE}" no responde 200: los casos de la barra oculta no verifican nada`).toBe(200);
+});
+
+/** Deja la página en el estado oculto, con la transición de colapso ya terminada. */
+async function hideNavBar(page: Page): Promise<void> {
+	await page.setViewportSize({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT });
+	await page.goto(ROUTE);
+	await expect(page.locator('h1').first()).toBeVisible();
+
+	// Sin esto, una página que no da para scrollear más allá del umbral dejaría el caso esperando a un
+	// estado inalcanzable, y el fallo hablaría de un timeout en vez de del fixture.
+	const reachableScroll = await page.evaluate(() => document.documentElement.scrollHeight - window.innerHeight);
+	expect(reachableScroll, `"${ROUTE}" no da para scrollear más allá del umbral que retrae la barra`).toBeGreaterThan(
+		400,
+	);
+
+	// Se scrollea desde adentro del sondeo, en tramos siempre hacia abajo, en vez de esperar un tiempo fijo
+	// entre dos saltos: el servicio descarta los eventos que llegan demasiado seguidos, y cuántos hacen
+	// falta depende de la máquina.
+	//
+	// La condición es la clase del estado oculto y no el mecanismo que lo saca de la interacción: así, con
+	// el defecto presente, los casos fallan por lo que afirman —el clic y el foco— y no por un timeout
+	// esperando el atributo que justamente falta.
+	await page.waitForFunction(
+		({ header, hiddenClass, step }) => {
+			if (document.querySelector(header)?.classList.contains(hiddenClass)) {
+				return true;
+			}
+			window.scrollBy(0, step);
+			return false;
+		},
+		{ header: HEADER_SELECTOR, hiddenClass: HIDDEN_CLASS, step: SCROLL_STEP },
+		{ polling: 100 },
+	);
+
+	// La clase cambia al empezar a ocultarse, pero el alto tarda lo que dura la transición. Se espera al
+	// final del colapso, y no un tiempo fijo, para que los casos midan el estado que dicen medir: con la
+	// barra a medio camino todavía hay franja que disputar y probarían otra cosa.
+	await expect
+		.poll(async () => (await page.locator(HEADER_SELECTOR).boundingBox())?.height, {
+			message: 'la barra no llegó a colapsar: los casos no probarían el estado oculto',
+		})
+		.toBe(0);
+}
+
+/** La caja del enlace de marca, que con la barra oculta sigue derramada sobre la franja superior. */
+async function brandLinkBox(page: Page) {
+	const box = await page.locator(BRAND_LINK).boundingBox();
+	if (!box) {
+		throw new Error('El enlace de marca no ocupa lugar: no habría dónde hacer clic');
+	}
+	return box;
+}
+
+test('la barra oculta no responde a los clics sobre su franja', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(status !== 200, `"${ROUTE}" no responde 200 en el dataset`);
+
+	await hideNavBar(page);
+	const box = await brandLinkBox(page);
+
+	// Control positivo: sin él, el caso pasaría igual con un enlace ya recortado, que es otra forma de
+	// arreglarlo y no la que este spec afirma. Que la barra haya colapsado lo verifica `hideNavBar`.
+	expect(box.width * box.height, 'el enlace de marca no ocupa área: el clic no caería sobre él').toBeGreaterThan(0);
+
+	// Se mide a quién le llega el evento y no si el enlace navegó: la navegación depende además del router
+	// y de la ruta destino, así que un caso montado sobre ella podría pasar por motivos ajenos al hit-test.
+	await page.evaluate((nav) => {
+		const scope = window as unknown as { clickTarget?: string };
+		document.addEventListener(
+			'click',
+			(event) => {
+				const target = event.target as Element | null;
+				scope.clickTarget = target?.closest(nav) ? 'nav' : (target?.tagName.toLowerCase() ?? 'ninguno');
+			},
+			{ capture: true, once: true },
+		);
+	}, NAV_SELECTOR);
+
+	await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+
+	const clickTarget = await page.evaluate(() => (window as unknown as { clickTarget?: string }).clickTarget);
+	expect(clickTarget, 'el clic sobre la franja de la barra oculta llegó a su contenido').not.toBe('nav');
+});
+
+test('la barra oculta no toma el foco', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(status !== 200, `"${ROUTE}" no responde 200 en el dataset`);
+
+	await hideNavBar(page);
+
+	const focusLandedInNavBar = await page.evaluate(
+		({ nav, brand }) => {
+			const link = document.querySelector<HTMLElement>(brand);
+			if (!link) {
+				throw new Error('No se encontró el enlace de marca');
+			}
+			link.focus();
+			return Boolean(document.activeElement?.closest(nav));
+		},
+		{ nav: NAV_SELECTOR, brand: BRAND_LINK },
+	);
+
+	expect(focusLandedInNavBar, 'el foco entró en una barra que la interfaz declara ausente').toBe(false);
+});

--- a/e2e/nav-hidden.spec.ts
+++ b/e2e/nav-hidden.spec.ts
@@ -19,16 +19,18 @@ const VIEWPORT_WIDTH = STACKING_VIEWPORTS[0].width;
 const ROUTE = `/story/${STABLE_SLUGS.story}`;
 
 const NAV_SELECTOR = 'cuentoneta-header';
+// La franja que colapsa, que es la que se mide: lo inerte es el componente entero, un nivel más arriba.
 const HEADER_SELECTOR = `${NAV_SELECTOR} header`;
 const BRAND_LINK = `${NAV_SELECTOR} a[aria-label="La Cuentoneta — Inicio"]`;
 
-// El servicio deriva la dirección de a pares de eventos de scroll por encima de 400px, así que el estado
-// oculto no se alcanza con un salto único: se scrollea de a tramos hasta que la barra se retrae.
+// El servicio deriva la dirección de a pares de eventos de scroll por encima de este umbral, así que el
+// estado oculto no se alcanza con un salto único: se scrollea de a tramos hasta que la barra se retrae.
+const SCROLL_THRESHOLD = 400;
 const SCROLL_STEP = 300;
 
-// La clase con que el componente expresa el estado oculto: es la señal de que la barra ya se retrajo,
-// disponible tanto con el defecto presente como con él corregido.
-const HIDDEN_CLASS = 'h-0';
+// La barra encabeza el documento y aporta seis paradas —marca, cuatro entradas y el botón del menú—, así
+// que un recorrido de este largo entra en ella de sobra si sigue siendo tabulable.
+const TAB_STEPS = 8;
 
 let status = 0;
 
@@ -42,45 +44,44 @@ test('la ruta existe en el dataset', () => {
 	expect(status, `"${ROUTE}" no responde 200: los casos de la barra oculta no verifican nada`).toBe(200);
 });
 
-/** Deja la página en el estado oculto, con la transición de colapso ya terminada. */
-async function hideNavBar(page: Page): Promise<void> {
+/** Abre la ruta en el único ancho donde la barra llega a ocultarse. */
+async function openRoute(page: Page): Promise<void> {
 	await page.setViewportSize({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT });
 	await page.goto(ROUTE);
 	await expect(page.locator('h1').first()).toBeVisible();
+}
 
-	// Sin esto, una página que no da para scrollear más allá del umbral dejaría el caso esperando a un
-	// estado inalcanzable, y el fallo hablaría de un timeout en vez de del fixture.
+/** Scrollea la ruta ya abierta hasta el estado oculto, con la transición de colapso ya terminada. */
+async function hideNavBar(page: Page): Promise<void> {
+	// Sin esto, una página que no da para scrollear lo suficiente dejaría el caso esperando a un estado
+	// inalcanzable, y el fallo hablaría de un timeout en vez de del fixture. El mínimo no es el umbral de
+	// 400px: el servicio descarta lo que no lo supera y recién después compara de a pares, así que hacen
+	// falta dos posiciones por encima, y la segunda dista un tramo de scroll de la primera.
 	const reachableScroll = await page.evaluate(() => document.documentElement.scrollHeight - window.innerHeight);
-	expect(reachableScroll, `"${ROUTE}" no da para scrollear más allá del umbral que retrae la barra`).toBeGreaterThan(
-		400,
-	);
+	expect(
+		reachableScroll,
+		`"${ROUTE}" no da para scrollear lo que hace falta para que la barra se retraiga`,
+	).toBeGreaterThan(SCROLL_THRESHOLD + SCROLL_STEP);
 
 	// Se scrollea desde adentro del sondeo, en tramos siempre hacia abajo, en vez de esperar un tiempo fijo
 	// entre dos saltos: el servicio descarta los eventos que llegan demasiado seguidos, y cuántos hacen
 	// falta depende de la máquina.
 	//
-	// La condición es la clase del estado oculto y no el mecanismo que lo saca de la interacción: así, con
-	// el defecto presente, los casos fallan por lo que afirman —el clic y el foco— y no por un timeout
-	// esperando el atributo que justamente falta.
-	await page.waitForFunction(
-		({ header, hiddenClass, step }) => {
-			if (document.querySelector(header)?.classList.contains(hiddenClass)) {
-				return true;
-			}
-			window.scrollBy(0, step);
-			return false;
-		},
-		{ header: HEADER_SELECTOR, hiddenClass: HIDDEN_CLASS, step: SCROLL_STEP },
-		{ polling: 100 },
-	);
-
-	// La clase cambia al empezar a ocultarse, pero el alto tarda lo que dura la transición. Se espera al
-	// final del colapso, y no un tiempo fijo, para que los casos midan el estado que dicen medir: con la
-	// barra a medio camino todavía hay franja que disputar y probarían otra cosa.
+	// La condición es el alto ya colapsado, que es a la vez la señal de que la barra se retrajo y de que su
+	// transición terminó. Dos motivos para no mirar en cambio el atributo que la saca de la interacción:
+	// con el defecto presente los casos fallarían por un timeout en vez de por lo que afirman, y a mitad de
+	// la transición todavía hay franja que disputar, así que probarían otra cosa.
 	await expect
-		.poll(async () => (await page.locator(HEADER_SELECTOR).boundingBox())?.height, {
-			message: 'la barra no llegó a colapsar: los casos no probarían el estado oculto',
-		})
+		.poll(
+			async () => {
+				const height = (await page.locator(HEADER_SELECTOR).boundingBox())?.height;
+				if (height !== 0) {
+					await page.evaluate((step) => window.scrollBy(0, step), SCROLL_STEP);
+				}
+				return height;
+			},
+			{ message: 'la barra no llegó a colapsar: los casos no probarían el estado oculto' },
+		)
 		.toBe(0);
 }
 
@@ -97,6 +98,7 @@ test('la barra oculta no responde a los clics sobre su franja', async ({ page })
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
 	test.skip(status !== 200, `"${ROUTE}" no responde 200 en el dataset`);
 
+	await openRoute(page);
 	await hideNavBar(page);
 	const box = await brandLinkBox(page);
 
@@ -121,26 +123,56 @@ test('la barra oculta no responde a los clics sobre su franja', async ({ page })
 	await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
 
 	const clickTarget = await page.evaluate(() => (window as unknown as { clickTarget?: string }).clickTarget);
+
+	// Control positivo del propio instrumento: sin él, un listener que nunca corrió dejaría `clickTarget`
+	// sin definir y la aserción de abajo pasaría sin que ningún clic haya ocurrido.
+	expect(clickTarget, 'el clic no le llegó a nadie: la aserción siguiente pasaría en vacío').toBeDefined();
 	expect(clickTarget, 'el clic sobre la franja de la barra oculta llegó a su contenido').not.toBe('nav');
 });
 
-test('la barra oculta no toma el foco', async ({ page }) => {
+/** Si el foco está, en este instante, dentro de la barra de navegación. */
+function focusIsInNavBar(page: Page) {
+	return page.evaluate((nav) => Boolean(document.activeElement?.closest(nav)), NAV_SELECTOR);
+}
+
+// Es el título literal del issue, y es lo que ninguna otra suite alcanza: el unitario afirma la política
+// de foco de happy-dom al llamar `focus()`, no el recorrido de tabulación que hace el navegador.
+test('la barra oculta no recibe el foco al tabular', async ({ page }) => {
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
 	test.skip(status !== 200, `"${ROUTE}" no responde 200 en el dataset`);
 
+	await openRoute(page);
+	await hideNavBar(page);
+	await page.evaluate(() => document.body.focus());
+
+	// Varias pulsaciones y no una: la barra encabeza el documento, así que con el defecto presente el
+	// recorrido entra en ella enseguida, y con el arreglo debe pasar de largo hacia el contenido.
+	for (let step = 0; step < TAB_STEPS; step++) {
+		await page.keyboard.press('Tab');
+		expect(await focusIsInNavBar(page), 'al tabular, el foco entró en una barra declarada ausente').toBe(false);
+	}
+
+	// Control positivo: si el recorrido nunca llegó a ningún lado, lo de arriba se cumpliría en vacío.
+	const focusedTag = await page.evaluate(() => document.activeElement?.tagName.toLowerCase());
+	expect(focusedTag, 'la tabulación no movió el foco a ningún lado').not.toBe('body');
+});
+
+// El foco que ya estaba adentro cuando la barra se oculta lo suelta el navegador, y solo él: happy-dom
+// consulta los ancestros inertes al enfocar, pero no reevalúa un foco ya puesto.
+test('la barra suelta el foco que ya tenía al ocultarse', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(status !== 200, `"${ROUTE}" no responde 200 en el dataset`);
+
+	await openRoute(page);
+	await page.locator(BRAND_LINK).focus();
+
+	// Control positivo: el escenario empieza con el foco adentro, que es lo que después se comprueba que
+	// no sobrevive al ocultamiento.
+	expect(await focusIsInNavBar(page), 'el foco no llegó a entrar en la barra: el caso no probaría nada').toBe(true);
+
 	await hideNavBar(page);
 
-	const focusLandedInNavBar = await page.evaluate(
-		({ nav, brand }) => {
-			const link = document.querySelector<HTMLElement>(brand);
-			if (!link) {
-				throw new Error('No se encontró el enlace de marca');
-			}
-			link.focus();
-			return Boolean(document.activeElement?.closest(nav));
-		},
-		{ nav: NAV_SELECTOR, brand: BRAND_LINK },
+	expect(await focusIsInNavBar(page), 'el foco quedó atrapado en una barra que la interfaz declara ausente').toBe(
+		false,
 	);
-
-	expect(focusLandedInNavBar, 'el foco entró en una barra que la interfaz declara ausente').toBe(false);
 });

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -170,15 +170,15 @@ describe('HeaderComponent', () => {
 		// Se afirma sobre el ancestro y no sobre la franja que colapsa: lo inerte es el componente entero,
 		// que es el alcance que incluye también al menú desplegable y a su backdrop.
 		it('should mark the whole component inert while hidden', async () => {
-			await renderHeader(false);
+			const { fixture } = await renderHeader(false);
 
-			expect(screen.getByRole('banner').closest('[inert]')).not.toBeNull();
+			expect(fixture.nativeElement).toHaveAttribute('inert');
 		});
 
-		it('should leave nothing inert while visible', async () => {
-			await renderHeader(true);
+		it('should leave the component interactive while visible', async () => {
+			const { fixture } = await renderHeader(true);
 
-			expect(screen.getByRole('banner').closest('[inert]')).toBeNull();
+			expect(fixture.nativeElement).not.toHaveAttribute('inert');
 		});
 
 		// El foco que ya estaba adentro cuando la barra se oculta lo suelta el navegador, y solo él:

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -115,9 +115,26 @@ describe('HeaderComponent', () => {
 			expect(banner).not.toHaveClass('h-0');
 		});
 
-		// Los cuatro casos siguientes cubren el contrato que las clases de colapso no expresan: una barra
-		// que la interfaz declara ausente no puede seguir recibiendo foco. `happy-dom` consulta los
-		// ancestros `inert` al enfocar, así que acá se afirma comportamiento y no solo el atributo emitido.
+		it('should close the mobile menu when the header hides', async () => {
+			const user = userEvent.setup();
+			const { rerender } = await renderHeader(true);
+			await user.click(screen.getByRole('button'));
+			expect(screen.getAllByRole('link', { name: 'Obras' })).toHaveLength(2);
+
+			await rerender({ inputs: { isVisible: false } });
+
+			// Vuelve a quedar solo el de escritorio: el del menú desplegable se fue con él. Se espera con
+			// `waitFor` porque el effect cierra el menú dentro del ciclo del cambio de input y el template
+			// lo refleja en la pasada siguiente.
+			await waitFor(() => expect(screen.getAllByRole('link', { name: 'Obras' })).toHaveLength(1));
+		});
+	});
+
+	// Lo que las clases de colapso no expresan: una barra que la interfaz declara ausente tampoco puede
+	// existir para el teclado. `happy-dom` consulta los ancestros `inert` al enfocar, así que acá se afirma
+	// comportamiento y no solo el atributo emitido; el clic y el árbol de accesibilidad los decide el
+	// navegador y quedan para el e2e.
+	describe('interaction while hidden', () => {
 		it('should keep the brand link out of reach while hidden', async () => {
 			await renderHeader(false);
 
@@ -150,27 +167,22 @@ describe('HeaderComponent', () => {
 
 		// El clic y la exclusión del árbol de accesibilidad los decide el navegador, no happy-dom: acá se
 		// afirma que el estado queda declarado, y el e2e comprueba lo que ese atributo produce de verdad.
-		it('should mark the header inert only while hidden', async () => {
-			const { rerender } = await renderHeader(true);
-			expect(screen.getByRole('banner')).not.toHaveAttribute('inert');
+		// Se afirma sobre el ancestro y no sobre la franja que colapsa: lo inerte es el componente entero,
+		// que es el alcance que incluye también al menú desplegable y a su backdrop.
+		it('should mark the whole component inert while hidden', async () => {
+			await renderHeader(false);
 
-			await rerender({ inputs: { isVisible: false } });
-
-			expect(screen.getByRole('banner')).toHaveAttribute('inert');
+			expect(screen.getByRole('banner').closest('[inert]')).not.toBeNull();
 		});
 
-		it('should close the mobile menu when the header hides', async () => {
-			const user = userEvent.setup();
-			const { rerender } = await renderHeader(true);
-			await user.click(screen.getByRole('button'));
-			expect(screen.getAllByRole('link', { name: 'Obras' })).toHaveLength(2);
+		it('should leave nothing inert while visible', async () => {
+			await renderHeader(true);
 
-			await rerender({ inputs: { isVisible: false } });
-
-			// Vuelve a quedar solo el de escritorio: el del menú desplegable se fue con él. Se espera con
-			// `waitFor` porque el effect cierra el menú dentro del ciclo del cambio de input y el template
-			// lo refleja en la pasada siguiente.
-			await waitFor(() => expect(screen.getAllByRole('link', { name: 'Obras' })).toHaveLength(1));
+			expect(screen.getByRole('banner').closest('[inert]')).toBeNull();
 		});
+
+		// El foco que ya estaba adentro cuando la barra se oculta lo suelta el navegador, y solo él:
+		// `happy-dom` consulta los ancestros inertes al enfocar, pero no reevalúa un foco ya puesto. Ese
+		// caso vive en el e2e.
 	});
 });

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -115,6 +115,50 @@ describe('HeaderComponent', () => {
 			expect(banner).not.toHaveClass('h-0');
 		});
 
+		// Los cuatro casos siguientes cubren el contrato que las clases de colapso no expresan: una barra
+		// que la interfaz declara ausente no puede seguir recibiendo foco. `happy-dom` consulta los
+		// ancestros `inert` al enfocar, así que acá se afirma comportamiento y no solo el atributo emitido.
+		it('should keep the brand link out of reach while hidden', async () => {
+			await renderHeader(false);
+
+			const brandLink = screen.getByRole('link', { name: 'La Cuentoneta — Inicio' });
+			brandLink.focus();
+
+			expect(brandLink).not.toHaveFocus();
+		});
+
+		// Sin este control, el caso de arriba pasaría igual con un componente que no deja enfocar nunca.
+		it('should let the brand link take focus while visible', async () => {
+			await renderHeader(true);
+
+			const brandLink = screen.getByRole('link', { name: 'La Cuentoneta — Inicio' });
+			brandLink.focus();
+
+			expect(brandLink).toHaveFocus();
+		});
+
+		// El otro control alcanzable en `xs`, que es el único ancho donde la barra llega a ocultarse: ahí
+		// los enlaces de escritorio están en `display: none` y el menú se abre por este botón.
+		it('should keep the menu toggler out of reach while hidden', async () => {
+			await renderHeader(false);
+
+			const toggler = screen.getByRole('button');
+			toggler.focus();
+
+			expect(toggler).not.toHaveFocus();
+		});
+
+		// El clic y la exclusión del árbol de accesibilidad los decide el navegador, no happy-dom: acá se
+		// afirma que el estado queda declarado, y el e2e comprueba lo que ese atributo produce de verdad.
+		it('should mark the header inert only while hidden', async () => {
+			const { rerender } = await renderHeader(true);
+			expect(screen.getByRole('banner')).not.toHaveAttribute('inert');
+
+			await rerender({ inputs: { isVisible: false } });
+
+			expect(screen.getByRole('banner')).toHaveAttribute('inert');
+		});
+
 		it('should close the mobile menu when the header hides', async () => {
 			const user = userEvent.setup();
 			const { rerender } = await renderHeader(true);

--- a/src/app/components/header/header.component.stories.ts
+++ b/src/app/components/header/header.component.stories.ts
@@ -20,7 +20,7 @@ export default {
 	},
 } as Meta<HeaderComponent>;
 
-export const Primary: StoryObj<HeaderComponent> = {
+export const Visible: StoryObj<HeaderComponent> = {
 	render: (args) => ({ props: args }),
 	args: { isVisible: true },
 	parameters: {
@@ -33,12 +33,20 @@ export const Primary: StoryObj<HeaderComponent> = {
 };
 
 export const Oculto: StoryObj<HeaderComponent> = {
-	render: (args) => ({ props: args }),
+	// El enlace de abajo es el destino contra el que se comprueba lo que la story afirma: sin nada más en
+	// el canvas, "el foco pasa de largo" no se distingue de un canvas donde no hay adónde ir.
+	render: (args) => ({
+		props: args,
+		template: `
+			<cuentoneta-header [isVisible]="isVisible" />
+			<a href="#" class="mt-24 inline-block font-inter text-sm underline">Primera parada fuera del encabezado</a>
+		`,
+	}),
 	args: { isVisible: false },
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Encabezado oculto, el estado al que llega el scroll hacia abajo en viewports angostos. La barra no responde al puntero ni entra en el orden de tabulación: tabulando desde acá el foco pasa de largo hacia el contenido de la página. Es el único lugar donde ese estado se puede recorrer con teclado en un viewport ancho, porque en el sitio solo ocurre en <code>xs</code>.</p><p><strong>Usos:</strong> todas las páginas del sitio, montado por el layout raíz.</p>`,
+				story: `<p>Encabezado oculto, el estado al que llega el scroll hacia abajo en viewports angostos. La barra no responde al puntero ni entra en el orden de tabulación: tabulando desde acá, la primera parada es el enlace de la página y no el contenido del encabezado. Es el único lugar donde ese estado se puede recorrer con teclado en un viewport ancho, porque en el sitio solo ocurre en <code>xs</code>.</p><p>La barra deja de responder al empezar a ocultarse y no al terminar, así que durante la transición sigue dibujándose sin recibir foco ni clics. Es deliberado: se está yendo, y encadenar la exclusión al final de la animación cambiaría una declaración por estado imperativo.</p><p><strong>Usos:</strong> todas las páginas del sitio, montado por el layout raíz.</p>`,
 			},
 		},
 	},

--- a/src/app/components/header/header.component.stories.ts
+++ b/src/app/components/header/header.component.stories.ts
@@ -7,7 +7,7 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: `<div><p>El <strong>HeaderComponent</strong> es el encabezado del sitio: logo, navegación principal y menú desplegable en viewports angostos. El input <code>isVisible</code> lo oculta al hacer scroll hacia abajo, colapsando alto, opacidad y desplazamiento en una transición que respeta <code>prefers-reduced-motion</code>.</p></div>`,
+				component: `<div><p>El <strong>HeaderComponent</strong> es el encabezado del sitio: logo, navegación principal y menú desplegable en viewports angostos. El input <code>isVisible</code> lo oculta al hacer scroll hacia abajo, colapsando alto, opacidad y desplazamiento en una transición que respeta <code>prefers-reduced-motion</code>. Al ocultarse deja además de recibir foco y clics, para que la barra que la interfaz declara ausente tampoco exista para el teclado ni para el puntero.</p></div>`,
 			},
 		},
 	},
@@ -27,6 +27,18 @@ export const Primary: StoryObj<HeaderComponent> = {
 		docs: {
 			description: {
 				story: `<p>Encabezado visible, que es como se sirve en todas las páginas. Alterná el control para ver la transición de ocultamiento, la misma que dispara el scroll hacia abajo.</p><p><strong>Usos:</strong> todas las páginas del sitio, montado por el layout raíz.</p>`,
+			},
+		},
+	},
+};
+
+export const Oculto: StoryObj<HeaderComponent> = {
+	render: (args) => ({ props: args }),
+	args: { isVisible: false },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Encabezado oculto, el estado al que llega el scroll hacia abajo en viewports angostos. La barra no responde al puntero ni entra en el orden de tabulación: tabulando desde acá el foco pasa de largo hacia el contenido de la página. Es el único lugar donde ese estado se puede recorrer con teclado en un viewport ancho, porque en el sitio solo ocurre en <code>xs</code>.</p><p><strong>Usos:</strong> todas las páginas del sitio, montado por el layout raíz.</p>`,
 			},
 		},
 	},

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -17,11 +17,14 @@ type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 		// haría perder contra el contenido de página. Ningún componente necesita conocerla para no taparla —
 		// los que elevan algo dentro de sí lo confinan con `isolate`.
 		class: 'fixed top-0 z-nav w-full items-center justify-center border-b-1 border-neutral-200 md:m-auto',
+		// Va en el host y no en el `<header>` que colapsa, para que alcance también al menú desplegable y a
+		// su backdrop, que son hermanos suyos. Hoy los desmonta el effect de abajo; así la garantía no
+		// depende de que siga haciéndolo.
+		'[attr.inert]': "isHidden() ? '' : null",
 	},
 	template: `
 		<header
 			[class]="visibilityClasses()"
-			[attr.inert]="isHidden() ? '' : null"
 			class="grid w-full grid-cols-[1fr_theme(spacing.6)] grid-rows-[theme(spacing.16)_1fr] bg-neutral-50 px-5 transition-[height,opacity,translate] duration-200 motion-reduce:transition-none md:grid-cols-2 md:grid-rows-1"
 		>
 			<section class="flex items-center">
@@ -101,8 +104,6 @@ export class HeaderComponent {
 
 	protected readonly visibilityClasses = computed(() => this.visibilityClassMap[this.isVisible()]);
 
-	// El estado oculto colapsa el alto y pinta transparente, y ninguna de las dos cosas saca al contenido
-	// del orden de tabulación ni del hit-test: sin esto, la barra ausente sigue siendo navegable.
 	protected readonly isHidden = computed(() => this.isVisible() === VisibilityState.Hidden);
 
 	private readonly collapseMenuOnHideEffect = effect(() => {

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -21,6 +21,7 @@ type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 	template: `
 		<header
 			[class]="visibilityClasses()"
+			[attr.inert]="isHidden() ? '' : null"
 			class="grid w-full grid-cols-[1fr_theme(spacing.6)] grid-rows-[theme(spacing.16)_1fr] bg-neutral-50 px-5 transition-[height,opacity,translate] duration-200 motion-reduce:transition-none md:grid-cols-2 md:grid-rows-1"
 		>
 			<section class="flex items-center">
@@ -100,8 +101,12 @@ export class HeaderComponent {
 
 	protected readonly visibilityClasses = computed(() => this.visibilityClassMap[this.isVisible()]);
 
+	// El estado oculto colapsa el alto y pinta transparente, y ninguna de las dos cosas saca al contenido
+	// del orden de tabulación ni del hit-test: sin esto, la barra ausente sigue siendo navegable.
+	protected readonly isHidden = computed(() => this.isVisible() === VisibilityState.Hidden);
+
 	private readonly collapseMenuOnHideEffect = effect(() => {
-		if (this.isVisible() === VisibilityState.Hidden) {
+		if (this.isHidden()) {
 			this.displayMenu.set(false);
 		}
 	});


### PR DESCRIPTION
## Contexto

Cuando la barra de navegación se ocultaba al hacer scroll hacia abajo, su contenido seguía siendo alcanzable con Tab y seguía recibiendo clics. El estado oculto aplica `h-0 -translate-y-full opacity-0`, y ninguna de esas tres declaraciones quita nada del árbol: `opacity: 0` solo pinta transparente, y el porcentaje de `-translate-y-full` se resuelve contra un alto que en ese mismo estado es cero, así que el desplazamiento se auto-cancela. El contenido quedaba apilado dentro de una caja de alto cero que no recorta, visible al hit-test y al orden de tabulación.

Para quien navega con teclado eso es una trampa de foco silenciosa: el foco entra en una barra que la interfaz declara ausente, sin ninguna indicación visual de dónde está.

## Qué cambia

Se aplica `inert` sobre el host del componente mientras el estado es oculto, mediante un `computed` que expresa ese estado y un binding de atributo. `inert` excluye el subárbol del orden de tabulación, del hit-test y del árbol de accesibilidad de una sola vez, y no participa del renderizado, así que la transición de alto, opacidad y desplazamiento sigue corriendo igual en las dos direcciones.

Va en el host y no en el `<header>` que colapsa para que alcance también al menú desplegable y a su backdrop, que son hermanos suyos: hoy los desmonta el effect que cierra el menú, y así la garantía de accesibilidad no depende de que ese effect siga haciéndolo.

Se descartaron las otras opciones evaluadas en el issue: `visibility: hidden` es transicionable de forma discreta y habría cortado la animación de salida salvo agregando `transition-discrete` y `@starting-style`; `pointer-events-none` no toca el orden de tabulación; y `overflow-hidden` no saca del foco ni del clic, y además recortaría el anillo de foco de los enlaces en el estado **visible**, que sería una regresión de accesibilidad.

El `computed` nuevo lo reusa el effect que cierra el menú desplegable, que hasta ahora repetía la comparación.

## Alcance real del defecto

Vale dejarlo escrito porque cambia dónde se puede verificar: `WindowLayoutService` solo oculta la barra cuando el viewport no supera `xs`. En ese ancho los enlaces de escritorio están en `display: none`, así que lo que hoy se fuga en producción es el enlace de marca y el botón del menú. El escenario de tabular por las cuatro entradas se reproduce forzando el input en anchos `md+`, que es lo que hace la story nueva. El defecto del contrato del componente es el mismo, y es el contrato lo que se corrige.

Queda deliberadamente **fuera de alcance** corregir el `-translate-y-full` que se auto-cancela: con `inert` aplicado el derrame no es alcanzable ni visible, y tocar el mapa de clases colisionaría con una rama en curso sin cerrar ningún criterio de este issue.

## Plan de pruebas

- **Unitario** (`header.component.spec.ts`): el enlace de marca y el botón del menú no toman el foco con la barra oculta, el control inverso de que el enlace **sí** lo toma con la barra visible, y que el componente queda inerte solo mientras está oculta. `happy-dom` consulta los ancestros `inert` al enfocar, así que los dos primeros afirman comportamiento y no solo el atributo emitido. Verificado que los tres casos que dependen del arreglo fallan sin él.
- **E2E** (`e2e/nav-hidden.spec.ts`, nuevo): en ancho `xs` sobre una obra del dataset, se scrollea hasta que la barra se retrae y se afirman las tres consecuencias que solo existen en un navegador real. Verificado que los seis casos sustantivos fallan con el defecto presente —cada uno por lo que afirma, no por un timeout— y pasan con el arreglo, en chromium y en firefox.
  - **Clic:** se mide a quién le llega el evento y no si el enlace navegó. Con el defecto presente el clic alcanzaba el enlace sin llegar a cambiar de página, así que un caso montado sobre la navegación pasaba en vacío.
  - **Tabulación:** se pulsa Tab de verdad, que es lo que el issue enuncia y lo único que el unitario no alcanza —ahí `focus()` solo ejercita la política de foco de `happy-dom`.
  - **Foco atrapado:** el escenario real en `xs` —el foco ya estaba dentro cuando la barra se oculta—. Solo el navegador lo suelta: `happy-dom` no reevalúa un foco ya puesto.
  - La espera del estado oculto sondea el alto ya colapsado, que es señal disponible con y sin el defecto y a la vez marca el final de la transición: con la barra a medio camino todavía hay franja que disputar y los casos probarían otra cosa.
- **Storybook:** story `Oculto` nueva, con un enlace hermano que le da destino al Tab — sin él, "el foco pasa de largo" no se distingue de un canvas donde no hay nada que enfocar. Es la única superficie donde ese estado se puede recorrer con teclado en un viewport ancho.
- **Gates locales:** `typecheck`, `lint`, `stylelint`, `test`, `check-agents` en verde, más `build`, `storybook:build` y el `e2e` nuevo corridos en local.

## Review

Corrió el `code-reviewer`, sin hallazgos críticos. Sus seis advertencias y seis sugerencias quedaron todas abordadas: el `inert` se movió al host, se sumaron los casos de tabulación y de foco atrapado, se agregaron los controles positivos que faltaban, la guarda de scroll pasó a derivar su umbral del mecanismo, el sondeo se desacopló de la clase de Tailwind y la story quedó comprobable en el canvas. No corrió el `security-auditor`: el diff no toca `src/api/**`, contenido del CMS, fetch externo ni dependencias.

Closes #2232.
