### PR TITLE
[#2277] - Corrige la configuración de Prettier: lockfiles y opción inexistente

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,6 @@
 
 /.nx/workspace-data
 /.nx/self-healing
+
+# Los reescribe pnpm en cada install: formatearlos solo produce un diff enorme que se revierte solo.
+pnpm-lock.yaml

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -5,7 +5,7 @@ export default {
 	tabWidth: 2,
 	semi: true,
 	bracketSpacing: true,
-	arrowFunctionParentheses: true,
+	arrowParens: 'always',
 	plugins: ['prettier-plugin-organize-attributes', 'prettier-plugin-tailwindcss'],
 	tailwindStylesheet: './src/tailwind.css',
 	attributeGroups: ['$ANGULAR_OUTPUT', '$ANGULAR_TWO_WAY_BINDING', '$ANGULAR_INPUT', '$ANGULAR_STRUCTURAL_DIRECTIVE'],


### PR DESCRIPTION
Corrige los dos defectos de la configuración de Prettier: el hook que reformatea los lockfiles y una opción que no existe.

## Los lockfiles

Van a `.prettierignore`, para que el hook de `pre-commit` deje de reformatearlos. Un solo patrón alcanza para los dos: Prettier lee el archivo con la semántica de `.gitignore`, así que un nombre sin barra coincide a cualquier profundidad y cubre también el del Studio.

Antes del cambio, `prettier --check` reportaba los dos lockfiles como "code style issues". Después, `prettier --file-info` devuelve `{"ignored": true}` para ambos. Como el `--check` es ambiguo con archivos ignorados —no distingue "ignorado" de "ya formateado"—, se verificó además de punta a punta con el hook real: con un lockfile modificado y staged, `pretty-quick --staged` reporta **0 archivos encontrados** y el diff staged queda en el cambio hecho a mano, en vez de convertirse en un reformateo del archivo entero.

## La opción inexistente

`arrowFunctionParentheses: true` no es una opción de Prettier —la herramienta avisaba en cada corrida que la ignoraba—. La real es `arrowParens`, y toma `'always'` o `'avoid'`, no un booleano. Pasa a `arrowParens: 'always'`, que es lo que la línea quería decir.

Se declara en vez de omitirse porque el archivo ya explicita otros defaults (`semi`, `bracketSpacing`) y porque deja el formato a salvo de un cambio de default futuro.

El cambio es **neutro sobre el formato del código**, y eso se verificó midiendo en vez de razonándolo: el chequeo de formato sobre `src/**/*.{ts,html}` reporta exactamente los mismos 509 archivos antes y después, y el aviso de opción desconocida desaparece.

## Un hallazgo que este PR no toca

Esos 509 archivos no son deuda de formato: son un artefacto de CRLF en Windows contra el `endOfLine: lf` de Prettier. Corriendo el mismo chequeo con `--end-of-line auto`, la cuenta baja a **un** archivo realmente sin formatear, `src/app/pages/about/about.component.html`, que ya estaba así en `develop`. Queda fuera del alcance de este PR para no mezclarlo con un cambio de configuración.

Closes #2277
