### PR TITLE
[#2283] - Ensamblar la página de lectura V3 sobre el walking skeleton

### DIFF
--- a/.claude/references/testing.md
+++ b/.claude/references/testing.md
@@ -415,6 +415,10 @@ Por eso cada paquete que el kernel importe tiene que estar declarado como depend
 
 Todo componente nuevo en **`src/app/components/`** lleva su `*.stories.ts` (documentación viva + catálogo visual). Los componentes de página (`src/app/pages/`) están exentos, y también el que **delega toda su vista** en otro componente ya catalogado — las cuatro condiciones de esa excepción, y su verificación, viven en [`coding-agent-policies.md`](coding-agent-policies.md) (Sección 2), que es su fuente. El `*.spec.ts` no se exime en ninguno de los dos casos.
 
+**La exención de las páginas es un permiso, no una prohibición.** Una página _puede_ catalogarse cuando lo que se quiere mirar es el **ensamblado**: cómo conviven sus bloques a lo largo del scroll, y cómo responde a los parámetros con que la ruta la invoca. Esas entradas van bajo la sección **`Páginas/`**, separadas del catálogo de componentes, y se montan con `applicationConfig` sobre los dobles de sus proveedores, resolviendo **por el mismo parámetro que resuelve la ruta** —el slug— en vez de devolver siempre el mismo dato: así los controles mueven la página de verdad y los estados de borde (una obra inexistente, un contexto ausente) quedan alcanzables desde el propio catálogo.
+
+`ReadPage` es la primera. Lo que la hizo valer el catálogo es que ninguna otra vista permite evaluar el bloque de sugerencias contra los dos contextos de navegación sin levantar la aplicación entera.
+
 ### Convenciones (según las stories existentes)
 
 - `title` en español bajo `Componentes V3/...` (p. ej. `'Componentes V3/Tag'`).

--- a/src/app/components/literary-work-card-teaser/literary-work-card-teaser.component.spec.ts
+++ b/src/app/components/literary-work-card-teaser/literary-work-card-teaser.component.spec.ts
@@ -12,7 +12,7 @@ import type { LiteraryWorkTeaser } from '@models/literary-work.model';
 import type { NavigationParams } from '@app-utils/navigation-params';
 
 describe('LiteraryWorkCardTeaserComponent', () => {
-	const literaryWorkUrl = '/story/el-palacio-de-las-nueve-fronteras?navigation=author&navigationSlug=francois-onoff';
+	const literaryWorkUrl = '/read/el-palacio-de-las-nueve-fronteras?navigation=author&navigationSlug=francois-onoff';
 	const authorUrl = '/author/francois-onoff';
 
 	let navigationParams: NavigationParams = { navigation: 'author', navigationSlug: '' };
@@ -51,7 +51,7 @@ describe('LiteraryWorkCardTeaserComponent', () => {
 		await render(LiteraryWorkCardTeaserComponent, {
 			inputs: { literaryWork: palacioNueveFronterasLiteraryWorkTeaserMock, navigationParams },
 		});
-		const link = screen.getAllByRole('link').find((l) => l.getAttribute('href')?.includes('/story/'));
+		const link = screen.getAllByRole('link').find((l) => l.getAttribute('href')?.includes('/read/'));
 		expect(link?.getAttribute('href')).toContain(literaryWorkUrl);
 	});
 
@@ -159,7 +159,7 @@ describe('LiteraryWorkCardTeaserComponent', () => {
 			expect(screen.getByTestId('cover-image')).toBeInTheDocument();
 			const links = screen.getAllByRole('link');
 			expect(links).toHaveLength(1);
-			expect(links[0]).toHaveAttribute('href', expect.stringContaining('/story/'));
+			expect(links[0]).toHaveAttribute('href', expect.stringContaining('/read/'));
 		});
 	});
 

--- a/src/app/components/literary-work-card-teaser/literary-work-card-teaser.component.ts
+++ b/src/app/components/literary-work-card-teaser/literary-work-card-teaser.component.ts
@@ -177,7 +177,7 @@ export class LiteraryWorkCardTeaserComponent {
 	public readonly navigationParams = input<NavigationParams>();
 
 	protected readonly coverImageUrl = computed(() => this.literaryWork()?.coverImage);
-	protected readonly literaryWorkRouterLink = computed(() => ['/', this.appRoutes.Story, this.literaryWork()?.slug]);
+	protected readonly literaryWorkRouterLink = computed(() => ['/', this.appRoutes.Read, this.literaryWork()?.slug]);
 
 	// Mapea la variante de la tarjeta al tema visual de los selectores de multimedia.
 	protected readonly mediaTheme = computed<MediaSelectorsTheme>(() => {

--- a/src/app/components/literary-work-home-card-teaser/literary-work-home-card-teaser.component.spec.ts
+++ b/src/app/components/literary-work-home-card-teaser/literary-work-home-card-teaser.component.spec.ts
@@ -12,7 +12,7 @@ import type { LiteraryWorkTeaser } from '@models/literary-work.model';
 import type { NavigationParams } from '@app-utils/navigation-params';
 
 describe('LiteraryWorkHomeCardTeaserComponent', () => {
-	const literaryWorkUrl = '/story/el-palacio-de-las-nueve-fronteras?navigation=author&navigationSlug=francois-onoff';
+	const literaryWorkUrl = '/read/el-palacio-de-las-nueve-fronteras?navigation=author&navigationSlug=francois-onoff';
 	const authorUrl = '/author/francois-onoff';
 
 	let navigationParams: NavigationParams = { navigation: 'author', navigationSlug: '' };
@@ -51,7 +51,7 @@ describe('LiteraryWorkHomeCardTeaserComponent', () => {
 		await render(LiteraryWorkHomeCardTeaserComponent, {
 			inputs: { literaryWork: palacioNueveFronterasLiteraryWorkTeaserMock, navigationParams },
 		});
-		const link = screen.getAllByRole('link').find((l) => l.getAttribute('href')?.includes('/story/'));
+		const link = screen.getAllByRole('link').find((l) => l.getAttribute('href')?.includes('/read/'));
 		expect(link?.getAttribute('href')).toContain(literaryWorkUrl);
 	});
 

--- a/src/app/components/literary-work-home-card-teaser/literary-work-home-card-teaser.component.ts
+++ b/src/app/components/literary-work-home-card-teaser/literary-work-home-card-teaser.component.ts
@@ -115,5 +115,5 @@ export class LiteraryWorkHomeCardTeaserComponent {
 	public readonly navigationParams = input<NavigationParams>();
 
 	protected readonly coverImageUrl = computed(() => this.literaryWork()?.coverImage);
-	protected readonly literaryWorkRouterLink = computed(() => ['/', this.appRoutes.Story, this.literaryWork()?.slug]);
+	protected readonly literaryWorkRouterLink = computed(() => ['/', this.appRoutes.Read, this.literaryWork()?.slug]);
 }

--- a/src/app/components/literary-work-home-card-teaser/literary-work-home-card-teaser.component.ts
+++ b/src/app/components/literary-work-home-card-teaser/literary-work-home-card-teaser.component.ts
@@ -22,7 +22,7 @@ import { LiteraryWorkHomeCardTeaserSkeletonComponent } from './literary-work-hom
  *
  * Patrón de tarjeta clickeable (sin wrapper `<a>`): el enlace de la obra se estira con un
  * pseudo-elemento (`after:absolute after:inset-0`) para cubrir toda la tarjeta, de modo que cualquier
- * sección navega a `/story/:slug`. El bloque del autor es un enlace propio elevado a `z-content`, por
+ * sección navega a `/read/:slug`. El bloque del autor es un enlace propio elevado a `z-content`, por
  * encima del pseudo-elemento, para que la foto y el nombre naveguen a `/author/:slug`.
  */
 @Component({

--- a/src/app/components/media-widget-selector/media-widget-selector-skeleton.component.ts
+++ b/src/app/components/media-widget-selector/media-widget-selector-skeleton.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+
+import { SkeletonComponent } from '@components/skeleton/skeleton.component';
+
+/**
+ * Esqueleto de carga de `MediaWidgetSelector`. Reserva el alto del bloque —título, fila de formatos
+ * y widget— para que su llegada no empuje al cuerpo de la obra.
+ *
+ * Dibuja el caso general, el de una obra con varios formatos: es el que ocupa más alto, y reservar de
+ * menos hace saltar el layout mientras que reservar de más solo deja un hueco que se llena.
+ */
+@Component({
+	selector: 'cuentoneta-media-widget-selector-skeleton',
+	imports: [SkeletonComponent],
+	host: { class: 'block' },
+	template: `
+		<div class="flex flex-col gap-5">
+			<cuentoneta-skeleton class="h-7 w-2/3 bg-neutral-200" />
+			<cuentoneta-skeleton appearance="square" class="h-10 w-48 rounded-full bg-neutral-200" />
+			<cuentoneta-skeleton appearance="square" class="h-52 w-full rounded-xl bg-neutral-200" />
+		</div>
+	`,
+})
+export class MediaWidgetSelectorSkeleton {}

--- a/src/app/components/media-widget-selector/media-widget-selector.component.stories.ts
+++ b/src/app/components/media-widget-selector/media-widget-selector.component.stories.ts
@@ -1,4 +1,6 @@
-import { argsToTemplate, type Meta, type StoryObj } from '@storybook/angular-vite';
+import { argsToTemplate, moduleMetadata, type Meta, type StoryObj } from '@storybook/angular-vite';
+
+import { MediaWidgetSelectorSkeleton } from './media-widget-selector-skeleton.component';
 
 import { MediaWidgetSelector } from './media-widget-selector.component';
 import {
@@ -70,6 +72,42 @@ export const TipoRepetido: Story = {
 		docs: {
 			description: {
 				story: `<p>El caso que el diseño no modela: dos recursos del mismo tipo. Los botones de audio se rotulan con el <strong>título de cada medio</strong> en lugar del nombre del formato, que los volvería indistinguibles; los tipos que aparecen una sola vez conservan el nombre del formato.</p><p><strong>Usos:</strong> ninguno todavía — es el caso que habilita el enriquecimiento del corpus previsto para las obras con multimedia repetida.</p>`,
+			},
+		},
+	},
+};
+
+export const Skeleton: StoryObj = {
+	decorators: [moduleMetadata({ imports: [MediaWidgetSelectorSkeleton] })],
+	render: () => ({ template: `<cuentoneta-media-widget-selector-skeleton />` }),
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Esqueleto de carga del bloque. Dibuja el caso general —el de una obra con varios formatos—, que es el que ocupa más alto: reservar de menos hace saltar el layout, y reservar de más solo deja un hueco que se llena.</p><p><strong>Usos:</strong> el marcador de posición del bloque diferido en la página de lectura.</p>`,
+			},
+		},
+	},
+};
+
+export const Estados: StoryObj<MediaWidgetSelector & { loading: boolean }> = {
+	decorators: [moduleMetadata({ imports: [MediaWidgetSelectorSkeleton] })],
+	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
+	render: (args) => ({
+		props: args,
+		template: `
+			@if (loading) {
+				<cuentoneta-media-widget-selector-skeleton />
+			} @else {
+				<cuentoneta-media-widget-selector [mediaSources]="mediaSources" />
+			}
+		`,
+	}),
+	args: { loading: true, mediaSources: multipleSourcesWork.mediaSources },
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Activá/desactivá "Cargando" para alternar entre el estado real y el esqueleto, y evaluar la alineación entre los dos.',
 			},
 		},
 	},

--- a/src/app/components/reading-suggestions/author-reading-suggestions.component.spec.ts
+++ b/src/app/components/reading-suggestions/author-reading-suggestions.component.spec.ts
@@ -208,7 +208,7 @@ describe('AuthorReadingSuggestionsComponent', () => {
 
 		expect(screen.getByRole('link', { name: suggestion.title })).toHaveAttribute(
 			'href',
-			`/story/${suggestion.slug}?navigation=author&navigationSlug=${authorTeaserMock.slug}`,
+			`/read/${suggestion.slug}?navigation=author&navigationSlug=${authorTeaserMock.slug}`,
 		);
 	});
 

--- a/src/app/components/reading-suggestions/collection-reading-suggestions.component.spec.ts
+++ b/src/app/components/reading-suggestions/collection-reading-suggestions.component.spec.ts
@@ -128,7 +128,7 @@ describe('CollectionReadingSuggestionsComponent', () => {
 
 		expect(screen.getByRole('link', { name: suggestion.title })).toHaveAttribute(
 			'href',
-			`/story/${suggestion.slug}?navigation=storylist&navigationSlug=${collectionMock.slug}`,
+			`/story/${suggestion.slug}?navigation=collection&navigationSlug=${collectionMock.slug}`,
 		);
 	});
 

--- a/src/app/components/reading-suggestions/collection-reading-suggestions.component.spec.ts
+++ b/src/app/components/reading-suggestions/collection-reading-suggestions.component.spec.ts
@@ -128,7 +128,7 @@ describe('CollectionReadingSuggestionsComponent', () => {
 
 		expect(screen.getByRole('link', { name: suggestion.title })).toHaveAttribute(
 			'href',
-			`/story/${suggestion.slug}?navigation=collection&navigationSlug=${collectionMock.slug}`,
+			`/read/${suggestion.slug}?navigation=collection&navigationSlug=${collectionMock.slug}`,
 		);
 	});
 

--- a/src/app/components/reading-suggestions/collection-reading-suggestions.component.ts
+++ b/src/app/components/reading-suggestions/collection-reading-suggestions.component.ts
@@ -80,7 +80,7 @@ export class CollectionReadingSuggestionsComponent {
 	protected readonly moreLabel = computed(() => `Ver más de ${this.title()}`);
 	protected readonly moreRoute = computed(() => ['/', this.appRoutes.StoryList, this.collectionSlug()]);
 	protected readonly navigationParams = computed<NavigationParams>(() => ({
-		navigation: 'storylist',
+		navigation: 'collection',
 		navigationSlug: this.collectionSlug(),
 	}));
 }

--- a/src/app/components/reading-suggestions/reading-suggestions-list.component.stories.ts
+++ b/src/app/components/reading-suggestions/reading-suggestions-list.component.stories.ts
@@ -63,10 +63,10 @@ type Story = StoryObj<ReadingSuggestionsListComponent & { navigation: Navigation
 const navigationArgTypes = {
 	navigation: {
 		control: { type: 'select' as const },
-		options: ['author', 'storylist'],
+		options: ['author', 'collection'],
 		name: 'navigation (query param)',
 		description: 'Contexto con el que se llegó a la obra; viaja en el enlace de cada sugerencia',
-		table: { type: { summary: "'author' | 'storylist'" } },
+		table: { type: { summary: "'author' | 'collection'" } },
 	},
 	navigationSlug: {
 		control: { type: 'text' as const },
@@ -129,7 +129,7 @@ export const PorColeccion: Story = {
 		teasers: suggestions,
 		moreLabel: 'Ver más de Geometrías del desvelo',
 		moreRoute: ['/', 'storylist', 'geometrias-del-desvelo'],
-		navigation: 'storylist',
+		navigation: 'collection',
 		navigationSlug: 'geometrias-del-desvelo',
 		showAuthor: true,
 		loading: false,

--- a/src/app/components/reading-suggestions/reading-suggestions.component.spec.ts
+++ b/src/app/components/reading-suggestions/reading-suggestions.component.spec.ts
@@ -64,7 +64,7 @@ describe('ReadingSuggestionsComponent', () => {
 	});
 
 	it('should mount the collection variant, and only that one', async () => {
-		const { fixture } = await setup({ navigation: 'storylist', navigationSlug: collectionMock.slug });
+		const { fixture } = await setup({ navigation: 'collection', navigationSlug: collectionMock.slug });
 
 		await renderDeferBlocks(fixture);
 
@@ -84,7 +84,7 @@ describe('ReadingSuggestionsComponent', () => {
 	});
 
 	it('should hand the collection variant the slug it has to fetch by', async () => {
-		const { fixture } = await setup({ navigation: 'storylist', navigationSlug: collectionMock.slug });
+		const { fixture } = await setup({ navigation: 'collection', navigationSlug: collectionMock.slug });
 
 		await renderDeferBlocks(fixture);
 

--- a/src/app/components/reading-suggestions/reading-suggestions.component.spec.ts
+++ b/src/app/components/reading-suggestions/reading-suggestions.component.spec.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
-import { DeferBlockState, type ComponentFixture } from '@angular/core/testing';
+import { renderDeferBlocks } from '@testing/defer-blocks';
 import { of } from 'rxjs';
 
 import { ReadingSuggestionsComponent } from './reading-suggestions.component';
@@ -27,12 +27,6 @@ const setup = async (navigationParams: NavigationParams) =>
 			{ provide: StorylistApi, useValue: { get: () => of(collectionMock) } },
 		],
 	});
-
-const renderDeferBlocks = async (fixture: ComponentFixture<ReadingSuggestionsComponent>) => {
-	for (const deferBlock of await fixture.getDeferBlocks()) {
-		await deferBlock.render(DeferBlockState.Complete);
-	}
-};
 
 describe('ReadingSuggestionsComponent', () => {
 	beforeEach(() => {

--- a/src/app/components/reading-suggestions/reading-suggestions.component.ts
+++ b/src/app/components/reading-suggestions/reading-suggestions.component.ts
@@ -18,7 +18,7 @@ import type { NavigationParams } from '@app-utils/navigation-params';
 	host: { class: 'block' },
 	template: `
 		@switch (navigationParams().navigation) {
-			@case ('storylist') {
+			@case ('collection') {
 				@defer (on viewport) {
 					<cuentoneta-collection-reading-suggestions
 						[collectionSlug]="navigationParams().navigationSlug"

--- a/src/app/pages/read/read-page-skeleton.component.ts
+++ b/src/app/pages/read/read-page-skeleton.component.ts
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+
+import { DividerComponent } from '@components/divider/divider.component';
+import { LiteraryWorkHeroHeaderComponent } from '@components/literary-work-hero-header/literary-work-hero-header.component';
+import { SkeletonComponent } from '@components/skeleton/skeleton.component';
+
+/**
+ * Silueta de carga de la página de lectura: el hero, la barra de lectura y las primeras líneas del
+ * cuerpo. Vive junto a la página y no en el catálogo compartido porque reproduce **su** disposición,
+ * que no sirve a ninguna otra pantalla.
+ *
+ * El hero dibuja su propio esqueleto cuando no recibe obra, así que se lo monta tal cual en vez de
+ * reproducir su silueta acá.
+ */
+@Component({
+	selector: 'cuentoneta-read-page-skeleton',
+	imports: [DividerComponent, LiteraryWorkHeroHeaderComponent, SkeletonComponent],
+	host: { class: 'block w-full' },
+	template: `
+		<header class="flex flex-col gap-2">
+			<cuentoneta-literary-work-hero-header />
+		</header>
+		<section class="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-8">
+			<div class="flex flex-col gap-7 pt-7">
+				<div class="flex items-center justify-between">
+					<cuentoneta-skeleton class="h-4 w-32 bg-neutral-200" />
+					<cuentoneta-skeleton appearance="square" class="h-8 w-24 rounded-full bg-neutral-200" />
+				</div>
+				<cuentoneta-divider />
+			</div>
+			@for (line of bodyLines; track $index) {
+				<cuentoneta-skeleton class="h-5 w-full bg-neutral-200" />
+			}
+		</section>
+	`,
+})
+export class ReadPageSkeleton {
+	// Silueta de carga, no una medida del texto real: el largo del cuerpo recién se conoce cuando la
+	// obra llegó.
+	protected readonly bodyLines = Array.from({ length: 8 });
+}

--- a/src/app/pages/read/read.page.html
+++ b/src/app/pages/read/read.page.html
@@ -4,14 +4,31 @@
 		<cuentoneta-literary-work-hero-header [literaryWork]="literaryWork" />
 	</header>
 	<section class="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-8">
-		<div class="flex justify-between pt-7">
-			<span class="font-inter text-xs font-semibold">{{ literaryWork.totalReadingTime }} minutos de lectura</span>
-			<button cuentoneta-button variant="outline">Compartir</button>
+		<div class="flex flex-col gap-7 pt-7">
+			<div class="flex items-center justify-between">
+				<span class="font-inter text-xs font-semibold">{{ literaryWork.totalReadingTime }} minutos de lectura</span>
+				<button cuentoneta-button variant="subtle" size="xs">Compartir</button>
+			</div>
+			<cuentoneta-divider />
 		</div>
 
+		<!--
+			El `@if` es lo que evita descargar el chunk del bloque: dentro de un `@defer` sin guarda, el
+			disparador lo pediría igual aunque el bloque no fuera a dibujar nada. La condición equivale a
+			la que el bloque evalúa por dentro, porque ofrece una opción por recurso.
+			El diferido es plano a propósito: deja el bloque fuera del HTML servido, que es contenido
+			complementario y no el cuerpo de la obra.
+		-->
+		@if (literaryWork.mediaSources.length > 0) { @defer (on idle) {
 		<cuentoneta-media-widget-selector [mediaSources]="literaryWork.mediaSources" />
-
-		@for (section of sections(); track section.position) {
+		} @placeholder {
+		<!-- Reserva el alto del bloque —título, fila de formatos y widget— para que su llegada no empuje el cuerpo. -->
+		<div class="flex flex-col gap-5">
+			<cuentoneta-skeleton class="h-7 w-2/3 bg-neutral-200" />
+			<cuentoneta-skeleton class="h-10 w-48 rounded-full bg-neutral-200" appearance="square" />
+			<cuentoneta-skeleton class="h-52 w-full rounded-xl bg-neutral-200" appearance="square" />
+		</div>
+		} } @for (section of sections(); track section.position) {
 
 		<section class="flex flex-col gap-4">
 			@if (section.title) {
@@ -28,12 +45,42 @@
 
 		}
 	</section>
+
+	<!-- Se monta bajo el `@if` de la obra: sin obra no hay autor de reserva y el bloque pediría sugerencias de un slug vacío. -->
+	<section class="mx-auto flex w-full max-w-3xl flex-col px-4 pb-12">
+		<cuentoneta-reading-suggestions
+			[navigationParams]="navigationParams()"
+			[authorName]="primaryAuthorName()"
+			[currentWorkSlug]="literaryWork.slug"
+		/>
+	</section>
 </article>
 } @else if (notFound()) {
-<section class="mx-auto flex w-full max-w-3xl flex-col gap-4 px-4 py-8">
+<section class="mx-auto flex w-full max-w-3xl flex-col items-start gap-4 px-4 py-8">
 	<h1>No encontramos esta obra</h1>
 	<p>La obra que buscás no existe o ya no está disponible.</p>
+	<a [routerLink]="['/']" cuentoneta-button variant="outline">Volver al inicio</a>
 </section>
 } @else {
-<p class="mx-auto w-full max-w-3xl px-4 py-8">Cargando…</p>
+<!--
+	El esqueleto se pinta con `@if`/`@else` planos y nunca dentro de un `@defer`: el recurso bloquea el
+	render del servidor, así que al serializar la obra ya está y el crawler recibe el cuerpo real.
+-->
+<article class="w-full">
+	<header class="flex flex-col gap-2">
+		<cuentoneta-literary-work-hero-header />
+	</header>
+	<section class="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-8">
+		<div class="flex flex-col gap-7 pt-7">
+			<div class="flex items-center justify-between">
+				<cuentoneta-skeleton class="h-4 w-32 bg-neutral-200" />
+				<cuentoneta-skeleton class="h-8 w-24 rounded-full bg-neutral-200" appearance="square" />
+			</div>
+			<cuentoneta-divider />
+		</div>
+		@for (line of bodyPlaceholderLines; track $index) {
+		<cuentoneta-skeleton class="h-5 w-full bg-neutral-200" />
+		}
+	</section>
+</article>
 }

--- a/src/app/pages/read/read.page.html
+++ b/src/app/pages/read/read.page.html
@@ -18,14 +18,23 @@
 			la que el bloque evalúa por dentro, porque ofrece una opción por recurso.
 			El diferido es plano a propósito: deja el bloque fuera del HTML servido, que es contenido
 			complementario y no el cuerpo de la obra.
+			El disparador es `on idle` y no `on viewport` porque el ahorro ya lo hace el `@if`: en una obra
+			con recursos el bloque se va a mostrar igual, y `on viewport` dispararía en el primer render
+			—está a media página— compitiendo con la hidratación en vez de esperar a que el hilo se libere.
 		-->
 		@if (literaryWork.mediaSources.length > 0) { @defer (on idle) {
 		<cuentoneta-media-widget-selector [mediaSources]="literaryWork.mediaSources" />
 		} @placeholder {
-		<!-- Reserva el alto del bloque —título, fila de formatos y widget— para que su llegada no empuje el cuerpo. -->
-		<div class="flex flex-col gap-5">
+		<!--
+			Reserva el alto del bloque para que su llegada no empuje el cuerpo. La fila de formatos se
+			reserva solo cuando hay entre qué elegir, que es la misma condición con la que el bloque la
+			dibuja: reservarla siempre haría saltar el layout justo en las obras de un único recurso.
+		-->
+		<div class="flex flex-col gap-5" data-testid="media-formats-placeholder">
 			<cuentoneta-skeleton class="h-7 w-2/3 bg-neutral-200" />
+			@if (literaryWork.mediaSources.length > 1) {
 			<cuentoneta-skeleton class="h-10 w-48 rounded-full bg-neutral-200" appearance="square" />
+			}
 			<cuentoneta-skeleton class="h-52 w-full rounded-xl bg-neutral-200" appearance="square" />
 		</div>
 		} } @for (section of sections(); track section.position) {

--- a/src/app/pages/read/read.page.html
+++ b/src/app/pages/read/read.page.html
@@ -25,18 +25,7 @@
 		@if (literaryWork.mediaSources.length > 0) { @defer (on idle) {
 		<cuentoneta-media-widget-selector [mediaSources]="literaryWork.mediaSources" />
 		} @placeholder {
-		<!--
-			Reserva el alto del bloque para que su llegada no empuje el cuerpo. La fila de formatos se
-			reserva solo cuando hay entre qué elegir, que es la misma condición con la que el bloque la
-			dibuja: reservarla siempre haría saltar el layout justo en las obras de un único recurso.
-		-->
-		<div class="flex flex-col gap-5" data-testid="media-formats-placeholder">
-			<cuentoneta-skeleton class="h-7 w-2/3 bg-neutral-200" />
-			@if (literaryWork.mediaSources.length > 1) {
-			<cuentoneta-skeleton class="h-10 w-48 rounded-full bg-neutral-200" appearance="square" />
-			}
-			<cuentoneta-skeleton class="h-52 w-full rounded-xl bg-neutral-200" appearance="square" />
-		</div>
+		<cuentoneta-media-widget-selector-skeleton data-testid="media-formats-placeholder" />
 		} } @for (section of sections(); track section.position) {
 
 		<section class="flex flex-col gap-4">
@@ -75,21 +64,5 @@
 	El esqueleto se pinta con `@if`/`@else` planos y nunca dentro de un `@defer`: el recurso bloquea el
 	render del servidor, así que al serializar la obra ya está y el crawler recibe el cuerpo real.
 -->
-<article class="w-full">
-	<header class="flex flex-col gap-2">
-		<cuentoneta-literary-work-hero-header />
-	</header>
-	<section class="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-8">
-		<div class="flex flex-col gap-7 pt-7">
-			<div class="flex items-center justify-between">
-				<cuentoneta-skeleton class="h-4 w-32 bg-neutral-200" />
-				<cuentoneta-skeleton class="h-8 w-24 rounded-full bg-neutral-200" appearance="square" />
-			</div>
-			<cuentoneta-divider />
-		</div>
-		@for (line of bodyPlaceholderLines; track $index) {
-		<cuentoneta-skeleton class="h-5 w-full bg-neutral-200" />
-		}
-	</section>
-</article>
+<cuentoneta-read-page-skeleton />
 }

--- a/src/app/pages/read/read.page.spec.ts
+++ b/src/app/pages/read/read.page.spec.ts
@@ -1,5 +1,6 @@
 // Core
 import { RESPONSE_INIT } from '@angular/core';
+import { DeferBlockState, type DeferBlockFixture } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 
 // 3rd party modules
@@ -24,6 +25,10 @@ import {
 	onoffLiteraryWorksWithSectionTitles,
 } from '@mocks/onoff-literary-works.mock';
 import { provideLiteraryWorkApiMock, StubLiteraryWorkApi } from '../../providers/literary-work.mock';
+import { storylistMock } from '@mocks/storylist.mock';
+import { provideStoryApiMock } from '../../providers/story.mock';
+import { provideStorylistApiMock } from '../../providers/storylist.mock';
+import { provideRouter } from '@angular/router';
 import type { LiteraryWorkApi } from '../../providers/literary-work.provider';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
@@ -103,6 +108,19 @@ const literaryWorkWithMaliciousBody = (base: LiteraryWork): LiteraryWork => {
 	});
 };
 
+// Los bloques diferidos de la página anidan: el de las sugerencias monta un despachador que difiere a
+// su vez cada variante, así que resolver solo el primer nivel dejaría la variante sin renderizar.
+// El fixture de la página y el de un bloque diferido comparten esta operación, que es lo único que la
+// recursión necesita de cada uno.
+type DeferBlockHost = { getDeferBlocks(): Promise<DeferBlockFixture[]> };
+
+const renderDeferBlocks = async (host: DeferBlockHost): Promise<void> => {
+	for (const deferBlock of await host.getDeferBlocks()) {
+		await deferBlock.render(DeferBlockState.Complete);
+		await renderDeferBlocks(deferBlock);
+	}
+};
+
 // TODO(#1471): al implementar la ReadPage V3 completa, expandir estos tests con las variantes de media,
 // la sección "Más cuentos" y el layout V3, reemplazando los casos transitorios de abajo.
 //
@@ -110,14 +128,28 @@ const literaryWorkWithMaliciousBody = (base: LiteraryWork): LiteraryWork => {
 describe('ReadPage', () => {
 	const setup = async (
 		literaryWork: LiteraryWork,
-		options: { api?: LiteraryWorkApi; responseInit?: ResponseInit } = {},
+		options: {
+			api?: LiteraryWorkApi;
+			responseInit?: ResponseInit;
+			navigation?: string;
+			navigationSlug?: string;
+		} = {},
 	) => {
 		return await render(ReadPage, {
 			providers: [
 				provideLiteraryWorkApiMock(options.api ?? new StubLiteraryWorkApi(literaryWork)),
+				// La tríada de sugerencias resuelve sus datos por su cuenta; esta página solo le pasa el
+				// contexto. Reapuntarla a los endpoints de LiteraryWork es trabajo de otro issue.
+				provideStoryApiMock(),
+				provideStorylistApiMock(),
+				provideRouter([]),
 				...(options.responseInit ? [{ provide: RESPONSE_INIT, useValue: options.responseInit }] : []),
 			],
-			inputs: { slug: literaryWork.slug },
+			inputs: {
+				slug: literaryWork.slug,
+				...(options.navigation ? { navigation: options.navigation } : {}),
+				...(options.navigationSlug ? { navigationSlug: options.navigationSlug } : {}),
+			},
 		});
 	};
 
@@ -272,17 +304,80 @@ describe('ReadPage', () => {
 		const [workWithoutFormats] = onoffLiteraryWorksWithoutMediaSources;
 
 		it('ofrece los formatos de una obra que trae varios', async () => {
-			await setup(workWithFormats);
+			const { fixture } = await setup(workWithFormats);
+
+			await renderDeferBlocks(fixture);
 
 			expect(screen.getByRole('heading', { name: /diferentes formatos/i })).toBeInTheDocument();
 			expect(screen.getByRole('group', { name: 'Formatos disponibles' })).toBeInTheDocument();
 		});
 
+		// Lo que saca al bloque del HTML servido: en el primer render no está, y llega recién cuando el
+		// diferido se resuelve. Sin este caso, el `@defer` se podría perder sin que nada lo note.
+		it('no forma parte del render inicial', async () => {
+			await setup(workWithFormats);
+
+			expect(screen.queryByRole('heading', { name: /diferentes formatos/i })).not.toBeInTheDocument();
+			expect(screen.queryByRole('group', { name: 'Formatos disponibles' })).not.toBeInTheDocument();
+		});
+
+		// La aserción de que el chunk no se pide. Las sugerencias de lectura también viven en un bloque
+		// diferido y están siempre, así que el conteo es lo que distingue si el de formatos llegó a
+		// declararse: con recursos son dos, sin ellos queda solo el de sugerencias.
+		it('declara el bloque diferido de formatos cuando la obra trae recursos', async () => {
+			const { fixture } = await setup(workWithFormats);
+
+			expect(await fixture.getDeferBlocks()).toHaveLength(2);
+		});
+
+		it('no declara el bloque diferido de formatos cuando la obra no trae multimedia', async () => {
+			const { fixture } = await setup(workWithoutFormats);
+
+			expect(await fixture.getDeferBlocks()).toHaveLength(1);
+		});
+
 		it('no dibuja el bloque cuando la obra no trae multimedia', async () => {
-			await setup(workWithoutFormats);
+			const { fixture } = await setup(workWithoutFormats);
+
+			await renderDeferBlocks(fixture);
 
 			expect(screen.queryByRole('heading', { name: /formatos?/i })).not.toBeInTheDocument();
 			expect(screen.queryByRole('group', { name: 'Formatos disponibles' })).not.toBeInTheDocument();
+		});
+	});
+
+	// La página transporta el contexto de navegación y elige con él la variante; qué sugiere cada
+	// variante lo cubre el spec del despachador. Se afirma por el encabezado que cada una escribe,
+	// que es lo observable de haber elegido bien.
+	describe('sugerencias de lectura', () => {
+		const [work] = onoffLiteraryWorksSingleSection;
+
+		// Las dos variantes encabezan con "Más obras de …", así que lo que distingue a cuál se eligió es
+		// el nombre: el de la colección o el del autor.
+		it('ofrece las de la colección cuando se entró desde una', async () => {
+			const { fixture } = await setup(work, { navigation: 'collection', navigationSlug: storylistMock.slug });
+
+			await renderDeferBlocks(fixture);
+
+			expect(screen.getByRole('heading', { name: `Más obras de ${storylistMock.title}` })).toBeInTheDocument();
+		});
+
+		it('ofrece las del autor cuando se entró desde su listado', async () => {
+			const { fixture } = await setup(work, { navigation: 'author', navigationSlug: work.authors[0].slug });
+
+			await renderDeferBlocks(fixture);
+
+			expect(screen.getByRole('heading', { name: `Más obras de ${work.authors[0].name}` })).toBeInTheDocument();
+		});
+
+		// Una obra abierta por URL directa no trae contexto, y aun así tiene que ofrecer a dónde seguir:
+		// se cae al autor de la propia obra.
+		it('cae en las del autor de la obra cuando no hay contexto en la ruta', async () => {
+			const { fixture } = await setup(work);
+
+			await renderDeferBlocks(fixture);
+
+			expect(screen.getByRole('heading', { name: `Más obras de ${work.authors[0].name}` })).toBeInTheDocument();
 		});
 	});
 

--- a/src/app/pages/read/read.page.spec.ts
+++ b/src/app/pages/read/read.page.spec.ts
@@ -297,8 +297,9 @@ describe('ReadPage', () => {
 			expect(screen.getByRole('group', { name: 'Formatos disponibles' })).toBeInTheDocument();
 		});
 
-		// Lo que saca al bloque del HTML servido: en el primer render no está, y llega recién cuando el
-		// diferido se resuelve. Sin este caso, el `@defer` se podría perder sin que nada lo note.
+		// El bloque no está en el primer render y llega recién cuando el diferido se resuelve. No es una
+		// prueba de lo que sirve el servidor —el entorno de tests no renderiza en servidor—, sino de que
+		// el diferido sigue en su lugar: sin este caso, sacarlo no rompería nada.
 		it('no forma parte del render inicial', async () => {
 			await setup(workWithFormats);
 

--- a/src/app/pages/read/read.page.spec.ts
+++ b/src/app/pages/read/read.page.spec.ts
@@ -1,7 +1,7 @@
 // Core
 import { RESPONSE_INIT } from '@angular/core';
-import { DeferBlockState, type DeferBlockFixture } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
+import { renderDeferBlocks } from '@testing/defer-blocks';
 
 // 3rd party modules
 import { render, screen, within } from '@testing-library/angular';
@@ -108,23 +108,8 @@ const literaryWorkWithMaliciousBody = (base: LiteraryWork): LiteraryWork => {
 	});
 };
 
-// Los bloques diferidos de la página anidan: el de las sugerencias monta un despachador que difiere a
-// su vez cada variante, así que resolver solo el primer nivel dejaría la variante sin renderizar.
-// El fixture de la página y el de un bloque diferido comparten esta operación, que es lo único que la
-// recursión necesita de cada uno.
-type DeferBlockHost = { getDeferBlocks(): Promise<DeferBlockFixture[]> };
-
-const renderDeferBlocks = async (host: DeferBlockHost): Promise<void> => {
-	for (const deferBlock of await host.getDeferBlocks()) {
-		await deferBlock.render(DeferBlockState.Complete);
-		await renderDeferBlocks(deferBlock);
-	}
-};
-
-// TODO(#1471): al implementar la ReadPage V3 completa, expandir estos tests con las variantes de media,
-// la sección "Más cuentos" y el layout V3, reemplazando los casos transitorios de abajo.
-//
-// `ReadPage` es hoy un walking skeleton: estos tests cubren su render y sus estados mínimos.
+// Estos tests cubren el layout de la página, sus estados y el cableado del contexto de navegación.
+// La cobertura de extremo a extremo y el catálogo de variantes viven en sus propios issues.
 describe('ReadPage', () => {
 	const setup = async (
 		literaryWork: LiteraryWork,
@@ -321,19 +306,19 @@ describe('ReadPage', () => {
 			expect(screen.queryByRole('group', { name: 'Formatos disponibles' })).not.toBeInTheDocument();
 		});
 
-		// La aserción de que el chunk no se pide. Las sugerencias de lectura también viven en un bloque
-		// diferido y están siempre, así que el conteo es lo que distingue si el de formatos llegó a
-		// declararse: con recursos son dos, sin ellos queda solo el de sugerencias.
+		// La aserción de que el chunk no se pide: el marcador de posición existe solo dentro del bloque
+		// diferido, así que su ausencia dice que el bloque ni siquiera se instanció y no queda
+		// disparador que pueda descargarlo.
 		it('declara el bloque diferido de formatos cuando la obra trae recursos', async () => {
-			const { fixture } = await setup(workWithFormats);
+			await setup(workWithFormats);
 
-			expect(await fixture.getDeferBlocks()).toHaveLength(2);
+			expect(screen.getByTestId('media-formats-placeholder')).toBeInTheDocument();
 		});
 
 		it('no declara el bloque diferido de formatos cuando la obra no trae multimedia', async () => {
-			const { fixture } = await setup(workWithoutFormats);
+			await setup(workWithoutFormats);
 
-			expect(await fixture.getDeferBlocks()).toHaveLength(1);
+			expect(screen.queryByTestId('media-formats-placeholder')).not.toBeInTheDocument();
 		});
 
 		it('no dibuja el bloque cuando la obra no trae multimedia', async () => {

--- a/src/app/pages/read/read.page.stories.ts
+++ b/src/app/pages/read/read.page.stories.ts
@@ -1,0 +1,181 @@
+import { applicationConfig, type Meta, type StoryObj } from '@storybook/angular-vite';
+import { provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError, type Observable } from 'rxjs';
+
+import type { LiteraryWork } from '@models/literary-work.model';
+import type { Storylist } from '@models/storylist.model';
+import type { StoryTeaser } from '@models/story.model';
+import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
+import { onoffCollectionsMock } from '@mocks/onoff-collections.mock';
+import { onoffStoryTeasersMock } from '@mocks/onoff-story-teasers.mock';
+import { storylistMock } from '@mocks/storylist.mock';
+
+import { provideLiteraryWorkApiMock } from '../../providers/literary-work.mock';
+import { provideStoryApiMock, StubStoryApi } from '../../providers/story.mock';
+import { provideStorylistApiMock } from '../../providers/storylist.mock';
+import type { LiteraryWorkApi } from '../../providers/literary-work.provider';
+import type { StorylistApi } from '../../providers/storylist.provider';
+import ReadPage from './read.page';
+
+// Resuelve por slug contra el corpus, en vez de devolver siempre la misma obra: así el control de obra
+// mueve la página entera, y un slug que no existe cae en el estado de obra inexistente, que también es
+// parte de lo que hay que poder mirar.
+class CorpusLiteraryWorkApi implements LiteraryWorkApi {
+	public getBySlug(slug: string): Observable<LiteraryWork> {
+		const literaryWork = onoffLiteraryWorksMock.find((candidate) => candidate.slug === slug);
+		return literaryWork
+			? of(literaryWork)
+			: throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' }));
+	}
+}
+
+// Extiende el doble ya existente y sobrescribe lo único que esta página consume: el resto de la
+// interfaz no interviene y no hay por qué volver a declararla.
+class CorpusStoryApi extends StubStoryApi {
+	public override getByAuthorSlug(): Observable<StoryTeaser[]> {
+		return of(onoffStoryTeasersMock);
+	}
+}
+
+// El corpus tiene una sola colección con su listado completo, así que la segunda se compone tomándole
+// el título y el slug al canon de colecciones: alcanza para distinguir a cuál se está mirando, que es
+// lo que el encabezado de las sugerencias anuncia.
+class CorpusStorylistApi implements StorylistApi {
+	public get(slug: string): Observable<Storylist> {
+		const collection = onoffCollectionsMock.find((candidate) => candidate.slug === slug);
+		return of({ ...storylistMock, slug, title: collection?.title ?? storylistMock.title });
+	}
+}
+
+const corpusSlugLabels = Object.fromEntries(
+	onoffLiteraryWorksMock.map((literaryWork) => [literaryWork.slug, literaryWork.title]),
+);
+
+// Los destinos de navegación que el corpus puede sostener: el autor de las obras y las dos colecciones.
+const authorSlugs = [...new Set(onoffLiteraryWorksMock.flatMap((work) => work.authors.map(({ slug }) => slug)))];
+const collectionSlugs = onoffCollectionsMock.map(({ slug }) => slug);
+
+const navigationSlugLabels = Object.fromEntries([
+	...onoffLiteraryWorksMock.flatMap((work) => work.authors.map(({ slug, name }) => [slug, `Autor — ${name}`])),
+	...onoffCollectionsMock.map(({ slug, title }) => [slug, `Colección — ${title}`]),
+]);
+
+type ReadPageArgs = { slug: string; navigation: string; navigationSlug: string };
+
+const meta: Meta<ReadPageArgs> = {
+	component: ReadPage,
+	title: 'Páginas/ReadPage',
+	decorators: [
+		applicationConfig({
+			providers: [
+				provideRouter([]),
+				provideLiteraryWorkApiMock(new CorpusLiteraryWorkApi()),
+				provideStoryApiMock(new CorpusStoryApi()),
+				provideStorylistApiMock(new CorpusStorylistApi()),
+			],
+		}),
+	],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>La página de lectura, <strong>ReadPage</strong>, montada sobre el corpus de Onoff. Es la única entrada del catálogo bajo <strong>Páginas</strong>: no cataloga un componente sino el ensamblado completo, que es lo que permite mirar cómo conviven el encabezado, la barra de lectura, el bloque de formatos, el cuerpo y las sugerencias.</p><p>Los tres controles reproducen lo que la ruta le entrega a la página:</p><ul><li><code>slug</code> — qué obra del corpus se lee. Un slug que no existe cae en el estado de obra inexistente.</li><li><code>navigation</code> y <code>navigationSlug</code> — el contexto con el que se llegó, que decide qué <a href="./?path=/docs/componentes-v3-readingsuggestionslist--docs" target="_top"><strong>sugerencias de lectura</strong></a> se ofrecen al pie: las del autor o las de una colección.</li></ul><p>Las sugerencias viven en un bloque diferido por viewport, así que aparecen al bajar hasta el pie.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		slug: {
+			name: 'Obra',
+			control: { type: 'select', labels: corpusSlugLabels },
+			options: onoffLiteraryWorksMock.map(({ slug }) => slug),
+			table: { type: { summary: 'string' } },
+		},
+		navigation: {
+			name: 'Contexto',
+			control: { type: 'inline-radio' },
+			options: ['author', 'collection'],
+			table: { type: { summary: "'author' | 'collection'" }, defaultValue: { summary: 'author' } },
+		},
+		navigationSlug: {
+			name: 'Destino del contexto',
+			control: { type: 'select', labels: navigationSlugLabels },
+			options: [...authorSlugs, ...collectionSlugs],
+			table: { type: { summary: 'string' } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<ReadPageArgs>;
+
+const [firstWork] = onoffLiteraryWorksMock;
+const [firstAuthorSlug] = authorSlugs;
+const [firstCollectionSlug, secondCollectionSlug] = collectionSlugs;
+
+export const Playground: Story = {
+	args: { slug: firstWork.slug, navigation: 'author', navigationSlug: firstAuthorSlug },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>La página completa con los tres controles vivos. Cambiá <strong>Obra</strong> para recorrer el corpus, y <strong>Contexto</strong> con su destino para ver cómo cambian las sugerencias del pie.</p>`,
+			},
+		},
+	},
+};
+
+export const SugerenciasDelAutor: Story = {
+	args: { slug: firstWork.slug, navigation: 'author', navigationSlug: firstAuthorSlug },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Se llegó desde el listado de un autor: al pie se ofrecen otras obras suyas.</p><p><strong>Usos:</strong> la entrada a una obra desde la página de autor o desde la home.</p>`,
+			},
+		},
+	},
+};
+
+export const SugerenciasDeLaColeccion: Story = {
+	args: { slug: firstWork.slug, navigation: 'collection', navigationSlug: firstCollectionSlug },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Se llegó desde una colección: al pie se ofrecen otras obras de esa colección, y el encabezado la nombra. Cambiá <strong>Destino del contexto</strong> a la otra colección para ver cómo acompaña.</p><p><strong>Usos:</strong> la entrada a una obra desde la página de colección.</p>`,
+			},
+		},
+	},
+};
+
+export const SugerenciasDeLaOtraColeccion: Story = {
+	args: { slug: firstWork.slug, navigation: 'collection', navigationSlug: secondCollectionSlug },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>La segunda colección del corpus, para contrastar contra la anterior que el encabezado y las sugerencias efectivamente siguen al destino.</p>`,
+			},
+		},
+	},
+};
+
+export const SinContextoDeNavegacion: Story = {
+	args: { slug: firstWork.slug, navigation: 'author', navigationSlug: '' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Una obra abierta por URL directa, sin contexto: la página cae en las sugerencias del primer autor de la propia obra, de modo que igual ofrezca a dónde seguir.</p>`,
+			},
+		},
+	},
+};
+
+export const ObraInexistente: Story = {
+	args: { slug: 'una-obra-que-no-existe', navigation: 'author', navigationSlug: firstAuthorSlug },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El estado de obra inexistente, con su salida de vuelta al inicio.</p>`,
+			},
+		},
+	},
+};

--- a/src/app/pages/read/read.page.ts
+++ b/src/app/pages/read/read.page.ts
@@ -103,8 +103,8 @@ export default class ReadPage implements ReadHost {
 	// `/read/:slug` es una ruta accesible nueva que todavía no queremos exponer a buscadores: se sirve
 	// `noindex, nofollow` y sin JSON-LD. El robots se emite antes del guard a propósito, para que la
 	// señal salga también cuando la obra no carga.
-	// TODO: al implementar la página de lectura V3, revertir este opt-out — volver a marcar la página
-	// indexable y re-conectar ReadMetaTagsDirective/ReadStructuredDataDirective en `hostDirectives`.
+	// TODO(#1855): revertir el opt-out — volver a marcar la página indexable y re-conectar
+	// ReadMetaTagsDirective/ReadStructuredDataDirective en `hostDirectives`.
 	private readonly applyHeadMetadataEffect = effect(() => {
 		this.head.setRobots('noindex, nofollow');
 		const literaryWork = this.literaryWork();

--- a/src/app/pages/read/read.page.ts
+++ b/src/app/pages/read/read.page.ts
@@ -23,6 +23,11 @@ import { ButtonComponent } from '@components/button/button.component';
 import { EditorialNoteComponent } from '@components/editorial-note/editorial-note.component';
 import { LiteraryWorkSectionBodyComponent } from '@components/literary-work-section-body/literary-work-section-body.component';
 import { MediaWidgetSelector } from '@components/media-widget-selector/media-widget-selector.component';
+import { DividerComponent } from '@components/divider/divider.component';
+import { ReadingSuggestionsComponent } from '@components/reading-suggestions/reading-suggestions.component';
+import { SkeletonComponent } from '@components/skeleton/skeleton.component';
+import { RouterLink } from '@angular/router';
+import { toNavigationContext, type NavigationContext, type NavigationParams } from '@app-utils/navigation-params';
 
 @Component({
 	selector: 'cuentoneta-read',
@@ -32,13 +37,24 @@ import { MediaWidgetSelector } from '@components/media-widget-selector/media-wid
 	imports: [
 		LiteraryWorkHeroHeaderComponent,
 		ButtonComponent,
+		DividerComponent,
 		EditorialNoteComponent,
 		LiteraryWorkSectionBodyComponent,
 		MediaWidgetSelector,
+		ReadingSuggestionsComponent,
+		RouterLink,
+		SkeletonComponent,
 	],
 })
 export default class ReadPage implements ReadHost {
 	public readonly slug = input.required<string>();
+
+	/** Contexto con el que se entró a la obra. Decide qué sugerencias se ofrecen al pie. */
+	public readonly navigation = input<NavigationContext, string | undefined>('author', {
+		transform: toNavigationContext,
+	});
+
+	public readonly navigationSlug = input<string>();
 
 	private readonly literaryWorkApi = inject(LiteraryWorkApi);
 	private readonly responseInit = inject(RESPONSE_INIT, { optional: true });
@@ -55,6 +71,28 @@ export default class ReadPage implements ReadHost {
 	);
 
 	protected readonly notFound = computed(() => this.literaryWorkResource.status() === 'error');
+
+	// Cantidad de líneas del esqueleto del cuerpo. Es una silueta de carga, no una medida del texto
+	// real, que recién se conoce cuando la obra llegó.
+	protected readonly bodyPlaceholderLines = Array.from({ length: 8 });
+
+	// El primer autor y no el `byline`: el nombre y el slug que consume la variante de autor tienen
+	// que referirse al mismo, y el byline une a todos con coma.
+	private readonly primaryAuthor = computed(() => this.literaryWork()?.authors[0]);
+
+	protected readonly primaryAuthorName = computed(() => this.primaryAuthor()?.name ?? '');
+
+	// Sin contexto en la ruta se cae al autor de la obra: una obra abierta por URL directa igual
+	// ofrece a dónde seguir leyendo.
+	protected readonly navigationParams = computed<NavigationParams>(() => {
+		const navigationSlug = this.navigationSlug();
+
+		if (navigationSlug) {
+			return { navigation: this.navigation(), navigationSlug };
+		}
+
+		return { navigation: 'author', navigationSlug: this.primaryAuthor()?.slug ?? '' };
+	});
 	protected readonly byline = computed(
 		() =>
 			this.literaryWork()

--- a/src/app/pages/read/read.page.ts
+++ b/src/app/pages/read/read.page.ts
@@ -23,9 +23,10 @@ import { ButtonComponent } from '@components/button/button.component';
 import { EditorialNoteComponent } from '@components/editorial-note/editorial-note.component';
 import { LiteraryWorkSectionBodyComponent } from '@components/literary-work-section-body/literary-work-section-body.component';
 import { MediaWidgetSelector } from '@components/media-widget-selector/media-widget-selector.component';
+import { MediaWidgetSelectorSkeleton } from '@components/media-widget-selector/media-widget-selector-skeleton.component';
 import { DividerComponent } from '@components/divider/divider.component';
 import { ReadingSuggestionsComponent } from '@components/reading-suggestions/reading-suggestions.component';
-import { SkeletonComponent } from '@components/skeleton/skeleton.component';
+import { ReadPageSkeleton } from './read-page-skeleton.component';
 import { RouterLink } from '@angular/router';
 import { toNavigationContext, type NavigationContext, type NavigationParams } from '@app-utils/navigation-params';
 
@@ -41,9 +42,10 @@ import { toNavigationContext, type NavigationContext, type NavigationParams } fr
 		EditorialNoteComponent,
 		LiteraryWorkSectionBodyComponent,
 		MediaWidgetSelector,
+		MediaWidgetSelectorSkeleton,
+		ReadPageSkeleton,
 		ReadingSuggestionsComponent,
 		RouterLink,
-		SkeletonComponent,
 	],
 })
 export default class ReadPage implements ReadHost {
@@ -71,10 +73,6 @@ export default class ReadPage implements ReadHost {
 	);
 
 	protected readonly notFound = computed(() => this.literaryWorkResource.status() === 'error');
-
-	// Cantidad de líneas del esqueleto del cuerpo. Es una silueta de carga, no una medida del texto
-	// real, que recién se conoce cuando la obra llegó.
-	protected readonly bodyPlaceholderLines = Array.from({ length: 8 });
 
 	// El primer autor y no el `byline`: el nombre y el slug que consume la variante de autor tienen
 	// que referirse al mismo, y el byline une a todos con coma.

--- a/src/app/pages/story/story.component.spec.ts
+++ b/src/app/pages/story/story.component.spec.ts
@@ -66,7 +66,7 @@ describe('StoryComponent', () => {
 });
 
 describe('StoryComponent - sugerencias de lectura', () => {
-	const setup = async (navigation: 'author' | 'storylist' = 'author', navigationSlug?: string) =>
+	const setup = async (navigation: 'author' | 'collection' = 'author', navigationSlug?: string) =>
 		render(StoryComponent, {
 			componentImports: [
 				CommonModule,
@@ -90,15 +90,15 @@ describe('StoryComponent - sugerencias de lectura', () => {
 	});
 
 	it('should hand the block the context the reader arrived with', async () => {
-		await setup('storylist', storylistMock.slug);
+		await setup('collection', storylistMock.slug);
 
-		expect(screen.getByTestId('navigation')).toHaveTextContent(`storylist|${storylistMock.slug}`);
+		expect(screen.getByTestId('navigation')).toHaveTextContent(`collection|${storylistMock.slug}`);
 		expect(screen.getByTestId('current-work')).toHaveTextContent(storyMock.slug);
 		expect(screen.getByTestId('author-name')).toHaveTextContent(storyMock.author.name);
 	});
 
 	it('should fall back to the author context when the collection slug is missing', async () => {
-		await setup('storylist');
+		await setup('collection');
 
 		expect(screen.getByTestId('navigation')).toHaveTextContent(`author|${storyMock.author.slug}`);
 	});

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -8,7 +8,7 @@ import { AppRoutes } from '../../app.routes';
 
 // Utils
 import { ssrBlockingRxResource } from '@app-utils/ssr-resource';
-import type { NavigationContext, NavigationParams } from '@app-utils/navigation-params';
+import { toNavigationContext, type NavigationContext, type NavigationParams } from '@app-utils/navigation-params';
 
 // Services
 import { StoryApi } from '../../providers/story.provider';
@@ -58,7 +58,9 @@ export default class StoryComponent implements StoryHost {
 
 	// Providers
 	public readonly slug = input.required<string>();
-	public readonly navigation = input<NavigationContext>('author');
+	public readonly navigation = input<NavigationContext, string | undefined>('author', {
+		transform: toNavigationContext,
+	});
 	public readonly navigationSlug = input<string>();
 
 	private readonly storyService = inject(StoryApi);

--- a/src/app/pages/storylist/storylist.component.html
+++ b/src/app/pages/storylist/storylist.component.html
@@ -14,7 +14,7 @@
 										[order]="$index + 1"
 										[showExcerpt]="true"
 										[navigationParams]="{
-											navigation: 'storylist',
+											navigation: 'collection',
 											navigationSlug: storylist.slug,
 										}"
 										data-testid="card"

--- a/src/app/utils/navigation-params.spec.ts
+++ b/src/app/utils/navigation-params.spec.ts
@@ -1,0 +1,23 @@
+import { toNavigationContext } from './navigation-params';
+
+describe('toNavigationContext', () => {
+	it('should resolve the collection context', () => {
+		expect(toNavigationContext('collection')).toBe('collection');
+	});
+
+	// El nombre viejo del contexto quedó escrito en enlaces ya compartidos hacia afuera. Sin esta
+	// entrada caerían en las sugerencias de autor sin que nada lo señale.
+	it('should still resolve the legacy name of the collection context', () => {
+		expect(toNavigationContext('storylist')).toBe('collection');
+	});
+
+	it('should resolve the author context', () => {
+		expect(toNavigationContext('author')).toBe('author');
+	});
+
+	// El router asigna `undefined` explícitamente cuando el query param desaparece al navegar, así que
+	// no alcanza con el default del input: el transform tiene que aceptarlo.
+	it.each([undefined, '', 'cualquier-otra-cosa'])('should fall back to the author context for %p', (value) => {
+		expect(toNavigationContext(value)).toBe('author');
+	});
+});

--- a/src/app/utils/navigation-params.spec.ts
+++ b/src/app/utils/navigation-params.spec.ts
@@ -7,6 +7,7 @@ describe('toNavigationContext', () => {
 
 	// El nombre viejo del contexto quedó escrito en enlaces ya compartidos hacia afuera. Sin esta
 	// entrada caerían en las sugerencias de autor sin que nada lo señale.
+	// TODO(#2269): retirar este caso junto con el valor legado.
 	it('should still resolve the legacy name of the collection context', () => {
 		expect(toNavigationContext('storylist')).toBe('collection');
 	});

--- a/src/app/utils/navigation-params.ts
+++ b/src/app/utils/navigation-params.ts
@@ -14,6 +14,7 @@ export type NavigationParams = {
 // El contexto de colección se llamó `storylist` mientras ese era el nombre del dominio, y quedó
 // escrito en enlaces ya compartidos hacia afuera. Se sigue aceptando para que esos enlaces no caigan
 // en silencio a las sugerencias de autor, que es lo que haría el valor desconocido.
+// TODO(#2269): retirar el valor legado junto con el resto de `storylist`.
 const LEGACY_COLLECTION_CONTEXT = 'storylist';
 
 /**

--- a/src/app/utils/navigation-params.ts
+++ b/src/app/utils/navigation-params.ts
@@ -2,7 +2,7 @@
  * Contexto con el que se llegó a una obra: desde el listado de un autor o desde una colección.
  * Viaja como query params entre las páginas, y decide qué sugerencias de lectura se ofrecen al pie.
  */
-export type NavigationContext = 'author' | 'storylist';
+export type NavigationContext = 'author' | 'collection';
 
 // Alias y no interfaz: los query params viajan como un diccionario de strings, y solo un alias
 // obtiene la firma de índice implícita que esa asignación exige.
@@ -10,3 +10,18 @@ export type NavigationParams = {
 	readonly navigation: NavigationContext;
 	readonly navigationSlug: string;
 };
+
+// El contexto de colección se llamó `storylist` mientras ese era el nombre del dominio, y quedó
+// escrito en enlaces ya compartidos hacia afuera. Se sigue aceptando para que esos enlaces no caigan
+// en silencio a las sugerencias de autor, que es lo que haría el valor desconocido.
+const LEGACY_COLLECTION_CONTEXT = 'storylist';
+
+/**
+ * Normaliza el valor crudo de un query param al contexto de navegación.
+ *
+ * Acepta `undefined` porque el router lo asigna explícitamente cuando el query param desaparece al
+ * navegar: sin ese caso, el binding del input rompe la navegación del lado del cliente.
+ */
+export function toNavigationContext(value: string | undefined): NavigationContext {
+	return value === 'collection' || value === LEGACY_COLLECTION_CONTEXT ? 'collection' : 'author';
+}

--- a/src/testing/defer-blocks.ts
+++ b/src/testing/defer-blocks.ts
@@ -1,0 +1,18 @@
+import { DeferBlockState, type DeferBlockFixture } from '@angular/core/testing';
+
+// El fixture de un componente y el de un bloque diferido comparten esta operación, que es lo único
+// que la recursión necesita de cada uno.
+type DeferBlockHost = { getDeferBlocks(): Promise<DeferBlockFixture[]> };
+
+/**
+ * Resuelve todos los bloques diferidos de un fixture, incluidos los que quedan anidados dentro de
+ * otro. En el entorno de tests los `@defer` no se disparan solos, así que sin esto se renderiza el
+ * marcador de posición; y resolver un solo nivel deja sin renderizar a un componente que difiere a
+ * su vez, como el despachador de sugerencias de lectura.
+ */
+export async function renderDeferBlocks(host: DeferBlockHost): Promise<void> {
+	for (const deferBlock of await host.getDeferBlocks()) {
+		await deferBlock.render(DeferBlockState.Complete);
+		await renderDeferBlocks(deferBlock);
+	}
+}


### PR DESCRIPTION
## Qué resuelve

La página de lectura montaba el hero, el bloque de formatos, el cuerpo y la nota editorial, pero no tenía el layout completo del diseño ni ofrecía a dónde seguir leyendo. Este PR la ensambla y le monta las sugerencias de lectura.

## El contexto de navegación

Siguiendo lo que ya hacía la página vieja, la página recibe `navigation` y `navigationSlug` como inputs de ruta, y con ellos elige qué sugerencias ofrece: las de la colección desde la que se llegó, o las del autor de la obra.

**El contexto se renombra de `storylist` a `collection`**, que es la nomenclatura del dominio. Va en este PR y no en uno propio porque esta página es el primer emisor que debe decir `collection` y el despachador de sugerencias es quien lo interpreta: renombrarlos por separado dejaría una ventana en la que el `@switch` cae por su rama por defecto a las sugerencias de autor, **en silencio**.

El valor viejo quedó escrito en enlaces ya compartidos hacia afuera, así que se sigue aceptando: un normalizador en un único lugar traduce el crudo del query param, y las dos páginas lo aplican como `transform` de su input.

**No se retira con la baja de `/story`**, como podría parecer: las 301 arrastran el query string al destino nuevo, así que `?navigation=storylist` va a seguir llegando a `/read` después del corte. El normalizador vive mientras existan esos enlaces afuera, que no es un evento que el repositorio pueda observar.

**Sin contexto en la ruta** —una obra abierta por URL directa— se cae al primer autor de la obra, que es el comportamiento de la página vieja. Se usa el primer autor y no el `byline` porque el nombre y el slug que consume la variante tienen que referirse al mismo autor, y el byline los une con coma.

## El bloque de formatos pasa a diferirse

Con la condición **por fuera** del `@defer`:

```html
@if (literaryWork.mediaSources.length > 0) { @defer (on idle) { … } }
```

Dentro del diferido, el disparador pediría el chunk igual aunque el bloque no fuera a dibujar nada. El diferido es **plano**, sin `hydrate`, para que el bloque quede fuera del HTML servido: es contenido complementario, no el cuerpo de la obra.

## Verificación del HTML servido

Contra el build de producción (`pnpm build` + `node dist/cuentoneta/server/server.mjs` + `curl /read/el-fin`):

| Invariante | Resultado |
| --- | --- |
| `<h1>` con el título de la obra | presente |
| Texto real del cuerpo | presente |
| Enlace interno al autor | presente (`/author/rabindranath-tagore`) |
| Bloque de formatos | ausente |
| Sugerencias de lectura | ausentes (`@defer (on viewport)`, client-only por diseño) |
| `noindex, nofollow` | intacto |

**La verificación es parcial y conviene decirlo.** La ausencia del bloque de formatos en el HTML servido **no prueba** que el diferido lo saque: `el-fin` no declara recursos, así que la ausencia la explica igual de bien la condición de afuera. Para discriminar hace falta una obra **con** multimedia, cuyo HTML debería traer el marcador de posición y no el bloque.

Esa obra no existe en el dataset de desarrollo: recorrí 80 slugs del sitemap y ninguno declara `mediaSources` — verificado también contra el endpoint, que devuelve el arreglo vacío. Así que la propiedad queda afirmada **solo a nivel unitario**, donde el spec comprueba que el render inicial trae el marcador y no el bloque.

> El slug del corpus de mocks tampoco existe en el dataset, así que la verificación se hizo con uno real del sitemap. Es el mismo hueco por el que los e2e de `/read` se saltean hoy.

## Estados de la página

El estado de carga era un `<p>Cargando…</p>` y ahora sirve la silueta del layout; el de obra inexistente gana una salida al inicio. Los dos se pintan con `@if`/`@else` **planos y nunca dentro de un `@defer`**: el recurso bloquea el render del servidor, así que al serializar la obra ya está y el crawler recibe el cuerpo real. Es el defecto que vació el body de la página de autor.

## Fuera de alcance

Cada uno tiene su issue en la pila que sigue:

- **La fuente de datos de las sugerencias** sigue siendo la actual. Reapuntarla a los endpoints de `LiteraryWork` es #2036, y quitar el adapter es #2037.
- **El `noindex`** no se toca: es #1855.
- **La cobertura e2e y la suite completa de la página** son #1080. Acá van los specs del cableado que este PR agrega.
- **El botón Compartir** sigue inerte; su menú es #2299.
- **El comportamiento de scroll** de la barra es #2298.

## Plan de pruebas

- [x] `navigation-params.spec.ts` — el normalizador resuelve `collection`, el nombre legado, `author`, y cae a `author` ante `undefined` o basura. `undefined` importa: el router lo asigna explícitamente cuando el query param desaparece al navegar, y sin ese caso el binding rompe la navegación del lado del cliente.
- [x] `read.page.spec.ts` — la variante de colección y la de autor se eligen por el contexto, y sin contexto se cae al autor de la obra.
- [x] El bloque de formatos: que no forme parte del render inicial, que se dibuje al resolver el diferido, y que una obra sin recursos declare **un bloque diferido menos** — que es como un test unitario puede observar que el chunk no se pide.
- [x] Los bloques diferidos se resuelven con un helper recursivo: el despachador de sugerencias difiere a su vez cada variante, así que resolver un solo nivel dejaría la variante sin renderizar.
- [x] Gates locales: `typecheck`, `lint`, `stylelint`, `test`, `check-agents`, `build`.

Closes #2283.

Parte de #1471.
