### PR TITLE
[#1836] - CollectionInfoPanel — DRY del bloque cover + título + tag + descripción

### DIFF
--- a/src/app/components/collection-info-panel/collection-info-panel-skeleton.component.ts
+++ b/src/app/components/collection-info-panel/collection-info-panel-skeleton.component.ts
@@ -1,0 +1,39 @@
+import { Component, computed, input } from '@angular/core';
+
+import { SkeletonComponent } from '@components/skeleton/skeleton.component';
+import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton.component';
+
+/**
+ * Estado de carga (esqueleto) de CollectionInfoPanelComponent. Replica su columna —portada, título,
+ * etiqueta y las líneas de la descripción— para que la sustitución por el panel real no mueva el layout.
+ */
+@Component({
+	selector: 'cuentoneta-collection-info-panel-skeleton',
+	imports: [SkeletonComponent, CoverImageSkeletonComponent],
+	host: { class: 'flex w-full flex-col gap-4', 'data-testid': 'collection-info-panel-skeleton' },
+	template: `
+		<cuentoneta-cover-image-skeleton />
+		<div class="flex w-full flex-col gap-4">
+			<div class="flex flex-col items-start gap-2">
+				<cuentoneta-skeleton appearance="line" class="h-7 w-40 bg-neutral-300" />
+				<cuentoneta-skeleton appearance="line" class="h-6 w-24 bg-neutral-300" />
+			</div>
+			<div class="flex w-full flex-col gap-1.5">
+				@for (line of descriptionPlaceholders(); track $index) {
+					<cuentoneta-skeleton appearance="line" class="h-4 w-full bg-neutral-300" />
+				}
+			</div>
+		</div>
+	`,
+})
+export class CollectionInfoPanelSkeletonComponent {
+	/**
+	 * Cuántas líneas de descripción dibuja. Acotado a [1, 10] para coincidir con el recorte que admite
+	 * el panel real.
+	 */
+	public readonly descriptionLines = input(4, {
+		transform: (value: number) => Math.min(10, Math.max(1, value)),
+	});
+
+	protected readonly descriptionPlaceholders = computed(() => Array.from({ length: this.descriptionLines() }));
+}

--- a/src/app/components/collection-info-panel/collection-info-panel-skeleton.component.ts
+++ b/src/app/components/collection-info-panel/collection-info-panel-skeleton.component.ts
@@ -18,7 +18,8 @@ import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton
 				<cuentoneta-skeleton appearance="line" class="h-7 w-40 bg-neutral-300" />
 				<cuentoneta-skeleton appearance="line" class="h-6 w-24 bg-neutral-300" />
 			</div>
-			<div class="flex w-full flex-col gap-1.5">
+			<!-- Barra de 16 px con 4 px de separación: los 20 px de interlineado que usa la descripción real. -->
+			<div class="flex w-full flex-col gap-1">
 				@for (line of descriptionPlaceholders(); track $index) {
 					<cuentoneta-skeleton appearance="line" class="h-4 w-full bg-neutral-300" />
 				}

--- a/src/app/components/collection-info-panel/collection-info-panel.component.spec.ts
+++ b/src/app/components/collection-info-panel/collection-info-panel.component.spec.ts
@@ -1,0 +1,113 @@
+// Librería de pruebas
+import { render, screen, within } from '@testing-library/angular';
+
+// Componentes
+import { CollectionInfoPanelComponent } from './collection-info-panel.component';
+
+// Mocks
+import {
+	onoffCollectionsWithRepresentativeImageryMock,
+	onoffCollectionsWithSampleImageryMock,
+} from '@mocks/onoff-collections.mock';
+
+// Utilidades de test
+import { clearAllMocks } from '@test-utils';
+
+const [representativeMock] = onoffCollectionsWithRepresentativeImageryMock;
+const [sampleMock] = onoffCollectionsWithSampleImageryMock;
+
+describe('CollectionInfoPanelComponent', () => {
+	beforeEach(() => {
+		clearAllMocks();
+	});
+
+	describe('sin colección', () => {
+		it('should render its skeleton', async () => {
+			await render(CollectionInfoPanelComponent);
+
+			expect(screen.getByTestId('collection-info-panel-skeleton')).toBeInTheDocument();
+			expect(screen.queryByTestId('description')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('con colección', () => {
+		it('should render the title', async () => {
+			await render(CollectionInfoPanelComponent, { inputs: { collection: representativeMock } });
+
+			expect(screen.getByText(representativeMock.title)).toBeInTheDocument();
+		});
+
+		// El panel deslizable ya nombra la colección en su encabezado: repetirlo la anunciaría dos veces.
+		it('should omit the title when the consumer already shows it', async () => {
+			await render(CollectionInfoPanelComponent, {
+				inputs: { collection: representativeMock, showTitle: false },
+			});
+
+			expect(screen.queryByText(representativeMock.title)).not.toBeInTheDocument();
+		});
+
+		it('should render the description served by the backend', async () => {
+			await render(CollectionInfoPanelComponent, { inputs: { collection: representativeMock } });
+
+			expect(screen.getByTestId('description')).not.toBeEmptyDOMElement();
+		});
+
+		// Todas las etiquetas del dominio, no la primera: recortar acá escondería en silencio las demás.
+		it('should render every tag of the collection', async () => {
+			await render(CollectionInfoPanelComponent, { inputs: { collection: representativeMock } });
+
+			const tags = screen.getByTestId('tags');
+			representativeMock.tags.forEach((tag) => expect(within(tags).getByText(tag.title)).toBeInTheDocument());
+		});
+
+		it('should omit the tag list when the collection has none', async () => {
+			await render(CollectionInfoPanelComponent, {
+				inputs: { collection: { ...representativeMock, tags: [] } },
+			});
+
+			expect(screen.queryByTestId('tags')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('portada', () => {
+		it('should render a single cover for representative imagery', async () => {
+			await render(CollectionInfoPanelComponent, { inputs: { collection: representativeMock } });
+
+			expect(screen.queryByTestId('cover-fan')).not.toBeInTheDocument();
+			expect(screen.getAllByTestId('cover')).toHaveLength(1);
+		});
+
+		it('should render the three-cover fan for sample imagery', async () => {
+			await render(CollectionInfoPanelComponent, { inputs: { collection: sampleMock } });
+
+			expect(within(screen.getByTestId('cover-fan')).getAllByTestId('cover')).toHaveLength(3);
+		});
+	});
+
+	describe('recorte de la descripción', () => {
+		// Cuántas líneas se muestran depende del alto de la columna que lo hospeda, así que lo decide el
+		// consumidor: sin ese dato el panel no recorta.
+		it('should not clamp when the consumer does not ask for it', async () => {
+			await render(CollectionInfoPanelComponent, { inputs: { collection: representativeMock } });
+
+			expect(screen.getByTestId('description').className).not.toMatch(/line-clamp-/);
+		});
+
+		it('should clamp to the requested number of lines', async () => {
+			await render(CollectionInfoPanelComponent, {
+				inputs: { collection: representativeMock, descriptionLines: 8 },
+			});
+
+			expect(screen.getByTestId('description')).toHaveClass('line-clamp-8');
+		});
+
+		// El safelist de Tailwind llega hasta 10: pedir más produciría una clase que no existe.
+		it('should cap the clamp at the highest safelisted value', async () => {
+			await render(CollectionInfoPanelComponent, {
+				inputs: { collection: representativeMock, descriptionLines: 40 },
+			});
+
+			expect(screen.getByTestId('description')).toHaveClass('line-clamp-10');
+		});
+	});
+});

--- a/src/app/components/collection-info-panel/collection-info-panel.component.spec.ts
+++ b/src/app/components/collection-info-panel/collection-info-panel.component.spec.ts
@@ -9,12 +9,24 @@ import {
 	onoffCollectionsWithRepresentativeImageryMock,
 	onoffCollectionsWithSampleImageryMock,
 } from '@mocks/onoff-collections.mock';
+import { cuentoTagMock, ensayoTagMock, novelaTagMock } from '@mocks/onoff-tags.mock';
+
+// Modelos
+import { createCollection, type Collection } from '@models/collection.model';
 
 // Utilidades de test
 import { clearAllMocks } from '@test-utils';
 
 const [representativeMock] = onoffCollectionsWithRepresentativeImageryMock;
 const [sampleMock] = onoffCollectionsWithSampleImageryMock;
+
+const availableTags = [cuentoTagMock, novelaTagMock, ensayoTagMock];
+
+// Deriva una variante del canon pasando por la factory, no por spread: el agregado está congelado y
+// armarlo a mano saltearía las invariantes que la factory existe para hacer cumplir.
+function collectionWithTags(base: Collection, count: number): Collection {
+	return createCollection({ ...base, tags: availableTags.slice(0, count) });
+}
 
 describe('CollectionInfoPanelComponent', () => {
 	beforeEach(() => {
@@ -46,18 +58,26 @@ describe('CollectionInfoPanelComponent', () => {
 			expect(screen.queryByText(representativeMock.title)).not.toBeInTheDocument();
 		});
 
-		it('should render the description served by the backend', async () => {
+		// La marcación tiene que sobrevivir: sin el bypass, el sanitizer de Angular recorta un HTML que el
+		// backend ya acotó a su allow-list, y el énfasis de la prosa se pierde sin que nada falle.
+		it('should preserve the markup of the sanitized description', async () => {
 			await render(CollectionInfoPanelComponent, { inputs: { collection: representativeMock } });
 
-			expect(screen.getByTestId('description')).not.toBeEmptyDOMElement();
+			const description = screen.getByTestId('description');
+			expect(description).not.toBeEmptyDOMElement();
+			expect(within(description).getAllByRole('paragraph').length).toBeGreaterThan(0);
 		});
 
 		// Todas las etiquetas del dominio, no la primera: recortar acá escondería en silencio las demás.
+		// El corpus trae una sola por colección, así que el caso se deriva por la factory con tres — con
+		// una, una plantilla que pintara `tags[0]` pasaría igual y el test no probaría nada.
 		it('should render every tag of the collection', async () => {
-			await render(CollectionInfoPanelComponent, { inputs: { collection: representativeMock } });
+			const collection = collectionWithTags(representativeMock, 3);
+			await render(CollectionInfoPanelComponent, { inputs: { collection } });
 
 			const tags = screen.getByTestId('tags');
-			representativeMock.tags.forEach((tag) => expect(within(tags).getByText(tag.title)).toBeInTheDocument());
+			expect(collection.tags).toHaveLength(3);
+			collection.tags.forEach((tag) => expect(within(tags).getByText(tag.title)).toBeInTheDocument());
 		});
 
 		it('should omit the tag list when the collection has none', async () => {

--- a/src/app/components/collection-info-panel/collection-info-panel.component.stories.ts
+++ b/src/app/components/collection-info-panel/collection-info-panel.component.stories.ts
@@ -1,0 +1,126 @@
+import { argsToTemplate, componentWrapperDecorator, Meta, StoryObj } from '@storybook/angular-vite';
+import { CollectionInfoPanelComponent } from './collection-info-panel.component';
+import {
+	onoffCollectionsWithRepresentativeImageryMock,
+	onoffCollectionsWithSampleImageryMock,
+} from '@mocks/onoff-collections.mock';
+
+const [representativeCollection] = onoffCollectionsWithRepresentativeImageryMock;
+const [sampleCollection] = onoffCollectionsWithSampleImageryMock;
+
+const meta: Meta<CollectionInfoPanelComponent> = {
+	title: 'Componentes V3/CollectionInfoPanel',
+	component: CollectionInfoPanelComponent,
+	parameters: {
+		layout: 'centered',
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>El <strong>CollectionInfoPanelComponent</strong> del Design System v3 muestra la información de una colección en una columna: portada, título, etiquetas y descripción.</p><p>Existe porque la página de colección monta ese mismo bloque en <strong>dos lugares</strong> —la barra lateral y el panel deslizable de la descripción—, y tenerlo escrito dos veces garantiza que diverjan. Las diferencias entre los dos montajes se expresan como inputs: el deslizable oculta el título, que su encabezado ya nombra, y no recorta la descripción.</p><p>La portada resuelve las dos formas que declara el dominio: una imagen representativa, o el abanico de tres portadas de obras de la colección. Se compone de <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a> (portadas), <a href="./?path=/docs/componentes-v3-tagslist--docs" target="_top"><strong>TagsList</strong></a> y <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> (etiquetas en variante <code>filled</code>).</p><p>Cuántas líneas se muestran de la descripción lo decide quien lo monta, porque depende del alto disponible en su columna; sin ese dato el panel no recorta. La descripción llega saneada desde el backend y se pinta como HTML. Sin colección, dibuja su propio esqueleto, <strong>CollectionInfoPanelSkeleton</strong>.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		collection: {
+			control: { type: 'object' },
+			description: 'La colección a mostrar. Ausente, el panel dibuja su esqueleto',
+			table: { type: { summary: 'Collection | undefined' } },
+		},
+		showTitle: {
+			control: 'boolean',
+			description: 'Muestra el título de la colección',
+			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'true' } },
+		},
+		descriptionLines: {
+			control: { type: 'number', min: 1, max: 10 },
+			description: 'Líneas visibles de la descripción. Sin valor, se muestra entera',
+			table: { type: { summary: 'number | undefined' }, defaultValue: { summary: 'undefined' } },
+		},
+		priority: {
+			control: 'boolean',
+			description: 'Marca la portada como prioritaria, para cuando el panel entra above-the-fold',
+			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
+		},
+	},
+	// La columna real de la página mide 364 px: fuera de ese ancho no se ve ni el recorte de la
+	// descripción ni el de las etiquetas.
+	decorators: [componentWrapperDecorator((story) => `<div class="w-91">${story}</div>`)],
+};
+
+export default meta;
+type Story = StoryObj<CollectionInfoPanelComponent>;
+
+export const Sidebar: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-collection-info-panel ${argsToTemplate(args)} />`,
+	}),
+	args: {
+		collection: representativeCollection,
+		descriptionLines: 8,
+		priority: true,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El montaje de la barra lateral: título visible, descripción recortada a ocho líneas y portada prioritaria, porque entra above-the-fold.</p><p><strong>Usos:</strong> columna de información de la página de colección.</p>`,
+			},
+		},
+	},
+};
+
+export const Drawer: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-collection-info-panel ${argsToTemplate(args)} />`,
+	}),
+	args: {
+		collection: representativeCollection,
+		showTitle: false,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El montaje del panel deslizable: sin título —su encabezado ya nombra la colección— y sin recorte, porque ahí la descripción se lee entera.</p><p><strong>Usos:</strong> contenido del panel que se abre al pedir "Leer más".</p>`,
+			},
+		},
+	},
+};
+
+export const AbanicoDePortadas: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-collection-info-panel ${argsToTemplate(args)} />`,
+	}),
+	args: {
+		collection: sampleCollection,
+		descriptionLines: 8,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>La colección sin imagen propia resuelve su portada con el abanico de tres portadas de obras que contiene, que es la otra forma que declara el dominio.</p><p><strong>Usos:</strong> colecciones que no tienen una imagen editorial cargada.</p>`,
+			},
+		},
+	},
+};
+
+export const Estados: StoryObj<CollectionInfoPanelComponent & { loading: boolean }> = {
+	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-collection-info-panel [collection]="loading ? undefined : collection" [descriptionLines]="descriptionLines" />`,
+	}),
+	args: {
+		collection: representativeCollection,
+		descriptionLines: 8,
+		loading: true,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El mismo slot alterna entre el panel y su esqueleto con el control <strong>Cargando</strong>: es la forma de comprobar que la sustitución no mueve el layout, que es para lo que el esqueleto existe.</p>`,
+			},
+		},
+	},
+};

--- a/src/app/components/collection-info-panel/collection-info-panel.component.stories.ts
+++ b/src/app/components/collection-info-panel/collection-info-panel.component.stories.ts
@@ -4,9 +4,25 @@ import {
 	onoffCollectionsWithRepresentativeImageryMock,
 	onoffCollectionsWithSampleImageryMock,
 } from '@mocks/onoff-collections.mock';
+import {
+	absurdoTagMock,
+	cuentoTagMock,
+	ensayoTagMock,
+	metaficcionTagMock,
+	novelaTagMock,
+	teatroTagMock,
+} from '@mocks/onoff-tags.mock';
+import { createCollection } from '@models/collection.model';
 
 const [representativeCollection] = onoffCollectionsWithRepresentativeImageryMock;
 const [sampleCollection] = onoffCollectionsWithSampleImageryMock;
+
+// El corpus trae una etiqueta por colección: la variante se deriva por la factory, que es la que hace
+// cumplir las invariantes del agregado.
+const collectionWithManyTags = createCollection({
+	...representativeCollection,
+	tags: [cuentoTagMock, novelaTagMock, ensayoTagMock, teatroTagMock, metaficcionTagMock, absurdoTagMock],
+});
 
 const meta: Meta<CollectionInfoPanelComponent> = {
 	title: 'Componentes V3/CollectionInfoPanel',
@@ -100,6 +116,24 @@ export const AbanicoDePortadas: Story = {
 		docs: {
 			description: {
 				story: `<p>La colección sin imagen propia resuelve su portada con el abanico de tres portadas de obras que contiene, que es la otra forma que declara el dominio.</p><p><strong>Usos:</strong> colecciones que no tienen una imagen editorial cargada.</p>`,
+			},
+		},
+	},
+};
+
+export const VariasEtiquetas: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-collection-info-panel ${argsToTemplate(args)} />`,
+	}),
+	args: {
+		collection: collectionWithManyTags,
+		descriptionLines: 8,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Con varias etiquetas se ve el recorte de <a href="./?path=/docs/componentes-v3-tagslist--docs" target="_top"><strong>TagsList</strong></a>: en esta columna angosta las que no entran se colapsan detrás de un contador. Es la única superficie donde ese comportamiento se puede mirar — depende de medidas reales y el entorno de tests no las computa.</p><p><strong>Usos:</strong> colecciones clasificadas con más de una etiqueta.</p>`,
 			},
 		},
 	},

--- a/src/app/components/collection-info-panel/collection-info-panel.component.ts
+++ b/src/app/components/collection-info-panel/collection-info-panel.component.ts
@@ -54,7 +54,8 @@ import { CollectionInfoPanelSkeletonComponent } from './collection-info-panel-sk
 						<p class="font-inter text-xl leading-7 font-bold text-neutral-900">{{ collection.title }}</p>
 					}
 					@if (collection.tags.length > 0) {
-						<cuentoneta-tags-list data-testid="tags">
+						<!-- Ancho completo: sin él la fila crece con su contenido y desborda la columna en vez de recortarse. -->
+						<cuentoneta-tags-list class="w-full" data-testid="tags">
 							@for (tag of collection.tags; track tag.slug) {
 								<cuentoneta-tag [label]="tag.title" variant="filled" />
 							}
@@ -76,9 +77,12 @@ export class CollectionInfoPanelComponent {
 
 	/** Sin valor, la descripción se muestra entera. */
 	public readonly descriptionLines = input(undefined, {
-		// Acotado a [1, 10] para coincidir con el safelist `line-clamp-{1..10}` de styles.css: la clase se
-		// construye dinámicamente y el escaneo estático de Tailwind no la detecta.
-		transform: (value: number | undefined) => (value === undefined ? undefined : Math.min(10, Math.max(1, value))),
+		// Acotado a los enteros de [1, 10] para coincidir con el safelist `line-clamp-{1..10}` de
+		// styles.css: la clase se construye dinámicamente, el escaneo estático de Tailwind no la detecta,
+		// y un valor fuera de esa forma —un decimal, por caso— produciría una clase inexistente y un
+		// recorte que desaparece sin que nada falle.
+		transform: (value: number | undefined) =>
+			value === undefined ? undefined : Math.min(10, Math.max(1, Math.trunc(value))),
 	});
 
 	/** Marca la portada como prioritaria: en la barra lateral entra above-the-fold. */

--- a/src/app/components/collection-info-panel/collection-info-panel.component.ts
+++ b/src/app/components/collection-info-panel/collection-info-panel.component.ts
@@ -1,0 +1,110 @@
+// Core
+import { Component, computed, inject, input } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+
+// Models
+import type { Collection } from '@models/collection.model';
+
+// Components
+import { CoverImageComponent } from '../cover-image/cover-image.component';
+import { TagComponent } from '../tag/tag.component';
+import { TagsListComponent } from '../tags-list/tags-list.component';
+import { CollectionInfoPanelSkeletonComponent } from './collection-info-panel-skeleton.component';
+
+/**
+ * Panel de información de una colección del Design System v3: portada, título, etiquetas y descripción,
+ * en una columna. Existe porque la página de colección muestra el mismo bloque en dos lugares —la barra
+ * lateral y el panel deslizable—, y tenerlo dos veces garantiza que diverjan.
+ *
+ * La portada resuelve las dos formas que declara el dominio: una imagen representativa, o el abanico de
+ * tres portadas de obras de la colección.
+ *
+ * La descripción llega **saneada desde el backend** y se pinta como HTML; cuántas líneas se muestran lo
+ * decide quien lo monta, porque depende del alto disponible en la columna que lo hospeda. Sin ese dato,
+ * el panel no recorta.
+ *
+ * Sin colección, dibuja su propio esqueleto.
+ */
+@Component({
+	selector: 'cuentoneta-collection-info-panel',
+	imports: [CoverImageComponent, TagComponent, TagsListComponent, CollectionInfoPanelSkeletonComponent],
+	host: { class: 'flex w-full flex-col gap-4' },
+	template: `
+		@if (collection(); as collection) {
+			@if (collection.imagery.kind === 'representative') {
+				<cuentoneta-cover-image [src]="collection.imagery.image" [priority]="priority()" data-testid="cover" />
+			} @else {
+				<section
+					class="relative isolate flex h-48 items-end justify-center overflow-hidden rounded-xl bg-neutral-100 px-3"
+					data-testid="cover-fan"
+				>
+					@for (image of collection.imagery.images; track $index) {
+						<cuentoneta-cover-image
+							[src]="image"
+							[priority]="priority()"
+							[class]="sampleImageClasses[$index]"
+							data-testid="cover"
+						/>
+					}
+				</section>
+			}
+			<div class="flex w-full flex-col gap-4">
+				<div class="flex flex-col items-start gap-2">
+					@if (showTitle()) {
+						<p class="font-inter text-xl leading-7 font-bold text-neutral-900">{{ collection.title }}</p>
+					}
+					@if (collection.tags.length > 0) {
+						<cuentoneta-tags-list data-testid="tags">
+							@for (tag of collection.tags; track tag.slug) {
+								<cuentoneta-tag [label]="tag.title" variant="filled" />
+							}
+						</cuentoneta-tags-list>
+					}
+				</div>
+				<div [innerHTML]="safeDescription()" [class]="descriptionClasses()" data-testid="description"></div>
+			</div>
+		} @else {
+			<cuentoneta-collection-info-panel-skeleton [descriptionLines]="descriptionLines() ?? 4" />
+		}
+	`,
+})
+export class CollectionInfoPanelComponent {
+	public readonly collection = input<Collection>();
+
+	/** El panel deslizable ya nombra la colección en su encabezado, y repetirlo sería anunciarlo dos veces. */
+	public readonly showTitle = input(true);
+
+	/** Sin valor, la descripción se muestra entera. */
+	public readonly descriptionLines = input(undefined, {
+		// Acotado a [1, 10] para coincidir con el safelist `line-clamp-{1..10}` de styles.css: la clase se
+		// construye dinámicamente y el escaneo estático de Tailwind no la detecta.
+		transform: (value: number | undefined) => (value === undefined ? undefined : Math.min(10, Math.max(1, value))),
+	});
+
+	/** Marca la portada como prioritaria: en la barra lateral entra above-the-fold. */
+	public readonly priority = input(false);
+
+	private readonly sanitizer = inject(DomSanitizer);
+
+	// El backend entrega la descripción ya saneada por el pipeline compartido, y el brand del tipo es la
+	// prueba de que pasó por ahí. Sin el bypass, el sanitizer de Angular vuelve a recortar una marcación
+	// que ya está acotada a la allow-list, y el énfasis de la prosa se pierde.
+	protected readonly safeDescription = computed(() => {
+		const collection = this.collection();
+		return collection ? this.sanitizer.bypassSecurityTrustHtml(collection.description) : undefined;
+	});
+
+	protected readonly descriptionClasses = computed(() => {
+		const lines = this.descriptionLines();
+		const base = 'font-inter text-sm leading-5 font-medium text-ellipsis text-neutral-700';
+		return lines === undefined ? base : `${base} line-clamp-${lines}`;
+	});
+
+	// Posiciones de las portadas en visualización múltiple a partir de las imágenes alusivas de las obras
+	// [0] central al frente con bottom-bleed, [1] lateral izquierda y [2] derecha desplazadas, con borde neutral-100.
+	protected readonly sampleImageClasses = [
+		'absolute bottom-[-8px] left-1/2 z-raised -translate-x-1/2 border-[3px] border-neutral-100',
+		'absolute top-[calc(50%_+_39.35px)] left-[calc(50%_-_82.75px)] z-content -translate-x-1/2 -translate-y-1/2 border-[3px] border-neutral-100',
+		'absolute top-[calc(50%_+_39.35px)] left-[calc(50%_+_83.03px)] z-content -translate-x-1/2 -translate-y-1/2 border-[3px] border-neutral-100',
+	] as const;
+}


### PR DESCRIPTION
## Qué resuelve

La página de colección muestra la misma columna —portada, título, etiquetas y descripción— en **dos lugares**: la barra lateral y el panel deslizable de la descripción. Escrita dos veces, la única garantía es que diverjan.

En el blueprint del spike #1826 ya eran **tres** copias: la rama de carga replicaba el bloque a mano con barras grises. Por eso este PR entrega el panel **y su esqueleto co-locado**.

## La API, y por qué cada input existe

```ts
collection = input<Collection>();               // ausente ⇒ esqueleto
showTitle = input(true);                        // el deslizable ya lo nombra en su encabezado
descriptionLines = input<number | undefined>(); // ausente ⇒ sin recorte
priority = input(false);                        // la barra lateral entra above-the-fold
```

Cada uno corresponde a una diferencia real entre los dos montajes. No hay `variant: 'sidebar' | 'drawer'`: eso empaquetaría dos decisiones independientes y clavaría adentro un número de líneas que depende del alto de la columna que hospeda al panel.

## Decisiones a revisar

**1. Recibe el agregado `Collection`, no campos sueltos.** Es como el repo tipa sus componentes contra el dominio —`NavigableCollectionTeaser`, `CollectionTeaserCard`, `LiteraryWorkHeroHeader`—, evita cablear cuatro bindings en cada uno de los dos montajes y conserva las invariantes que la factory hace cumplir. Tampoco se ensancha a `CollectionBase` ni a una unión con el teaser: ningún consumidor lo pide, y es exactamente el movimiento que la rama del spike ya revirtió en su commit `87f2147a`.

**2. Las etiquetas se renderizan todas, no la primera.** El issue las nombra en singular; el diseño muestra una fila. **Gana el diseño, y el dominio lo confirma**: `Collection.tags` es `readonly Tag[]`. El singular describe el blueprint (`collection.tags[0]`), no el modelo — hoy el corpus carga una sola etiqueta por colección, que es de dónde viene la confusión. Recortar en el componente haría desaparecer en silencio la segunda el día que el CMS la cargue.

**3. Dos divergencias deliberadas contra el nodo de Figma**, las dos por usar **TagsList** en vez de una fila propia:

| Diseño | Implementación | Por qué |
| --- | --- | --- |
| `flex-wrap` | Una línea con contador `+N` | El panel vive en una columna de 364 px sobre una descripción recortada por líneas: el `wrap` haría crecer el alto con cada etiqueta, y el alto constante es lo que permite que el esqueleto alinee 1:1 |
| `gap: 4px` | `gap: 6px` | Es el gap del componente de lista ya catalogado. Cambiarlo es una decisión de Design System para todos sus consumidores, no un ajuste por instancia |

**4. El clamp condicional 4/3 del epic no aplica acá.** Verificado contra el blueprint: `[excerptLines]="collection.config.showAuthors ? 3 : 4"` es del extracto de las **tarjetas de obra** del listado, no de la descripción de la colección, que se recorta a 8 líneas sin condición.

## Qué NO entra

**El "Leer más", el drawer y la detección de overflow son de #1835.** El panel no conoce a ninguno de sus dos consumidores: sin output de "leer más", sin `ClampOverflowDirective` y sin `Drawer` entre sus imports.

Lo que sí deja preparado es la forma que #1835 necesita: la descripción es **un único elemento**, recortado **por líneas** y con la clase de clamp computada — las dos precondiciones que el docblock de esa directiva declara. El botón, que debe vivir fuera del elemento observado, entra como hermano cuando #1835 lo agregue.

**Tampoco hay consumidores todavía**: `src/app/pages/collection/` no existe en `develop` — la página la aterriza #1833. La reutilización se garantiza por API y por catálogo; el montaje doble lo hace ese issue.

## Plan de pruebas

**Automatizado — 11 casos** con el corpus de Onoff por selectores de capacidad (`onoffCollectionsWithRepresentativeImageryMock` / `…WithSampleImageryMock`), nunca importando una colección puntual:

- Título presente por defecto y ausente con `showTitle: false` — los dos montajes.
- **Una etiqueta por cada tag del dominio**, y ninguna fila cuando la colección no tiene.
- Descripción no vacía, servida como HTML saneado.
- Portada única con imagery `representative`; **tres portadas dentro del abanico** con `sample`.
- Sin `descriptionLines` no hay ninguna clase `line-clamp-*`; con 8 hay `line-clamp-8`; con 40 se acota a `line-clamp-10`, que es hasta donde llega el safelist de Tailwind.
- Sin colección, el esqueleto y nada del contenido real.

**Gates locales en verde:** `typecheck`, `lint`, `test` (2249), `stylelint`, `build` y `storybook:build`.

**Manual — pendiente de revisión visual.** El recorte `+N` de las etiquetas depende de medidas reales y no se puede evaluar en el entorno de tests: hay que mirar la story en el navegador, en la columna de 364 px. Lo mismo para la alineación entre el panel y su esqueleto, que es lo que la story `Estados` existe para comparar.

Closes #1836

Parte de #1472.
