### PR TITLE
[#1838] - Directivas MetaTags + StructuredData de CollectionPage

### DIFF
--- a/.claude/references/angular-state.md
+++ b/.claude/references/angular-state.md
@@ -165,7 +165,7 @@ Cuándo **bloquear**: rutas cuyo HTML server-rendered debe traer contenido/meta 
 
 Cada componente de página compone su SEO en el campo **`hostDirectives`** del decorador `@Component` (distinto de `host`, ver [`angular-components.md`](angular-components.md#host-element)). Hay exactamente **dos formas**, elegidas según si la ruta es indexable:
 
-- **Página indexable** (`RenderMode.Server`/`Prerender` sin `noindex`): `hostDirectives: [<Page>MetaTagsDirective, <Page>StructuredDataDirective]`. Ambas extienden `AbstractMetaTagsDirective`/`AbstractStructuredDataDirective`; la `<Page>MetaTagsDirective` emite `setRobots('index, follow')` y la `<Page>StructuredDataDirective` inyecta el JSON-LD. Ejemplos: `home`, `author`, `story`, `storylist`.
+- **Página indexable** (`RenderMode.Server`/`Prerender` sin `noindex`): `hostDirectives: [<Page>MetaTagsDirective, <Page>StructuredDataDirective]`. Ambas extienden `AbstractMetaTagsDirective`/`AbstractStructuredDataDirective`; la `<Page>MetaTagsDirective` emite `setRobots('index, follow')` y la `<Page>StructuredDataDirective` inyecta el JSON-LD. Ejemplos: `home`, `author`, `story`, `storylist`, `collection`.
 - **Página no indexable** (`noindex`): `hostDirectives: [HeadMetadataDirective]` (la directiva genérica, sin structured data) y el componente llama `setRobots('noindex, ...')` en su constructor. Ejemplos: `about`, `authors`, `stories`, `dmca`. La ausencia de structured data acá es intencional, no un hueco.
 
 Una página indexable **nunca** debe usar la forma no indexable: quedaría sin structured data y sin `setRobots('index...')` de forma silenciosa.

--- a/e2e/_utils/seo-fixtures.ts
+++ b/e2e/_utils/seo-fixtures.ts
@@ -20,11 +20,12 @@ export const SCHEMA_IDS = Object.freeze({
 	breadcrumbStory: 'breadcrumb-story',
 	profilePage: 'profile-page',
 	breadcrumbAuthor: 'breadcrumb-author',
-	// TODO(#2269): los dos se quedan sin emisor al retirarse la página de storylist, que es la única que
-	// los escribe. Los de `CollectionPage` —abajo— no se renombran para ocupar el lugar que liberan.
+	// TODO(#2269): al retirarse la página de storylist, `collection` pasa a nombrar el bloque de
+	// `CollectionPage` —el dueño del término en el dominio— y `breadcrumbStorylist` desaparece.
 	collection: 'collection',
 	breadcrumbStorylist: 'breadcrumb-storylist',
 	breadcrumbRead: 'breadcrumb-read',
+	// TODO(#2269): `collection-page` es un nombre prestado hasta que se libere `collection`.
 	collectionPage: 'collection-page',
 	breadcrumbCollection: 'breadcrumb-collection',
 } as const);

--- a/e2e/_utils/seo-fixtures.ts
+++ b/e2e/_utils/seo-fixtures.ts
@@ -1,6 +1,7 @@
 export const STABLE_SLUGS = Object.freeze({
 	story: 'el-aleph',
 	author: 'jorge-luis-borges',
+	// TODO(#2269): muere con la ruta; `nav-stacking.spec.ts` también lo consume y pasa a `collection`.
 	storylist: 'verano-2022',
 	// Cada slug de acá tiene que existir en los dos datasets que sirven a los e2e (development en local,
 	// staging en CI): el que exista solo en uno deja sus casos salteados justo donde tenían que correr.
@@ -19,6 +20,8 @@ export const SCHEMA_IDS = Object.freeze({
 	breadcrumbStory: 'breadcrumb-story',
 	profilePage: 'profile-page',
 	breadcrumbAuthor: 'breadcrumb-author',
+	// TODO(#2269): los dos se quedan sin emisor al retirarse la página de storylist, que es la única que
+	// los escribe. Los de `CollectionPage` —abajo— no se renombran para ocupar el lugar que liberan.
 	collection: 'collection',
 	breadcrumbStorylist: 'breadcrumb-storylist',
 	breadcrumbRead: 'breadcrumb-read',

--- a/e2e/_utils/seo-fixtures.ts
+++ b/e2e/_utils/seo-fixtures.ts
@@ -5,6 +5,9 @@ export const STABLE_SLUGS = Object.freeze({
 	// Cada slug de acá tiene que existir en los dos datasets que sirven a los e2e (development en local,
 	// staging en CI): el que exista solo en uno deja sus casos salteados justo donde tenían que correr.
 	literaryWork: 'el-fin',
+	// El mismo de storylist a propósito: las dos rutas sirven la misma colección hasta que una redirija
+	// a la otra, y compartir el slug deja esa comparación al alcance.
+	collection: 'verano-2022',
 } as const);
 
 export const SITEWIDE_SCHEMA_IDS = Object.freeze(['organization', 'website'] as const);
@@ -19,4 +22,6 @@ export const SCHEMA_IDS = Object.freeze({
 	collection: 'collection',
 	breadcrumbStorylist: 'breadcrumb-storylist',
 	breadcrumbRead: 'breadcrumb-read',
+	collectionPage: 'collection-page',
+	breadcrumbCollection: 'breadcrumb-collection',
 } as const);

--- a/e2e/seo/collection.spec.ts
+++ b/e2e/seo/collection.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests e2e de SEO para la página de colección (`/collection/:slug`, entidad Collection).
+ *
+ * Sobre el HTML server-rendered (lo que ve el crawler, sin ejecutar JS):
+ *  - A. Status 404 real del SSR para una colección inexistente (no 200 con página vacía).
+ *  - B. Meta tags: title, description, og:/twitter:, canonical a la URL de la colección,
+ *       robots indexable y keywords.
+ *  - C. Datos estructurados: JSON-LD CollectionPage (mainEntity ItemList ordenado) y BreadcrumbList.
+ *  - D. Bloques sitewide Organization y WebSite.
+ *  - E. La tanda completa de invariantes de una página indexable.
+ *
+ * A diferencia de la página de storylist, acá la tanda completa corre sin `fixme`: el encabezado y el
+ * listado de obras se server-renderizan sin diferir, así que el HTML trae H1 real y enlaces a `/read/`.
+ */
+import { test, expect } from '@playwright/test';
+
+import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
+import { assertValidJsonLd } from '@testing/json-ld-validation';
+import { collectIndexableHtmlViolations } from '../_utils/seo-invariants';
+import { STABLE_SLUGS, SCHEMA_IDS, SITEWIDE_SCHEMA_IDS } from '../_utils/seo-fixtures';
+
+const collectionPath = `/collection/${STABLE_SLUGS.collection}`;
+const requiredJsonLdIds = [...SITEWIDE_SCHEMA_IDS, SCHEMA_IDS.collectionPage, SCHEMA_IDS.breadcrumbCollection];
+
+test('collection — A: una colección inexistente responde 404 real en SSR', async ({ request }) => {
+	const response = await request.get('/collection/coleccion-inexistente-e2e');
+	expect(response.status()).toBe(404);
+});
+
+test.describe('collection — HTML server-rendered de una colección existente', () => {
+	let html: string;
+
+	test.beforeAll(async ({ request }) => {
+		html = await (await request.get(collectionPath)).text();
+	});
+
+	test('B: meta tags en el HTML server-rendered', () => {
+		expect(getTitleText(html)).toBeTruthy();
+		expect(getMetaContent(html, 'description')).toBeTruthy();
+		expect(getMetaContent(html, 'og:title')).toBeTruthy();
+		expect(getMetaContent(html, 'og:description')).toBeTruthy();
+		expect(getMetaContent(html, 'twitter:title')).toBeTruthy();
+		expect(getMetaContent(html, 'twitter:description')).toBeTruthy();
+		expect(getCanonicalHref(html)).toContain(collectionPath);
+		expect(getMetaContent(html, 'keywords')).toBeTruthy();
+		// Se afirma la ausencia de `noindex` y no la presencia de `index`, que pasaría con las dos
+		// políticas: `noindex` contiene ese substring.
+		expect(getMetaContent(html, 'robots')).not.toContain('noindex');
+	});
+
+	test('C: JSON-LD CollectionPage con el listado ordenado de sus obras', async () => {
+		const collection = parseJsonLdBlocks(html).get(SCHEMA_IDS.collectionPage);
+		await assertValidJsonLd(collection);
+
+		const mainEntity = collection?.['mainEntity'] as Record<string, unknown>;
+		expect(mainEntity?.['@type']).toBe('ItemList');
+		expect(Number(mainEntity?.['numberOfItems'])).toBeGreaterThan(0);
+
+		const [firstItem] = (mainEntity?.['itemListElement'] ?? []) as Record<string, unknown>[];
+		expect(firstItem?.['position']).toBe(1);
+		expect(String(firstItem?.['url'])).toContain('/read/');
+	});
+
+	test('C: JSON-LD BreadcrumbList', async () => {
+		const breadcrumb = parseJsonLdBlocks(html).get(SCHEMA_IDS.breadcrumbCollection);
+		await assertValidJsonLd(breadcrumb);
+
+		expect((breadcrumb?.['itemListElement'] as unknown[])?.length).toBeGreaterThanOrEqual(2);
+	});
+
+	test('C: no reusa el identificador de bloque de la página de storylist', () => {
+		const blocks = parseJsonLdBlocks(html);
+
+		expect(blocks.has(SCHEMA_IDS.collection)).toBe(false);
+	});
+
+	test('D: bloques sitewide Organization y WebSite presentes', () => {
+		const blocks = parseJsonLdBlocks(html);
+
+		expect(blocks.get(SCHEMA_IDS.organization)?.['@type']).toBe('Organization');
+		expect(blocks.get(SCHEMA_IDS.website)?.['@type']).toBe('WebSite');
+	});
+
+	test('E: invariantes de página indexable (ssr, title, canonical, robots, h1, cuerpo, enlaces, jsonld)', async () => {
+		expect(
+			await collectIndexableHtmlViolations(html, {
+				path: collectionPath,
+				requiredJsonLdIds,
+				requiredInternalLinkPrefix: '/read/',
+			}),
+		).toEqual([]);
+	});
+});

--- a/e2e/seo/collection.spec.ts
+++ b/e2e/seo/collection.spec.ts
@@ -5,7 +5,8 @@
  *  - A. Status 404 real del SSR para una colección inexistente (no 200 con página vacía).
  *  - B. Meta tags: title, description, og:/twitter:, canonical a la URL de la colección,
  *       robots indexable y keywords.
- *  - C. Datos estructurados: JSON-LD CollectionPage (mainEntity ItemList ordenado) y BreadcrumbList.
+ *  - C. Datos estructurados: JSON-LD CollectionPage (mainEntity ItemList ordenado) y, aparte,
+ *       BreadcrumbList.
  *  - D. Bloques sitewide Organization y WebSite.
  *  - E. La tanda completa de invariantes de una página indexable.
  *
@@ -31,7 +32,11 @@ test.describe('collection — HTML server-rendered de una colección existente',
 	let html: string;
 
 	test.beforeAll(async ({ request }) => {
-		html = await (await request.get(collectionPath)).text();
+		const response = await request.get(collectionPath);
+		// Sin esto, un slug que desapareció del dataset hace fallar los cinco casos por "expected truthy",
+		// sin nombrar la causa. Se afirma en vez de saltearse: es el skip el que ya dejó un verde engañoso.
+		expect(response.status(), `No existe la colección "${STABLE_SLUGS.collection}" en el dataset`).toBe(200);
+		html = await response.text();
 	});
 
 	test('B: meta tags en el HTML server-rendered', () => {
@@ -66,12 +71,6 @@ test.describe('collection — HTML server-rendered de una colección existente',
 		await assertValidJsonLd(breadcrumb);
 
 		expect((breadcrumb?.['itemListElement'] as unknown[])?.length).toBeGreaterThanOrEqual(2);
-	});
-
-	test('C: no reusa el identificador de bloque de la página de storylist', () => {
-		const blocks = parseJsonLdBlocks(html);
-
-		expect(blocks.has(SCHEMA_IDS.collection)).toBe(false);
 	});
 
 	test('D: bloques sitewide Organization y WebSite presentes', () => {

--- a/src/app/pages/collection/collection-host.ts
+++ b/src/app/pages/collection/collection-host.ts
@@ -1,0 +1,9 @@
+import { InjectionToken, type Signal } from '@angular/core';
+
+import { type Collection } from '@models/collection.model';
+
+export interface CollectionHost {
+	readonly collection: Signal<Collection | undefined>;
+}
+
+export const COLLECTION_HOST = new InjectionToken<CollectionHost>('COLLECTION_HOST');

--- a/src/app/pages/collection/collection-meta-tags.directive.spec.ts
+++ b/src/app/pages/collection/collection-meta-tags.directive.spec.ts
@@ -1,0 +1,99 @@
+import { clearAllMocks, spyOn } from '@test-utils';
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+
+import { geometriasDelDesveloCollectionMock } from '@mocks/onoff-collections.mock';
+import { type Collection } from '@models/collection.model';
+import { AppRoutes } from '../../app.routes';
+import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { CollectionMetaTagsDirective } from './collection-meta-tags.directive';
+import { COLLECTION_HOST } from './collection-host';
+
+describe('CollectionMetaTagsDirective', () => {
+	const collectionSignal = signal<Collection | undefined>(undefined);
+
+	function instantiate(): void {
+		TestBed.runInInjectionContext(() => new CollectionMetaTagsDirective());
+	}
+
+	beforeEach(() => {
+		clearAllMocks();
+		collectionSignal.set(undefined);
+		TestBed.configureTestingModule({
+			providers: [
+				CollectionMetaTagsDirective,
+				HeadMetadataDirective,
+				{ provide: COLLECTION_HOST, useValue: { collection: collectionSignal.asReadonly() } },
+			],
+		});
+	});
+
+	it('should not set meta tags while the collection is undefined', () => {
+		const titleSpy = spyOn(TestBed.inject(Title), 'setTitle');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(titleSpy).not.toHaveBeenCalled();
+	});
+
+	it('should set the title from the collection when it resolves', () => {
+		collectionSignal.set(geometriasDelDesveloCollectionMock);
+		const titleSpy = spyOn(TestBed.inject(Title), 'setTitle');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(titleSpy).toHaveBeenCalledWith(expect.stringContaining(geometriasDelDesveloCollectionMock.title));
+	});
+
+	it('should set the canonical URL from the collection slug via buildCanonicalUrl', () => {
+		collectionSignal.set(geometriasDelDesveloCollectionMock);
+		const canonicalSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setCanonicalUrl');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(canonicalSpy).toHaveBeenCalledWith(
+			buildCanonicalUrl(`${AppRoutes.Collection}/${geometriasDelDesveloCollectionMock.slug}`),
+		);
+	});
+
+	// Es el literal del que depende que el guardrail de indexado exija el combo de directivas, así que
+	// se afirma solo y no de arrastre dentro de otro caso.
+	it('should declare the page as indexable', () => {
+		collectionSignal.set(geometriasDelDesveloCollectionMock);
+		const robotsSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setRobots');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(robotsSpy).toHaveBeenCalledWith('index, follow');
+	});
+
+	it('should include the collection tags in the keywords', () => {
+		collectionSignal.set(geometriasDelDesveloCollectionMock);
+		const keywordsSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setKeywords');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(keywordsSpy).toHaveBeenCalledWith(
+			expect.arrayContaining(geometriasDelDesveloCollectionMock.tags.map((tag) => tag.title.toLowerCase())),
+		);
+	});
+
+	it('should re-apply the meta tags when the collection signal changes', () => {
+		collectionSignal.set(geometriasDelDesveloCollectionMock);
+		const titleSpy = spyOn(TestBed.inject(Title), 'setTitle');
+		instantiate();
+		TestBed.tick();
+
+		collectionSignal.set({ ...geometriasDelDesveloCollectionMock, title: 'Otra colección' });
+		TestBed.tick();
+
+		expect(titleSpy).toHaveBeenLastCalledWith(expect.stringContaining('Otra colección'));
+	});
+});

--- a/src/app/pages/collection/collection-meta-tags.directive.ts
+++ b/src/app/pages/collection/collection-meta-tags.directive.ts
@@ -1,0 +1,38 @@
+import { Directive, inject, untracked } from '@angular/core';
+
+import { AppRoutes } from '../../app.routes';
+import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { AbstractMetaTagsDirective } from '../../directives/abstract-meta-tags.directive';
+import { COLLECTION_HOST } from './collection-host';
+
+@Directive({
+	selector: '[cuentonetaCollectionMetaTags]',
+	hostDirectives: [HeadMetadataDirective],
+})
+export class CollectionMetaTagsDirective extends AbstractMetaTagsDirective {
+	private readonly host = inject(COLLECTION_HOST);
+
+	protected applyMetaTags(): void {
+		const collection = this.host.collection();
+		if (!collection) {
+			return;
+		}
+		untracked(() => {
+			this.head.setTitle(collection.title);
+			this.head.setDescription(
+				'Una colección de La Cuentoneta: una iniciativa que busca fomentar y hacer accesible la lectura digital.',
+			);
+			this.head.setCanonicalUrl(buildCanonicalUrl(`${AppRoutes.Collection}/${collection.slug}`));
+			this.head.setRobots('index, follow');
+			this.head.setKeywords([
+				'literatura',
+				'poemas',
+				'cuentos',
+				'textos',
+				collection.title.toLowerCase(),
+				...collection.tags.map((tag) => tag.title.toLowerCase()),
+			]);
+		});
+	}
+}

--- a/src/app/pages/collection/collection-structured-data.directive.spec.ts
+++ b/src/app/pages/collection/collection-structured-data.directive.spec.ts
@@ -56,6 +56,7 @@ describe('CollectionStructuredDataDirective', () => {
 
 	// La página de storylist emite su propio bloque bajo `collection`. Que los ids no se pisen es lo
 	// que permite distinguirlos mientras las dos rutas convivan.
+	// TODO(#2269): este caso se borra con esa página — sin emisor rival, no queda con qué colisionar.
 	it('should not emit under the schema id the storylist page uses', () => {
 		collectionSignal.set(geometriasDelDesveloCollectionMock);
 

--- a/src/app/pages/collection/collection-structured-data.directive.spec.ts
+++ b/src/app/pages/collection/collection-structured-data.directive.spec.ts
@@ -1,0 +1,80 @@
+import { clearAllMocks } from '@test-utils';
+import { TestBed } from '@angular/core/testing';
+import { DOCUMENT } from '@angular/common';
+import { signal } from '@angular/core';
+
+import { geometriasDelDesveloCollectionMock } from '@mocks/onoff-collections.mock';
+import { type Collection } from '@models/collection.model';
+import { CollectionStructuredDataDirective } from './collection-structured-data.directive';
+import { COLLECTION_HOST } from './collection-host';
+
+describe('CollectionStructuredDataDirective', () => {
+	const collectionSignal = signal<Collection | undefined>(undefined);
+
+	function instantiate(): void {
+		TestBed.runInInjectionContext(() => new CollectionStructuredDataDirective());
+	}
+
+	beforeEach(() => {
+		clearAllMocks();
+		collectionSignal.set(undefined);
+		TestBed.configureTestingModule({
+			providers: [
+				CollectionStructuredDataDirective,
+				{ provide: COLLECTION_HOST, useValue: { collection: collectionSignal.asReadonly() } },
+			],
+		});
+	});
+
+	afterEach(() => {
+		TestBed.inject(DOCUMENT)
+			.head.querySelectorAll('script[data-schema-id]')
+			.forEach((el) => el.remove());
+	});
+
+	it('should not emit JSON-LD while the collection is undefined', () => {
+		instantiate();
+		TestBed.tick();
+
+		expect(TestBed.inject(DOCUMENT).head.querySelector('script[data-schema-id="collection-page"]')).toBeNull();
+	});
+
+	it('should emit the CollectionPage and breadcrumb JSON-LD when the collection resolves', () => {
+		collectionSignal.set(geometriasDelDesveloCollectionMock);
+
+		instantiate();
+		TestBed.tick();
+
+		const head = TestBed.inject(DOCUMENT).head;
+		expect(
+			JSON.parse(head.querySelector('script[data-schema-id="collection-page"]')?.textContent ?? '{}'),
+		).toMatchObject({ '@type': 'CollectionPage' });
+		expect(
+			JSON.parse(head.querySelector('script[data-schema-id="breadcrumb-collection"]')?.textContent ?? '{}'),
+		).toMatchObject({ '@type': 'BreadcrumbList' });
+	});
+
+	// La página de storylist emite su propio bloque bajo `collection`. Que los ids no se pisen es lo
+	// que permite distinguirlos mientras las dos rutas convivan.
+	it('should not emit under the schema id the storylist page uses', () => {
+		collectionSignal.set(geometriasDelDesveloCollectionMock);
+
+		instantiate();
+		TestBed.tick();
+
+		expect(TestBed.inject(DOCUMENT).head.querySelector('script[data-schema-id="collection"]')).toBeNull();
+	});
+
+	it('should remove both JSON-LD blocks when destroyed', () => {
+		collectionSignal.set(geometriasDelDesveloCollectionMock);
+		instantiate();
+		TestBed.tick();
+		const head = TestBed.inject(DOCUMENT).head;
+		expect(head.querySelector('script[data-schema-id="collection-page"]')).not.toBeNull();
+
+		TestBed.resetTestingModule();
+
+		expect(head.querySelector('script[data-schema-id="collection-page"]')).toBeNull();
+		expect(head.querySelector('script[data-schema-id="breadcrumb-collection"]')).toBeNull();
+	});
+});

--- a/src/app/pages/collection/collection-structured-data.directive.spec.ts
+++ b/src/app/pages/collection/collection-structured-data.directive.spec.ts
@@ -54,9 +54,9 @@ describe('CollectionStructuredDataDirective', () => {
 		).toMatchObject({ '@type': 'BreadcrumbList' });
 	});
 
-	// La página de storylist emite su propio bloque bajo `collection`. Que los ids no se pisen es lo
-	// que permite distinguirlos mientras las dos rutas convivan.
-	// TODO(#2269): este caso se borra con esa página — sin emisor rival, no queda con qué colisionar.
+	// La página de storylist ocupa `collection`. Que los ids no se pisen es lo que permite distinguir
+	// los bloques mientras las dos rutas convivan.
+	// TODO(#2269): este caso se invierte al renombrarse el id — pasa a afirmar que sí emite `collection`.
 	it('should not emit under the schema id the storylist page uses', () => {
 		collectionSignal.set(geometriasDelDesveloCollectionMock);
 

--- a/src/app/pages/collection/collection-structured-data.directive.ts
+++ b/src/app/pages/collection/collection-structured-data.directive.ts
@@ -1,0 +1,37 @@
+import { Directive, inject, untracked } from '@angular/core';
+
+import { environment } from '../../environments/environment';
+import { AbstractStructuredDataDirective } from '../../directives/abstract-structured-data.directive';
+import { COLLECTION_HOST } from './collection-host';
+import { buildCollectionBreadcrumb, buildCollectionPageSchema } from './collection.schema';
+
+@Directive({
+	selector: '[cuentonetaCollectionStructuredData]',
+})
+export class CollectionStructuredDataDirective extends AbstractStructuredDataDirective {
+	private readonly host = inject(COLLECTION_HOST);
+
+	// Ids propios y no `collection`, que ya lo emite la página de storylist: mientras las dos rutas
+	// coexistan, un id compartido haría ambiguo qué bloque se está mirando.
+	private readonly pageSchemaId = 'collection-page';
+	private readonly breadcrumbSchemaId = 'breadcrumb-collection';
+
+	protected applyStructuredData(): void {
+		const collection = this.host.collection();
+		if (!collection) {
+			return;
+		}
+		untracked(() => {
+			this.schemaOrg.setPageScopedJsonLd(this.pageSchemaId, buildCollectionPageSchema(collection, environment.website));
+			this.schemaOrg.setPageScopedJsonLd(
+				this.breadcrumbSchemaId,
+				buildCollectionBreadcrumb(collection, environment.website),
+			);
+		});
+	}
+
+	protected removeStructuredData(): void {
+		this.schemaOrg.removeJsonLd(this.pageSchemaId);
+		this.schemaOrg.removeJsonLd(this.breadcrumbSchemaId);
+	}
+}

--- a/src/app/pages/collection/collection-structured-data.directive.ts
+++ b/src/app/pages/collection/collection-structured-data.directive.ts
@@ -11,10 +11,10 @@ import { buildCollectionBreadcrumb, buildCollectionPageSchema } from './collecti
 export class CollectionStructuredDataDirective extends AbstractStructuredDataDirective {
 	private readonly host = inject(COLLECTION_HOST);
 
-	// Ids propios y no `collection`, que ya lo emite la página de storylist: mientras las dos rutas
-	// coexistan, un id compartido haría ambiguo qué bloque se está mirando.
-	// TODO(#2269): al morir esa página este comentario queda nombrando algo inexistente y hay que
-	// reescribirlo. Los ids no cambian: el issue explica por qué no se ocupa el lugar que se libera.
+	// `collection` es el nombre que le corresponde a este bloque por el modelo de dominio, pero lo
+	// ocupa la página de storylist, que es la deprecada. Hasta que se retire, un id compartido haría
+	// ambiguo qué bloque se está mirando, así que se toma uno prestado.
+	// TODO(#2269): al retirarse esa página, renombrar este id a `collection`.
 	private readonly pageSchemaId = 'collection-page';
 	private readonly breadcrumbSchemaId = 'breadcrumb-collection';
 

--- a/src/app/pages/collection/collection-structured-data.directive.ts
+++ b/src/app/pages/collection/collection-structured-data.directive.ts
@@ -13,6 +13,8 @@ export class CollectionStructuredDataDirective extends AbstractStructuredDataDir
 
 	// Ids propios y no `collection`, que ya lo emite la página de storylist: mientras las dos rutas
 	// coexistan, un id compartido haría ambiguo qué bloque se está mirando.
+	// TODO(#2269): al morir esa página este comentario queda nombrando algo inexistente y hay que
+	// reescribirlo. Los ids no cambian: el issue explica por qué no se ocupa el lugar que se libera.
 	private readonly pageSchemaId = 'collection-page';
 	private readonly breadcrumbSchemaId = 'breadcrumb-collection';
 

--- a/src/app/pages/collection/collection.page.spec.ts
+++ b/src/app/pages/collection/collection.page.spec.ts
@@ -129,11 +129,9 @@ describe('CollectionPage', () => {
 
 	// Las directivas tienen su propio spec: lo que se ejercita acá es el cableado, que ninguno de los
 	// dos ve — que la página las declare y les provea la colección que resolvió.
-	// Todo lo de este bloque vive en el `head`, que no tiene rol accesible: se consulta por selector, de
-	// ahí el acceso directo al nodo.
-	/* eslint-disable testing-library/no-node-access */
 	describe('indexado', () => {
 		afterEach(() => {
+			// eslint-disable-next-line testing-library/no-node-access -- el <head> no tiene rol accesible: se consulta por selector
 			document.head.querySelectorAll('script[data-schema-id]').forEach((el) => el.remove());
 		});
 
@@ -143,6 +141,7 @@ describe('CollectionPage', () => {
 		it('should point the canonical URL at the collection', async () => {
 			await renderPage(showingAuthors);
 
+			// eslint-disable-next-line testing-library/no-node-access -- el <head> no tiene rol accesible: se consulta por selector
 			expect(document.head.querySelector('link[rel="canonical"]')?.getAttribute('href')).toContain(
 				`/collection/${showingAuthors.slug}`,
 			);
@@ -151,9 +150,10 @@ describe('CollectionPage', () => {
 		it('should emit both JSON-LD blocks', async () => {
 			await renderPage(showingAuthors);
 
+			/* eslint-disable testing-library/no-node-access -- el <head> no tiene rol accesible: se consulta por selector */
 			expect(document.head.querySelector('script[data-schema-id="collection-page"]')).not.toBeNull();
 			expect(document.head.querySelector('script[data-schema-id="breadcrumb-collection"]')).not.toBeNull();
+			/* eslint-enable testing-library/no-node-access */
 		});
 	});
-	/* eslint-enable testing-library/no-node-access */
 });

--- a/src/app/pages/collection/collection.page.spec.ts
+++ b/src/app/pages/collection/collection.page.spec.ts
@@ -126,4 +126,30 @@ describe('CollectionPage', () => {
 			expect(within(screen.getByTestId('literary-works')).getAllByTestId('description')[0]).toHaveClass('line-clamp-4');
 		});
 	});
+
+	// Las directivas tienen su propio spec: lo que se ejercita acá es el cableado, que ninguno de los
+	// dos ve — que la página las declare y les provea la colección que resolvió.
+	describe('indexado', () => {
+		afterEach(() => {
+			document.head.querySelectorAll('script[data-schema-id]').forEach((el) => el.remove());
+		});
+
+		// La canónica sale de la colección resuelta, así que verla apuntar al slug correcto prueba que la
+		// directiva la recibió. El `robots` no sirve para esto: en un build no indexable —el de los tests—
+		// se fuerza a `noindex` sin mirar lo que la página pidió, y eso lo cubre el spec de la directiva.
+		it('should point the canonical URL at the collection', async () => {
+			await renderPage(showingAuthors);
+
+			expect(document.head.querySelector('link[rel="canonical"]')?.getAttribute('href')).toContain(
+				`/collection/${showingAuthors.slug}`,
+			);
+		});
+
+		it('should emit both JSON-LD blocks', async () => {
+			await renderPage(showingAuthors);
+
+			expect(document.head.querySelector('script[data-schema-id="collection-page"]')).not.toBeNull();
+			expect(document.head.querySelector('script[data-schema-id="breadcrumb-collection"]')).not.toBeNull();
+		});
+	});
 });

--- a/src/app/pages/collection/collection.page.spec.ts
+++ b/src/app/pages/collection/collection.page.spec.ts
@@ -129,6 +129,9 @@ describe('CollectionPage', () => {
 
 	// Las directivas tienen su propio spec: lo que se ejercita acá es el cableado, que ninguno de los
 	// dos ve — que la página las declare y les provea la colección que resolvió.
+	// Todo lo de este bloque vive en el `head`, que no tiene rol accesible: se consulta por selector, de
+	// ahí el acceso directo al nodo.
+	/* eslint-disable testing-library/no-node-access */
 	describe('indexado', () => {
 		afterEach(() => {
 			document.head.querySelectorAll('script[data-schema-id]').forEach((el) => el.remove());
@@ -152,4 +155,5 @@ describe('CollectionPage', () => {
 			expect(document.head.querySelector('script[data-schema-id="breadcrumb-collection"]')).not.toBeNull();
 		});
 	});
+	/* eslint-enable testing-library/no-node-access */
 });

--- a/src/app/pages/collection/collection.page.ts
+++ b/src/app/pages/collection/collection.page.ts
@@ -1,29 +1,18 @@
 // Core
-import {
-	Component,
-	computed,
-	effect,
-	forwardRef,
-	inject,
-	input,
-	RESPONSE_INIT,
-	signal,
-	untracked,
-} from '@angular/core';
+import { Component, computed, effect, forwardRef, inject, input, RESPONSE_INIT, signal } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { NgTemplateOutlet } from '@angular/common';
 
 // Utils
 import { progressiveRxResource, ssrBlockingRxResource } from '@app-utils/ssr-resource';
-import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
 
 // Services
 import { CollectionApi } from '../../providers/collection.provider';
 
 // SEO
-import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
-import { AppRoutes } from '../../app.routes';
 import { COLLECTION_HOST, type CollectionHost } from './collection-host';
+import { CollectionMetaTagsDirective } from './collection-meta-tags.directive';
+import { CollectionStructuredDataDirective } from './collection-structured-data.directive';
 
 // Components
 import { CollectionInfoPanelComponent } from '@components/collection-info-panel/collection-info-panel.component';
@@ -38,7 +27,7 @@ import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 	selector: 'cuentoneta-collection',
 	templateUrl: './collection.page.html',
 	providers: [{ provide: COLLECTION_HOST, useExisting: forwardRef(() => CollectionPage) }],
-	hostDirectives: [HeadMetadataDirective],
+	hostDirectives: [CollectionMetaTagsDirective, CollectionStructuredDataDirective],
 	imports: [
 		CollectionInfoPanelComponent,
 		DrawerComponent,
@@ -55,7 +44,6 @@ export default class CollectionPage implements CollectionHost {
 
 	private readonly collectionApi = inject(CollectionApi);
 	private readonly responseInit = inject(RESPONSE_INIT, { optional: true });
-	private readonly head = inject(HeadMetadataDirective);
 
 	// Cuántas colecciones se ofrecen al pie. El criterio con que se eligen todavía no existe: hoy es el
 	// orden del catálogo, salteando la que se está leyendo.
@@ -91,25 +79,6 @@ export default class CollectionPage implements CollectionHost {
 		const slug = this.slug();
 		const catalog = this.catalogResource.hasValue() ? this.catalogResource.value() : [];
 		return catalog.filter((collection) => collection.slug !== slug).slice(0, this.suggestedCollectionsCount);
-	});
-
-	// `/collection/:slug` es una ruta nueva que todavía no se expone a buscadores: se sirve
-	// `noindex, nofollow` y sin datos estructurados. El robots se emite antes del guard a propósito,
-	// para que la señal salga también cuando la colección no carga.
-	// TODO: al conectar las directivas de indexado de la página, revertir este opt-out (#1838).
-	private readonly applyHeadMetadataEffect = effect(() => {
-		this.head.setRobots('noindex, nofollow');
-		const collection = this.collection();
-		if (!collection) {
-			return;
-		}
-		untracked(() => {
-			this.head.setTitle(collection.title);
-			this.head.setDescription(
-				'Una colección de La Cuentoneta: una iniciativa que busca fomentar y hacer accesible la lectura digital.',
-			);
-			this.head.setCanonicalUrl(buildCanonicalUrl(`${AppRoutes.Collection}/${collection.slug}`));
-		});
 	});
 
 	// Un fallo transitorio no puede salir 200: el borde cachearía una página vacía como si fuera la

--- a/src/app/pages/collection/collection.page.ts
+++ b/src/app/pages/collection/collection.page.ts
@@ -1,5 +1,15 @@
 // Core
-import { Component, computed, effect, inject, input, RESPONSE_INIT, signal, untracked } from '@angular/core';
+import {
+	Component,
+	computed,
+	effect,
+	forwardRef,
+	inject,
+	input,
+	RESPONSE_INIT,
+	signal,
+	untracked,
+} from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { NgTemplateOutlet } from '@angular/common';
 
@@ -13,6 +23,7 @@ import { CollectionApi } from '../../providers/collection.provider';
 // SEO
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { AppRoutes } from '../../app.routes';
+import { COLLECTION_HOST, type CollectionHost } from './collection-host';
 
 // Components
 import { CollectionInfoPanelComponent } from '@components/collection-info-panel/collection-info-panel.component';
@@ -26,6 +37,7 @@ import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 @Component({
 	selector: 'cuentoneta-collection',
 	templateUrl: './collection.page.html',
+	providers: [{ provide: COLLECTION_HOST, useExisting: forwardRef(() => CollectionPage) }],
 	hostDirectives: [HeadMetadataDirective],
 	imports: [
 		CollectionInfoPanelComponent,
@@ -38,7 +50,7 @@ import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 		SkeletonComponent,
 	],
 })
-export default class CollectionPage {
+export default class CollectionPage implements CollectionHost {
 	public readonly slug = input.required<string>();
 
 	private readonly collectionApi = inject(CollectionApi);
@@ -70,7 +82,7 @@ export default class CollectionPage {
 		defaultValue: [],
 	});
 
-	protected readonly collection = computed(() =>
+	public readonly collection = computed(() =>
 		this.collectionResource.hasValue() ? this.collectionResource.value() : undefined,
 	);
 	protected readonly notFound = computed(() => this.collectionResource.status() === 'error');

--- a/src/app/pages/collection/collection.schema.spec.ts
+++ b/src/app/pages/collection/collection.schema.spec.ts
@@ -1,0 +1,58 @@
+import { geometriasDelDesveloCollectionMock } from '@mocks/onoff-collections.mock';
+
+import { assertValidJsonLd } from '@testing/json-ld-validation';
+import { buildCollectionBreadcrumb, buildCollectionPageSchema } from './collection.schema';
+
+const websiteUrl = 'https://www.cuentoneta.ar/';
+
+describe('buildCollectionPageSchema', () => {
+	it('should build a schema.org-valid CollectionPage', async () => {
+		await expect(
+			assertValidJsonLd(buildCollectionPageSchema(geometriasDelDesveloCollectionMock, websiteUrl)),
+		).resolves.toBeUndefined();
+	});
+
+	it('should build a CollectionPage with an ordered ItemList of its literary works', () => {
+		const schema = buildCollectionPageSchema(geometriasDelDesveloCollectionMock, websiteUrl);
+
+		expect(schema).toMatchObject({
+			'@context': 'https://schema.org',
+			'@type': 'CollectionPage',
+			name: 'Geometrías del desvelo',
+			url: 'https://www.cuentoneta.ar/collection/geometrias-del-desvelo',
+			inLanguage: 'es-AR',
+			mainEntity: {
+				'@type': 'ItemList',
+				numberOfItems: geometriasDelDesveloCollectionMock.literaryWorks.length,
+				itemListElement: geometriasDelDesveloCollectionMock.literaryWorks.map((literaryWork, index) => ({
+					'@type': 'ListItem',
+					position: index + 1,
+					url: `https://www.cuentoneta.ar/read/${literaryWork.slug}`,
+					name: literaryWork.title,
+				})),
+			},
+		});
+	});
+});
+
+describe('buildCollectionBreadcrumb', () => {
+	it('should build the trail Inicio → collection', () => {
+		const schema = buildCollectionBreadcrumb(geometriasDelDesveloCollectionMock, websiteUrl);
+
+		expect(schema['itemListElement']).toEqual([
+			{ '@type': 'ListItem', position: 1, name: 'Inicio', item: { '@id': 'https://www.cuentoneta.ar/home' } },
+			{
+				'@type': 'ListItem',
+				position: 2,
+				name: 'Geometrías del desvelo',
+				item: { '@id': 'https://www.cuentoneta.ar/collection/geometrias-del-desvelo' },
+			},
+		]);
+	});
+
+	it('should build a schema.org-valid BreadcrumbList', async () => {
+		await expect(
+			assertValidJsonLd(buildCollectionBreadcrumb(geometriasDelDesveloCollectionMock, websiteUrl)),
+		).resolves.toBeUndefined();
+	});
+});

--- a/src/app/pages/collection/collection.schema.spec.ts
+++ b/src/app/pages/collection/collection.schema.spec.ts
@@ -23,7 +23,7 @@ describe('buildCollectionPageSchema', () => {
 			inLanguage: 'es-AR',
 			mainEntity: {
 				'@type': 'ItemList',
-				numberOfItems: geometriasDelDesveloCollectionMock.literaryWorks.length,
+				numberOfItems: geometriasDelDesveloCollectionMock.count,
 				itemListElement: geometriasDelDesveloCollectionMock.literaryWorks.map((literaryWork, index) => ({
 					'@type': 'ListItem',
 					position: index + 1,

--- a/src/app/pages/collection/collection.schema.ts
+++ b/src/app/pages/collection/collection.schema.ts
@@ -20,7 +20,7 @@ export function buildCollectionPageSchema(collection: Collection, websiteUrl: st
 		inLanguage: 'es-AR',
 		mainEntity: {
 			'@type': 'ItemList',
-			numberOfItems: collection.literaryWorks.length,
+			numberOfItems: collection.count,
 			itemListElement: collection.literaryWorks.map((literaryWork, index) => ({
 				'@type': 'ListItem',
 				position: index + 1,

--- a/src/app/pages/collection/collection.schema.ts
+++ b/src/app/pages/collection/collection.schema.ts
@@ -1,0 +1,41 @@
+import { Location } from '@angular/common';
+import { type BreadcrumbList, type CollectionPage, type WithContext } from 'schema-dts';
+
+import { type Collection } from '@models/collection.model';
+import { buildBreadcrumbSchema } from '@utils/schema-org.builders';
+
+/**
+ * Construye el JSON-LD `CollectionPage` de una colección, con un `ItemList` ordenado de las obras
+ * que la integran (posición + URL + título), para que los answer engines entiendan la colección.
+ *
+ * Los ítems apuntan a `/read/:slug`, que es a donde enlaza el listado de la página.
+ */
+export function buildCollectionPageSchema(collection: Collection, websiteUrl: string): WithContext<CollectionPage> {
+	const baseUrl = Location.stripTrailingSlash(websiteUrl);
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'CollectionPage',
+		name: collection.title,
+		url: `${baseUrl}/collection/${collection.slug}`,
+		inLanguage: 'es-AR',
+		mainEntity: {
+			'@type': 'ItemList',
+			numberOfItems: collection.literaryWorks.length,
+			itemListElement: collection.literaryWorks.map((literaryWork, index) => ({
+				'@type': 'ListItem',
+				position: index + 1,
+				url: `${baseUrl}/read/${literaryWork.slug}`,
+				name: literaryWork.title,
+			})),
+		},
+	};
+}
+
+/** Construye el `BreadcrumbList` de la página de una colección: Inicio → colección. */
+export function buildCollectionBreadcrumb(collection: Collection, websiteUrl: string): WithContext<BreadcrumbList> {
+	const baseUrl = Location.stripTrailingSlash(websiteUrl);
+	return buildBreadcrumbSchema([
+		{ name: 'Inicio', url: `${baseUrl}/home` },
+		{ name: collection.title, url: `${baseUrl}/collection/${collection.slug}` },
+	]);
+}


### PR DESCRIPTION
`/collection/:slug` nació fuera de los buscadores: se servía `noindex, nofollow` y sin datos estructurados, con la metadata inlineada en un effect de la página. Este PR revierte ese opt-out y le da a la página el par de host directives que el guardrail de indexado exige para una ruta indexable.

## Qué entra

- **`CollectionMetaTagsDirective`** — título, descripción, canónica, `index, follow` y palabras clave. Las etiquetas de la colección entran a las keywords: no está en el enunciado del issue, pero el invariante e2e de páginas indexables las exige y las tres páginas equivalentes ya las emiten.
- **`CollectionStructuredDataDirective`** — JSON-LD `CollectionPage` con el `ItemList` ordenado de las obras, más el `BreadcrumbList`.
- **`COLLECTION_HOST`** — el token que le da a las directivas la colección que la página resolvió, con la forma que ya usan las otras cuatro páginas indexables.
- **Cobertura e2e** de indexado sobre el HTML server-rendered, y la referencia de agentes al día.

## Decisiones que conviene mirar en la review

**El effect viejo se borra entero, no se comenta.** El guardrail que clasifica una página como indexable busca el literal `setRobots` sobre el texto crudo del archivo y se queda con la primera coincidencia, sin distinguir comentarios: una mención dejada "por las dudas" haría que la página siguiera contando como opt-out y el gate daría verde sin verificar nada.

**El identificador `collection-page` es prestado y se devuelve.** `collection` es el nombre que le corresponde a este bloque por el modelo de dominio, pero hoy lo ocupa la página de storylist, que es la deprecada. Mientras las dos rutas convivan, un identificador compartido volvería ambigua cualquier aserción sobre el HTML servido, así que `CollectionPage` emite bajo `collection-page` (`breadcrumb-collection` ya está alineado). El renombre al retirarse storylist quedó anotado en #2269, con un `TODO` en cada uno de los cuatro puntos de código que se tocan.

**El spec de la página no afirma el `robots`**, aunque sea el cambio de fondo: en un build no indexable —el de los tests— se fuerza a `noindex` sin mirar lo que la página pidió. Ese literal lo verifica el spec de la directiva, que espía la llamada; el spec de la página verifica el cableado, que es lo que ninguna de las dos ve por separado.

**El slug del e2e es `verano-2022`**, el mismo que ya usa el de storylist. Verifiqué que exista en los dos datasets que sirven a los e2e (`development` y `staging`, ambos con las mismas 27 colecciones publicadas), así que los casos no quedan salteados. Compartirlo deja al alcance la comparación del día que una ruta redirija a la otra.

**La tanda completa de invariantes corre sin diferirse**, a diferencia del e2e de storylist, que la tiene en `fixme`: aquella página difiere su encabezado y su listado, y el servidor emite esqueletos; ésta los sirve enteros, así que el H1 real y los enlaces a `/read/` se pueden exigir.

## Dos tareas del issue resultaron no ser trabajo

- **Migrar el resource a `ssrBlockingRxResource`** ya estaba hecho: la página lo usa para la colección y `progressiveRxResource` para el catálogo desde que se creó. Queda como verificación.
- **Registrar la ruta como `indexable` en el spec del guardrail** es un no-op por diseño: el spec no tiene registro que mantener, descubre las páginas desde las rutas del servidor y deriva la indexabilidad del propio código. Al desaparecer el `noindex`, la página pasa a exigir el combo sola.

## Dos rutas indexables sirviendo la misma colección: por qué se acepta

A partir de este PR, `/storylist/:slug` y `/collection/:slug` emiten **las dos** `index, follow`, canónica auto-referencial y un `CollectionPage` — y sirven la misma colección. Es una decisión, no un efecto lateral, y se apoya en la cadencia acordada del hito: **un solo release `develop → master` al final**, con merges incrementales a `develop` por ola. El 301 que reapunta el indexado (#2270) y el listado de entrada (#2288) están en este mismo milestone, así que la ventana de contenido duplicado vive en `develop` y nunca llega a producción.

Se descartaron las dos alternativas: apuntar la canónica de la ruta nueva a la vieja obligaría a revertirla en #2270 y dejaría la página firmando una URL que va a dejar de existir; sostener el `noindex` hasta #2270 vaciaría este issue de contenido y dejaría el combo de directivas sin verificar en CI hasta el final del hito.

## Lo que queda afuera, y dónde está trazado

- **`/collection/:slug` no está en el sitemap** y nada del sitio enlaza todavía a esa ruta, así que hoy queda indexable pero huérfana. No hace falta un issue nuevo: el sitemap entra en el alcance de #2270 y el listado de entrada es #2288.
- **Los ítems del `ItemList` apuntan a `/read/:slug`, que hoy se sirve `noindex, nofollow`.** Es coherente —el listado describe la composición de la colección, no promete la indexación de cada obra—, pero el valor SEO completo de esta página llega recién cuando esa ruta se destape (#2040), para que la medición posterior no lea eso como una regresión de este cambio.
- **La descripción sigue siendo la frase editorial fija.** Derivarla de la de cada colección necesita un util de HTML→texto plano que no existe en el frontend; habilitaría a la vez la meta description y el `description` del JSON-LD.

## Plan de pruebas

**Gates, todos verdes:** los catorce checks del PR, incluido `e2e` — que es el que estrena el spec nuevo contra el dataset de `staging` y el único capaz de desmentir el supuesto del slug estable. En local corrí además la suite completa de unitarios (2332 pasan), `typecheck`, `lint`, `stylelint` y `check:agents`.

**Verificado a mano:**

- `grep -n setRobots src/app/pages/collection/collection.page.ts` no devuelve ninguna línea — el guardrail parsea el texto crudo del archivo y una mención comentada lo engañaría.
- El slug `verano-2022` existe publicado en `development` y en `staging` (las mismas 27 colecciones en los dos), consultado contra los datasets.
- `collection.page.html` no tiene ningún bloque diferido, que es lo que habilita exigir en el e2e el H1 real y los enlaces a `/read/`.

**Cobertura nueva:** cuatro specs unitarios (los dos builders de JSON-LD y las dos directivas), el bloque de indexado del spec de la página —que ejercita el cableado, lo que ninguna de las dos mitades ve por separado— y el e2e sobre el HTML server-rendered. El guardrail `seo-host-directives.spec.ts` cubre el cambio de rama solo, sin necesitar modificaciones.

Closes #1838.

Parte de #1472.
