### PR TITLE
[#1834] - Directiva reutilizable de detección de overflow vertical (clamp + Leer más)

### DIFF
--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -22,7 +22,7 @@
 Archivos clave:
 
 - **`vitest.config.ts`** — `globals: true`, `environment: 'happy-dom'`, `setupFiles: ['src/test-setup.ts']`, `include: ['src/**/*.{test,spec}.ts']`. Inlina `@sanity` y bundles `fesm` para que Vite los transforme. Coverage solo en CI (`CI=true`/`COVERAGE=true`).
-- **`src/test-setup.ts`** — inicializa el `TestBed` zoneless (Angular 22 corre zoneless por defecto cuando `zone.js` no está presente; no se llama a `provideZonelessChangeDetection()`). El `ErrorHandler` **relanza** cualquier error no manejado para que falle el test. Instala el stub global de `IntersectionObserver`.
+- **`src/test-setup.ts`** — inicializa el `TestBed` zoneless (Angular 22 corre zoneless por defecto cuando `zone.js` no está presente; no se llama a `provideZonelessChangeDetection()`). El `ErrorHandler` **relanza** cualquier error no manejado para que falle el test. Instala los stubs globales de `IntersectionObserver`, de `ResizeObserver` y de `document.fonts`.
 - **`src/test-utils.ts`** — los wrappers obligatorios (ver abajo).
 
 > Esta es la config de **la app** (`@cuentoneta/app`). El Studio de Sanity (`cms/`) tiene su propia config de Vitest, independiente — ver [Segunda config de Vitest: el Studio (`cms/`)](#segunda-config-de-vitest-el-studio-cms).
@@ -226,6 +226,48 @@ describe('TagsOverflowDirective', () => {
 ```
 
 > Nota: el stub es temporal. El browser mode de Vitest provee un `IntersectionObserver` real, lo que permitiría testear con layout real en vez de simular el callback a mano.
+
+---
+
+## `ResizeObserver` en tests
+
+`happy-dom` tampoco implementa `ResizeObserver` ni computa layout: todas las medidas dan cero. `src/test-setup.ts` instala un **stub global** (`src/testing/resize-observer.stub.ts`) para que cualquier directiva o componente que mida su host se pueda renderizar.
+
+Los specs que necesitan **simular una medición** (p. ej. `ClampOverflowDirective`, que decide si ofrecer un "Leer más") reutilizan los helpers del mismo stub:
+
+| Helper                        | Efecto                                                                                     |
+| ----------------------------- | ------------------------------------------------------------------------------------------ |
+| `installResizeObserverStub()` | (Re)instala el stub y resetea los observers capturados                                     |
+| `setMeasuredSize(el, size)`   | Fija el `scrollHeight` y el `clientHeight` que el entorno de tests deja en cero            |
+| `triggerResize()`             | Entrega el callback de los observers **conectados**, como haría un resize real             |
+| `activeObserverCount()`       | Cuántos observers siguen conectados — afirma que una directiva desconecta el suyo al morir |
+
+```typescript
+const { detectChanges } = await render(ClampHostComponent);
+
+setMeasuredSize(screen.getByTestId('text'), { scrollHeight: 200, clientHeight: 100 });
+triggerResize();
+detectChanges();
+
+expect(screen.getByRole('button', { name: 'Leer más' })).toBeInTheDocument();
+```
+
+El `detectChanges()` no es ceremonia: el callback del observer corre fuera de Angular, así que la app zoneless no repinta sola tras escribir la signal.
+
+### Cuál de los dos observers, y por qué no da igual
+
+No son intercambiables, porque responden preguntas distintas:
+
+| Caso                                                      | Herramienta            | Por qué                                                                                                                                                           |
+| --------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Recorte **horizontal** de una lista de hijos (`TagsList`) | `IntersectionObserver` | Hay N nodos reales que comparar contra la caja del contenedor: el observer **es** la medición                                                                     |
+| Recorte **vertical** de un texto (`line-clamp-*`)         | `ResizeObserver`       | Lo que desborda son line boxes, no nodos: no hay target que observar. La medición es `scrollHeight > clientHeight`, y el observer solo decide **cuándo** re-medir |
+
+Un centinela dentro del `-webkit-box` del clamp alteraría el conteo de líneas que se pretende medir, y fuera del clamp nunca se recortaría: por eso el eje vertical no se resuelve con IO.
+
+### `document.fonts` en tests
+
+`happy-dom` no lo expone. `src/test-setup.ts` instala un doble **controlable** (`src/testing/document-fonts.stub.ts`), que deja `document.fonts.ready` pendiente hasta que el spec llame a `resolveFontsReady()`. Es lo que hace afirmable el caso de la fuente que carga tarde: con un `leading` explícito la caja no cambia de alto, así que el `ResizeObserver` no dispara y solo crece el contenido.
 
 ---
 
@@ -476,6 +518,7 @@ Si el componente **renderiza su propio skeleton** según un input (p. ej. cuando
 - **Service/repository de backend** → spec funcional; si necesita aislar el repository, module mocking con el bloque `eslint-disable` + nota #1503.
 - **Mocks/timers** → siempre desde `@test-utils`; `clearAllMocks()` en `beforeEach`.
 - **Componente que usa `IntersectionObserver`** → `installIntersectionObserverStub()` en `beforeEach`; simular overflow con `markOutsideViewport` / `markInsideViewport`.
+- **Directiva que mide su host** → `installResizeObserverStub()` en `beforeEach`; fijar medidas con `setMeasuredSize`, entregar el callback con `triggerResize()` y llamar a `detectChanges()`; afirmar la desconexión con `activeObserverCount()`.
 - **Lógica Node pura de `cms/`** → spec propio con Vitest standalone (`pnpm sanity:test`); dobles escritos a mano (`Spy*`/`Stub*`/`Fake*`), sin `@test-utils`.
 - **Migración de datos de Sanity (`cms/migrations/<slug>/`)** → `index.spec.ts` co-locado que ejercita `migrate.document`; corre con `pnpm sanity:test` dentro del gate `studio-build`; sin `@test-utils` (imports explícitos de `vitest`, igual que el resto de `cms/`) — ver [`sanity-migrations.md`](sanity-migrations.md).
 - **Document type de Sanity (`cms/schemas/<tipo>.ts`)** → **sin spec**. Un test que afirma que un campo se declara con cierto tipo, o que otro no está, repite lo que el archivo de al lado dice literalmente. Lo que sí protege contra una regresión ya existe: `cms/schema.json` y `src/sanity/types.ts` están versionados, así que un cambio de forma aparece en el diff de los generados, y el gate `studio-build` compila el Studio.

--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -195,7 +195,7 @@ Variantes: `queryBy*` (cuando se espera ausencia, no lanza), `findBy*` (async, e
 
 ## `IntersectionObserver` en tests
 
-`happy-dom` no implementa `IntersectionObserver`. `src/test-setup.ts` instala un **stub global** (`src/testing/intersection-observer.stub.ts`) para que cualquier componente que use IO se pueda renderizar.
+`happy-dom` trae un `IntersectionObserver` que no hace nada: alcanza para renderizar, pero nunca entrega un callback. `src/test-setup.ts` instala un **stub global** (`src/testing/intersection-observer.stub.ts`) que sí lo entrega bajo control del spec.
 
 Los specs que necesitan **simular overflow** (p. ej. `TagsListComponent` / `TagsOverflowDirective`, que recorta tags por ancho con `IntersectionObserver`) reutilizan los helpers del mismo stub:
 
@@ -231,7 +231,7 @@ describe('TagsOverflowDirective', () => {
 
 ## `ResizeObserver` en tests
 
-`happy-dom` tampoco implementa `ResizeObserver` ni computa layout: todas las medidas dan cero. `src/test-setup.ts` instala un **stub global** (`src/testing/resize-observer.stub.ts`) para que cualquier directiva o componente que mida su host se pueda renderizar.
+`happy-dom` trae un `ResizeObserver` que no hace nada y **no computa layout**: todas las medidas dan cero y ningún resize ocurre. `src/test-setup.ts` instala un **stub global** (`src/testing/resize-observer.stub.ts`) que no está para poder renderizar —el no-op alcanza para eso— sino para **controlar** la medición.
 
 Los specs que necesitan **simular una medición** (p. ej. `ClampOverflowDirective`, que decide si ofrecer un "Leer más") reutilizan los helpers del mismo stub:
 
@@ -252,7 +252,7 @@ detectChanges();
 expect(screen.getByRole('button', { name: 'Leer más' })).toBeInTheDocument();
 ```
 
-El `detectChanges()` no es ceremonia: el callback del observer corre fuera de Angular, así que la app zoneless no repinta sola tras escribir la signal.
+El `detectChanges()` aporta **sincronía**, no repintado: la escritura de la signal programa la detección igual, pero el spec asserta en la misma vuelta. La alternativa es esperarla —`await fixture.whenStable()`, como hace el spec de `TagsOverflowDirective`—; lo que no funciona es assertar sin ninguna de las dos.
 
 ### Cuál de los dos observers, y por qué no da igual
 

--- a/src/app/directives/clamp-overflow.directive.spec.ts
+++ b/src/app/directives/clamp-overflow.directive.spec.ts
@@ -14,9 +14,7 @@ import { ClampOverflowDirective } from './clamp-overflow.directive';
 @Component({
 	imports: [ClampOverflowDirective],
 	template: `
-		<p #clamp="cuentonetaClampOverflow" cuentonetaClampOverflow class="line-clamp-3" data-testid="text">
-			Un texto cualquiera
-		</p>
+		<p #clamp="cuentonetaClampOverflow" cuentonetaClampOverflow class="line-clamp-3">Un texto cualquiera</p>
 		@if (clamp.isOverflowing()) {
 			<button type="button">Leer más</button>
 		}
@@ -32,16 +30,35 @@ describe('ClampOverflowDirective', () => {
 		installDocumentFontsStub();
 	});
 
+	afterEach(() => {
+		// Las medidas del prototipo son de un solo caso: dejarlas puestas las heredaría el resto.
+		Reflect.deleteProperty(HTMLParagraphElement.prototype, 'scrollHeight');
+		Reflect.deleteProperty(HTMLParagraphElement.prototype, 'clientHeight');
+	});
+
 	it('should not report overflow before measuring', async () => {
 		await render(ClampHostComponent);
 
 		expect(readMore()).not.toBeInTheDocument();
 	});
 
+	// El primer valor no lo produce ningún resize: un ResizeObserver entrega una medición al empezar a
+	// observar. Las medidas se fijan en el prototipo porque el elemento todavía no existe cuando la
+	// directiva lo observa.
+	it('should report overflow from the initial observation, with no resize', async () => {
+		Object.defineProperty(HTMLParagraphElement.prototype, 'scrollHeight', { value: 200, configurable: true });
+		Object.defineProperty(HTMLParagraphElement.prototype, 'clientHeight', { value: 100, configurable: true });
+
+		const { detectChanges } = await render(ClampHostComponent);
+		detectChanges();
+
+		expect(readMore()).toBeInTheDocument();
+	});
+
 	it('should report overflow when the content exceeds the visible box', async () => {
 		const { detectChanges } = await render(ClampHostComponent);
 
-		setMeasuredSize(screen.getByTestId('text'), { scrollHeight: 200, clientHeight: 100 });
+		setMeasuredSize(screen.getByText('Un texto cualquiera'), { scrollHeight: 200, clientHeight: 100 });
 		triggerResize();
 		detectChanges();
 
@@ -51,7 +68,7 @@ describe('ClampOverflowDirective', () => {
 	it('should not report overflow when the content fits', async () => {
 		const { detectChanges } = await render(ClampHostComponent);
 
-		setMeasuredSize(screen.getByTestId('text'), { scrollHeight: 100, clientHeight: 100 });
+		setMeasuredSize(screen.getByText('Un texto cualquiera'), { scrollHeight: 100, clientHeight: 100 });
 		triggerResize();
 		detectChanges();
 
@@ -62,7 +79,7 @@ describe('ClampOverflowDirective', () => {
 	it('should tolerate a sub-pixel difference', async () => {
 		const { detectChanges } = await render(ClampHostComponent);
 
-		setMeasuredSize(screen.getByTestId('text'), { scrollHeight: 101, clientHeight: 100 });
+		setMeasuredSize(screen.getByText('Un texto cualquiera'), { scrollHeight: 101, clientHeight: 100 });
 		triggerResize();
 		detectChanges();
 
@@ -72,7 +89,7 @@ describe('ClampOverflowDirective', () => {
 	// El caso que una medición única no cubre: al ensancharse el host, el texto deja de recortarse.
 	it('should stop reporting overflow once the content fits again', async () => {
 		const { detectChanges } = await render(ClampHostComponent);
-		const text = screen.getByTestId('text');
+		const text = screen.getByText('Un texto cualquiera');
 
 		setMeasuredSize(text, { scrollHeight: 200, clientHeight: 100 });
 		triggerResize();
@@ -88,13 +105,12 @@ describe('ClampOverflowDirective', () => {
 
 	// La fuente tardía crece el contenido sin cambiar la caja, así que el observer no dispara.
 	it('should re-measure once the fonts finish loading', async () => {
-		const { detectChanges } = await render(ClampHostComponent);
+		await render(ClampHostComponent);
 
-		setMeasuredSize(screen.getByTestId('text'), { scrollHeight: 200, clientHeight: 100 });
-		await resolveFontsReady();
-		detectChanges();
+		setMeasuredSize(screen.getByText('Un texto cualquiera'), { scrollHeight: 200, clientHeight: 100 });
+		resolveFontsReady();
 
-		expect(readMore()).toBeInTheDocument();
+		expect(await screen.findByRole('button', { name: 'Leer más' })).toBeInTheDocument();
 	});
 
 	it('should disconnect its observer when the view is destroyed', async () => {
@@ -104,5 +120,19 @@ describe('ClampOverflowDirective', () => {
 		fixture.destroy();
 
 		expect(activeObserverCount()).toBe(0);
+	});
+
+	// La continuación de la carga de fuentes sobrevive al observer: sin cancelarla, mediría sobre una
+	// vista ya destruida y escribiría estado que nadie va a leer.
+	it('should not measure after the view is destroyed', async () => {
+		const { fixture } = await render(ClampHostComponent);
+		const directive = fixture.debugElement.query((node) => node.name === 'p').injector.get(ClampOverflowDirective);
+		setMeasuredSize(screen.getByText('Un texto cualquiera'), { scrollHeight: 200, clientHeight: 100 });
+
+		fixture.destroy();
+		resolveFontsReady();
+		await Promise.resolve();
+
+		expect(directive.isOverflowing()).toBe(false);
 	});
 });

--- a/src/app/directives/clamp-overflow.directive.spec.ts
+++ b/src/app/directives/clamp-overflow.directive.spec.ts
@@ -1,0 +1,108 @@
+import { Component } from '@angular/core';
+import { render, screen } from '@testing-library/angular';
+import { installDocumentFontsStub, resolveFontsReady } from '@testing/document-fonts.stub';
+import {
+	activeObserverCount,
+	installResizeObserverStub,
+	setMeasuredSize,
+	triggerResize,
+} from '@testing/resize-observer.stub';
+import { ClampOverflowDirective } from './clamp-overflow.directive';
+
+// La directiva se ejercita por su comportamiento observable —el "Leer más" aparece o no— y no leyendo
+// la signal: es el contrato que consume una plantilla.
+@Component({
+	imports: [ClampOverflowDirective],
+	template: `
+		<p #clamp="cuentonetaClampOverflow" cuentonetaClampOverflow class="line-clamp-3" data-testid="text">
+			Un texto cualquiera
+		</p>
+		@if (clamp.isOverflowing()) {
+			<button type="button">Leer más</button>
+		}
+	`,
+})
+class ClampHostComponent {}
+
+const readMore = (): HTMLElement | null => screen.queryByRole('button', { name: 'Leer más' });
+
+describe('ClampOverflowDirective', () => {
+	beforeEach(() => {
+		installResizeObserverStub();
+		installDocumentFontsStub();
+	});
+
+	it('should not report overflow before measuring', async () => {
+		await render(ClampHostComponent);
+
+		expect(readMore()).not.toBeInTheDocument();
+	});
+
+	it('should report overflow when the content exceeds the visible box', async () => {
+		const { detectChanges } = await render(ClampHostComponent);
+
+		setMeasuredSize(screen.getByTestId('text'), { scrollHeight: 200, clientHeight: 100 });
+		triggerResize();
+		detectChanges();
+
+		expect(readMore()).toBeInTheDocument();
+	});
+
+	it('should not report overflow when the content fits', async () => {
+		const { detectChanges } = await render(ClampHostComponent);
+
+		setMeasuredSize(screen.getByTestId('text'), { scrollHeight: 100, clientHeight: 100 });
+		triggerResize();
+		detectChanges();
+
+		expect(readMore()).not.toBeInTheDocument();
+	});
+
+	// El redondeo sub-pixel del alto de línea deja un píxel de más en un texto que entra justo.
+	it('should tolerate a sub-pixel difference', async () => {
+		const { detectChanges } = await render(ClampHostComponent);
+
+		setMeasuredSize(screen.getByTestId('text'), { scrollHeight: 101, clientHeight: 100 });
+		triggerResize();
+		detectChanges();
+
+		expect(readMore()).not.toBeInTheDocument();
+	});
+
+	// El caso que una medición única no cubre: al ensancharse el host, el texto deja de recortarse.
+	it('should stop reporting overflow once the content fits again', async () => {
+		const { detectChanges } = await render(ClampHostComponent);
+		const text = screen.getByTestId('text');
+
+		setMeasuredSize(text, { scrollHeight: 200, clientHeight: 100 });
+		triggerResize();
+		detectChanges();
+		expect(readMore()).toBeInTheDocument();
+
+		setMeasuredSize(text, { scrollHeight: 200, clientHeight: 200 });
+		triggerResize();
+		detectChanges();
+
+		expect(readMore()).not.toBeInTheDocument();
+	});
+
+	// La fuente tardía crece el contenido sin cambiar la caja, así que el observer no dispara.
+	it('should re-measure once the fonts finish loading', async () => {
+		const { detectChanges } = await render(ClampHostComponent);
+
+		setMeasuredSize(screen.getByTestId('text'), { scrollHeight: 200, clientHeight: 100 });
+		await resolveFontsReady();
+		detectChanges();
+
+		expect(readMore()).toBeInTheDocument();
+	});
+
+	it('should disconnect its observer when the view is destroyed', async () => {
+		const { fixture } = await render(ClampHostComponent);
+		expect(activeObserverCount()).toBe(1);
+
+		fixture.destroy();
+
+		expect(activeObserverCount()).toBe(0);
+	});
+});

--- a/src/app/directives/clamp-overflow.directive.ts
+++ b/src/app/directives/clamp-overflow.directive.ts
@@ -1,0 +1,66 @@
+import { afterNextRender, Directive, effect, ElementRef, inject, signal } from '@angular/core';
+
+/**
+ * Informa si el contenido de su host desborda el recorte por líneas (`line-clamp-*`) que tenga aplicado,
+ * comparando el alto del contenido contra el visible. Existe para decidir si ofrecer un "Leer más": sin la
+ * medición habría que mostrarlo siempre, también cuando el texto entra completo.
+ *
+ * Observa el host con `ResizeObserver` porque el recorte depende del ancho disponible, y en zoneless un
+ * resize de ventana no dispara detección de cambios por sí solo. Con `line-clamp-N` la caja mide
+ * `min(contenido, N líneas)`, así que todo cambio de contenido que cruce ese umbral también la cambia y
+ * vuelve a medir; el caso que el observer no ve es la fuente que carga tarde con un `leading` explícito,
+ * donde la caja no cambia y solo crece el contenido, y por eso se re-mide al resolverse `document.fonts`.
+ *
+ * Sin layout (SSR) el observer no se crea y el host se reporta como no desbordado, que es el estado
+ * seguro: se omite el "Leer más" en vez de ofrecerlo sobre un texto entero, y al hidratar el control
+ * aparece en vez de desaparecer bajo el cursor.
+ *
+ * **Precondición:** el host tiene que estar recortado por líneas, no por un alto fijo — con un alto fijo
+ * la medición informa cualquier desborde, no el del recorte. El control que se ofrezca debe vivir **fuera**
+ * del elemento observado: adentro cambiaría lo que se mide.
+ */
+@Directive({
+	selector: '[cuentonetaClampOverflow]',
+	exportAs: 'cuentonetaClampOverflow',
+})
+export class ClampOverflowDirective {
+	private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+
+	private readonly overflowing = signal(false);
+	public readonly isOverflowing = this.overflowing.asReadonly();
+
+	// El redondeo sub-pixel del alto de línea hace que un texto que entra justo mida un píxel de más.
+	private readonly overflowTolerancePx = 1;
+
+	// El observer recién se crea tras el primer render, que solo ocurre en el navegador.
+	private readonly ready = signal(false);
+	private readonly markReadyAfterFirstRender = afterNextRender(() => this.ready.set(true));
+
+	private readonly observeHostEffect = effect((onCleanup) => {
+		if (!this.ready()) {
+			return;
+		}
+
+		const observer = new ResizeObserver(() => this.measure());
+		observer.observe(this.host.nativeElement);
+
+		let cancelled = false;
+		if ('fonts' in document) {
+			document.fonts.ready.then(() => {
+				if (!cancelled) {
+					this.measure();
+				}
+			});
+		}
+
+		onCleanup(() => {
+			cancelled = true;
+			observer.disconnect();
+		});
+	});
+
+	private measure(): void {
+		const element = this.host.nativeElement;
+		this.overflowing.set(element.scrollHeight > element.clientHeight + this.overflowTolerancePx);
+	}
+}

--- a/src/app/directives/clamp-overflow.directive.ts
+++ b/src/app/directives/clamp-overflow.directive.ts
@@ -45,13 +45,11 @@ export class ClampOverflowDirective {
 		observer.observe(this.host.nativeElement);
 
 		let cancelled = false;
-		if ('fonts' in document) {
-			document.fonts.ready.then(() => {
-				if (!cancelled) {
-					this.measure();
-				}
-			});
-		}
+		document.fonts.ready.then(() => {
+			if (!cancelled) {
+				this.measure();
+			}
+		});
 
 		onCleanup(() => {
 			cancelled = true;

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -5,7 +5,9 @@ import { ErrorHandler, NgModule } from '@angular/core';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 
+import { installDocumentFontsStub } from '@testing/document-fonts.stub';
 import { installIntersectionObserverStub } from '@testing/intersection-observer.stub';
+import { installResizeObserverStub } from '@testing/resize-observer.stub';
 
 // Angular 22 corre el TestBed en modo zoneless por defecto cuando zone.js no está presente,
 // por eso no se provee `provideZonelessChangeDetection()` explícitamente. El ErrorHandler relanza
@@ -29,6 +31,10 @@ class ZonelessTestModule {}
 // Algunos specs sustituyen los imports del componente vía `componentImports` y dependen de ese default.
 getTestBed().initTestEnvironment([BrowserTestingModule, ZonelessTestModule], platformBrowserTesting());
 
-// jsdom/happy-dom no implementan IntersectionObserver: se instala un stub global para todos los tests.
-// Los specs que necesitan controlar el observer (simular overflow) reutilizan los helpers del mismo stub.
+// jsdom/happy-dom no implementan los observers de layout ni exponen `document.fonts`: se instalan sus
+// stubs globales para todos los tests, de modo que cualquier componente o directiva que los use se pueda
+// renderizar. Los specs que necesitan controlarlos (simular overflow, resolver la carga de fuentes)
+// reutilizan los helpers de cada stub.
 installIntersectionObserverStub();
+installResizeObserverStub();
+installDocumentFontsStub();

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -31,10 +31,9 @@ class ZonelessTestModule {}
 // Algunos specs sustituyen los imports del componente vía `componentImports` y dependen de ese default.
 getTestBed().initTestEnvironment([BrowserTestingModule, ZonelessTestModule], platformBrowserTesting());
 
-// jsdom/happy-dom no implementan los observers de layout ni exponen `document.fonts`: se instalan sus
-// stubs globales para todos los tests, de modo que cualquier componente o directiva que los use se pueda
-// renderizar. Los specs que necesitan controlarlos (simular overflow, resolver la carga de fuentes)
-// reutilizan los helpers de cada stub.
+// happy-dom trae los observers de layout como constructores que no hacen nada —alcanzan para renderizar,
+// pero nunca entregan un callback— y no expone `document.fonts`. Estos stubs globales dan el control que
+// falta: los specs que necesitan simular overflow o resolver la carga de fuentes usan sus helpers.
 installIntersectionObserverStub();
 installResizeObserverStub();
 installDocumentFontsStub();

--- a/src/testing/document-fonts.stub.ts
+++ b/src/testing/document-fonts.stub.ts
@@ -1,0 +1,33 @@
+// Doble controlable de `document.fonts` para tests: el entorno de tests no lo expone, y el caso "la
+// fuente carga tarde y cambia la altura del texto" tiene que ser afirmable.
+//
+// Sustituye un entorno, no un almacenamiento, así que sigue la taxonomía `Controllable*`: el spec
+// decide cuándo la carga de fuentes termina, en vez de esperar a que ocurra.
+let resolveReady: (() => void) | undefined;
+
+/**
+ * Instala `document.fonts` con una promesa `ready` pendiente hasta que el spec la resuelva.
+ *
+ * No hace nada sin `document`: los specs de `tools/` corren en entorno Node y comparten este setup.
+ */
+export function installDocumentFontsStub(): void {
+	if (typeof document === 'undefined') {
+		return;
+	}
+
+	const ready = new Promise<void>((resolve) => {
+		resolveReady = resolve;
+	});
+
+	Object.defineProperty(document, 'fonts', {
+		value: { ready },
+		configurable: true,
+	});
+}
+
+/** Resuelve la carga de fuentes, como haría el navegador al terminar de aplicarlas. */
+export async function resolveFontsReady(): Promise<void> {
+	resolveReady?.();
+	// Cede el turno para que las continuaciones encoladas sobre `ready` corran antes de asertar.
+	await Promise.resolve();
+}

--- a/src/testing/document-fonts.stub.ts
+++ b/src/testing/document-fonts.stub.ts
@@ -26,8 +26,6 @@ export function installDocumentFontsStub(): void {
 }
 
 /** Resuelve la carga de fuentes, como haría el navegador al terminar de aplicarlas. */
-export async function resolveFontsReady(): Promise<void> {
+export function resolveFontsReady(): void {
 	resolveReady?.();
-	// Cede el turno para que las continuaciones encoladas sobre `ready` corran antes de asertar.
-	await Promise.resolve();
 }

--- a/src/testing/resize-observer.stub.ts
+++ b/src/testing/resize-observer.stub.ts
@@ -1,11 +1,11 @@
-// Stub global de ResizeObserver para tests (el entorno de tests no lo implementa). Se instala en
-// test-setup para que las directivas que miden su host se puedan renderizar, y expone el control que un
-// observer real no da: qué elementos están observados, cuándo se entrega el callback y cuántos observers
-// siguen conectados.
+// Stub global de ResizeObserver para tests. happy-dom trae un constructor que no hace nada, así que un
+// componente que lo use igual se renderiza: este stub no está para eso, sino para el control que ni el
+// no-op ni un observer real dan — qué elementos están observados, cuándo se entrega el callback y
+// cuántos observers siguen conectados.
 //
-// El entorno de tests no computa layout, así que un ResizeObserver real nunca dispararía y las medidas
-// darían todas cero. Estos helpers sustituyen ese entorno: `setMeasuredSize` fija el alto real y el
-// visible de un elemento, y `triggerResize` entrega el callback de forma síncrona.
+// El entorno de tests no computa layout, así que las medidas darían todas cero y ningún resize ocurre.
+// Estos helpers sustituyen ese entorno: `setMeasuredSize` fija el alto real y el visible de un elemento,
+// y `triggerResize` entrega el callback de forma síncrona.
 let observers: ResizeObserverStub[] = [];
 
 class ResizeObserverStub {
@@ -16,8 +16,12 @@ class ResizeObserverStub {
 		observers.push(this);
 	}
 
+	// Un ResizeObserver real entrega una primera medición al empezar a observar, sin esperar a que
+	// nada cambie de tamaño. Es el camino por el que una directiva obtiene su valor inicial, así que
+	// el stub lo reproduce: sin esto, ningún test cubriría esa entrega.
 	public observe(target: Element): void {
 		this.targets.push(target);
+		this.deliver();
 	}
 
 	public unobserve(target: Element): void {
@@ -37,7 +41,7 @@ class ResizeObserverStub {
 	}
 
 	public deliver(): void {
-		if (!this.connected) {
+		if (!this.connected || this.targets.length === 0) {
 			return;
 		}
 		const entries = this.targets.map((target) => ({ target }) as ResizeObserverEntry);

--- a/src/testing/resize-observer.stub.ts
+++ b/src/testing/resize-observer.stub.ts
@@ -1,0 +1,76 @@
+// Stub global de ResizeObserver para tests (el entorno de tests no lo implementa). Se instala en
+// test-setup para que las directivas que miden su host se puedan renderizar, y expone el control que un
+// observer real no da: qué elementos están observados, cuándo se entrega el callback y cuántos observers
+// siguen conectados.
+//
+// El entorno de tests no computa layout, así que un ResizeObserver real nunca dispararía y las medidas
+// darían todas cero. Estos helpers sustituyen ese entorno: `setMeasuredSize` fija el alto real y el
+// visible de un elemento, y `triggerResize` entrega el callback de forma síncrona.
+let observers: ResizeObserverStub[] = [];
+
+class ResizeObserverStub {
+	private readonly targets: Element[] = [];
+	private connected = true;
+
+	constructor(private readonly callback: ResizeObserverCallback) {
+		observers.push(this);
+	}
+
+	public observe(target: Element): void {
+		this.targets.push(target);
+	}
+
+	public unobserve(target: Element): void {
+		const index = this.targets.indexOf(target);
+		if (index !== -1) {
+			this.targets.splice(index, 1);
+		}
+	}
+
+	public disconnect(): void {
+		this.connected = false;
+		this.targets.length = 0;
+	}
+
+	public isConnected(): boolean {
+		return this.connected;
+	}
+
+	public deliver(): void {
+		if (!this.connected) {
+			return;
+		}
+		const entries = this.targets.map((target) => ({ target }) as ResizeObserverEntry);
+		this.callback(entries, this as unknown as ResizeObserver);
+	}
+}
+
+/** Instala el stub como `ResizeObserver` global y resetea el estado capturado. */
+export function installResizeObserverStub(): void {
+	(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub;
+	observers = [];
+}
+
+/**
+ * Fija el alto del contenido y el alto visible de un elemento, que el entorno de tests deja en cero.
+ * Un `scrollHeight` mayor que el `clientHeight` es lo que una directiva de recorte lee como desborde.
+ */
+export function setMeasuredSize(element: Element, size: { scrollHeight: number; clientHeight: number }): void {
+	Object.defineProperty(element, 'scrollHeight', { value: size.scrollHeight, configurable: true });
+	Object.defineProperty(element, 'clientHeight', { value: size.clientHeight, configurable: true });
+}
+
+/** Entrega el callback de los observers todavía conectados, como haría un resize real. */
+export function triggerResize(): void {
+	for (const observer of observers) {
+		observer.deliver();
+	}
+}
+
+/**
+ * Cuántos observers siguen conectados. Es lo que permite afirmar que una directiva desconecta el suyo
+ * al destruirse: un observer que sobrevive a su host sigue escribiendo estado sobre una vista muerta.
+ */
+export function activeObserverCount(): number {
+	return observers.filter((observer) => observer.isConnected()).length;
+}


### PR DESCRIPTION
## Qué resuelve

Un texto con `line-clamp-N` no dice si se recortó. Sin medirlo, ofrecer un "Leer más" lo muestra también sobre textos que entran completos, y no mostrarlo nunca esconde la mitad de una descripción larga.

`ClampOverflowDirective` (`[cuentonetaClampOverflow]`) compara el alto del contenido contra el visible y expone `isOverflowing` como signal de solo lectura, legible desde la plantilla por `exportAs`:

```html
<p #clamp="cuentonetaClampOverflow" cuentonetaClampOverflow class="line-clamp-8">{{ description }}</p>
@if (clamp.isOverflowing()) {
	<button type="button" (click)="openDrawer()">Leer más</button>
}
```

## Decisiones a revisar

**1. Signal de solo lectura, no `output`.** Un output obligaría al consumidor a espejar el estado en una signal propia, y no tendría valor inicial — que es justo lo que hace falta para decidir el primer render.

**2. `ResizeObserver`, no el `IntersectionObserver` del recorte horizontal.** No es preferencia: son preguntas distintas. En `TagsOverflowDirective` hay N nodos reales que comparar contra la caja del contenedor, así que el observer **es** la medición. Acá lo que desborda son líneas de texto, no nodos: no hay target que observar. La medición es `scrollHeight > clientHeight` y el observer solo decide **cuándo** re-medir. Un centinela dentro del `-webkit-box` del clamp alteraría el conteo de líneas que se pretende medir, y fuera del clamp nunca se recortaría.

**3. La fuente tardía se cierra con `document.fonts`, no con más observers.** Re-medir en cada resize cubre el contenido dinámico **por construcción**: con `line-clamp-N` la caja mide `min(contenido, N líneas)`, así que todo cambio que cruza el umbral la cambia y dispara el observer, y los que no lo cruzan no cambian la respuesta. El hueco real es otro — con un `leading` explícito, una fuente que carga tarde crece el contenido sin mover la caja —, y se cierra re-midiendo cuando `document.fonts` resuelve.

**4. Default conservador en SSR.** Sin layout no se crea nada y el host se reporta como no desbordado, por dos razones: se omite un control en vez de ofrecerlo sobre un texto entero, y al hidratar el botón **aparece** en vez de desaparecer bajo el cursor.

**5. Sin lifecycle hooks.** El observer se crea en un `effect` que espera al primer render y se desconecta en su `onCleanup`, que además cancela la continuación de `document.fonts.ready` para no escribir la signal sobre una vista ya destruida.

## Precondición documentada

El host tiene que estar recortado **por líneas** y no por un alto fijo, y el control que se ofrezca debe vivir **fuera** del elemento observado: adentro cambiaría lo que se mide y podría redisparar el observer. Está en el docblock de la directiva.

## Herramientas de test que suma

Dos dobles globales, instalados en `src/test-setup.ts` junto al de `IntersectionObserver` que ya existía:

| Archivo | Qué aporta |
| --- | --- |
| `src/testing/resize-observer.stub.ts` | `installResizeObserverStub()`, `setMeasuredSize()`, `triggerResize()` y `activeObserverCount()` — este último es lo que permite **afirmar la desconexión** |
| `src/testing/document-fonts.stub.ts` | Doble controlable de `document.fonts`: el spec decide cuándo termina la carga |

Ambos son un port ampliado de lo que el spike #1826 había dejado en su rama. El de fuentes no hace nada sin `document`, porque los specs de `tools/` corren en entorno Node y comparten el mismo setup.

Estos entornos de test **sí traen** los dos observers, como constructores que no hacen nada: los stubs no existen para poder renderizar —eso ya funciona— sino para controlar cuándo se entrega el callback y con qué medidas. `document.fonts`, en cambio, falta de verdad. La documentación del repo decía lo contrario y quedó corregida.

## Plan de pruebas

**Automatizado — 9 casos** que ejercitan el **comportamiento observable** (aparece o no el botón), no la signal:

- No reporta desborde antes de medir — el default de SSR.
- Contenido más alto que el área visible → aparece; contenido que entra → no aparece.
- Tolerancia sub-pixel: `scrollHeight` 101 contra `clientHeight` 100 no cuenta como desborde.
- **Reactividad en los dos sentidos**: si el host se ensancha hasta contener el texto, el botón desaparece — el caso que una medición única no cubría.
- **Fuente tardía**: sin ningún resize, resolver `document.fonts.ready` re-mide y el botón aparece.
- **Primer valor sin ningún resize**: la medición que el observer entrega al empezar a observar, que es por donde llega el valor inicial en el navegador.
- **Limpieza**: al destruir la vista no queda ningún observer conectado, y resolver las fuentes después ya no mide.

Los dos casos que la review destapó —el primer valor y la cancelación— se verificaron por mutación: quitando la entrega inicial del stub falla el primero, y quitando el guard de cancelación falla el segundo.

**Gates locales en verde:** `typecheck`, `lint`, `test` (2247), `stylelint` y `check-agents`. El resto corre acá.

## Lo que no entra, y por qué

La cuarta tarea del issue pide un **e2e de navegador**. No puede aterrizar acá: Playwright corre contra el server SSR de producción y **ninguna ruta monta la directiva** todavía. Su primer consumidor es #1835, que a su vez espera a #1833. Que `line-clamp-N` produzca efectivamente `scrollHeight > clientHeight`, que el observer real dispare al cambiar el viewport y que el botón aparezca con fuentes reales solo se puede verificar ahí.

La tarea se traslada a #1835, anotada en su cuerpo. Alternativas descartadas: montar una ruta de producción de prueba solo para el test, y adoptar el browser mode de Vitest, que es un cambio de infraestructura ajeno a este issue.

Closes #1834

Parte de #1472.
