### PR TITLE
[#1811] - Componente Divider del Design System V3

### DIFF
--- a/src/app/components/divider/divider.component.spec.ts
+++ b/src/app/components/divider/divider.component.spec.ts
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/angular';
+import { DividerComponent } from './divider.component';
+
+// Las orientaciones se comparan con renders independientes, nunca con `rerender`: Angular Testing
+// Library no reevalúa los bindings del host al reusar el fixture, así que `aria-orientation` y las
+// clases quedarían con el valor del primer render y la aserción pasaría por el motivo equivocado.
+const renderDivider = (template: string) => render(template, { imports: [DividerComponent] });
+
+const bothAxes = [
+	['horizontal', '<cuentoneta-divider />'],
+	['vertical', '<cuentoneta-divider orientation="vertical" />'],
+] as const;
+
+describe('DividerComponent', () => {
+	describe('semántica', () => {
+		it('should expose the separator role', async () => {
+			await renderDivider(`<cuentoneta-divider />`);
+			expect(screen.getByRole('separator')).toBeInTheDocument();
+		});
+
+		it.each(bothAxes)('should announce the %s orientation', async (axis, template) => {
+			await renderDivider(template);
+			expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', axis);
+		});
+
+		// El separador es estructural, no un control: no proyecta contenido, no expone rol de widget
+		// y no se suma al orden de tabulación. Es la invariante que enuncia la definición del diseño.
+		// La focusabilidad se afirma por la ausencia de `tabindex` y no llamando a `focus()`: el DOM
+		// de los tests enfoca cualquier elemento sin modelar si es focusable, así que esa vía
+		// verificaría el entorno en vez del componente.
+		it('should not be interactive', async () => {
+			await renderDivider(`<cuentoneta-divider />`);
+			const divider = screen.getByRole('separator');
+			expect(divider).toBeEmptyDOMElement();
+			expect(divider).not.toHaveAttribute('tabindex');
+			expect(screen.queryByRole('button')).not.toBeInTheDocument();
+			expect(screen.queryByRole('link')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('orientación horizontal', () => {
+		it('should be the default orientation', async () => {
+			await renderDivider(`<cuentoneta-divider />`);
+			const divider = screen.getByRole('separator');
+			expect(divider).toHaveClass('h-px');
+			expect(divider).toHaveClass('w-full');
+		});
+
+		it('should not take the geometry of the vertical axis', async () => {
+			await renderDivider(`<cuentoneta-divider orientation="horizontal" />`);
+			const divider = screen.getByRole('separator');
+			expect(divider).not.toHaveClass('w-px');
+			expect(divider).not.toHaveClass('self-stretch');
+		});
+	});
+
+	describe('orientación vertical', () => {
+		it('should be one pixel wide and stretch to the available height', async () => {
+			await renderDivider(`<cuentoneta-divider orientation="vertical" />`);
+			const divider = screen.getByRole('separator');
+			expect(divider).toHaveClass('w-px');
+			expect(divider).toHaveClass('self-stretch');
+		});
+
+		it('should not take the geometry of the horizontal axis', async () => {
+			await renderDivider(`<cuentoneta-divider orientation="vertical" />`);
+			const divider = screen.getByRole('separator');
+			expect(divider).not.toHaveClass('h-px');
+			expect(divider).not.toHaveClass('w-full');
+		});
+	});
+
+	describe('caja común a las dos orientaciones', () => {
+		it.each(bothAxes)('should paint the neutral line on the %s axis', async (_axis, template) => {
+			await renderDivider(template);
+			expect(screen.getByRole('separator')).toHaveClass('bg-neutral-200');
+		});
+
+		// Sin `block` un elemento custom es inline y no toma ancho; sin `shrink-0` el único píxel se
+		// comprime a cero en una fila apretada. Las dos clases son la razón de que la línea se vea.
+		it.each(bothAxes)('should keep its box from collapsing on the %s axis', async (_axis, template) => {
+			await renderDivider(template);
+			const divider = screen.getByRole('separator');
+			expect(divider).toHaveClass('block');
+			expect(divider).toHaveClass('shrink-0');
+		});
+	});
+});

--- a/src/app/components/divider/divider.component.stories.ts
+++ b/src/app/components/divider/divider.component.stories.ts
@@ -1,4 +1,6 @@
-import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
+import { argsToTemplate, type Meta, type StoryObj } from '@storybook/angular-vite';
+
+import { corpusLiteraryWorkTeasers } from '@mocks/onoff-corpus.storybook';
 
 import { DividerComponent } from './divider.component';
 
@@ -18,6 +20,7 @@ const meta: Meta<DividerComponent> = {
 	},
 	argTypes: {
 		orientation: {
+			description: 'Eje sobre el que se dibuja la línea. La vertical espera un contenedor flex o grid con alto.',
 			control: { type: 'inline-radio' },
 			options: ['horizontal', 'vertical'],
 			table: { type: { summary: `'horizontal' | 'vertical'` }, defaultValue: { summary: 'horizontal' } },
@@ -51,11 +54,15 @@ export const Playground: Story = {
 
 export const Horizontal: Story = {
 	render: () => ({
+		props: { works: corpusLiteraryWorkTeasers.slice(0, 3) },
 		template: `
 			<div class="flex max-w-md flex-col gap-4 font-inter text-sm text-neutral-700">
-				<p>La casa de Asterión</p>
-				<cuentoneta-divider />
-				<p>El jardín de senderos que se bifurcan</p>
+				@for (work of works; track work.slug; let last = $last) {
+					<p>{{ work.title }}</p>
+					@if (!last) {
+						<cuentoneta-divider />
+					}
+				}
 			</div>
 		`,
 	}),
@@ -72,11 +79,12 @@ export const Vertical: Story = {
 	render: () => ({
 		// `items-stretch` es lo que la variante vertical necesita: se estira sobre el alto del
 		// contenedor, así que dentro de un contenedor block quedaría con alto cero.
+		props: { work: corpusLiteraryWorkTeasers[0] },
 		template: `
 			<div class="flex items-stretch gap-4 font-inter text-sm text-neutral-700">
-				<p>12 min de lectura</p>
+				<p>{{ work.totalReadingTime }} min de lectura</p>
 				<cuentoneta-divider orientation="vertical" />
-				<p>Cuento</p>
+				<p>{{ work.tags[0].title }}</p>
 			</div>
 		`,
 	}),

--- a/src/app/components/divider/divider.component.stories.ts
+++ b/src/app/components/divider/divider.component.stories.ts
@@ -1,0 +1,110 @@
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
+
+import { DividerComponent } from './divider.component';
+
+const meta: Meta<DividerComponent> = {
+	component: DividerComponent,
+	title: 'Componentes V3/Divider',
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+			description: {
+				component: `<div><p>La línea divisoria del Design System v3, <strong>DividerComponent</strong>: una línea de 1px en neutral-200 que separa visualmente contenidos, secciones o grupos de elementos sin introducir una interrupción fuerte en la interfaz. El elemento anfitrión <em>es</em> la línea: no proyecta contenido, no expone acciones ni controles interactivos, y se anuncia como separador (<code>role="separator"</code>) con su orientación.</p><ul><li><strong>horizontal</strong> (default): 1px de alto, ocupa el ancho del contenedor.</li><li><strong>vertical</strong>: 1px de ancho, toma el alto disponible del contenedor.</li></ul></div>`,
+			},
+		},
+		layout: 'padded',
+	},
+	argTypes: {
+		orientation: {
+			control: { type: 'inline-radio' },
+			options: ['horizontal', 'vertical'],
+			table: { type: { summary: `'horizontal' | 'vertical'` }, defaultValue: { summary: 'horizontal' } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<DividerComponent>;
+
+export const Playground: Story = {
+	render: (args) => ({
+		props: args,
+		// La caja flex con alto le da a la variante vertical el eje sobre el que estirarse; sin ella
+		// el control de orientación parecería no hacer nada.
+		template: `
+			<div class="flex h-24 items-stretch">
+				<cuentoneta-divider ${argsToTemplate(args)} />
+			</div>
+		`,
+	}),
+	args: { orientation: 'horizontal' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Alterná el control <code>orientation</code> para ver los dos ejes en el mismo contenedor.</p>`,
+			},
+		},
+	},
+};
+
+export const Horizontal: Story = {
+	render: () => ({
+		template: `
+			<div class="flex max-w-md flex-col gap-4 font-inter text-sm text-neutral-700">
+				<p>La casa de Asterión</p>
+				<cuentoneta-divider />
+				<p>El jardín de senderos que se bifurcan</p>
+			</div>
+		`,
+	}),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Variante <strong>horizontal</strong> (default): separa elementos organizados verticalmente. Mantiene una altura fija de 1px y ocupa el ancho disponible del contenedor.</p><p><strong>Usos:</strong> Story, Story List, Author Profile y Author List.</p>`,
+			},
+		},
+	},
+};
+
+export const Vertical: Story = {
+	render: () => ({
+		// `items-stretch` es lo que la variante vertical necesita: se estira sobre el alto del
+		// contenedor, así que dentro de un contenedor block quedaría con alto cero.
+		template: `
+			<div class="flex items-stretch gap-4 font-inter text-sm text-neutral-700">
+				<p>12 min de lectura</p>
+				<cuentoneta-divider orientation="vertical" />
+				<p>Cuento</p>
+			</div>
+		`,
+	}),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Variante <strong>vertical</strong>: separa elementos organizados horizontalmente. Mantiene un ancho fijo de 1px y ocupa la altura disponible del contenedor, por lo que espera un contenedor flex o grid con alto resuelto.</p><p><strong>Usos:</strong> Story List, Author Profile y Author List.</p>`,
+			},
+		},
+	},
+};
+
+export const Showcase: Story = {
+	render: () => ({
+		template: `
+			<div class="flex max-w-md flex-col gap-6 font-inter text-sm text-neutral-700">
+				<div class="flex flex-col gap-4">
+					<p>Horizontal</p>
+					<cuentoneta-divider />
+					<p>Separa elementos apilados</p>
+				</div>
+				<div class="flex items-stretch gap-4">
+					<p>Vertical</p>
+					<cuentoneta-divider orientation="vertical" />
+					<p>Separa elementos en fila</p>
+				</div>
+			</div>
+		`,
+	}),
+	parameters: { docs: { description: { story: 'Las dos orientaciones: horizontal y vertical.' } } },
+};

--- a/src/app/components/divider/divider.component.ts
+++ b/src/app/components/divider/divider.component.ts
@@ -1,0 +1,53 @@
+import { Component, computed, input } from '@angular/core';
+
+/**
+ * Eje sobre el que se dibuja la línea divisoria:
+ * - `horizontal` (default): 1px de alto, ocupa el ancho del contenedor. Separa elementos apilados.
+ * - `vertical`: 1px de ancho, toma el alto disponible. Separa elementos dispuestos en fila.
+ */
+export type DividerOrientation = 'horizontal' | 'vertical';
+
+/**
+ * Línea divisoria del Design System v3. Componente de presentación cuyo elemento anfitrión *es* la
+ * línea: no proyecta contenido ni acepta interacción.
+ *
+ * La variante `vertical` se estira con `self-stretch`, así que necesita un contenedor flex o grid
+ * con alto resuelto; dentro de un contenedor block queda con alto cero y no se ve.
+ *
+ * @example
+ * ```html
+ * <!-- Entre dos bloques apilados -->
+ * <cuentoneta-divider />
+ *
+ * <!-- Entre dos columnas de una fila -->
+ * <div class="flex items-stretch gap-4">
+ *   <p>Izquierda</p>
+ *   <cuentoneta-divider orientation="vertical" />
+ *   <p>Derecha</p>
+ * </div>
+ * ```
+ */
+@Component({
+	selector: 'cuentoneta-divider',
+	template: '',
+	host: {
+		role: 'separator',
+		'[attr.aria-orientation]': 'orientation()',
+		'[class]': 'hostClasses()',
+	},
+})
+export class DividerComponent {
+	/** Eje sobre el que se dibuja la línea */
+	public readonly orientation = input<DividerOrientation>('horizontal');
+
+	// `block` porque un elemento custom es inline por defecto y una línea inline no toma ancho;
+	// `shrink-0` para que el único píxel no se comprima a cero dentro de un contenedor apretado.
+	private readonly baseClasses = 'block shrink-0 bg-neutral-200';
+
+	private readonly orientationClasses: Record<DividerOrientation, string> = {
+		horizontal: 'h-px w-full',
+		vertical: 'w-px self-stretch',
+	};
+
+	protected readonly hostClasses = computed(() => `${this.baseClasses} ${this.orientationClasses[this.orientation()]}`);
+}

--- a/src/app/components/drawer/drawer.component.stories.ts
+++ b/src/app/components/drawer/drawer.component.stories.ts
@@ -7,6 +7,7 @@ import { CoverImageComponent } from '@components/cover-image/cover-image.compone
 import { TagComponent } from '@components/tag/tag.component';
 import { PortableTextParserComponent } from '@components/portable-text-parser/portable-text-parser.component';
 import { NavigableCollectionTeaserComponent } from '@components/navigable-collection-teaser/navigable-collection-teaser.component';
+import { DividerComponent } from '@components/divider/divider.component';
 import { storylistMock, storylistTeaserRepresentativeMock, storylistTeaserSampleMock } from '@mocks/storylist.mock';
 
 type DrawerArgs = DrawerComponent & { direction: DrawerDirection };
@@ -120,7 +121,13 @@ export const ComposicionCollectionPage: Story = {
 	name: 'Composición CollectionPage',
 	decorators: [
 		moduleMetadata({
-			imports: [CoverImageComponent, TagComponent, PortableTextParserComponent, NavigableCollectionTeaserComponent],
+			imports: [
+				CoverImageComponent,
+				TagComponent,
+				PortableTextParserComponent,
+				NavigableCollectionTeaserComponent,
+				DividerComponent,
+			],
 		}),
 	],
 	render: (args) => ({
@@ -148,7 +155,7 @@ export const ComposicionCollectionPage: Story = {
 					classes="font-inter text-sm font-medium text-neutral-700"
 					class="flex flex-col gap-2"
 				/>
-				<div class="h-px w-full bg-neutral-200" role="separator"></div>
+				<cuentoneta-divider />
 				<div class="flex flex-col gap-4">
 					<h2 class="font-inter text-base font-bold text-neutral-900">Otras colecciones sugeridas</h2>
 					@for (item of suggested; track item.slug) {


### PR DESCRIPTION
## Descripción

Suma al Design System V3 el componente **Divider**: una línea de 1px en `neutral-200` con dos orientaciones, que hoy no existía en el repo.

El elemento anfitrión `<cuentoneta-divider>` **es** la línea — el componente no tiene plantilla, no proyecta contenido ni acepta interacción, tal como enuncia la definición del componente en Figma ("no contiene texto, acciones ni controles interactivos").

## Decisiones

**Orientación como eje.** Un único input `orientation` con union type exportado (`DividerOrientation`), el mapa eje→clases como `readonly` de instancia y la composición en un `computed()` sobre `host: { '[class]': … }`. Es exactamente el patrón de ejes independientes que estrenó `ButtonComponent` y que ya sigue `TagComponent`.

| Eje | Clases | Por qué |
| --- | --- | --- |
| base | `block shrink-0 bg-neutral-200` | Un elemento custom es `inline` por defecto y una línea inline no toma ancho; sin `shrink-0` el único píxel se comprime a cero en una fila apretada |
| `horizontal` | `h-px w-full` | Alto fijo de 1px, ocupa el ancho del contenedor |
| `vertical` | `w-px self-stretch` | Ancho fijo de 1px, toma el alto disponible |

Los tamaños fijos del canvas de Figma (`w-[287px]` / `h-[67px]`) no se trasladan: son la caja del ejemplo, y la propia documentación del componente dice que se adapta al espacio disponible sobre el eje correspondiente.

**Separador semántico, no decoración.** El host expone `role="separator"` con `aria-orientation` derivado del input. El repo ya trataba la línea divisoria como separador semántico: los decks y la página de autor usan `<hr>` (rol implícito), y la story del drawer dibujaba a mano `<div class="h-px w-full bg-neutral-200" role="separator">` — justo el marcado que este componente canoniza.

**Sin token nuevo.** `--color-neutral-200` ya está declarado en el `@theme` de `src/tailwind.css`. Nota menor: está como `hsl(0, 0%, 90%)`, que computa a `#e6e6e6` y no al `#e5e5e5` exacto de Figma — un punto sobre 255 por canal, imperceptible. No lo toco acá porque el token lo consume medio Design System y cambiarlo excede el alcance de este issue.

**Fuera de alcance.** Este PR entrega el primitivo; no lo aplica en ninguna página. La aplicación en las sugerencias de lectura es criterio de aceptación de #2284 (que está bloqueado por este issue), y el carril de la página de colección va por su propia rama. Mezclarlo acá volvería este primitivo no mergeable de forma independiente.

## Plan de pruebas

- [ ] `divider.component.spec.ts` — 12 casos: rol de separador, orientación anunciada por eje, geometría exclusiva de cada eje (que la horizontal no tome las clases de la vertical y viceversa), el token de color y las clases que impiden el colapso de la caja, y la no interactividad (elemento vacío, sin `tabindex`, sin roles de widget).
- [ ] Las orientaciones se comparan con **renders independientes**, nunca con `rerender`: Angular Testing Library no reevalúa los bindings del host al reusar el fixture, así que las aserciones sobre `aria-orientation` leerían el valor del primer render.
- [ ] Storybook bajo `Componentes V3/Divider` con `Playground`, `Horizontal`, `Vertical` y `Showcase`, verificadas en el navegador.
- [ ] Gates locales: `typecheck`, `lint`, `stylelint`, `test`, `check-agents`.
- [ ] Gates del PR: `build`, `storybook`, `studio-build`, `e2e`.

Closes #1811.

Parte de #1471.
