### PR TITLE
[#1833] - CollectionPage + ruta /collection/:slug + estados

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -43,6 +43,10 @@ export const serverRoutes: Array<ServerRoute> = [
 		renderMode: RenderMode.Server,
 	},
 	{
+		path: `${AppRoutes.Collection}/:slug`,
+		renderMode: RenderMode.Server,
+	},
+	{
 		path: '**',
 		renderMode: RenderMode.Prerender,
 	},

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -47,6 +47,10 @@ export const appRoutes: Routes = [
 		loadComponent: () => import('./pages/read/read.page'),
 	},
 	{
+		path: `${AppRoutes.Collection}/:slug`,
+		loadComponent: () => import('./pages/collection/collection.page'),
+	},
+	{
 		path: AppRoutes.About,
 		loadComponent: () => import('./pages/about/about.component'),
 	},

--- a/src/app/components/drawer/drawer.component.stories.ts
+++ b/src/app/components/drawer/drawer.component.stories.ts
@@ -8,7 +8,8 @@ import { TagComponent } from '@components/tag/tag.component';
 import { PortableTextParserComponent } from '@components/portable-text-parser/portable-text-parser.component';
 import { NavigableCollectionTeaserComponent } from '@components/navigable-collection-teaser/navigable-collection-teaser.component';
 import { DividerComponent } from '@components/divider/divider.component';
-import { storylistMock, storylistTeaserRepresentativeMock, storylistTeaserSampleMock } from '@mocks/storylist.mock';
+import { storylistMock } from '@mocks/storylist.mock';
+import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
 
 type DrawerArgs = DrawerComponent & { direction: DrawerDirection };
 
@@ -134,7 +135,7 @@ export const ComposicionCollectionPage: Story = {
 		props: {
 			...args,
 			collection: storylistMock,
-			suggested: [storylistTeaserRepresentativeMock, storylistTeaserSampleMock],
+			suggested: onoffCollectionTeasersMock,
 		},
 		template: `
 			${openButton}

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.spec.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.spec.ts
@@ -2,10 +2,10 @@ import { render, screen } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
 
 import { NavigableCollectionTeaserComponent } from './navigable-collection-teaser.component';
-import { storylistTeaserRepresentativeMock } from '@mocks/storylist.mock';
+import { geometriasDelDesveloCollectionTeaserMock } from '@mocks/onoff-collections.mock';
 
 describe('NavigableCollectionTeaserComponent', () => {
-	const collection = storylistTeaserRepresentativeMock;
+	const collection = geometriasDelDesveloCollectionTeaserMock;
 	const setup = (teaser = collection) =>
 		render(NavigableCollectionTeaserComponent, { inputs: { collection: teaser }, providers: [provideRouter([])] });
 

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
@@ -2,7 +2,8 @@ import { argsToTemplate, componentWrapperDecorator, Meta, moduleMetadata, StoryO
 
 import { NavigableCollectionTeaserComponent } from './navigable-collection-teaser.component';
 import { NavigableCollectionTeaserSkeletonComponent } from './navigable-collection-teaser-skeleton.component';
-import { storylistTeaserRepresentativeMock } from '@mocks/storylist.mock';
+import { geometriasDelDesveloCollectionTeaserMock } from '@mocks/onoff-collections.mock';
+import { createCollectionTeaser } from '@models/collection.model';
 
 const meta: Meta<NavigableCollectionTeaserComponent> = {
 	component: NavigableCollectionTeaserComponent,
@@ -20,7 +21,7 @@ const meta: Meta<NavigableCollectionTeaserComponent> = {
 		collection: {
 			control: { type: 'object' },
 			description: 'Teaser de la colección (title, slug, count, tags)',
-			table: { type: { summary: 'StorylistTeaser' }, defaultValue: { summary: 'required' } },
+			table: { type: { summary: 'CollectionTeaser' }, defaultValue: { summary: 'required' } },
 		},
 	},
 };
@@ -31,7 +32,7 @@ type Story = StoryObj<NavigableCollectionTeaserComponent>;
 export const Default: Story = {
 	name: 'Por defecto',
 	render: (args) => ({ props: args, template: `<cuentoneta-navigable-collection-teaser ${argsToTemplate(args)} />` }),
-	args: { collection: storylistTeaserRepresentativeMock },
+	args: { collection: geometriasDelDesveloCollectionTeaserMock },
 	parameters: {
 		docs: {
 			description: {
@@ -44,7 +45,7 @@ export const Default: Story = {
 export const SinCategoria: Story = {
 	name: 'Sin categoría',
 	render: (args) => ({ props: args, template: `<cuentoneta-navigable-collection-teaser ${argsToTemplate(args)} />` }),
-	args: { collection: { ...storylistTeaserRepresentativeMock, tags: [] } },
+	args: { collection: createCollectionTeaser({ ...geometriasDelDesveloCollectionTeaserMock, tags: [] }) },
 	parameters: {
 		docs: {
 			description: {
@@ -58,10 +59,10 @@ export const TituloLargo: Story = {
 	name: 'Título largo',
 	render: (args) => ({ props: args, template: `<cuentoneta-navigable-collection-teaser ${argsToTemplate(args)} />` }),
 	args: {
-		collection: {
-			...storylistTeaserRepresentativeMock,
+		collection: createCollectionTeaser({
+			...geometriasDelDesveloCollectionTeaserMock,
 			title: 'Book & Morfi: Especial Michis y Perritos en adopción en el refugio',
-		},
+		}),
 	},
 	decorators: [componentWrapperDecorator((story) => `<div style="width:320px">${story}</div>`)],
 	parameters: {
@@ -88,7 +89,7 @@ export const Estados: StoryObj<NavigableCollectionTeaserComponent & { loading: b
 			</div>
 		`,
 	}),
-	args: { loading: true, collection: storylistTeaserRepresentativeMock },
+	args: { loading: true, collection: geometriasDelDesveloCollectionTeaserMock },
 	parameters: {
 		docs: { description: { story: 'Activá/desactivá "Cargando" para alternar entre el estado real y el skeleton.' } },
 	},

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
@@ -1,7 +1,7 @@
 import { Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
-import type { StorylistTeaser } from '@models/storylist.model';
+import type { CollectionTeaser } from '@models/collection.model';
 import { AppRoutes } from '../../app.routes';
 import { ImageProfileComponent } from '../image-profile/image-profile.component';
 import { TagComponent } from '../tag/tag.component';
@@ -48,5 +48,5 @@ import { TagComponent } from '../tag/tag.component';
 export class NavigableCollectionTeaserComponent {
 	protected readonly appRoutes = AppRoutes;
 
-	public readonly collection = input.required<StorylistTeaser>();
+	public readonly collection = input.required<CollectionTeaser>();
 }

--- a/src/app/pages/collection/collection.page.html
+++ b/src/app/pages/collection/collection.page.html
@@ -14,7 +14,7 @@
 				[showAuthor]="collection.config.showAuthors"
 				[showExcerpt]="true"
 				[showMultimedia]="true"
-				[excerptLines]="excerptLinesFor(collection.config.showAuthors)"
+				[excerptLines]="excerptLines()"
 				[tagLabel]="collection.tags[0]?.title"
 			/>
 			}

--- a/src/app/pages/collection/collection.page.html
+++ b/src/app/pages/collection/collection.page.html
@@ -1,0 +1,63 @@
+<main class="mx-auto flex w-full max-w-310 gap-16 px-4 py-8">
+	@if (collection(); as collection) {
+	<div class="flex min-w-0 flex-1 flex-col gap-8">
+		<h1 class="font-inter text-3xl font-bold text-neutral-900">{{ collection.title }}</h1>
+		<div class="flex flex-col gap-8" data-testid="literary-works">
+			@for (literaryWork of collection.literaryWorks; track literaryWork._id; let index = $index) { @if (index >= 2) {
+			<cuentoneta-divider />
+			}
+			<cuentoneta-literary-work-card-teaser
+				[literaryWork]="literaryWork"
+				[variant]="index === 0 ? 'highlighted' : 'on-white'"
+				[order]="index + 1"
+				[priority]="index === 0"
+				[showAuthor]="collection.config.showAuthors"
+				[showExcerpt]="true"
+				[showMultimedia]="true"
+				[excerptLines]="excerptLinesFor(collection.config.showAuthors)"
+				[tagLabel]="collection.tags[0]?.title"
+			/>
+			}
+		</div>
+	</div>
+
+	<cuentoneta-divider orientation="vertical" class="hidden lg:block" />
+
+	<aside class="hidden w-91 shrink-0 flex-col gap-10 lg:flex" data-testid="collection-info">
+		<cuentoneta-collection-info-panel [collection]="collection" />
+		@if (suggestedCollections().length > 0) {
+		<section class="flex flex-col gap-4">
+			<h2 class="font-inter text-lg font-bold text-neutral-900">Otras colecciones sugeridas</h2>
+			@for (suggested of suggestedCollections(); track suggested.slug) {
+			<cuentoneta-navigable-collection-teaser [collection]="suggested" data-testid="suggested-collection" />
+			}
+		</section>
+		}
+	</aside>
+	} @else if (notFound()) {
+	<section class="flex w-full flex-col gap-4">
+		<h1>No encontramos esta colección</h1>
+		<p>La colección que buscás no existe o ya no está disponible.</p>
+	</section>
+	} @else {
+	<div class="flex min-w-0 flex-1 flex-col gap-8" aria-busy="true">
+		<cuentoneta-skeleton appearance="line" class="h-9 w-72 bg-neutral-300" />
+		<div class="flex flex-col gap-8">
+			@for (placeholder of [1, 2, 3]; track placeholder) {
+			<cuentoneta-literary-work-card-teaser [showExcerpt]="true" [showMultimedia]="true" />
+			}
+		</div>
+	</div>
+
+	<cuentoneta-divider orientation="vertical" class="hidden lg:block" />
+
+	<aside class="hidden w-91 shrink-0 flex-col gap-10 lg:flex" aria-busy="true">
+		<cuentoneta-collection-info-panel />
+		<section class="flex flex-col gap-4">
+			@for (placeholder of [1, 2, 3]; track placeholder) {
+			<cuentoneta-navigable-collection-teaser-skeleton />
+			}
+		</section>
+	</aside>
+	}
+</main>

--- a/src/app/pages/collection/collection.page.spec.ts
+++ b/src/app/pages/collection/collection.page.spec.ts
@@ -1,0 +1,129 @@
+// Librería de pruebas
+import { render, screen, within } from '@testing-library/angular';
+import { provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
+
+// Página
+import CollectionPage from './collection.page';
+
+// Providers
+import type { CollectionApi } from '../../providers/collection.provider';
+import { provideCollectionApiMock, StubCollectionApi } from '../../providers/collection.mock';
+
+// Modelos
+import type { Collection, CollectionTeaser } from '@models/collection.model';
+
+// Mocks
+import {
+	onoffCollectionsHidingAuthorsMock,
+	onoffCollectionsMock,
+	onoffCollectionsShowingAuthorsMock,
+} from '@mocks/onoff-collections.mock';
+
+// Utilidades de test
+import { clearAllMocks } from '@test-utils';
+
+const [showingAuthors] = onoffCollectionsShowingAuthorsMock;
+const [hidingAuthors] = onoffCollectionsHidingAuthorsMock;
+
+// El doble del provider nunca falla —cae a la primera colección—, así que los casos de error necesitan
+// uno que lance: sin esto, el estado de no encontrada daría verde sin ejercitarse.
+class FailingCollectionApi implements CollectionApi {
+	constructor(private readonly error: unknown) {}
+
+	public getBySlug(): Observable<Collection> {
+		return throwError(() => this.error);
+	}
+
+	public getAll(): Observable<CollectionTeaser[]> {
+		return of([]);
+	}
+}
+
+const renderPage = (collection: Collection) =>
+	render(CollectionPage, {
+		inputs: { slug: collection.slug },
+		providers: [provideRouter([]), provideCollectionApiMock(new StubCollectionApi(onoffCollectionsMock))],
+	});
+
+const renderFailingPage = (error: unknown) =>
+	render(CollectionPage, {
+		inputs: { slug: 'inexistente' },
+		providers: [provideRouter([]), provideCollectionApiMock(new FailingCollectionApi(error))],
+	});
+
+describe('CollectionPage', () => {
+	beforeEach(() => {
+		clearAllMocks();
+	});
+
+	describe('contenido', () => {
+		it('should render the title of the collection as its heading', async () => {
+			await renderPage(showingAuthors);
+
+			expect(screen.getByRole('heading', { level: 1, name: showingAuthors.title })).toBeInTheDocument();
+		});
+
+		it('should render one card per literary work of the collection', async () => {
+			await renderPage(showingAuthors);
+
+			showingAuthors.literaryWorks.forEach((literaryWork) =>
+				expect(screen.getByText(literaryWork.title)).toBeInTheDocument(),
+			);
+		});
+
+		it('should render the information panel of the collection', async () => {
+			await renderPage(showingAuthors);
+
+			const panel = screen.getByTestId('collection-info');
+			expect(within(panel).getByTestId('description')).toBeInTheDocument();
+		});
+	});
+
+	describe('colecciones sugeridas', () => {
+		it('should offer other collections of the catalogue', async () => {
+			await renderPage(showingAuthors);
+
+			expect(screen.getAllByTestId('suggested-collection').length).toBeGreaterThan(0);
+		});
+
+		// Ofrecer la colección que se está leyendo sería un enlace a la misma página.
+		it('should not offer the collection being read', async () => {
+			await renderPage(showingAuthors);
+
+			const suggested = screen.getAllByTestId('suggested-collection');
+			suggested.forEach((teaser) => expect(teaser).not.toHaveTextContent(showingAuthors.title));
+		});
+	});
+
+	describe('estado de no encontrada', () => {
+		it('should tell the reader when the collection does not exist', async () => {
+			await renderFailingPage(new HttpErrorResponse({ status: 404 }));
+
+			expect(screen.getByRole('heading', { level: 1, name: /No encontramos esta colección/ })).toBeInTheDocument();
+		});
+
+		it('should not render the information panel', async () => {
+			await renderFailingPage(new HttpErrorResponse({ status: 404 }));
+
+			expect(screen.queryByTestId('description')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('recorte del extracto', () => {
+		// Con el autor visible el extracto dispone de una línea menos: la regla la fija la colección,
+		// no la tarjeta.
+		it('should clamp to three lines when the collection shows authors', async () => {
+			await renderPage(showingAuthors);
+
+			expect(within(screen.getByTestId('literary-works')).getAllByTestId('description')[0]).toHaveClass('line-clamp-3');
+		});
+
+		it('should clamp to four lines when the collection hides authors', async () => {
+			await renderPage(hidingAuthors);
+
+			expect(within(screen.getByTestId('literary-works')).getAllByTestId('description')[0]).toHaveClass('line-clamp-4');
+		});
+	});
+});

--- a/src/app/pages/collection/collection.page.ts
+++ b/src/app/pages/collection/collection.page.ts
@@ -1,0 +1,105 @@
+// Core
+import { Component, computed, effect, inject, input, RESPONSE_INIT, untracked } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+
+// Utils
+import { progressiveRxResource, ssrBlockingRxResource } from '@app-utils/ssr-resource';
+import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+
+// Services
+import { CollectionApi } from '../../providers/collection.provider';
+
+// SEO
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { AppRoutes } from '../../app.routes';
+
+// Components
+import { CollectionInfoPanelComponent } from '@components/collection-info-panel/collection-info-panel.component';
+import { DividerComponent } from '@components/divider/divider.component';
+import { LiteraryWorkCardTeaserComponent } from '@components/literary-work-card-teaser/literary-work-card-teaser.component';
+import { NavigableCollectionTeaserComponent } from '@components/navigable-collection-teaser/navigable-collection-teaser.component';
+import { NavigableCollectionTeaserSkeletonComponent } from '@components/navigable-collection-teaser/navigable-collection-teaser-skeleton.component';
+import { SkeletonComponent } from '@components/skeleton/skeleton.component';
+
+@Component({
+	selector: 'cuentoneta-collection',
+	templateUrl: './collection.page.html',
+	hostDirectives: [HeadMetadataDirective],
+	imports: [
+		CollectionInfoPanelComponent,
+		DividerComponent,
+		LiteraryWorkCardTeaserComponent,
+		NavigableCollectionTeaserComponent,
+		NavigableCollectionTeaserSkeletonComponent,
+		SkeletonComponent,
+	],
+})
+export default class CollectionPage {
+	public readonly slug = input.required<string>();
+
+	private readonly collectionApi = inject(CollectionApi);
+	private readonly responseInit = inject(RESPONSE_INIT, { optional: true });
+	private readonly head = inject(HeadMetadataDirective);
+
+	// Cuántas colecciones se ofrecen al pie. El criterio con que se eligen todavía no existe: hoy es el
+	// orden del catálogo, salteando la que se está leyendo.
+	private readonly suggestedCollectionsCount = 3;
+
+	// Bloquea el render del servidor: con un recurso progresivo el HTML se serializa antes de la
+	// respuesta, y una colección inexistente saldría 200 con esqueleto — un 404 blando y cacheable.
+	private readonly collectionResource = ssrBlockingRxResource({
+		params: this.slug,
+		stream: ({ params }) => this.collectionApi.getBySlug(params),
+		defaultValue: undefined,
+	});
+
+	// El catálogo es accesorio: si falla, el bloque de sugeridas queda vacío y la página se sirve igual.
+	private readonly catalogResource = progressiveRxResource({
+		stream: () => this.collectionApi.getAll(),
+		defaultValue: [],
+	});
+
+	protected readonly collection = computed(() =>
+		this.collectionResource.hasValue() ? this.collectionResource.value() : undefined,
+	);
+	protected readonly notFound = computed(() => this.collectionResource.status() === 'error');
+
+	protected readonly suggestedCollections = computed(() => {
+		const slug = this.slug();
+		const catalog = this.catalogResource.hasValue() ? this.catalogResource.value() : [];
+		return catalog.filter((collection) => collection.slug !== slug).slice(0, this.suggestedCollectionsCount);
+	});
+
+	// `/collection/:slug` es una ruta nueva que todavía no se expone a buscadores: se sirve
+	// `noindex, nofollow` y sin datos estructurados. El robots se emite antes del guard a propósito,
+	// para que la señal salga también cuando la colección no carga.
+	// TODO: al conectar las directivas de indexado de la página, revertir este opt-out (#1838).
+	private readonly applyHeadMetadataEffect = effect(() => {
+		this.head.setRobots('noindex, nofollow');
+		const collection = this.collection();
+		if (!collection) {
+			return;
+		}
+		untracked(() => {
+			this.head.setTitle(collection.title);
+			this.head.setDescription(
+				'Una colección de La Cuentoneta: una iniciativa que busca fomentar y hacer accesible la lectura digital.',
+			);
+			this.head.setCanonicalUrl(buildCanonicalUrl(`${AppRoutes.Collection}/${collection.slug}`));
+		});
+	});
+
+	// Un fallo transitorio no puede salir 200: el borde cachearía una página vacía como si fuera la
+	// colección. Solo la ausencia real de la colección es un 404.
+	private readonly respondErrorStatusEffect = effect(() => {
+		const error = this.collectionResource.error();
+		if (!error || !this.responseInit) {
+			return;
+		}
+		this.responseInit.status = error instanceof HttpErrorResponse && error.status === 404 ? 404 : 503;
+	});
+
+	protected excerptLinesFor(showAuthors: boolean): number {
+		return showAuthors ? 3 : 4;
+	}
+}

--- a/src/app/pages/collection/collection.page.ts
+++ b/src/app/pages/collection/collection.page.ts
@@ -99,7 +99,6 @@ export default class CollectionPage {
 		this.responseInit.status = error instanceof HttpErrorResponse && error.status === 404 ? 404 : 503;
 	});
 
-	protected excerptLinesFor(showAuthors: boolean): number {
-		return showAuthors ? 3 : 4;
-	}
+	// Con el autor a la vista, al extracto le queda una línea menos.
+	protected readonly excerptLines = computed(() => (this.collection()?.config.showAuthors ? 3 : 4));
 }

--- a/src/mocks/onoff-collections.mock.ts
+++ b/src/mocks/onoff-collections.mock.ts
@@ -87,6 +87,14 @@ export const onoffCollectionsWithSampleImageryMock: Collection[] = onoffCollecti
 	(collection) => collection.imagery.kind === 'sample',
 );
 
+export const onoffCollectionsShowingAuthorsMock: Collection[] = onoffCollectionsMock.filter(
+	(collection) => collection.config.showAuthors,
+);
+
+export const onoffCollectionsHidingAuthorsMock: Collection[] = onoffCollectionsMock.filter(
+	(collection) => !collection.config.showAuthors,
+);
+
 export const onoffCollectionsWithMediaSourcesMock: Collection[] = onoffCollectionsMock.filter(
 	(collection) => collection.mediaSources.length > 0,
 );


### PR DESCRIPTION
> **PR apilado sobre [#2300](https://github.com/cuentoneta/cuentoneta/pull/2300) (#1837).** Su base es `feat/1837-componente-de-portada-de-coleccion`, no `develop`: la página monta `CollectionCover`, que entra en ese PR. **Mergear #2300 primero.**

## Qué resuelve

La ruta `/collection/:slug` existía como constante desde el rename, pero nada la servía. El dominio, el backend y el provider están desde 2.10.0, y la página vivía únicamente en la rama del spike. Esta es la versión real, compuesta con los componentes del sistema de diseño.

## Decisiones a revisar

**1. El recurso de la colección bloquea el SSR; el catálogo de sugeridas no.** Con un recurso progresivo el HTML se serializa **antes** de la respuesta, así que una colección inexistente saldría **200 con un esqueleto** — un 404 blando, y cacheable por el borde. Es el mismo motivo por el que `ReadPage` bloquea. El catálogo va progresivo porque es accesorio: si falla, el bloque queda vacío y la página se sirve igual.

**2. 404 solo para la ausencia real; 503 para todo lo demás.** Un backend caído, una colección malformada o un DTO que las factories del ACL rechazan **no** son "no existe". Si salieran 200 —o 404— el borde cachearía el fallo transitorio como si fuera la respuesta.

**3. Nace `noindex`, como nació `/read`.** Es una ruta nueva que todavía no se expone a buscadores; las directivas de indexado son de #1838, que arranca explícitamente "cuando la CollectionPage pase a indexable". El robots se emite **antes** del guard, para que la señal salga también cuando la colección no carga. El `TODO` en el código nombra el issue abierto que lo revierte.

**4. `RenderMode.Server`, no `Prerender`.** Prerenderizar exigiría enumerar los slugs contra Sanity en tiempo de build, y ninguna ruta `:slug` del repo lo hace.

**5. Los estados de carga usan los esqueletos que cada componente ya dibuja.** El blueprint repetía sus barras a mano; acá `LiteraryWorkCardTeaser` sin obra y `CollectionInfoPanel` sin colección dibujan el suyo. Si el componente cambia, su esqueleto lo acompaña sin que la página se entere.

**6. Una sola portada prioritaria.** El blueprint marcaba la de la tarjeta destacada **y** la del panel; dos candidatas al LCP son ninguna. Queda solo la primera tarjeta.

**7. `NavigableCollectionTeaser` se retipa contra `CollectionTeaser`.** Estaba tipado contra el teaser del agregado en baja, que **no** es asignable —le faltan campos y su descripción es de otro tipo—, así que sin esto la página no compila. Es el mismo cambio que el spike ya había hecho. Arrastra su spec, su story y la del drawer al corpus de colecciones.

## Qué queda afuera, y por qué

**El acceso a la descripción completa es de #1835.** El panel se monta **sin** `descriptionLines`: recorte, "Leer más" y drawer son un paquete indivisible — recortar sin ofrecer cómo leer el resto es una regresión, no un estado intermedio. El input ya existe para que #1835 lo pase.

**El criterio de recomendación no existe todavía** (#1839): hoy las sugeridas son el orden del catálogo, salteando la que se está leyendo. El recorte es de disposición, no de producto.

**El e2e es de #1840.**

## Un hallazgo preexistente que esta página vuelve visible

`LiteraryWorkCardTeaser` enlaza a **`/story/:slug`**, no a `/read/:slug`: su `literaryWorkRouterLink` está clavado a la ruta vieja. Fuera de alcance acá —es material de #2270, que reapunta el indexado—, pero conviene tenerlo presente: la página nueva enlaza a la página que el hito retira.

## Plan de pruebas

**Automatizado — 9 casos**, con el corpus por selectores de capacidad (se agregan dos derivados por predicado, `onoffCollectionsShowingAuthorsMock` y `…HidingAuthorsMock`, porque distinguir colecciones por nombre propio está prohibido en specs):

- Título como encabezado de nivel 1, una tarjeta por obra, y el panel de información dentro de su columna.
- Sugeridas: se ofrecen otras colecciones del catálogo, y **nunca la que se está leyendo**.
- No encontrada: se le dice al lector, y no se renderiza el panel.
- Recorte condicional: tres líneas cuando la colección muestra autores, cuatro cuando los oculta.

Los casos de error usan un doble que **lanza**: el stub del provider nunca falla —cae a la primera colección—, así que sin eso el estado de no encontrada daría verde sin ejercitarse.

**Gates locales en verde:** `typecheck`, `lint`, `test` (2294) y `build`. El guardrail de SEO descubre la ruta nueva solo y pasa, porque la página declara su host directive.

**Pendiente de verificación visual:** el layout de dos columnas contra el nodo `4795:2050`, que no pude comparar todavía.

Closes #1833

Parte de #1472.
