### PR TITLE
[#1840] - Test e2e del flujo CollectionPage

### DIFF
--- a/e2e/_utils/collection-fixtures.spec.ts
+++ b/e2e/_utils/collection-fixtures.spec.ts
@@ -1,0 +1,51 @@
+import { descriptionText, pickMostDescriptiveCollection, type CollectionCatalogEntry } from './collection-fixtures';
+
+function entry(slug: string, description: string): CollectionCatalogEntry {
+	return { slug, title: slug, description };
+}
+
+describe('descriptionText', () => {
+	it('quita el marcado y deja el texto legible', () => {
+		expect(descriptionText('<p>Una <strong>colección</strong> de verano</p>')).toBe('Una colección de verano');
+	});
+
+	it('colapsa los espacios que deja el marcado quitado', () => {
+		expect(descriptionText('<p>Uno</p>\n\n<p>Dos</p>')).toBe('Uno Dos');
+	});
+
+	it('devuelve cadena vacía con una descripción sin texto', () => {
+		expect(descriptionText('<p></p>')).toBe('');
+	});
+});
+
+describe('pickMostDescriptiveCollection', () => {
+	it('devuelve undefined con un catálogo vacío', () => {
+		expect(pickMostDescriptiveCollection([])).toBeUndefined();
+	});
+
+	it('elige la de descripción más larga', () => {
+		const catalog = [entry('corta', '<p>Breve</p>'), entry('larga', '<p>Una descripción bastante más extensa</p>')];
+
+		expect(pickMostDescriptiveCollection(catalog)?.slug).toBe('larga');
+	});
+
+	// El desempate estable es lo que hace que el spec lea siempre la misma página: sin él, la elección
+	// dependería del orden en que el CMS devolvió el catálogo.
+	it('desempata por slug ante descripciones del mismo largo', () => {
+		const catalog = [entry('otono', '<p>Mismo largo</p>'), entry('invierno', '<p>Mismo largo</p>')];
+
+		expect(pickMostDescriptiveCollection(catalog)?.slug).toBe('invierno');
+		expect(pickMostDescriptiveCollection([...catalog].reverse())?.slug).toBe('invierno');
+	});
+
+	// El largo se mide sobre el texto y no sobre el marcado: una descripción envuelta en más etiquetas
+	// no es una descripción más larga.
+	it('mide el texto y no el marcado', () => {
+		const catalog = [
+			entry('marcada', '<div><p><strong><em>Corta</em></strong></p></div>'),
+			entry('extensa', '<p>Bastante más texto que la otra</p>'),
+		];
+
+		expect(pickMostDescriptiveCollection(catalog)?.slug).toBe('extensa');
+	});
+});

--- a/e2e/_utils/collection-fixtures.ts
+++ b/e2e/_utils/collection-fixtures.ts
@@ -7,6 +7,7 @@
  */
 import type { APIRequestContext } from '@playwright/test';
 
+import { collectionTeaserListDtoSchema, type CollectionTeaserDto } from '@models/collection.dto';
 import { VIEWPORT_WIDTHS_NUMERIC } from '@utils/screen.utils';
 
 // La columna lateral y el panel deslizable viven tras `hidden lg:flex`, así que hace falta superar el
@@ -16,12 +17,13 @@ export const DESKTOP_VIEWPORT = Object.freeze({ width: VIEWPORT_WIDTHS_NUMERIC.x
 
 const CATALOG_ROUTE = '/api/collection';
 
-/** Lo único que los specs consumen del teaser que entrega el catálogo. */
-export interface CollectionCatalogEntry {
-	slug: string;
-	title: string;
-	description: string;
-}
+/**
+ * Lo único que los specs consumen del teaser que entrega el catálogo.
+ *
+ * Se deriva del DTO en lugar de reescribirlo: un rename en el contrato de wire rompe acá en compilación,
+ * y no en runtime como una descripción que llega vacía.
+ */
+export type CollectionCatalogEntry = Readonly<Pick<CollectionTeaserDto, 'slug' | 'title' | 'description'>>;
 
 export async function fetchCollectionCatalog(request: APIRequestContext): Promise<CollectionCatalogEntry[]> {
 	const response = await request.get(CATALOG_ROUTE);
@@ -30,7 +32,14 @@ export async function fetchCollectionCatalog(request: APIRequestContext): Promis
 	if (response.status() !== 200) {
 		throw new Error(`"${CATALOG_ROUTE}" respondió ${response.status()}: el catálogo de colecciones no está`);
 	}
-	return response.json();
+
+	// Se valida contra el schema que ya define el contrato: sin esto, un cambio de shape llegaría al spec
+	// como una descripción vacía —o sea, como "esta colección no desborda"— en vez de como lo que es.
+	const catalog = collectionTeaserListDtoSchema.safeParse(await response.json());
+	if (!catalog.success) {
+		throw new Error(`"${CATALOG_ROUTE}" no cumple el contrato del catálogo: ${catalog.error.message}`);
+	}
+	return catalog.data;
 }
 
 /** Texto plano de una descripción saneada, para compararla contra lo que se lee en pantalla. */

--- a/e2e/_utils/collection-fixtures.ts
+++ b/e2e/_utils/collection-fixtures.ts
@@ -1,0 +1,64 @@
+/**
+ * Fixtures del catálogo de colecciones para los e2e de la página de colección.
+ *
+ * La identidad de la colección que se lee sale de `STABLE_SLUGS`, pero el largo de su descripción no:
+ * un slug no dice nada sobre cuánto texto le cargó la curaduría, y ese texto es justamente lo que decide
+ * si el recorte desborda. Se resuelve entonces contra el catálogo real, en runtime.
+ */
+import type { APIRequestContext } from '@playwright/test';
+
+import { VIEWPORT_WIDTHS_NUMERIC } from '@utils/screen.utils';
+
+// La columna lateral y el panel deslizable viven tras `hidden lg:flex`, así que hace falta superar el
+// breakpoint `lg`. Se toma el ancho de `xl` y no el borde exacto porque `setViewportSize` fija el tamaño
+// de la ventana con la barra de scroll incluida: al ras del breakpoint, el ancho útil queda por debajo.
+export const DESKTOP_VIEWPORT = Object.freeze({ width: VIEWPORT_WIDTHS_NUMERIC.xl, height: 900 });
+
+const CATALOG_ROUTE = '/api/collection';
+
+/** Lo único que los specs consumen del teaser que entrega el catálogo. */
+export interface CollectionCatalogEntry {
+	slug: string;
+	title: string;
+	description: string;
+}
+
+export async function fetchCollectionCatalog(request: APIRequestContext): Promise<CollectionCatalogEntry[]> {
+	const response = await request.get(CATALOG_ROUTE);
+	// Un catálogo caído y un catálogo vacío llevan a fixtures distintos, y sin esto los dos llegarían
+	// como una lista sin entradas.
+	if (response.status() !== 200) {
+		throw new Error(`"${CATALOG_ROUTE}" respondió ${response.status()}: el catálogo de colecciones no está`);
+	}
+	return response.json();
+}
+
+/** Texto plano de una descripción saneada, para compararla contra lo que se lee en pantalla. */
+export function descriptionText(html: string): string {
+	return html
+		.replace(/<[^>]+>/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/**
+ * La colección de descripción más larga del catálogo, que es la candidata a desbordar el recorte.
+ *
+ * El desempate por slug mantiene la elección estable entre corridas: sin él, dos descripciones del mismo
+ * largo harían que el spec leyera una página distinta según el orden en que el CMS devolvió el catálogo.
+ */
+export function pickMostDescriptiveCollection(
+	catalog: readonly CollectionCatalogEntry[],
+): CollectionCatalogEntry | undefined {
+	return catalog.reduce<CollectionCatalogEntry | undefined>((mostDescriptive, candidate) => {
+		if (!mostDescriptive) {
+			return candidate;
+		}
+		const candidateLength = descriptionText(candidate.description).length;
+		const currentLength = descriptionText(mostDescriptive.description).length;
+		if (candidateLength > currentLength) {
+			return candidate;
+		}
+		return candidateLength === currentLength && candidate.slug < mostDescriptive.slug ? candidate : mostDescriptive;
+	}, undefined);
+}

--- a/e2e/collection-content.spec.ts
+++ b/e2e/collection-content.spec.ts
@@ -26,12 +26,12 @@ test.beforeAll(async ({ request }) => {
 
 // Guardas como casos propios, no como `skip` silencioso: un dataset sin el fixture es un problema de la
 // infraestructura de test, no un motivo para que el gate quede verde sin haber mirado nada.
-test('la colección estable existe en el dataset', () => {
+test('collection — la colección estable existe en el dataset', () => {
 	expect(status, `"${ROUTE}" no responde 200: los casos de la página no verifican nada`).toBe(200);
 	expect(collection, `el catálogo no trae "${STABLE_SLUGS.collection}": no habría con qué comparar`).toBeDefined();
 });
 
-test('el catálogo ofrece otra colección además de la que se lee', () => {
+test('collection — el catálogo ofrece otra colección además de la que se lee', () => {
 	expect(
 		catalog.length,
 		'el catálogo trae una sola colección: el bloque de sugeridas no tendría qué mostrar',
@@ -45,7 +45,7 @@ async function openCollection(page: Page): Promise<void> {
 	await expect(page.locator('main h1')).toBeVisible();
 }
 
-test('el listado muestra las obras de la colección y cada una lleva a su lectura', async ({ page }) => {
+test('collection — el listado muestra las obras y cada una lleva a su lectura', async ({ page }) => {
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
 	test.skip(status !== 200, `"${ROUTE}" no responde 200 en el dataset`);
 
@@ -66,9 +66,13 @@ test('el listado muestra las obras de la colección y cada una lleva a su lectur
 	expect(new Set(destinations).size, `hay obras que comparten destino: ${destinations}`).toBe(destinations.length);
 });
 
-test('la columna muestra la información de la colección', async ({ page }) => {
+test('collection — la columna muestra la información de la colección', async ({ page }) => {
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
-	test.skip(status !== 200 || !collection, `"${ROUTE}" no responde 200 en el dataset`);
+	test.skip(status !== 200, `"${ROUTE}" no responde 200 en el dataset`);
+	// Separado del anterior y no unido por `||`: un motivo compuesto reporta siempre el primero, y quien
+	// lea el resultado diagnosticaría un 404 donde lo que falta es la entrada del catálogo.
+	// eslint-disable-next-line playwright/no-skipped-test -- ídem
+	test.skip(!collection, `el catálogo no trae "${STABLE_SLUGS.collection}"`);
 
 	await openCollection(page);
 
@@ -83,11 +87,25 @@ test('la columna muestra la información de la colección', async ({ page }) => 
 	await expect(info.getByTestId('description')).not.toBeEmpty();
 });
 
+// El panel de la descripción existe en la plantilla desde el primer render, y hasta que alguien lo abra no
+// debe aportar nada a la página. Se mira su botón de cierre porque es lo único que el panel trae siempre:
+// el resto de su contenido está gateado, así que un panel indebidamente presente pasaría inadvertido.
+test('collection — el panel de la descripción no aporta nada antes de abrirse', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(status !== 200, `"${ROUTE}" no responde 200 en el dataset`);
+
+	await openCollection(page);
+
+	await expect(page.getByRole('button', { name: 'Cerrar' })).toHaveCount(0);
+});
+
 // Que el bloque exista prueba además que el recurso progresivo del catálogo resolvió en el cliente: en el
 // HTML del servidor no está.
-test('la columna ofrece otras colecciones y ninguna es la que se está leyendo', async ({ page }) => {
+test('collection — la columna ofrece otras colecciones y ninguna es la que se está leyendo', async ({ page }) => {
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
-	test.skip(status !== 200 || catalog.length < 2, `"${ROUTE}" no responde 200 en el dataset`);
+	test.skip(status !== 200, `"${ROUTE}" no responde 200 en el dataset`);
+	// eslint-disable-next-line playwright/no-skipped-test -- ídem
+	test.skip(catalog.length < 2, 'el catálogo trae una sola colección: no hay otra que ofrecer');
 
 	await openCollection(page);
 

--- a/e2e/collection-content.spec.ts
+++ b/e2e/collection-content.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Contenido de la página de colección: el listado de obras, la columna con la información de la colección
+ * y el bloque de otras colecciones sugeridas.
+ *
+ * `e2e/seo/collection.spec.ts` ya mira esta ruta, pero mira el HTML que ve el crawler. Acá se ejercita la
+ * página hidratada, que es lo único que alcanza las dos cosas que aquel no puede: la columna lateral, que
+ * vive tras un breakpoint y por lo tanto depende del ancho real del viewport, y el bloque de sugeridas,
+ * que se alimenta de un recurso progresivo y en el HTML del servidor todavía no existe.
+ */
+import { expect, test, type Page } from '@playwright/test';
+
+import { DESKTOP_VIEWPORT, fetchCollectionCatalog, type CollectionCatalogEntry } from './_utils/collection-fixtures';
+import { STABLE_SLUGS } from './_utils/seo-fixtures';
+
+const ROUTE = `/collection/${STABLE_SLUGS.collection}`;
+
+let status = 0;
+let catalog: CollectionCatalogEntry[] = [];
+let collection: CollectionCatalogEntry | undefined;
+
+test.beforeAll(async ({ request }) => {
+	status = (await request.get(ROUTE)).status();
+	catalog = await fetchCollectionCatalog(request);
+	collection = catalog.find((entry) => entry.slug === STABLE_SLUGS.collection);
+});
+
+// Guardas como casos propios, no como `skip` silencioso: un dataset sin el fixture es un problema de la
+// infraestructura de test, no un motivo para que el gate quede verde sin haber mirado nada.
+test('la colección estable existe en el dataset', () => {
+	expect(status, `"${ROUTE}" no responde 200: los casos de la página no verifican nada`).toBe(200);
+	expect(collection, `el catálogo no trae "${STABLE_SLUGS.collection}": no habría con qué comparar`).toBeDefined();
+});
+
+test('el catálogo ofrece otra colección además de la que se lee', () => {
+	expect(
+		catalog.length,
+		'el catálogo trae una sola colección: el bloque de sugeridas no tendría qué mostrar',
+	).toBeGreaterThan(1);
+});
+
+/** Abre la ruta en un ancho donde la columna lateral existe, con el contenido ya resuelto. */
+async function openCollection(page: Page): Promise<void> {
+	await page.setViewportSize(DESKTOP_VIEWPORT);
+	await page.goto(ROUTE);
+	await expect(page.locator('main h1')).toBeVisible();
+}
+
+test('el listado muestra las obras de la colección y cada una lleva a su lectura', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(status !== 200, `"${ROUTE}" no responde 200 en el dataset`);
+
+	await openCollection(page);
+
+	const cards = page.getByTestId('literary-works').locator('cuentoneta-literary-work-card-teaser');
+
+	// Control positivo: sin él, un listado vacío dejaría la aserción de destinos cumpliéndose en vacío.
+	await expect(cards.first()).toBeVisible();
+
+	// Se cuentan los enlaces a la lectura contra las tarjetas y no se afirma que *todos* los enlaces del
+	// listado lleven ahí: la tarjeta enlaza además al autor cuando la curaduría lo muestra.
+	const readingLinks = page.getByTestId('literary-works').locator('a[href^="/read/"]');
+	expect(await readingLinks.count(), 'alguna obra del listado no ofrece su lectura').toBe(await cards.count());
+
+	// Cada tarjeta lleva a *su* obra: sin esto, N enlaces al mismo destino darían el mismo conteo.
+	const destinations = await readingLinks.evaluateAll((links) => links.map((link) => link.getAttribute('href') ?? ''));
+	expect(new Set(destinations).size, `hay obras que comparten destino: ${destinations}`).toBe(destinations.length);
+});
+
+test('la columna muestra la información de la colección', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(status !== 200 || !collection, `"${ROUTE}" no responde 200 en el dataset`);
+
+	await openCollection(page);
+
+	// El título sale del catálogo y no de una constante: el spec afirma que la página muestra la colección
+	// que el API dice que es, no que muestre un texto que el propio spec eligió.
+	await expect(page.locator('main h1')).toHaveText(collection?.title ?? '');
+
+	const info = page.getByTestId('collection-info');
+	await expect(info.locator('cuentoneta-collection-cover')).toBeVisible();
+
+	// Scopeado a la columna: `description` también rotula el extracto de cada tarjeta de obra.
+	await expect(info.getByTestId('description')).not.toBeEmpty();
+});
+
+// Que el bloque exista prueba además que el recurso progresivo del catálogo resolvió en el cliente: en el
+// HTML del servidor no está.
+test('la columna ofrece otras colecciones y ninguna es la que se está leyendo', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(status !== 200 || catalog.length < 2, `"${ROUTE}" no responde 200 en el dataset`);
+
+	await openCollection(page);
+
+	const info = page.getByTestId('collection-info');
+	await expect(info.getByRole('heading', { name: 'Otras colecciones sugeridas' })).toBeVisible();
+
+	const suggested = info.getByTestId('suggested-collection').getByRole('link');
+	await expect(suggested.first()).toBeVisible();
+
+	const destinations = await suggested.evaluateAll((links) => links.map((link) => link.getAttribute('href') ?? ''));
+	expect(
+		destinations.every((href) => href.startsWith('/collection/')),
+		`destinos ajenos: ${destinations}`,
+	).toBe(true);
+	expect(destinations, 'la colección que se está leyendo se ofrece a sí misma').not.toContain(ROUTE);
+});

--- a/e2e/collection-content.spec.ts
+++ b/e2e/collection-content.spec.ts
@@ -59,7 +59,7 @@ test('el listado muestra las obras de la colección y cada una lleva a su lectur
 	// Se cuentan los enlaces a la lectura contra las tarjetas y no se afirma que *todos* los enlaces del
 	// listado lleven ahí: la tarjeta enlaza además al autor cuando la curaduría lo muestra.
 	const readingLinks = page.getByTestId('literary-works').locator('a[href^="/read/"]');
-	expect(await readingLinks.count(), 'alguna obra del listado no ofrece su lectura').toBe(await cards.count());
+	await expect(readingLinks, 'alguna obra del listado no ofrece su lectura').toHaveCount(await cards.count());
 
 	// Cada tarjeta lleva a *su* obra: sin esto, N enlaces al mismo destino darían el mismo conteo.
 	const destinations = await readingLinks.evaluateAll((links) => links.map((link) => link.getAttribute('href') ?? ''));

--- a/e2e/collection-description-drawer.spec.ts
+++ b/e2e/collection-description-drawer.spec.ts
@@ -72,6 +72,15 @@ async function openDescriptionDrawer(page: Page): Promise<Locator> {
  * pantalla. Actuar ahí mide una caja que no es la que se ve y, si además se interrumpe la transición, el
  * cierre queda esperando un `transitionend` que ya no llega.
  */
+/** La caja que ocupa el panel, para elegir un punto que quede fuera de ella. */
+async function panelBox(drawer: Locator) {
+	const box = await drawer.boundingBox();
+	if (!box) {
+		throw new Error('El panel no ocupa lugar: no habría caja de la cual quedar afuera');
+	}
+	return box;
+}
+
 async function settleIn(drawer: Locator): Promise<void> {
 	await expect
 		.poll(async () => (await drawer.boundingBox())?.x ?? Number.POSITIVE_INFINITY, {
@@ -120,10 +129,7 @@ test('el panel se cierra al hacer clic fuera', async ({ page }) => {
 	test.skip(!readMoreIsVisible, 'ninguna colección del dataset desborda el recorte');
 
 	const drawer = await openDescriptionDrawer(page);
-	const box = await drawer.boundingBox();
-	if (!box) {
-		throw new Error('El panel no ocupa lugar: no habría caja de la cual quedar afuera');
-	}
+	const box = await panelBox(drawer);
 
 	// El panel entra por la derecha, así que el margen izquierdo del viewport es backdrop. El control
 	// positivo descarta que el punto elegido caiga sobre el panel, que cerraría por otro motivo —el botón,

--- a/e2e/collection-description-drawer.spec.ts
+++ b/e2e/collection-description-drawer.spec.ts
@@ -49,13 +49,13 @@ test.beforeAll(async ({ request, browser }) => {
 
 // Guardas como casos propios, no como `skip` silencioso: un dataset sin el fixture es un problema de la
 // infraestructura de test, no un motivo para que el gate quede verde sin haber mirado nada.
-test('el catálogo trae alguna colección con descripción', () => {
+test('collection — el catálogo trae alguna colección con descripción', () => {
 	expect(mostDescriptive, 'ninguna colección del catálogo tiene descripción: no habría qué recortar').toBeDefined();
 });
 
 // Es a la vez la guarda de los casos del panel y la primera mitad de la tarea que los motiva: que el
 // acceso a la descripción completa aparezca cuando el texto desborda su recorte.
-test('alguna colección desborda el recorte de ocho líneas y ofrece leerla entera', () => {
+test('collection — alguna colección desborda el recorte y ofrece leerla entera', () => {
 	expect(
 		readMoreIsVisible,
 		`la descripción más larga del catálogo ("${mostDescriptive?.slug}") no desborda el recorte: los casos del panel no verificarían nada`,
@@ -74,14 +74,6 @@ async function openDescriptionDrawer(page: Page): Promise<Locator> {
 	return drawer;
 }
 
-/**
- * Espera a que el panel llegue a su posición de entrada.
- *
- * No alcanza con que esté visible ni con que lleve `data-open`: ese atributo dispara la transición, no la
- * termina, y durante los 300 ms que dura el panel está en el documento pero todavía corrido fuera de la
- * pantalla. Actuar ahí mide una caja que no es la que se ve y, si además se interrumpe la transición, el
- * cierre queda esperando un `transitionend` que ya no llega.
- */
 /** La caja que ocupa el panel, para elegir un punto que quede fuera de ella. */
 async function panelBox(drawer: Locator) {
 	const box = await drawer.boundingBox();
@@ -91,15 +83,42 @@ async function panelBox(drawer: Locator) {
 	return box;
 }
 
+/**
+ * Espera a que el panel termine de entrar.
+ *
+ * No alcanza con que esté visible ni con que lleve `data-open`: ese atributo dispara la transición, no la
+ * termina, y durante los 300 ms que dura el panel está en el documento pero todavía corrido fuera de la
+ * pantalla. Actuar ahí mide una caja que no es la que se ve y, si además se interrumpe la transición, el
+ * cierre queda esperando un `transitionend` que ya no llega.
+ *
+ * La llegada se afirma por quietud —dos muestras consecutivas en la misma posición— y no por un umbral de
+ * pantalla: un umbral se cumple apenas el panel asoma, y cuánto margen queda entre ese instante y el final
+ * depende del ancho del panel, del viewport y de la dirección. Como efecto lateral, comparar la posición
+ * de partida con la de llegada es la única aserción de que el slide sigue ocurriendo tras atar el display
+ * al atributo `open`.
+ */
 async function settleIn(drawer: Locator): Promise<void> {
+	const startX = (await panelBox(drawer)).x;
+	let previousX = Number.POSITIVE_INFINITY;
+
 	await expect
-		.poll(async () => (await drawer.boundingBox())?.x ?? Number.POSITIVE_INFINITY, {
-			message: 'el panel no llegó a entrar en la pantalla',
-		})
-		.toBeLessThan(DESKTOP_VIEWPORT.width);
+		.poll(
+			async () => {
+				const { x } = await panelBox(drawer);
+				const isStill = x === previousX;
+				previousX = x;
+				return isStill;
+			},
+			{ message: 'el panel no llegó a detenerse en su posición de entrada' },
+		)
+		.toBe(true);
+
+	expect(previousX, 'el panel no se desplazó al abrirse: la transición de entrada dejó de ocurrir').toBeLessThan(
+		startX,
+	);
 }
 
-test('el panel muestra la descripción completa', async ({ page }) => {
+test('collection — el panel muestra la descripción completa', async ({ page }) => {
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reportan las guardas de arriba; repetirla acá sería el mismo fallo dos veces
 	test.skip(!readMoreIsVisible, 'ninguna colección del dataset desborda el recorte');
 
@@ -114,7 +133,7 @@ test('el panel muestra la descripción completa', async ({ page }) => {
 
 // El cierre se afirma con `toBeHidden` y no leyendo el atributo `open`: el drawer llama a `close()` recién
 // al terminar la transición, así que el elemento sigue abierto durante los 300 ms que dura.
-test('el panel se cierra con el botón de cierre', async ({ page }) => {
+test('collection — el panel se cierra con el botón de cierre', async ({ page }) => {
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reportan las guardas de arriba; repetirla acá sería el mismo fallo dos veces
 	test.skip(!readMoreIsVisible, 'ninguna colección del dataset desborda el recorte');
 
@@ -124,7 +143,7 @@ test('el panel se cierra con el botón de cierre', async ({ page }) => {
 	await expect(drawer).toBeHidden();
 });
 
-test('el panel se cierra con Escape', async ({ page }) => {
+test('collection — el panel se cierra con Escape', async ({ page }) => {
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reportan las guardas de arriba; repetirla acá sería el mismo fallo dos veces
 	test.skip(!readMoreIsVisible, 'ninguna colección del dataset desborda el recorte');
 
@@ -134,7 +153,7 @@ test('el panel se cierra con Escape', async ({ page }) => {
 	await expect(drawer).toBeHidden();
 });
 
-test('el panel se cierra al hacer clic fuera', async ({ page }) => {
+test('collection — el panel se cierra al hacer clic fuera', async ({ page }) => {
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reportan las guardas de arriba; repetirla acá sería el mismo fallo dos veces
 	test.skip(!readMoreIsVisible, 'ninguna colección del dataset desborda el recorte');
 

--- a/e2e/collection-description-drawer.spec.ts
+++ b/e2e/collection-description-drawer.spec.ts
@@ -19,6 +19,10 @@ import {
 
 const READ_MORE = 'Leer más';
 
+// Holgado a propósito: el `beforeAll` corre una sola vez y su veredicto decide si los casos del panel
+// corren o se saltean, así que conviene esperar de más antes que declarar ausente un contenido que está.
+const FIXTURE_TIMEOUT = 15_000;
+
 let mostDescriptive: CollectionCatalogEntry | undefined;
 let readMoreIsVisible = false;
 
@@ -33,7 +37,13 @@ test.beforeAll(async ({ request, browser }) => {
 	const page = await browser.newPage({ viewport: DESKTOP_VIEWPORT });
 	await page.goto(`/collection/${mostDescriptive.slug}`);
 	const readMore = page.getByTestId('collection-info').getByRole('button', { name: READ_MORE });
-	readMoreIsVisible = await readMore.isVisible().catch(() => false);
+	// Se espera al control en vez de preguntar si está: el recorte se mide después de hidratar, así que una
+	// lectura instantánea devuelve "no desborda" en una página que todavía no terminó de resolverse. Solo
+	// el vencimiento del plazo significa que el contenido no da.
+	readMoreIsVisible = await readMore
+		.waitFor({ state: 'visible', timeout: FIXTURE_TIMEOUT })
+		.then(() => true)
+		.catch(() => false);
 	await page.close();
 });
 

--- a/e2e/collection-description-drawer.spec.ts
+++ b/e2e/collection-description-drawer.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Acceso a la descripción completa de una colección y cierre del panel que la muestra.
+ *
+ * Es lo único de la suite que mide el desborde real del recorte. El spec unitario de `ClampOverflowDirective`
+ * le fija las medidas a mano porque happy-dom no computa layout, así que la aparición del control —que
+ * depende de que ocho líneas no alcancen para el texto— solo se puede afirmar en un navegador de verdad.
+ *
+ * La colección que se lee acá no es la estable: es la de descripción más larga del catálogo, que es la
+ * única con chances de desbordar. Ver `_utils/collection-fixtures.ts`.
+ */
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+import {
+	DESKTOP_VIEWPORT,
+	fetchCollectionCatalog,
+	pickMostDescriptiveCollection,
+	type CollectionCatalogEntry,
+} from './_utils/collection-fixtures';
+
+const READ_MORE = 'Leer más';
+
+let mostDescriptive: CollectionCatalogEntry | undefined;
+let readMoreIsVisible = false;
+
+test.beforeAll(async ({ request, browser }) => {
+	mostDescriptive = pickMostDescriptiveCollection(await fetchCollectionCatalog(request));
+	if (!mostDescriptive) {
+		return;
+	}
+
+	// El estado del fixture se resuelve una sola vez: sin esto, una curaduría de descripciones cortas
+	// produciría el mismo fallo en cada uno de los casos de abajo en vez de una vez, acá.
+	const page = await browser.newPage({ viewport: DESKTOP_VIEWPORT });
+	await page.goto(`/collection/${mostDescriptive.slug}`);
+	const readMore = page.getByTestId('collection-info').getByRole('button', { name: READ_MORE });
+	readMoreIsVisible = await readMore.isVisible().catch(() => false);
+	await page.close();
+});
+
+// Guardas como casos propios, no como `skip` silencioso: un dataset sin el fixture es un problema de la
+// infraestructura de test, no un motivo para que el gate quede verde sin haber mirado nada.
+test('el catálogo trae alguna colección con descripción', () => {
+	expect(mostDescriptive, 'ninguna colección del catálogo tiene descripción: no habría qué recortar').toBeDefined();
+});
+
+// Es a la vez la guarda de los casos del panel y la primera mitad de la tarea que los motiva: que el
+// acceso a la descripción completa aparezca cuando el texto desborda su recorte.
+test('alguna colección desborda el recorte de ocho líneas y ofrece leerla entera', () => {
+	expect(
+		readMoreIsVisible,
+		`la descripción más larga del catálogo ("${mostDescriptive?.slug}") no desborda el recorte: los casos del panel no verificarían nada`,
+	).toBe(true);
+});
+
+/** Abre la ruta y despliega el panel con la descripción completa. */
+async function openDescriptionDrawer(page: Page): Promise<Locator> {
+	await page.setViewportSize(DESKTOP_VIEWPORT);
+	await page.goto(`/collection/${mostDescriptive?.slug}`);
+	await page.getByTestId('collection-info').getByRole('button', { name: READ_MORE }).click();
+
+	const drawer = page.getByRole('dialog');
+	await expect(drawer).toBeVisible();
+	await settleIn(drawer);
+	return drawer;
+}
+
+/**
+ * Espera a que el panel llegue a su posición de entrada.
+ *
+ * No alcanza con que esté visible ni con que lleve `data-open`: ese atributo dispara la transición, no la
+ * termina, y durante los 300 ms que dura el panel está en el documento pero todavía corrido fuera de la
+ * pantalla. Actuar ahí mide una caja que no es la que se ve y, si además se interrumpe la transición, el
+ * cierre queda esperando un `transitionend` que ya no llega.
+ */
+async function settleIn(drawer: Locator): Promise<void> {
+	await expect
+		.poll(async () => (await drawer.boundingBox())?.x ?? Number.POSITIVE_INFINITY, {
+			message: 'el panel no llegó a entrar en la pantalla',
+		})
+		.toBeLessThan(DESKTOP_VIEWPORT.width);
+}
+
+test('el panel muestra la descripción completa', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reportan las guardas de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(!readMoreIsVisible, 'ninguna colección del dataset desborda el recorte');
+
+	const drawer = await openDescriptionDrawer(page);
+
+	// Se compara el marcado y no el texto: la descripción llega saneada desde el backend y el panel la
+	// pinta tal cual, así que la igualdad afirma a la vez que se muestra entera —el recorte de la columna
+	// es visual, y un `toContainText` pasaría igual con las ocho líneas— y que conserva su prosa.
+	const shown = await drawer.getByTestId('description').innerHTML();
+	expect(shown).toBe(mostDescriptive?.description);
+});
+
+// El cierre se afirma con `toBeHidden` y no leyendo el atributo `open`: el drawer llama a `close()` recién
+// al terminar la transición, así que el elemento sigue abierto durante los 300 ms que dura.
+test('el panel se cierra con el botón de cierre', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reportan las guardas de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(!readMoreIsVisible, 'ninguna colección del dataset desborda el recorte');
+
+	const drawer = await openDescriptionDrawer(page);
+	await drawer.getByRole('button', { name: 'Cerrar' }).click();
+
+	await expect(drawer).toBeHidden();
+});
+
+test('el panel se cierra con Escape', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reportan las guardas de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(!readMoreIsVisible, 'ninguna colección del dataset desborda el recorte');
+
+	const drawer = await openDescriptionDrawer(page);
+	await page.keyboard.press('Escape');
+
+	await expect(drawer).toBeHidden();
+});
+
+test('el panel se cierra al hacer clic fuera', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reportan las guardas de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(!readMoreIsVisible, 'ninguna colección del dataset desborda el recorte');
+
+	const drawer = await openDescriptionDrawer(page);
+	const box = await drawer.boundingBox();
+	if (!box) {
+		throw new Error('El panel no ocupa lugar: no habría caja de la cual quedar afuera');
+	}
+
+	// El panel entra por la derecha, así que el margen izquierdo del viewport es backdrop. El control
+	// positivo descarta que el punto elegido caiga sobre el panel, que cerraría por otro motivo —el botón,
+	// por ejemplo— y daría el mismo verde sin haber probado el backdrop.
+	const outsideX = box.x / 2;
+	const outsideY = DESKTOP_VIEWPORT.height / 2;
+	expect(outsideX, 'el punto elegido cae dentro del panel: el clic no probaría el backdrop').toBeLessThan(box.x);
+
+	await page.mouse.click(outsideX, outsideY);
+
+	await expect(drawer).toBeHidden();
+});

--- a/src/app/components/drawer/drawer.component.spec.ts
+++ b/src/app/components/drawer/drawer.component.spec.ts
@@ -104,6 +104,18 @@ describe('DrawerComponent', () => {
 		expect(fixture.componentInstance.afterClosedCount).toBe(1);
 	});
 
+	// El efecto real —que el panel cerrado no ocupe lugar ni retenga foco— lo afirma el e2e, que es el
+	// único que computa layout. Acá se fija la declaración que lo produce: un display incondicional pisa
+	// el `display: none` del diálogo cerrado y devuelve el panel a la página.
+	it('should tie the dialog display to the open attribute', async () => {
+		await render(HostComponent);
+		const classes = getDialog().className.split(/\s+/);
+
+		expect(classes).toContain('hidden');
+		expect(classes).toContain('open:flex');
+		expect(classes).not.toContain('flex');
+	});
+
 	it('should close on backdrop click but not on content click', async () => {
 		const user = userEvent.setup();
 		const { fixture } = await render(HostComponent);

--- a/src/app/components/drawer/drawer.component.ts
+++ b/src/app/components/drawer/drawer.component.ts
@@ -39,6 +39,10 @@ export type DrawerDirection = 'left' | 'right' | 'top' | 'bottom';
 	hostDirectives: [DrawerTransitionDirective, { directive: DrawerPanelDirective, inputs: ['direction'] }],
 	host: { class: 'contents' },
 	template: `
+		<!-- El display va atado al atributo \`open\`: una clase de display incondicional pisa el \`display: none\`
+		     que el navegador aplica al diálogo cerrado, y el panel queda en la página —fuera de pantalla por el
+		     transform, pero con caja y con su botón de cierre todavía enfocable. El atributo sobrevive toda la
+		     transición de salida, así que el slide sigue viéndose. -->
 		<dialog
 			[class]="panel.panelClasses()"
 			[attr.data-open]="transition.isTransitionedIn() ? '' : null"
@@ -47,7 +51,7 @@ export type DrawerDirection = 'left' | 'right' | 'top' | 'bottom';
 			[attr.aria-describedby]="description() ? descriptionId : null"
 			#dialog
 			tabindex="-1"
-			class="m-0 flex max-w-full flex-col gap-5 overflow-y-auto rounded-xl bg-white p-10 transition-transform duration-300 ease-out backdrop:bg-black/60 motion-reduce:duration-[0.01ms]"
+			class="m-0 hidden max-w-full flex-col gap-5 overflow-y-auto rounded-xl bg-white p-10 transition-transform duration-300 ease-out backdrop:bg-black/60 open:flex motion-reduce:duration-[0.01ms]"
 		>
 			<button
 				(click)="close()"

--- a/src/app/components/drawer/drawer.component.ts
+++ b/src/app/components/drawer/drawer.component.ts
@@ -39,10 +39,6 @@ export type DrawerDirection = 'left' | 'right' | 'top' | 'bottom';
 	hostDirectives: [DrawerTransitionDirective, { directive: DrawerPanelDirective, inputs: ['direction'] }],
 	host: { class: 'contents' },
 	template: `
-		<!-- El display va atado al atributo \`open\`: una clase de display incondicional pisa el \`display: none\`
-		     que el navegador aplica al diálogo cerrado, y el panel queda en la página —fuera de pantalla por el
-		     transform, pero con caja y con su botón de cierre todavía enfocable. El atributo sobrevive toda la
-		     transición de salida, así que el slide sigue viéndose. -->
 		<dialog
 			[class]="panel.panelClasses()"
 			[attr.data-open]="transition.isTransitionedIn() ? '' : null"


### PR DESCRIPTION
## Qué hace

Suma cobertura e2e del flujo de la página de colección: el listado de obras, la columna con la información de la colección, el bloque de otras colecciones sugeridas, el acceso a la descripción completa cuando el texto desborda el recorte, y el cierre del panel por sus tres vías (botón, Escape y clic fuera).

Es lo que ninguna otra suite alcanza. `e2e/seo/collection.spec.ts` mira esta misma ruta, pero mira el HTML que ve el crawler; acá se ejercita la página hidratada, que es lo único que llega a la columna lateral —vive tras un breakpoint, así que depende del ancho real del viewport— y al bloque de sugeridas, que se alimenta de un recurso progresivo y en el HTML del servidor todavía no existe. El desborde del recorte tampoco se puede afirmar en otro lado: el spec unitario de la directiva le fija las medidas a mano, porque happy-dom no computa layout.

## Cómo elige el contenido

Dos fuentes distintas, porque son dos hechos distintos:

- La **identidad** de la colección sale de `STABLE_SLUGS.collection`, como el resto de la suite.
- La **propiedad de curaduría** —que exista una descripción lo bastante larga como para desbordar ocho líneas— se resuelve en runtime contra `GET /api/collection`, tomando la de descripción más larga. Un slug no dice nada sobre cuánto texto le cargó la curaduría: hardcodearlo grabaría en el repositorio un hecho que un editor del CMS rompe sin tocar el código.

Las guardas de fixture van como casos propios y no como skips silenciosos, siguiendo el idiom de `nav-hidden.spec.ts`: un dataset sin el contenido es un problema de la infraestructura de test, no un motivo para que el gate quede verde sin haber mirado nada.

## Defecto que la cobertura destapó

El `<dialog>` del drawer declaraba `flex` de forma incondicional, y esa clase pisa el `display: none` que el navegador aplica a un diálogo cerrado. Cerrado, el panel seguía en la página: fuera de pantalla por el transform, pero con una caja de 704×868 y con su botón de cierre **todavía enfocable al tabular** — la misma clase de defecto que este repositorio ya corrigió en la barra de navegación oculta.

El arreglo ata el display al atributo `open`, que sobrevive toda la transición de salida (el drawer lo quita recién en `transitionend`), así que el slide no cambia. Va con su caso de regresión en el spec del componente.

## Plan de pruebas

- **Los once gates de CI, verdes.** El `e2e` corre contra el dataset `staging`: 150 pasados, 8 salteados —todos preexistentes, ajenos a este diff— y ningún caso flaky.
- **Los doce casos nuevos, verdes en Chromium y Firefox** contra un build de producción local, sin ninguno salteado. Que no queden salteados es parte de lo que se verificó: un skip acá significaría que el dataset no tiene el contenido y que el gate corre en vacío.
- **Control negativo del caso de regresión del drawer**: con el fix revertido y reconstruido, `collection — el panel de la descripción no aporta nada antes de abrirse` sale en rojo contando un botón de cierre en una página donde nadie abrió nada. Con el fix, cuenta cero.
- **El defecto del drawer se verificó por medición, no por lectura**: con el panel cerrado, `display: flex`, caja de 704×868 y el botón de cierre recibiendo el foco.
- **Suite de Vitest completa**: 2340 pasados, incluidos el spec del helper de fixtures y el caso nuevo del componente drawer.

Dos cosas quedan fuera y conviene decirlas: la suite `e2e/seo/**` falla en local por entorno —el server sin las variables de producción sirve `noindex, nofollow`—, lo que no ocurre en CI; y el warning de lint en `e2e/seo/sitemap.spec.ts` es anterior a esta rama.

Closes #1840.

Parte de #1472.
