### PR TITLE
[#2272] - Genera release para versión 2.10.3 de La Cuentoneta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,37 @@ La lista de características futuras a implementar puede hallarse en la sección
 
 Los hitos futuros de desarrollo, en los cuales se detallan las funcionalidades a desarrollar y los cambios a implementar, pueden encontrarse en las secciones [milestones](https://github.com/cuentoneta/cuentoneta/milestones) y [projects](https://github.com/cuentoneta/cuentoneta/projects) del repositorio de Github del proyecto.
 
+## Versión 2.10.3 (2026-08-19)
+
+La versión 2.10.3 es un patch de un solo frente: pone al día las dependencias que Dependabot dejó acumuladas mientras 2.10.2 estaba cerrado. No trae cambios de producto, y por eso su verificación no pregunta si algo nuevo funciona sino si todo lo anterior sigue funcionando.
+
+Lo que manda el riesgo son los **dos saltos mayores de Sanity**, que comparten línea de versión y se evaluaron como par: `@sanity/client` 7.25.0 → 8.0.0 en la aplicación (#2250) y `@sanity/cli` 7.18.0 → 8.0.0 en el Studio (#2247). El del CLI es el que más se siente en el release: el deploy del Studio deja de ser un paso desatendido y pasa a ser la primera ejecución real con la línea 8. El tercer mayor previsto para el hito, `@sanity/ui` 4.0.3, **no entra**: rompe el type-check del Studio y se difiere a 2.11.0 con su propio issue.
+
+El resto es puesta al día sin cambio de mayor: el grupo `minor-and-patch` de la aplicación con 44 paquetes —Angular 22.1.2, Storybook 10.5.8, Hono 4.13.2, Vite 8.2.1 y typescript-eslint 8.67.0 entre ellos (#2249)—, el del Studio con 4 (#2246), y la familia `@ng-icons` —core, font-awesome y simple-icons— de 34.0.0 a 35.0.1, que se mueve en lockstep y por eso viajó junta (#2275).
+
+Cierra una corrección de tooling detectada en el camino: Prettier reformateaba los lockfiles en cada corrida y su configuración declaraba una opción que ya no existe (#2277).
+
+### Cambios completos
+
+Ver el changelog completo en [2.10.3](https://github.com/cuentoneta/cuentoneta/releases/tag/2.10.3)
+
+### Cambios
+
+#### Sanity (saltos mayores)
+
+- [#2250] - Actualiza @sanity/client de 7.25.0 a 8.0.0 en la aplicación.
+- [#2247] - Actualiza @sanity/cli de 7.18.0 a 8.0.0 en el Studio.
+
+#### Dependencias
+
+- [#2249] - Actualiza el grupo minor-and-patch de la aplicación (44 paquetes).
+- [#2246] - Actualiza el grupo minor-and-patch del Studio (4 paquetes).
+- [#2275] - Actualiza @ng-icons a 35.0.1 en la aplicación.
+
+#### Tooling
+
+- [#2277] - Excluye los lockfiles del formateo de Prettier y quita una opción inexistente.
+
 ## Versión 2.10.2 (2026-08-19)
 
 La versión 2.10.2 es un patch de cinco frentes, todos de alcance cerrado.

--- a/cms/package.json
+++ b/cms/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/cms",
 	"private": true,
-	"version": "2.10.2",
+	"version": "2.10.3",
 	"description": "",
 	"main": "package.json",
 	"author": "Ramiro Olivencia <ramiro@olivencia.com.ar>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cuentoneta/app",
 	"type": "module",
-	"version": "2.10.2",
+	"version": "2.10.3",
 	"imports": {
 		"#tailwind-theme": "./src/tailwind.css"
 	},


### PR DESCRIPTION
Closes #2272

Prepara el release de la versión **2.10.3**: bump de versión en lockstep (aplicación + Studio) y entrada de changelog.

## Alcance

2.10.3 es un patch de un solo frente: pone al día las dependencias que Dependabot dejó acumuladas mientras 2.10.2 estaba cerrado. No trae cambios de producto.

| PR | Cambio | Ámbito |
| --- | --- | --- |
| #2250 | `@sanity/client` 7.25.0 → **8.0.0** (mayor) | app |
| #2247 | `@sanity/cli` 7.18.0 → **8.0.0** (mayor) | Studio |
| #2249 | grupo `minor-and-patch`, 44 paquetes | app |
| #2246 | grupo `minor-and-patch`, 4 paquetes | Studio |
| #2275 | `@ng-icons` 34.0.0 → 35.0.1 | app |
| #2277 | Prettier: lockfiles excluidos + opción inexistente | tooling |

El tercer salto mayor previsto para el hito, `@sanity/ui` 4.0.3 (#2248), **queda fuera** por decisión explícita: rompe el type-check del Studio y ya está reasignado al milestone 2.11.0.

## Verificación

- Gates sobre `develop` @ `6a6164c3`, con todos los bumps aplicados: **9/9 verdes** (los dos restantes, `check-findings` y `guard-config`, solo corren por eventos de PR).
- Gates en local sobre esta rama: `typecheck`, `lint`, `stylelint`, `test` (2184 pasados), `build`, `storybook`, `studio-build` (type-check + tests + build del Studio) y `check-agents`, todos verdes.
- Dry-run de la extracción de notas de `release.yml`: la sección `## Versión 2.10.3` devuelve 30 líneas y corta correctamente en la anterior.
- Lockstep confirmado: `package.json` y `cms/package.json` en 2.10.3.
- **Peso inicial**: 429.64 kB raw / 118.15 kB de transfer, contra 118.11 kB medidos en 2.10.2. Mover 44 paquetes no movió el arranque. Colateralmente, con Angular 22.1.4 el `Initial total` del reporte ya incluye el chunk de `@angular/core`, así que la salvedad de que subestimaba el arranque real dejó de aplicar.

## Documentación

Sin cambios. Ningún documento de `docs/`, `CLAUDE.md` ni `.claude/` cita las versiones 7 de `@sanity/client` o `@sanity/cli`, y el resto de los bumps son minor/patch sin salto documentable. La única mención con número —`sanity-plugin-markdown@^9.0.6` compatible con Sanity v5, en `docs/LITERARY_WORK_DESIGN.md`— sigue siendo verdadera: el plugin quedó en `^9.0.11`, dentro del mismo rango, y `sanity` sigue en la línea 5.

## Migraciones de Sanity

**Ninguna.** Esta ventana no introduce migraciones y `cms/migrations/` no cambió respecto de 2.10.2.

## Pasos manuales para completar la release

1. Mergear este PR a `develop`.
2. Tras el merge, el workflow `prepare-release-pr` crea/actualiza el PR `develop → master` y dispara `ci.yml` sobre `develop` (el PR no gatilla checks por sí mismo por la anti-recursión del `GITHUB_TOKEN`; la señal de CI está en la corrida sobre `develop`). Revisarlo y mergearlo a `master` → dispara `release.yml` (tag 2.10.3 + GitHub Release + deploy de Sanity Studio). El deploy de la app lo cubre Vercel por integración Git nativa.
3. Verificar post-release: workflow Release verde (jobs `release` y `deploy-studio`), Release 2.10.3 publicado, y la aplicación en producción sin regresiones.
4. **Particular de este release:** el deploy del Studio es la primera ejecución real con `@sanity/cli` 8. Confirmar que terminó bien y que el Studio desplegado abre, lista documentos y guarda una edición.
