### PR TITLE
[#2233] - Sincroniza el schema extraído y acota el alcance del barrido

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -970,7 +970,7 @@
 				"value": {
 					"type": "boolean"
 				},
-				"optional": true
+				"optional": false
 			},
 			"tags": {
 				"type": "objectAttribute",

--- a/scripts/required-fields-sweep/required-fields-sweep.groq.spec.ts
+++ b/scripts/required-fields-sweep/required-fields-sweep.groq.spec.ts
@@ -63,7 +63,9 @@ describe('buildFieldCountQuery', () => {
 			insideArray: true,
 		};
 
-		expect(buildFieldCountQuery(field).publishedQuery).toContain('count(tabs[!defined(slug.current)]) > 0');
+		expect(buildFieldCountQuery(field).publishedQuery).toContain(
+			'count(tabs[defined(slug) && !defined(slug.current)]) > 0',
+		);
 	});
 
 	it('rejects a document type that is not an identifier', () => {
@@ -107,6 +109,31 @@ describe('the generated queries, evaluated', () => {
 		];
 
 		expect(await count(buildFieldCountQuery(field).publishedQuery, withResources)).toBe(1);
+	});
+
+	// Un ítem que no trae el objeto contenedor entero incumple **un** dato, no uno por cada campo de
+	// ese objeto: sin el guard, el mismo documento se cuenta en la fila de `tabs.slug` y en la de
+	// `tabs.slug.current`, y el reporte exagera el problema.
+	it('does not count an item that lacks the whole nested object as breaching its every field', async () => {
+		const field: RequiredFieldPath = {
+			documentType: 'storylist',
+			segments: ['tabs', 'slug', 'current'],
+			insideArray: true,
+		};
+		const withoutSlugObject = [{ _id: 'a', _type: 'storylist', tabs: [{ title: 'sin slug' }] }];
+
+		expect(await count(buildFieldCountQuery(field).publishedQuery, withoutSlugObject)).toBe(0);
+	});
+
+	it('does count an item whose nested object exists but misses the attribute', async () => {
+		const field: RequiredFieldPath = {
+			documentType: 'storylist',
+			segments: ['tabs', 'slug', 'current'],
+			insideArray: true,
+		};
+		const withEmptySlug = [{ _id: 'a', _type: 'storylist', tabs: [{ slug: {} }] }];
+
+		expect(await count(buildFieldCountQuery(field).publishedQuery, withEmptySlug)).toBe(1);
 	});
 
 	// El caso que la perspectiva no distingue: el mismo documento vive publicado y como borrador, y

--- a/scripts/required-fields-sweep/required-fields-sweep.groq.ts
+++ b/scripts/required-fields-sweep/required-fields-sweep.groq.ts
@@ -35,7 +35,13 @@ function missingPredicate(segments: readonly string[]): string {
 // vez de emitir una consulta que contaría mal en silencio.
 function missingInArrayPredicate(segments: readonly string[]): string {
 	const [arrayPath, ...rest] = segments;
-	return `count(${arrayPath}[!defined(${rest.join('.')})]) > 0`;
+	// El mismo guard que la rama de arriba, aplicado dentro del ítem: sin él, un elemento que no trae
+	// el objeto contenedor entero se cuenta una vez por cada campo de ese objeto, y el reporte dice
+	// que faltan varios datos donde falta uno.
+	const parents = rest.slice(0, -1);
+	const missing =
+		parents.length === 0 ? `!defined(${rest[0]})` : `defined(${parents.join('.')}) && !defined(${rest.join('.')})`;
+	return `count(${arrayPath}[${missing}]) > 0`;
 }
 
 // El nombre de tipo y los segmentos se interpolan en el texto de la query, no viajan como parámetro:

--- a/scripts/required-fields-sweep/required-fields-sweep.report.ts
+++ b/scripts/required-fields-sweep/required-fields-sweep.report.ts
@@ -35,10 +35,14 @@ export function breachesOf(counts: readonly FieldBreach[]): FieldBreach[] {
  * Cadena determinista del conjunto de hallazgos. Es lo que vuelve idempotente al job: mismo conjunto
  * ⇒ misma huella ⇒ no se escribe nada.
  */
-export function fingerprint(breaches: readonly FieldBreach[]): string {
+export function fingerprint(breaches: readonly FieldBreach[], uncovered: readonly UncoveredPath[] = []): string {
 	// Sin los conteos a propósito: que una obra nueva sume un incumplimiento al mismo campo no es un
 	// hallazgo distinto, y reescribiría el seguimiento cada semana sin que nada haya cambiado.
-	return [...new Set(breaches.map((breach) => breach.label))].sort().join('|');
+	const labels = breaches.map((breach) => breach.label);
+	// Los puntos ciegos entran a la huella porque el reporte los publica: si cambian y la huella no,
+	// el seguimiento se queda mostrando una lista que dejó de ser cierta.
+	const blind = uncovered.map((path) => `~${path.documentType}.${path.segments.join('.')}`);
+	return [...new Set([...labels, ...blind])].sort().join('|');
 }
 
 function breachRows(breaches: readonly FieldBreach[]): string[] {
@@ -70,7 +74,7 @@ export function formatReportBody(report: SweepReport): string {
 		...breachRows(report.breaches),
 		...uncoveredSection,
 		'',
-		`${FINGERPRINT_PREFIX} ${fingerprint(report.breaches)} -->`,
+		`${FINGERPRINT_PREFIX} ${fingerprint(report.breaches, report.uncovered)} -->`,
 	].join('\n');
 }
 
@@ -87,9 +91,11 @@ export function decideAction(input: { report: SweepReport; existing: { body: str
 		if (existing === null || !existing.body.includes(FINGERPRINT_PREFIX)) {
 			return { kind: 'noop' };
 		}
+		// El cuerpo se reemplaza entero: conservar la tabla dejaría el issue afirmando que esos campos
+		// se incumplen, justo debajo del aviso de que ya no.
 		return {
 			kind: 'resolved',
-			body: existing.body.replace(new RegExp(`${FINGERPRINT_PREFIX}[^>]*-->`), '<!-- resuelto -->'),
+			body: 'Ya no quedan campos requeridos que el dato persistido incumpla.\n\n<!-- resuelto -->',
 			comment: 'Ya no quedan campos requeridos incumplidos. Se puede cerrar este seguimiento.',
 		};
 	}

--- a/scripts/required-fields-sweep/required-fields-sweep.schema.spec.ts
+++ b/scripts/required-fields-sweep/required-fields-sweep.schema.spec.ts
@@ -155,7 +155,11 @@ describe('scanRequiredFields', () => {
 		const { uncovered } = scanRequiredFields([node] as never);
 
 		expect(uncovered).toEqual([
-			{ documentType: 'story', segments: ['content', 'epigraphs'], reason: 'array dentro de otro array' },
+			{
+				documentType: 'story',
+				segments: ['content', 'epigraphs'],
+				reason: 'no se desciende: array dentro de otro array',
+			},
 		]);
 	});
 
@@ -174,7 +178,7 @@ describe('scanRequiredFields', () => {
 		const { uncovered } = scanRequiredFields([node] as never);
 
 		expect(uncovered).toEqual([
-			{ documentType: 'storylist', segments: ['mediaSources'], reason: 'array de tipos unión' },
+			{ documentType: 'storylist', segments: ['mediaSources'], reason: 'no se desciende: array de tipos unión' },
 		]);
 	});
 

--- a/scripts/required-fields-sweep/required-fields-sweep.schema.ts
+++ b/scripts/required-fields-sweep/required-fields-sweep.schema.ts
@@ -116,6 +116,12 @@ function descendInline(
 	acc: Accumulator,
 ): void {
 	const name = node.name;
+	// Los internos de un tipo del sistema los escribe el Studio, no quien carga contenido: el recorte
+	// y el foco de una imagen no son un dato editorial que alguien pueda incumplir, y descender ahí
+	// llenaría el reporte de filas que nadie puede accionar.
+	if (name?.startsWith('sanity.')) {
+		return;
+	}
 	const resolved = name ? acc.types.get(name) : undefined;
 
 	if (!name || !resolved) {
@@ -140,17 +146,18 @@ function descendArray(
 	acc: Accumulator,
 ): void {
 	const member = node.of;
-	// El predicado de conteo sabe filtrar un array por su contenido, pero no anidar un segundo filtro
-	// adentro: emitiría una consulta válida que cuenta otra cosa, sin fallar.
-	if (insideArray) {
-		acc.uncovered.push({ documentType, segments, reason: 'array dentro de otro array' });
+	// Un array de uniones tiene tantas formas como miembros, y el predicado no puede distinguirlas sin
+	// ramificar por `_type`. Se chequea antes que el anidamiento porque una unión lo es igual estando
+	// anidada, y nombrar la razón precisa es lo que hace accionable el punto ciego.
+	if (member?.type === 'union') {
+		acc.uncovered.push({ documentType, segments, reason: 'no se desciende: array de tipos unión' });
 		return;
 	}
-	// Un array de uniones tiene tantas formas como miembros, y el predicado de conteo no puede
-	// distinguirlas sin ramificar por `_type`. Se declara el punto ciego en vez de omitirlo: uno
-	// visible es accionable, uno silencioso reproduce el problema que este barrido existe para cerrar.
-	if (member?.type === 'union') {
-		acc.uncovered.push({ documentType, segments, reason: 'array de tipos unión' });
+	// El predicado de conteo sabe filtrar un array por su contenido, pero no anidar un segundo filtro
+	// adentro: emitiría una consulta válida que cuenta otra cosa, sin fallar. Que el atributo exista sí
+	// se mide; lo que no se mira es lo que hay dentro.
+	if (insideArray) {
+		acc.uncovered.push({ documentType, segments, reason: 'no se desciende: array dentro de otro array' });
 		return;
 	}
 	descend(member, documentType, segments, true, acc);


### PR DESCRIPTION
Seis correcciones al barrido de campos requeridos, salidas de una review posterior al merge de #2239. La primera invalidaba la promesa central de ese trabajo.

## El schema extraído había quedado desincronizado

#2239 volvió requerido `literaryWork.badLanguage` en el schema del Studio y regeneró `src/sanity/types.ts`, pero **no** `cms/schema.json`: al regenerar los tipos se descartó ese archivo para evitar un diff de formato — correcto mientras su contenido no cambiaba, incorrecto cuando sí.

El barrido lee `cms/schema.json`. Con el archivo viejo, el campo seguía figurando como opcional, así que **la primera corrida programada habría reportado cero incumplimientos sobre las obras literarias** que el propio README de la migración censa. Falsificaba exactamente lo que ese PR promete: que un campo requerido nuevo entra al barrido en el mismo PR que lo declara.

El diff real es una línea (`"optional": true` → `false`); el resto es formato del extractor.

## Deja de barrer lo que escribe el Studio

Los tipos del sistema estaban filtrados a nivel de documento, pero no como tipos embebidos: el recorrido emitía una fila por cada `hotspot.{x,y,height,width}` y `crop.{top,bottom,left,right}` de cada imagen, en siete tipos de documento. Eran **63 de 125 campos** —y con ellos la mitad de las consultas de cada corrida— midiendo algo que ningún editor puede incumplir.

Quedan 62 campos, con los mismos hallazgos.

## Un ítem incompleto se contaba una vez por cada campo

La rama de arriba ya exigía que el padre existiera antes de reclamar un campo anidado, "para que el reporte no diga que faltan cinco datos donde falta uno". Dentro de un array faltaba ese mismo guard, así que un elemento sin el objeto contenedor entero inflaba varias filas a la vez. Cubierto ahora con dos casos que lo evalúan con `groq-js`.

## Tres correcciones al reporte

- **La razón del punto ciego nombra qué no se hizo** (`no se desciende: …`) y se evalúa antes la unión que el anidamiento, porque una unión lo es igual estando anidada. Antes, un path podía figurar como medido y como inmedible sin que se entendiera que son cosas distintas: el atributo se mide, lo que no se mira es su contenido.
- **Los puntos ciegos entran a la huella.** El reporte los publica, así que si cambian y la huella no, el seguimiento se queda mostrando una lista que dejó de ser cierta.
- **Al resolverse, el cuerpo se reemplaza entero.** Conservar la tabla dejaba el issue afirmando que esos campos se incumplen, justo debajo del aviso de que ya no.

## Plan de pruebas

- 47 tests sobre los tres núcleos puros (dos nuevos, para el doble conteo dentro de arrays, evaluados con `groq-js` contra datasets sintéticos).
- Barrido corrido de punta a punta contra un dataset real: de 125 campos a 62, con los mismos dos incumplimientos detectados y 11 puntos ciegos declarados.
- Gates locales: `typecheck`, `lint` y el type-check del Studio en verde.

El schema sincronizado se verificó leyendo `cms/schema.json` directamente: `story.badLanguage` y `literaryWork.badLanguage` figuran ahora los dos como requeridos.

Parte de #2233.
