### PR TITLE
[#2255] - Separar apariencia, geometría y estado en los ejes de Button

### DIFF
--- a/src/app/components/button/button.component.spec.ts
+++ b/src/app/components/button/button.component.spec.ts
@@ -43,15 +43,17 @@ describe('ButtonComponent', () => {
 			expect(button).toHaveClass('border-neutral-300');
 		});
 
-		it.each(['filled', 'subtle'])('should not draw a border on the %s appearance', async (type) => {
+		it.each(['filled', 'subtle'])('should not draw a visible border on the %s appearance', async (type) => {
 			await render(`<button cuentoneta-button type="${type}">Botón</button>`, {
 				imports: [ButtonComponent],
 			});
-			expect(screen.getByRole('button')).not.toHaveClass('border');
+			const button = screen.getByRole('button');
+			expect(button).not.toHaveClass('border-neutral-300');
+			expect(button).toHaveClass('border-transparent');
 		});
 
-		// La aserción que prueba que la apariencia soltó su geometría: `subtle` heredó de `share` un
-		// padding y un tamaño de fuente propios, y ahora toma los del tamaño por defecto.
+		// La aserción que prueba que la apariencia no aporta geometría: el padding y el tamaño de
+		// fuente los fija el eje `size`, no la apariencia elegida.
 		it('should leave the geometry to the size axis', async () => {
 			await render(`<button cuentoneta-button type="subtle">Compartir</button>`, {
 				imports: [ButtonComponent],
@@ -70,7 +72,16 @@ describe('ButtonComponent', () => {
 			});
 			const button = screen.getByRole('button');
 			expect(button).toHaveClass('bg-white');
-			expect(button).not.toHaveClass('border');
+			expect(button).not.toHaveClass('border-neutral-300');
+		});
+
+		// El ancho del borde es de la caja y no de la apariencia: las tres lo reservan, así que
+		// cambiar de apariencia no mueve el layout.
+		it.each(['filled', 'outline', 'subtle'])('should reserve the border width on the %s appearance', async (type) => {
+			await render(`<button cuentoneta-button type="${type}">Botón</button>`, {
+				imports: [ButtonComponent],
+			});
+			expect(screen.getByRole('button')).toHaveClass('border');
 		});
 	});
 
@@ -126,9 +137,18 @@ describe('ButtonComponent', () => {
 				const button = screen.getByRole('button');
 				expect(button).toHaveClass('bg-neutral-900');
 				expect(button).toHaveClass('text-neutral-50');
-				expect(button).not.toHaveClass('border');
+				expect(button).not.toHaveClass('border-neutral-300');
 			},
 		);
+
+		// Marcar vigente a un botón `outline` no puede achicarle la caja: en un grupo de opciones,
+		// elegir una haría reflowear la fila entera.
+		it('should keep the box intact when an outline button becomes active', async () => {
+			await render(`<button cuentoneta-button type="outline" [active]="true">Botón</button>`, {
+				imports: [ButtonComponent],
+			});
+			expect(screen.getByRole('button')).toHaveClass('border');
+		});
 
 		it('should not alter the geometry', async () => {
 			await render(`<button cuentoneta-button size="xs" [active]="true">Botón</button>`, {

--- a/src/app/components/button/button.component.spec.ts
+++ b/src/app/components/button/button.component.spec.ts
@@ -18,41 +18,144 @@ describe('ButtonComponent', () => {
 			});
 			expect(screen.getByText('Ver todo')).toBeInTheDocument();
 		});
+	});
 
-		it('should apply filled type classes by default', async () => {
+	describe('appearance axis', () => {
+		it.each([
+			['filled', 'bg-white'],
+			['outline', 'bg-white'],
+			['subtle', 'bg-neutral-100'],
+		])('should apply the background of the %s appearance', async (type, background) => {
+			await render(`<button cuentoneta-button type="${type}">Botón</button>`, {
+				imports: [ButtonComponent],
+			});
+			const button = screen.getByRole('button');
+			expect(button).toHaveClass(background);
+			expect(button).toHaveClass('text-neutral-900');
+		});
+
+		it('should draw a border only on the outline appearance', async () => {
+			await render(`<button cuentoneta-button type="outline">Outline</button>`, {
+				imports: [ButtonComponent],
+			});
+			const button = screen.getByRole('button');
+			expect(button).toHaveClass('border');
+			expect(button).toHaveClass('border-neutral-300');
+		});
+
+		it.each(['filled', 'subtle'])('should not draw a border on the %s appearance', async (type) => {
+			await render(`<button cuentoneta-button type="${type}">Botón</button>`, {
+				imports: [ButtonComponent],
+			});
+			expect(screen.getByRole('button')).not.toHaveClass('border');
+		});
+
+		// La aserción que prueba que la apariencia soltó su geometría: `subtle` heredó de `share` un
+		// padding y un tamaño de fuente propios, y ahora toma los del tamaño por defecto.
+		it('should leave the geometry to the size axis', async () => {
+			await render(`<button cuentoneta-button type="subtle">Compartir</button>`, {
+				imports: [ButtonComponent],
+			});
+			const button = screen.getByRole('button');
+			expect(button).toHaveClass('px-6');
+			expect(button).toHaveClass('py-3');
+			expect(button).toHaveClass('text-sm');
+			expect(button).not.toHaveClass('px-3');
+			expect(button).not.toHaveClass('text-xs');
+		});
+
+		it('should default to the filled appearance', async () => {
 			await render(`<button cuentoneta-button>Filled</button>`, {
 				imports: [ButtonComponent],
 			});
 			const button = screen.getByRole('button');
 			expect(button).toHaveClass('bg-white');
-			expect(button).toHaveClass('px-6');
-			expect(button).toHaveClass('py-3');
-			expect(button).toHaveClass('text-sm');
 			expect(button).not.toHaveClass('border');
 		});
+	});
 
-		it('should apply outline type classes', async () => {
-			await render(`<button cuentoneta-button type="outline">Outline</button>`, {
+	describe('size axis', () => {
+		it.each([
+			['md', ['px-6', 'py-3', 'text-sm', 'gap-2']],
+			['xs', ['px-3', 'py-2', 'text-xs', 'gap-1']],
+		])('should apply the geometry of the %s size', async (size, classes) => {
+			await render(`<button cuentoneta-button size="${size}">Botón</button>`, {
+				imports: [ButtonComponent],
+			});
+			const button = screen.getByRole('button');
+			classes.forEach((className) => expect(button).toHaveClass(className));
+		});
+
+		it('should default to the md size', async () => {
+			await render(`<button cuentoneta-button>Botón</button>`, {
+				imports: [ButtonComponent],
+			});
+			const button = screen.getByRole('button');
+			expect(button).toHaveClass('px-6');
+			expect(button).toHaveClass('py-3');
+		});
+
+		// La invariancia que falla si alguien vuelve a meter geometría dentro de una apariencia.
+		it('should keep the outline appearance intact in the xs size', async () => {
+			await render(`<button cuentoneta-button type="outline" size="xs">Botón</button>`, {
 				imports: [ButtonComponent],
 			});
 			const button = screen.getByRole('button');
 			expect(button).toHaveClass('bg-white');
-			expect(button).toHaveClass('border');
 			expect(button).toHaveClass('border-neutral-300');
-			expect(button).toHaveClass('px-6');
-			expect(button).toHaveClass('py-3');
+			expect(button).toHaveClass('px-3');
 		});
 
-		it('should apply share type classes', async () => {
-			await render(`<button cuentoneta-button type="share">Share</button>`, {
+		it('should keep the subtle appearance intact in the md size', async () => {
+			await render(`<button cuentoneta-button type="subtle" size="md">Botón</button>`, {
 				imports: [ButtonComponent],
 			});
 			const button = screen.getByRole('button');
 			expect(button).toHaveClass('bg-neutral-100');
+			expect(button).toHaveClass('px-6');
+		});
+	});
+
+	describe('active state', () => {
+		it.each(['filled', 'outline', 'subtle'])(
+			'should invert the contrast of the %s appearance when active',
+			async (type) => {
+				await render(`<button cuentoneta-button type="${type}" [active]="true">Botón</button>`, {
+					imports: [ButtonComponent],
+				});
+				const button = screen.getByRole('button');
+				expect(button).toHaveClass('bg-neutral-900');
+				expect(button).toHaveClass('text-neutral-50');
+				expect(button).not.toHaveClass('border');
+			},
+		);
+
+		it('should not alter the geometry', async () => {
+			await render(`<button cuentoneta-button size="xs" [active]="true">Botón</button>`, {
+				imports: [ButtonComponent],
+			});
+			const button = screen.getByRole('button');
 			expect(button).toHaveClass('px-3');
 			expect(button).toHaveClass('py-2');
 			expect(button).toHaveClass('text-xs');
 			expect(button).toHaveClass('gap-1');
+		});
+
+		it('should default to inactive, preserving the chosen appearance', async () => {
+			await render(`<button cuentoneta-button type="subtle">Botón</button>`, {
+				imports: [ButtonComponent],
+			});
+			const button = screen.getByRole('button');
+			expect(button).toHaveClass('bg-neutral-100');
+			expect(button).not.toHaveClass('bg-neutral-900');
+		});
+
+		// Anunciar la elección es del contenedor que coordina el grupo, no del botón que se pinta.
+		it('should not announce the choice with aria-pressed', async () => {
+			await render(`<button cuentoneta-button [active]="true">Botón</button>`, {
+				imports: [ButtonComponent],
+			});
+			expect(screen.getByRole('button')).not.toHaveAttribute('aria-pressed');
 		});
 	});
 
@@ -69,7 +172,7 @@ describe('ButtonComponent', () => {
 		});
 
 		it('should display the link text', async () => {
-			await render(`<a cuentoneta-button href="/storylist">Ver todo</a>`, {
+			await render(`<a cuentoneta-button href="/collection">Ver todo</a>`, {
 				imports: [ButtonComponent],
 				providers: defaultProviders,
 			});

--- a/src/app/components/button/button.component.spec.ts
+++ b/src/app/components/button/button.component.spec.ts
@@ -25,8 +25,8 @@ describe('ButtonComponent', () => {
 			['filled', 'bg-white'],
 			['outline', 'bg-white'],
 			['subtle', 'bg-neutral-100'],
-		])('should apply the background of the %s appearance', async (type, background) => {
-			await render(`<button cuentoneta-button type="${type}">Botón</button>`, {
+		])('should apply the background of the %s appearance', async (variant, background) => {
+			await render(`<button cuentoneta-button variant="${variant}">Botón</button>`, {
 				imports: [ButtonComponent],
 			});
 			const button = screen.getByRole('button');
@@ -35,7 +35,7 @@ describe('ButtonComponent', () => {
 		});
 
 		it('should draw a border only on the outline appearance', async () => {
-			await render(`<button cuentoneta-button type="outline">Outline</button>`, {
+			await render(`<button cuentoneta-button variant="outline">Outline</button>`, {
 				imports: [ButtonComponent],
 			});
 			const button = screen.getByRole('button');
@@ -43,8 +43,8 @@ describe('ButtonComponent', () => {
 			expect(button).toHaveClass('border-neutral-300');
 		});
 
-		it.each(['filled', 'subtle'])('should not draw a visible border on the %s appearance', async (type) => {
-			await render(`<button cuentoneta-button type="${type}">Botón</button>`, {
+		it.each(['filled', 'subtle'])('should not draw a visible border on the %s appearance', async (variant) => {
+			await render(`<button cuentoneta-button variant="${variant}">Botón</button>`, {
 				imports: [ButtonComponent],
 			});
 			const button = screen.getByRole('button');
@@ -55,7 +55,7 @@ describe('ButtonComponent', () => {
 		// La aserción que prueba que la apariencia no aporta geometría: el padding y el tamaño de
 		// fuente los fija el eje `size`, no la apariencia elegida.
 		it('should leave the geometry to the size axis', async () => {
-			await render(`<button cuentoneta-button type="subtle">Compartir</button>`, {
+			await render(`<button cuentoneta-button variant="subtle">Compartir</button>`, {
 				imports: [ButtonComponent],
 			});
 			const button = screen.getByRole('button');
@@ -77,12 +77,15 @@ describe('ButtonComponent', () => {
 
 		// El ancho del borde es de la caja y no de la apariencia: las tres lo reservan, así que
 		// cambiar de apariencia no mueve el layout.
-		it.each(['filled', 'outline', 'subtle'])('should reserve the border width on the %s appearance', async (type) => {
-			await render(`<button cuentoneta-button type="${type}">Botón</button>`, {
-				imports: [ButtonComponent],
-			});
-			expect(screen.getByRole('button')).toHaveClass('border');
-		});
+		it.each(['filled', 'outline', 'subtle'])(
+			'should reserve the border width on the %s appearance',
+			async (variant) => {
+				await render(`<button cuentoneta-button variant="${variant}">Botón</button>`, {
+					imports: [ButtonComponent],
+				});
+				expect(screen.getByRole('button')).toHaveClass('border');
+			},
+		);
 	});
 
 	describe('size axis', () => {
@@ -108,7 +111,7 @@ describe('ButtonComponent', () => {
 
 		// La invariancia que falla si alguien vuelve a meter geometría dentro de una apariencia.
 		it('should keep the outline appearance intact in the xs size', async () => {
-			await render(`<button cuentoneta-button type="outline" size="xs">Botón</button>`, {
+			await render(`<button cuentoneta-button variant="outline" size="xs">Botón</button>`, {
 				imports: [ButtonComponent],
 			});
 			const button = screen.getByRole('button');
@@ -118,7 +121,7 @@ describe('ButtonComponent', () => {
 		});
 
 		it('should keep the subtle appearance intact in the md size', async () => {
-			await render(`<button cuentoneta-button type="subtle" size="md">Botón</button>`, {
+			await render(`<button cuentoneta-button variant="subtle" size="md">Botón</button>`, {
 				imports: [ButtonComponent],
 			});
 			const button = screen.getByRole('button');
@@ -130,8 +133,8 @@ describe('ButtonComponent', () => {
 	describe('active state', () => {
 		it.each(['filled', 'outline', 'subtle'])(
 			'should invert the contrast of the %s appearance when active',
-			async (type) => {
-				await render(`<button cuentoneta-button type="${type}" [active]="true">Botón</button>`, {
+			async (variant) => {
+				await render(`<button cuentoneta-button variant="${variant}" [active]="true">Botón</button>`, {
 					imports: [ButtonComponent],
 				});
 				const button = screen.getByRole('button');
@@ -144,7 +147,7 @@ describe('ButtonComponent', () => {
 		// Marcar vigente a un botón `outline` no puede achicarle la caja: en un grupo de opciones,
 		// elegir una haría reflowear la fila entera.
 		it('should keep the box intact when an outline button becomes active', async () => {
-			await render(`<button cuentoneta-button type="outline" [active]="true">Botón</button>`, {
+			await render(`<button cuentoneta-button variant="outline" [active]="true">Botón</button>`, {
 				imports: [ButtonComponent],
 			});
 			expect(screen.getByRole('button')).toHaveClass('border');
@@ -162,7 +165,7 @@ describe('ButtonComponent', () => {
 		});
 
 		it('should default to inactive, preserving the chosen appearance', async () => {
-			await render(`<button cuentoneta-button type="subtle">Botón</button>`, {
+			await render(`<button cuentoneta-button variant="subtle">Botón</button>`, {
 				imports: [ButtonComponent],
 			});
 			const button = screen.getByRole('button');
@@ -199,8 +202,8 @@ describe('ButtonComponent', () => {
 			expect(screen.getByText('Ver todo')).toBeInTheDocument();
 		});
 
-		it('should apply outline type classes on anchor', async () => {
-			await render(`<a cuentoneta-button type="outline" href="/test">Outline Link</a>`, {
+		it('should apply outline variant classes on anchor', async () => {
+			await render(`<a cuentoneta-button variant="outline" href="/test">Outline Link</a>`, {
 				imports: [ButtonComponent],
 				providers: defaultProviders,
 			});

--- a/src/app/components/button/button.component.stories.ts
+++ b/src/app/components/button/button.component.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, StoryObj, applicationConfig } from '@storybook/angular-vite';
+import { argsToTemplate, Meta, StoryObj, applicationConfig } from '@storybook/angular-vite';
 import { ButtonComponent } from './button.component';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { faBrandFacebook, faBrandTwitter, faBrandWhatsapp } from '@ng-icons/font-awesome/brands';
@@ -13,18 +13,35 @@ const meta: Meta<ButtonComponent> = {
 				sourceState: 'shown',
 			},
 			description: {
-				component: `<div><p>El <strong>ButtonComponent</strong> del Design System v3 es un componente basado en atributo (<code>cuentoneta-button</code>) que se aplica indistintamente sobre elementos <code>&lt;button&gt;</code> y <code>&lt;a&gt;</code>, manteniendo estilos consistentes y la semántica correcta de cada elemento (acción vs. navegación).</p><p>Se implementa en tres variantes seleccionables mediante el input <code>type</code>:</p><ul><li><strong>filled</strong> (default): fondo blanco, sin borde, para la acción principal.</li><li><strong>outline</strong>: fondo blanco con borde neutral-300, para acciones secundarias y enlaces de tipo "Ver todo".</li><li><strong>share</strong>: fondo neutral-100, tamaño más compacto, pensado para botones de compartir en redes (admite un ícono al inicio).</li></ul></div>`,
+				component: `<div><p>El <strong>ButtonComponent</strong> del Design System v3 es un componente basado en atributo (<code>cuentoneta-button</code>) que se aplica indistintamente sobre elementos <code>&lt;button&gt;</code> y <code>&lt;a&gt;</code>, manteniendo estilos consistentes y la semántica correcta de cada elemento (acción vs. navegación).</p><p>Su API son <strong>tres ejes independientes</strong> que se combinan libremente, en lugar de un catálogo de variantes:</p><ul><li><code>type</code> — la <strong>apariencia</strong>: fondo, borde y color de texto. <code>filled</code> (default, fondo blanco sin borde), <code>outline</code> (fondo blanco con borde neutral-300) y <code>subtle</code> (fondo neutral-100 sin borde).</li><li><code>size</code> — la <strong>geometría</strong>: padding, tamaño de fuente y separación entre ícono y texto. <code>md</code> (default) y <code>xs</code>.</li><li><code>active</code> — el <strong>estado</strong> de opción vigente dentro de un grupo, que reemplaza la apariencia por el contraste invertido.</li></ul><p>Están separados porque mezclarlos obliga a agregar una variante nueva cada vez que una pantalla necesita una apariencia existente en otro tamaño, y esa variante termina nombrada por su consumidor en lugar de por su apariencia.</p><p>Coordinar qué opción está vigente, que la elección sea excluyente y anunciarla con <code>aria-pressed</code> son responsabilidad del componente contenedor: el botón solo sabe pintarse.</p></div>`,
 			},
 		},
 	},
 	argTypes: {
 		type: {
-			control: 'select',
-			options: ['filled', 'outline', 'share'],
-			description: 'Estilo visual del botón basado en el sistema de diseño de Figma',
+			control: 'inline-radio',
+			options: ['filled', 'outline', 'subtle'],
+			description: 'Apariencia del botón: fondo, borde y color de texto',
 			table: {
-				type: { summary: "'filled' | 'outline' | 'share'" },
+				type: { summary: "'filled' | 'outline' | 'subtle'" },
 				defaultValue: { summary: 'filled' },
+			},
+		},
+		size: {
+			control: 'inline-radio',
+			options: ['md', 'xs'],
+			description: 'Geometría del botón: padding, tamaño de fuente y separación entre ícono y texto',
+			table: {
+				type: { summary: "'md' | 'xs'" },
+				defaultValue: { summary: 'md' },
+			},
+		},
+		active: {
+			control: 'boolean',
+			description: 'Marca al botón como la opción vigente dentro de un grupo',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'false' },
 			},
 		},
 	},
@@ -38,49 +55,52 @@ const meta: Meta<ButtonComponent> = {
 export default meta;
 type Story = StoryObj<ButtonComponent>;
 
-export const Filled: Story = {
+export const Playground: Story = {
 	render: (args) => ({
 		props: args,
-		template: `<button cuentoneta-button [type]="type">Button</button>`,
+		template: `<button cuentoneta-button ${argsToTemplate(args)}>Button</button>`,
 	}),
 	args: {
 		type: 'filled',
+		size: 'md',
+		active: false,
 	},
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Variante <strong>filled</strong> (default): fondo blanco sin borde, para la acción principal de un bloque.</p><p><strong>Usos:</strong> llamados a la acción primarios sobre fondos de marca o destacados.</p>`,
+				story: `<p>Los tres ejes como controles vivos sobre una misma instancia: cualquier combinación de apariencia, geometría y estado se expresa sin agregar valores al catálogo.</p>`,
 			},
 		},
 	},
 };
 
-export const Outline: Story = {
-	render: (args) => ({
-		props: args,
-		template: `<button cuentoneta-button [type]="type">Ver todo</button>`,
-	}),
-	args: {
-		type: 'outline',
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: `<p>Variante <strong>outline</strong>: fondo blanco con borde neutral-300, para acciones secundarias.</p><p><strong>Usos:</strong> enlaces "Ver todo" al pie de los listados de la Home y secciones de exploración.</p>`,
-			},
-		},
-	},
-};
-
-export const Share: Story = {
+export const Appearances: Story = {
 	render: () => ({
-		template: `				<div>
-					<div class="flex items-center gap-2">
-						<button cuentoneta-button type="share"><ng-icon name="faBrandFacebook"/>Facebook</button>
-						<button cuentoneta-button type="share"><ng-icon name="faBrandTwitter"/>Twitter</button>
-						<button cuentoneta-button type="share"><ng-icon name="faBrandWhatsapp"/>WhatsApp</button>
-					</div>
-				</div>`,
+		template: `
+			<div class="flex flex-wrap items-center gap-4">
+				<button cuentoneta-button type="filled">Filled</button>
+				<button cuentoneta-button type="outline">Outline</button>
+				<button cuentoneta-button type="subtle">Subtle</button>
+			</div>
+		`,
+	}),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Las tres apariencias al mismo tamaño: lo único que cambia entre ellas es el fondo, el borde y el color del texto.</p><p><strong>Usos:</strong> <code>filled</code> para la acción principal de un bloque, <code>outline</code> para acciones secundarias y enlaces "Ver todo", <code>subtle</code> para acciones de menor jerarquía sobre fondos claros.</p>`,
+			},
+		},
+	},
+};
+
+export const Sizes: Story = {
+	render: () => ({
+		template: `
+			<div class="flex flex-wrap items-center gap-4">
+				<button cuentoneta-button type="subtle" size="md"><ng-icon name="faBrandWhatsapp" />Medium</button>
+				<button cuentoneta-button type="subtle" size="xs"><ng-icon name="faBrandWhatsapp" />Extra small</button>
+			</div>
+		`,
 		moduleMetadata: {
 			imports: [NgIcon],
 		},
@@ -88,7 +108,60 @@ export const Share: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Variante <strong>share</strong>: tamaño compacto con fondo neutral-100; admite un ícono de red al inicio del texto.</p><p><strong>Usos:</strong> barra de compartir en redes dentro de la página de Story.</p>`,
+				story: `<p>La misma apariencia en las dos geometrías: cambian el padding, el tamaño de fuente y la separación entre el ícono y el texto, y nada más.</p>`,
+			},
+		},
+	},
+};
+
+export const ActiveOption: Story = {
+	render: (args) => ({
+		props: args,
+		template: `
+			<div class="flex flex-wrap items-center gap-4">
+				<button cuentoneta-button type="filled" [active]="active">Filled</button>
+				<button cuentoneta-button type="outline" [active]="active">Outline</button>
+				<button cuentoneta-button type="subtle" [active]="active">Subtle</button>
+			</div>
+		`,
+	}),
+	args: {
+		active: true,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El estado de opción vigente reemplaza la apariencia por el contraste invertido, igual en las tres: estar elegido es un estado del botón y no una apariencia más del catálogo. El control <code>active</code> alterna contra el estado normal.</p><p>El botón no emite <code>aria-pressed</code> ni decide quién está elegido: eso lo aporta el contenedor que coordina el grupo.</p>`,
+			},
+		},
+	},
+};
+
+export const AxesMatrix: Story = {
+	render: () => ({
+		template: `
+			<div class="flex flex-col gap-4">
+				<div class="flex flex-wrap items-center gap-4">
+					<button cuentoneta-button type="filled" size="md">Filled md</button>
+					<button cuentoneta-button type="outline" size="md">Outline md</button>
+					<button cuentoneta-button type="subtle" size="md">Subtle md</button>
+				</div>
+				<div class="flex flex-wrap items-center gap-4">
+					<button cuentoneta-button type="filled" size="xs">Filled xs</button>
+					<button cuentoneta-button type="outline" size="xs">Outline xs</button>
+					<button cuentoneta-button type="subtle" size="xs">Subtle xs</button>
+				</div>
+				<div class="flex flex-wrap items-center gap-4">
+					<button cuentoneta-button type="outline" size="md" [active]="true">Vigente md</button>
+					<button cuentoneta-button type="outline" size="xs" [active]="true">Vigente xs</button>
+				</div>
+			</div>
+		`,
+	}),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>La grilla de apariencia × geometría, más la fila de opción vigente: el catálogo es el producto de los ejes, no una lista de variantes que haya que enumerar.</p>`,
 			},
 		},
 	},
@@ -96,7 +169,7 @@ export const Share: Story = {
 
 export const OnAnchorElement: Story = {
 	render: () => ({
-		template: `<a cuentoneta-button type="outline" routerLink="/storylist">Ver todo</a>`,
+		template: `<a cuentoneta-button type="outline" routerLink="/collection">Ver todo</a>`,
 	}),
 	parameters: {
 		docs: {
@@ -113,33 +186,16 @@ export const Disabled: Story = {
 			<div class="flex flex-wrap items-center gap-4">
 				<button cuentoneta-button type="filled" disabled>Filled</button>
 				<button cuentoneta-button type="outline" disabled>Outline</button>
-				<button cuentoneta-button type="share" disabled>Share</button>
+				<button cuentoneta-button type="subtle" disabled>Subtle</button>
+				<button cuentoneta-button type="outline" [active]="true" disabled>Vigente</button>
 			</div>
 		`,
 	}),
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Estado deshabilitado (<code>disabled</code>) de las tres variantes: cursor bloqueado y opacidad reducida.</p><p><strong>Usos:</strong> acciones no disponibles temporalmente (p. ej. mientras se completa una precondición).</p>`,
+				story: `<p>El estado deshabilitado es independiente de los tres ejes: baja la opacidad y bloquea el cursor sobre cualquier combinación, incluida la opción vigente.</p><p><strong>Usos:</strong> acciones no disponibles temporalmente (p. ej. mientras se completa una precondición).</p>`,
 			},
 		},
-	},
-};
-
-export const Showcase: Story = {
-	render: () => ({
-		template: `
-			<div class="flex flex-wrap items-center gap-4">
-				<button cuentoneta-button type="filled">Filled</button>
-				<button cuentoneta-button type="outline">Outline</button>
-				<button cuentoneta-button type="share"><ng-icon name="faBrandTwitter"/>Share</button>
-			</div>
-		`,
-		moduleMetadata: {
-			imports: [NgIcon],
-		},
-	}),
-	parameters: {
-		docs: { description: { story: 'Las tres variantes activas: filled, outline y share.' } },
 	},
 };

--- a/src/app/components/button/button.component.stories.ts
+++ b/src/app/components/button/button.component.stories.ts
@@ -13,12 +13,12 @@ const meta: Meta<ButtonComponent> = {
 				sourceState: 'shown',
 			},
 			description: {
-				component: `<div><p>El <strong>ButtonComponent</strong> del Design System v3 es un componente basado en atributo (<code>cuentoneta-button</code>) que se aplica indistintamente sobre elementos <code>&lt;button&gt;</code> y <code>&lt;a&gt;</code>, manteniendo estilos consistentes y la semántica correcta de cada elemento (acción vs. navegación).</p><p>Su API son <strong>tres ejes independientes</strong> que se combinan libremente, en lugar de un catálogo de variantes:</p><ul><li><code>type</code> — la <strong>apariencia</strong>: fondo, borde y color de texto. <code>filled</code> (default, fondo blanco sin borde), <code>outline</code> (fondo blanco con borde neutral-300) y <code>subtle</code> (fondo neutral-100 sin borde).</li><li><code>size</code> — la <strong>geometría</strong>: padding, tamaño de fuente y separación entre ícono y texto. <code>md</code> (default) y <code>xs</code>.</li><li><code>active</code> — el <strong>estado</strong> de opción vigente dentro de un grupo, que reemplaza la apariencia por el contraste invertido.</li></ul><p>Están separados porque mezclarlos obliga a agregar una variante nueva cada vez que una pantalla necesita una apariencia existente en otro tamaño, y esa variante termina nombrada por su consumidor en lugar de por su apariencia.</p><p>Coordinar qué opción está vigente, que la elección sea excluyente y anunciarla con <code>aria-pressed</code> son responsabilidad del componente contenedor: el botón solo sabe pintarse.</p></div>`,
+				component: `<div><p>El <strong>ButtonComponent</strong> del Design System v3 es un componente basado en atributo (<code>cuentoneta-button</code>) que se aplica indistintamente sobre elementos <code>&lt;button&gt;</code> y <code>&lt;a&gt;</code>, manteniendo estilos consistentes y la semántica correcta de cada elemento (acción vs. navegación).</p><p>Su API son <strong>tres ejes independientes</strong> que se combinan libremente, en lugar de un catálogo de variantes:</p><ul><li><code>variant</code> — la <strong>apariencia</strong>: fondo, borde y color de texto. <code>filled</code> (default, fondo blanco sin borde), <code>outline</code> (fondo blanco con borde neutral-300) y <code>subtle</code> (fondo neutral-100 sin borde).</li><li><code>size</code> — la <strong>geometría</strong>: padding, tamaño de fuente y separación entre ícono y texto. <code>md</code> (default) y <code>xs</code>.</li><li><code>active</code> — el <strong>estado</strong> de opción vigente dentro de un grupo, que reemplaza la apariencia por el contraste invertido.</li></ul><p>Están separados porque mezclarlos obliga a agregar una variante nueva cada vez que una pantalla necesita una apariencia existente en otro tamaño, y esa variante termina nombrada por su consumidor en lugar de por su apariencia.</p><p>Coordinar qué opción está vigente, que la elección sea excluyente y anunciarla con <code>aria-pressed</code> son responsabilidad del componente contenedor: el botón solo sabe pintarse.</p></div>`,
 			},
 		},
 	},
 	argTypes: {
-		type: {
+		variant: {
 			control: 'inline-radio',
 			options: ['filled', 'outline', 'subtle'],
 			description: 'Apariencia del botón: fondo, borde y color de texto',
@@ -61,7 +61,7 @@ export const Playground: Story = {
 		template: `<button cuentoneta-button ${argsToTemplate(args)}>Button</button>`,
 	}),
 	args: {
-		type: 'filled',
+		variant: 'filled',
 		size: 'md',
 		active: false,
 	},
@@ -78,9 +78,9 @@ export const Appearances: Story = {
 	render: () => ({
 		template: `
 			<div class="flex flex-wrap items-center gap-4">
-				<button cuentoneta-button type="filled">Filled</button>
-				<button cuentoneta-button type="outline">Outline</button>
-				<button cuentoneta-button type="subtle">Subtle</button>
+				<button cuentoneta-button variant="filled">Filled</button>
+				<button cuentoneta-button variant="outline">Outline</button>
+				<button cuentoneta-button variant="subtle">Subtle</button>
 			</div>
 		`,
 	}),
@@ -97,8 +97,8 @@ export const Sizes: Story = {
 	render: () => ({
 		template: `
 			<div class="flex flex-wrap items-center gap-4">
-				<button cuentoneta-button type="subtle" size="md"><ng-icon name="faBrandWhatsapp" />Medium</button>
-				<button cuentoneta-button type="subtle" size="xs"><ng-icon name="faBrandWhatsapp" />Extra small</button>
+				<button cuentoneta-button variant="subtle" size="md"><ng-icon name="faBrandWhatsapp" />Medium</button>
+				<button cuentoneta-button variant="subtle" size="xs"><ng-icon name="faBrandWhatsapp" />Extra small</button>
 			</div>
 		`,
 		moduleMetadata: {
@@ -119,9 +119,9 @@ export const ActiveOption: Story = {
 		props: args,
 		template: `
 			<div class="flex flex-wrap items-center gap-4">
-				<button cuentoneta-button type="filled" [active]="active">Filled</button>
-				<button cuentoneta-button type="outline" [active]="active">Outline</button>
-				<button cuentoneta-button type="subtle" [active]="active">Subtle</button>
+				<button cuentoneta-button variant="filled" [active]="active">Filled</button>
+				<button cuentoneta-button variant="outline" [active]="active">Outline</button>
+				<button cuentoneta-button variant="subtle" [active]="active">Subtle</button>
 			</div>
 		`,
 	}),
@@ -142,18 +142,18 @@ export const AxesMatrix: Story = {
 		template: `
 			<div class="flex flex-col gap-4">
 				<div class="flex flex-wrap items-center gap-4">
-					<button cuentoneta-button type="filled" size="md">Filled md</button>
-					<button cuentoneta-button type="outline" size="md">Outline md</button>
-					<button cuentoneta-button type="subtle" size="md">Subtle md</button>
+					<button cuentoneta-button variant="filled" size="md">Filled md</button>
+					<button cuentoneta-button variant="outline" size="md">Outline md</button>
+					<button cuentoneta-button variant="subtle" size="md">Subtle md</button>
 				</div>
 				<div class="flex flex-wrap items-center gap-4">
-					<button cuentoneta-button type="filled" size="xs">Filled xs</button>
-					<button cuentoneta-button type="outline" size="xs">Outline xs</button>
-					<button cuentoneta-button type="subtle" size="xs">Subtle xs</button>
+					<button cuentoneta-button variant="filled" size="xs">Filled xs</button>
+					<button cuentoneta-button variant="outline" size="xs">Outline xs</button>
+					<button cuentoneta-button variant="subtle" size="xs">Subtle xs</button>
 				</div>
 				<div class="flex flex-wrap items-center gap-4">
-					<button cuentoneta-button type="outline" size="md" [active]="true">Vigente md</button>
-					<button cuentoneta-button type="outline" size="xs" [active]="true">Vigente xs</button>
+					<button cuentoneta-button variant="outline" size="md" [active]="true">Vigente md</button>
+					<button cuentoneta-button variant="outline" size="xs" [active]="true">Vigente xs</button>
 				</div>
 			</div>
 		`,
@@ -169,7 +169,7 @@ export const AxesMatrix: Story = {
 
 export const OnAnchorElement: Story = {
 	render: () => ({
-		template: `<a cuentoneta-button type="outline" routerLink="/collection">Ver todo</a>`,
+		template: `<a cuentoneta-button variant="outline" routerLink="/collection">Ver todo</a>`,
 	}),
 	parameters: {
 		docs: {
@@ -184,10 +184,10 @@ export const Disabled: Story = {
 	render: () => ({
 		template: `
 			<div class="flex flex-wrap items-center gap-4">
-				<button cuentoneta-button type="filled" disabled>Filled</button>
-				<button cuentoneta-button type="outline" disabled>Outline</button>
-				<button cuentoneta-button type="subtle" disabled>Subtle</button>
-				<button cuentoneta-button type="outline" [active]="true" disabled>Vigente</button>
+				<button cuentoneta-button variant="filled" disabled>Filled</button>
+				<button cuentoneta-button variant="outline" disabled>Outline</button>
+				<button cuentoneta-button variant="subtle" disabled>Subtle</button>
+				<button cuentoneta-button variant="outline" [active]="true" disabled>Vigente</button>
 			</div>
 		`,
 	}),

--- a/src/app/components/button/button.component.stories.ts
+++ b/src/app/components/button/button.component.stories.ts
@@ -1,7 +1,7 @@
 import { argsToTemplate, Meta, StoryObj, applicationConfig } from '@storybook/angular-vite';
 import { ButtonComponent } from './button.component';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { faBrandFacebook, faBrandTwitter, faBrandWhatsapp } from '@ng-icons/font-awesome/brands';
+import { faBrandWhatsapp } from '@ng-icons/font-awesome/brands';
 
 const meta: Meta<ButtonComponent> = {
 	title: 'Componentes V3/Button',
@@ -47,7 +47,7 @@ const meta: Meta<ButtonComponent> = {
 	},
 	decorators: [
 		applicationConfig({
-			providers: [provideIcons({ faBrandFacebook, faBrandTwitter, faBrandWhatsapp })],
+			providers: [provideIcons({ faBrandWhatsapp })],
 		}),
 	],
 };

--- a/src/app/components/button/button.component.ts
+++ b/src/app/components/button/button.component.ts
@@ -45,7 +45,6 @@ export type ButtonSize = 'md' | 'xs';
 @Component({
 	// eslint-disable-next-line @angular-eslint/component-selector -- Attribute selector usa el prefijo cuentoneta- pero restringido a tags <button> y <a>
 	selector: 'button[cuentoneta-button], a[cuentoneta-button]',
-	standalone: true,
 	template: `<ng-content />`,
 	host: {
 		'[class]': 'hostClasses()',

--- a/src/app/components/button/button.component.ts
+++ b/src/app/components/button/button.component.ts
@@ -1,12 +1,18 @@
 import { Component, computed, input } from '@angular/core';
 
 /**
- * Variantes de tipo de botón basadas en el sistema de diseño de Figma
- * - `filled`: Fondo blanco, sin borde
- * - `outline`: Fondo blanco con borde neutral-300
- * - `share`: Fondo neutral-100, tamaño más pequeño para botones de compartir
+ * Apariencia del botón: fondo, borde y color de texto. No gobierna la geometría.
+ * - `filled`: fondo blanco, sin borde
+ * - `outline`: fondo blanco con borde neutral-300
+ * - `subtle`: fondo neutral-100, sin borde
  */
-export type ButtonType = 'filled' | 'outline' | 'share';
+export type ButtonType = 'filled' | 'outline' | 'subtle';
+
+/**
+ * Geometría del botón: padding, tamaño de fuente y separación entre ícono y texto.
+ * No gobierna la apariencia.
+ */
+export type ButtonSize = 'md' | 'xs';
 
 /**
  * Componente Button
@@ -14,19 +20,26 @@ export type ButtonType = 'filled' | 'outline' | 'share';
  * Un componente basado en atributo que puede aplicarse tanto a elementos `<button>` como `<a>`.
  * Proporciona estilos consistentes basados en el sistema de diseño de Figma.
  *
+ * Expone tres ejes independientes que se combinan libremente: `type` (apariencia), `size`
+ * (geometría) y `active` (estado). Coordinar qué opción está vigente dentro de un grupo, que la
+ * elección sea excluyente y anunciarla con `aria-pressed` son responsabilidad del contenedor.
+ *
  * @example
  * ```html
  * <!-- En un elemento button -->
  * <button cuentoneta-button type="outline">Click me</button>
  *
  * <!-- En un elemento anchor con RouterLink -->
- * <a cuentoneta-button type="outline" [routerLink]="'/storylist'">Ver todo</a>
+ * <a cuentoneta-button type="outline" [routerLink]="'/collection'">Ver todo</a>
  *
- * <!-- Variante de botón compartir -->
- * <button cuentoneta-button type="share">
+ * <!-- Apariencia tenue en la geometría chica -->
+ * <button cuentoneta-button type="subtle" size="xs">
  *   <ng-icon name="shareIcon" />
  *   Compartir
  * </button>
+ *
+ * <!-- La opción vigente dentro de un grupo -->
+ * <button cuentoneta-button type="outline" [active]="true">Audio</button>
  * ```
  */
 @Component({
@@ -39,21 +52,37 @@ export type ButtonType = 'filled' | 'outline' | 'share';
 	},
 })
 export class ButtonComponent {
-	/** Variante del tipo de botón - determina el estilo visual */
+	/** Apariencia del botón: fondo, borde y color de texto */
 	public readonly type = input<ButtonType>('filled');
 
-	/** Clases del host calculadas según el tipo de botón */
+	/** Geometría del botón: padding, tamaño de fuente y separación entre ícono y texto */
+	public readonly size = input<ButtonSize>('md');
+
+	/** Marca al botón como la opción vigente dentro de un grupo */
+	public readonly active = input(false);
+
+	private readonly baseClasses =
+		'inline-flex cursor-pointer items-center justify-center font-inter font-semibold no-underline transition-colors duration-200 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50';
+
+	private readonly typeClasses: Record<ButtonType, string> = {
+		filled: 'bg-white text-neutral-900 hover:bg-neutral-50 active:bg-neutral-100',
+		outline: 'bg-white text-neutral-900 border border-neutral-300 hover:bg-neutral-50 active:bg-neutral-100',
+		subtle: 'bg-neutral-100 text-neutral-900 hover:bg-neutral-200 active:bg-neutral-300',
+	};
+
+	private readonly sizeClasses: Record<ButtonSize, string> = {
+		md: 'px-6 py-3 text-sm gap-2',
+		xs: 'px-3 py-2 text-xs gap-1',
+	};
+
+	private readonly activeClasses = 'bg-neutral-900 text-neutral-50 hover:bg-neutral-800 active:bg-neutral-700';
+
+	/** Clases del host calculadas componiendo los tres ejes */
 	protected readonly hostClasses = computed(() => {
-		const baseClasses =
-			'inline-flex cursor-pointer items-center justify-center font-inter font-semibold no-underline transition-colors duration-200 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50';
+		// El estado activo reemplaza la apariencia en vez de sumarse a ella: el contraste invertido
+		// es el mismo para las tres, así que superponerlas dejaría fondos y bordes en conflicto.
+		const appearance = this.active() ? this.activeClasses : this.typeClasses[this.type()];
 
-		const typeClasses: Record<ButtonType, string> = {
-			filled: 'bg-white text-neutral-900 px-6 py-3 text-sm hover:bg-neutral-50 active:bg-neutral-100',
-			outline:
-				'bg-white text-neutral-900 border border-1 border-neutral-300 px-6 py-3 text-sm hover:bg-neutral-50 active:bg-neutral-100',
-			share: 'bg-neutral-100 text-neutral-900 px-3 py-2 text-xs gap-1 hover:bg-neutral-200 active:bg-neutral-300',
-		};
-
-		return `${baseClasses} ${typeClasses[this.type()]}`;
+		return `${this.baseClasses} ${appearance} ${this.sizeClasses[this.size()]}`;
 	});
 }

--- a/src/app/components/button/button.component.ts
+++ b/src/app/components/button/button.component.ts
@@ -61,12 +61,14 @@ export class ButtonComponent {
 	/** Marca al botón como la opción vigente dentro de un grupo */
 	public readonly active = input(false);
 
+	// El ancho del borde se reserva acá, transparente, y cada apariencia solo le pone color: si lo
+	// declarara `outline`, elegirla o marcarla vigente cambiaría la caja 2px y reflowearía la fila.
 	private readonly baseClasses =
-		'inline-flex cursor-pointer items-center justify-center font-inter font-semibold no-underline transition-colors duration-200 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50';
+		'inline-flex cursor-pointer items-center justify-center font-inter font-semibold no-underline transition-colors duration-200 rounded-full border border-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50';
 
 	private readonly typeClasses: Record<ButtonType, string> = {
 		filled: 'bg-white text-neutral-900 hover:bg-neutral-50 active:bg-neutral-100',
-		outline: 'bg-white text-neutral-900 border border-neutral-300 hover:bg-neutral-50 active:bg-neutral-100',
+		outline: 'bg-white text-neutral-900 border-neutral-300 hover:bg-neutral-50 active:bg-neutral-100',
 		subtle: 'bg-neutral-100 text-neutral-900 hover:bg-neutral-200 active:bg-neutral-300',
 	};
 

--- a/src/app/components/button/button.component.ts
+++ b/src/app/components/button/button.component.ts
@@ -6,7 +6,7 @@ import { Component, computed, input } from '@angular/core';
  * - `outline`: fondo blanco con borde neutral-300
  * - `subtle`: fondo neutral-100, sin borde
  */
-export type ButtonType = 'filled' | 'outline' | 'subtle';
+export type ButtonVariant = 'filled' | 'outline' | 'subtle';
 
 /**
  * Geometría del botón: padding, tamaño de fuente y separación entre ícono y texto.
@@ -20,26 +20,26 @@ export type ButtonSize = 'md' | 'xs';
  * Un componente basado en atributo que puede aplicarse tanto a elementos `<button>` como `<a>`.
  * Proporciona estilos consistentes basados en el sistema de diseño de Figma.
  *
- * Expone tres ejes independientes que se combinan libremente: `type` (apariencia), `size`
+ * Expone tres ejes independientes que se combinan libremente: `variant` (apariencia), `size`
  * (geometría) y `active` (estado). Coordinar qué opción está vigente dentro de un grupo, que la
  * elección sea excluyente y anunciarla con `aria-pressed` son responsabilidad del contenedor.
  *
  * @example
  * ```html
  * <!-- En un elemento button -->
- * <button cuentoneta-button type="outline">Click me</button>
+ * <button cuentoneta-button variant="outline">Click me</button>
  *
  * <!-- En un elemento anchor con RouterLink -->
- * <a cuentoneta-button type="outline" [routerLink]="'/collection'">Ver todo</a>
+ * <a cuentoneta-button variant="outline" [routerLink]="'/collection'">Ver todo</a>
  *
  * <!-- Apariencia tenue en la geometría chica -->
- * <button cuentoneta-button type="subtle" size="xs">
+ * <button cuentoneta-button variant="subtle" size="xs">
  *   <ng-icon name="shareIcon" />
  *   Compartir
  * </button>
  *
  * <!-- La opción vigente dentro de un grupo -->
- * <button cuentoneta-button type="outline" [active]="true">Audio</button>
+ * <button cuentoneta-button variant="outline" [active]="true">Audio</button>
  * ```
  */
 @Component({
@@ -52,7 +52,7 @@ export type ButtonSize = 'md' | 'xs';
 })
 export class ButtonComponent {
 	/** Apariencia del botón: fondo, borde y color de texto */
-	public readonly type = input<ButtonType>('filled');
+	public readonly variant = input<ButtonVariant>('filled');
 
 	/** Geometría del botón: padding, tamaño de fuente y separación entre ícono y texto */
 	public readonly size = input<ButtonSize>('md');
@@ -65,7 +65,7 @@ export class ButtonComponent {
 	private readonly baseClasses =
 		'inline-flex cursor-pointer items-center justify-center font-inter font-semibold no-underline transition-colors duration-200 rounded-full border border-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50';
 
-	private readonly typeClasses: Record<ButtonType, string> = {
+	private readonly variantClasses: Record<ButtonVariant, string> = {
 		filled: 'bg-white text-neutral-900 hover:bg-neutral-50 active:bg-neutral-100',
 		outline: 'bg-white text-neutral-900 border-neutral-300 hover:bg-neutral-50 active:bg-neutral-100',
 		subtle: 'bg-neutral-100 text-neutral-900 hover:bg-neutral-200 active:bg-neutral-300',
@@ -82,7 +82,7 @@ export class ButtonComponent {
 	protected readonly hostClasses = computed(() => {
 		// El estado activo reemplaza la apariencia en vez de sumarse a ella: el contraste invertido
 		// es el mismo para las tres, así que superponerlas dejaría fondos y bordes en conflicto.
-		const appearance = this.active() ? this.activeClasses : this.typeClasses[this.type()];
+		const appearance = this.active() ? this.activeClasses : this.variantClasses[this.variant()];
 
 		return `${this.baseClasses} ${appearance} ${this.sizeClasses[this.size()]}`;
 	});

--- a/src/app/components/reading-suggestions/reading-suggestions-list.component.ts
+++ b/src/app/components/reading-suggestions/reading-suggestions-list.component.ts
@@ -63,7 +63,7 @@ import type { NavigationParams } from '@app-utils/navigation-params';
 				@if (loading()) {
 					<cuentoneta-skeleton appearance="line" class="h-11 w-full max-w-56 rounded-full bg-neutral-300" />
 				} @else if (moreRoute()) {
-					<a [routerLink]="moreRoute()" cuentoneta-button type="outline" class="self-start">{{ moreLabel() }}</a>
+					<a [routerLink]="moreRoute()" cuentoneta-button variant="outline" class="self-start">{{ moreLabel() }}</a>
 				}
 			</section>
 		}

--- a/src/app/pages/read/read.page.html
+++ b/src/app/pages/read/read.page.html
@@ -6,7 +6,7 @@
 	<section class="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-8">
 		<div class="flex justify-between pt-7">
 			<span class="font-inter text-xs font-semibold">{{ literaryWork.totalReadingTime }} minutos de lectura</span>
-			<button cuentoneta-button type="outline">Compartir</button>
+			<button cuentoneta-button variant="outline">Compartir</button>
 		</div>
 		@for (section of sections(); track section.position) {
 


### PR DESCRIPTION
## Qué resuelve

`ButtonComponent` exponía un único input `type` que mezclaba dos dimensiones: `share` no era solo "fondo `neutral-100`", también fijaba `px-3 py-2 text-xs gap-1`. Mientras las combinaciones en uso coincidieran una a una con los valores del enum el acople no molestaba, pero en cuanto una pantalla necesitaba una apariencia existente en otro tamaño la única salida era agregar una variante al catálogo, nombrada por su consumidor y no por su apariencia.

Este PR deja tres ejes que se combinan libremente:

| Eje | Gobierna | Valores |
| --- | --- | --- |
| `variant` | apariencia: fondo, borde y color de texto | `filled` (default) · `outline` · `subtle` |
| `size` | geometría: padding, tamaño de fuente y separación ícono↔texto | `md` (default) · `xs` |
| `active` | estado de opción vigente dentro de un grupo | `boolean` (default `false`) |

El eje de tamaño no inventa nada: sus dos valores **ya existían** escondidos dentro del mapa de clases, uno por variante. Lo que cambia es que ahora se pueden combinar con cualquier apariencia.

## Dos renombres, por la misma razón

**`share` → `subtle`.** `share` nombraba **dónde** se usa el botón, que es el defecto que este issue viene a corregir y que su criterio de aceptación prohíbe explícitamente ("ningún valor de `type` nombra a una pantalla o a un componente consumidor"). Dejarlo en pie habría cerrado el issue incumpliendo su propio criterio, en el mismo catálogo que el trabajo deja terminado.

El nombre sale del repo, no de un catálogo externo: el input `theme` de **MediaSelectors** ya llama `subtle` a esta misma superficie y resuelve al mismo `bg-neutral-100`. Se descartaron `soft`, `gray`, `neutral` y `solid` porque los cuatro colisionan en significado con **Tag** o con el propio `MediaSelectorsTheme`.

**El input `type` → `variant`.** Colisionaba con el atributo homónimo de `<button>`: `<button cuentoneta-button type="outline">` dejaba en el DOM un `type` inválido cuyo estado por defecto es `submit`, así que dentro de un formulario estos botones lo habrían enviado. Verificado renderizando el componente — `button.type` resolvía a `submit`. Ningún consumidor vive hoy dentro de un formulario, así que no había bug activo, pero el HTML servido salía con un valor que el estándar no admite. `variant` no colisiona con nada del elemento y es el nombre que ya usan **Tag**, **ImageProfile**, **EditorialNote** y **LiteraryWorkCardTeaser** para su eje de apariencia.

**Migración de consumidores: dos líneas.** Los únicos dos usos en `src/` pasan de `type="outline"` a `variant="outline"`, con la geometría por defecto, así que su render queda idéntico. Dato que refuerza el primer renombre: la acción "Compartir" de la página de lectura **ya se dibujaba con `outline`** — ni su propio caso de uso terminó consumiendo la variante que llevaba su nombre.

## Decisiones a revisar

**1. `active` reemplaza la apariencia, no se suma a ella.** El contraste invertido (`bg-neutral-900` + `text-neutral-50`) es el mismo para las tres apariencias: superponerlas dejaría fondos en conflicto. Estar elegido es un estado del botón, no una apariencia más del catálogo.

**2. El ancho del borde es de la caja, no de la apariencia.** Las clases base declaran `border border-transparent` y cada apariencia solo le pone color. Sin eso, marcar vigente a un botón `outline` le sacaba el borde de 1px y le achicaba la caja 2px en cada eje: en un grupo de opciones —el caso de uso que motiva el input— elegir una hacía reflowear la fila entera, o sea que el eje de estado terminaba alterando la geometría. Dos tests fijan la invariante.

**3. La coordinación del grupo queda afuera, y el spec lo fija.** Quién está elegido, que la elección sea excluyente y el anuncio por `aria-pressed` son del contenedor. Hay un test que afirma que el botón **no** emite `aria-pressed`, para que esa división sea verificable y no una convención escrita.

**4. `active` se mergea sin consumidor, a propósito.** El selector de formatos multimedia que lo motivó no se va a construir sobre este componente. Se implementa igual porque **un eje es API y un valor no lo es**: agregar un eje después obliga a repensar la composición de clases y revisar a todos los consumidores —el costo que este PR está pagando ahora—, mientras que agregar un valor a un eje existente cuesta una línea. Sin eje de estado, la próxima pantalla que necesite "la opción vigente" agrega un valor a la apariencia nombrado por ella, que es literalmente cómo nació el acople que este issue corrige.

**5. Se descartó un tercer tamaño `sm`.** Su única justificación era ese selector. Queda como hueco reservado entre `md` y `xs` para cuando aparezca un consumidor real.

## Cambios de menor porte

- Los mapas de clases pasan a `private readonly` de instancia, como pide la convención de configuración de la clase, y dejan de reconstruirse en cada recomputo.
- `md` suma `gap-2`: si el gap es del eje geometría, tiene que estar declarado en **todos** sus valores; si no, un botón con ícono en `md` cae a `gap-0` sin que nada lo declare.
- Se quita el `border-1` redundante (`border` ya fija 1px) y el `standalone: true`, que es el default desde la adopción de los defaults de Angular 22.
- Las stories dejan de ser un catálogo de variantes (`Filled`/`Outline`/`Share`/`Showcase`) y pasan a documentar los ejes: `Playground`, `Appearances`, `Sizes`, `ActiveOption` y `AxesMatrix`, más `OnAnchorElement` y `Disabled`.

## Plan de pruebas

**Automatizado.** El spec cubre cada eje **por separado** y no solo sus combinaciones, que es lo que impide que la geometría vuelva a meterse dentro de una apariencia sin que nada falle:

- **Eje apariencia** — cada valor aplica su fondo; solo `outline` pinta el color del borde; `subtle` toma la geometría del eje `size` y no la suya (la aserción que habría fallado antes de este cambio).
- **Eje geometría** — cada tamaño aplica sus cuatro clases, e **invariancia cruzada**: la misma apariencia rendereada en los dos tamaños conserva idénticas sus clases de apariencia.
- **Eje estado** — las tres apariencias convergen al contraste invertido, el estado no toca la geometría, la caja no se mueve al activarse, y el botón no emite `aria-pressed`.
- Cada caso hace su propio `render`: un binding de host `[class]` puede quedar con el valor inicial tras un re-render de la testing library.

**Gates.** Locales en verde: `typecheck`, `lint`, `test` (2204), `stylelint`, `check-agents`, `storybook:build` y `build`. El resto corre acá. El `build` importa especialmente en este PR: es el gate que compila plantillas con `ngtsc`, y el único que atraparía un atributo estático viejo en un `.html` tras el renombre del input — el `typecheck` no lo ve.

**Manual.** Revisar el catálogo de Storybook: que las seis celdas de la matriz de ejes rendericen con la caja del mismo alto, y que alternar `active` en la story correspondiente no mueva la fila.

Closes #2255
