### PR TITLE
[#2266] - Campos aditivos de landing y migración de referencias

### DIFF
--- a/cms/migrations/relink-landing-to-collection-and-literary-work/README.md
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/README.md
@@ -1,0 +1,91 @@
+# `relink-landing-to-collection-and-literary-work`
+
+Puebla los campos de la página de inicio y del contenido rotativo que referencian **colecciones** y **obras literarias**, derivándolos de los que referencian storylists e historias. **No toca los campos de origen.**
+
+| Documento         | Campo de origen | Campo que puebla        |
+| ----------------- | --------------- | ----------------------- |
+| `landingPage`     | `cards`         | `collections`           |
+| `landingPage`     | `latestReads`   | `latestLiteraryWorks`   |
+| `rotatingContent` | `mostRead`      | `mostReadLiteraryWorks` |
+
+## Prerequisito
+
+**`storylist-to-collection` y `story-to-literary-work` tienen que estar aplicadas con `--no-dry-run` en el mismo dataset.** Las referencias nuevas se derivan del identificador del documento migrado; si ese documento no existe y la referencia es fuerte, el content lake rechaza la transacción entera al escribir.
+
+El dry-run **no** lo detecta: imprime mutaciones sin llegar al servidor. Por eso la verificación de referencias colgadas de más abajo es un paso obligatorio del procedimiento, no una sugerencia.
+
+## Por qué campos nuevos y no un renombre
+
+El Studio y la aplicación no despliegan a la vez. Si se reusaran los nombres de campo no habría orden seguro: desplegar el código primero lo deja leyendo documentos que todavía referencian el tipo viejo, y migrar primero deja al código todavía desplegado leyendo lo que ya cambió de forma. Con campos nuevos las dos formas conviven y ningún lector se queda sin fuente.
+
+Los campos viejos quedan intactos. Su baja va en un PR de limpieza posterior, cuando ningún lector los consulte.
+
+## Cuándo corre
+
+Después de desplegar el Studio con los campos nuevos y **antes** de que la aplicación los lea. Es segura en toda esa ventana porque no modifica nada que alguien esté leyendo: los campos nuevos nacen vacíos y nadie los consulta hasta el despliegue que cambia el contrato.
+
+**Se re-corre una vez más después de ese despliegue.** El endpoint que genera las semanas futuras copia hacia adelante los campos del último documento existente, y hasta ese despliegue arrastra sólo los viejos: cualquier semana generada en el medio nace sin los campos nuevos. La re-corrida cierra ese hueco.
+
+Es re-corrible porque escribe con `setIfMissing` y no con `set`: un campo ya poblado —por la corrida anterior o por una edición hecha a mano en el Studio— no se pisa.
+
+## Comandos
+
+Desde `cms/`. El destino va siempre explícito: `--project` y `--dataset` son **inseparables** y pasar uno solo aborta. El identificador de proyecto se resuelve del entorno, nunca se escribe literal.
+
+```bash
+# Dry-run (es el comportamiento por defecto)
+pnpm exec sanity migration run relink-landing-to-collection-and-literary-work \
+  --project "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')" \
+  --dataset <destino>
+
+# Aplicar. `--no-confirm` hace falta cuando no hay TTY.
+pnpm exec sanity migration run relink-landing-to-collection-and-literary-work \
+  --project "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')" \
+  --dataset <destino> --no-dry-run --no-confirm
+```
+
+Orden de datasets: `development` → `staging` → `production`, con censo antes y verificación después de cada uno.
+
+## Censo previo
+
+```groq
+{
+  'landingPages': count(*[_type == 'landingPage' && !(_id in path('drafts.**'))]),
+  'cards':        count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].cards[]),
+  'latestReads':  count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].latestReads[]),
+  'rotating':     count(*[_type == 'rotatingContent']),
+  'mostRead':     count(*[_type == 'rotatingContent'].mostRead[])
+}
+```
+
+## Verificación posterior
+
+Dos cosas, y las dos importan:
+
+```groq
+// 1. Cada campo nuevo tiene tantas referencias como su origen.
+{
+  'cards':        count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].cards[]),
+  'collections':  count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].collections[]),
+  'latestReads':  count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].latestReads[]),
+  'latestWorks':  count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].latestLiteraryWorks[]),
+  'mostRead':     count(*[_type == 'rotatingContent'].mostRead[]),
+  'mostReadWorks':count(*[_type == 'rotatingContent'].mostReadLiteraryWorks[])
+}
+
+// 2. Ninguna referencia nueva quedó colgada. Es la que no se puede omitir: la
+//    derivación produce un identificador bien formado aunque el destino no exista.
+{
+  'collectionsResueltas': count(*[_type == 'landingPage'].collections[]->_id),
+  'latestWorksResueltas': count(*[_type == 'landingPage'].latestLiteraryWorks[]->_id),
+  'mostReadResueltas':    count(*[_type == 'rotatingContent'].mostReadLiteraryWorks[]->_id)
+}
+```
+
+Los conteos de la segunda consulta tienen que coincidir con los de la primera. Si no coinciden, hay referencias apuntando a documentos que no existen y el prerequisito no estaba cumplido.
+
+**Ningún gate de CI detecta un dataset sin migrar:** el job de e2e corre contra `staging` y pasaría en verde igual. Es responsabilidad de quien despliega.
+
+## Reversión
+
+`revert-relink-landing-to-collection-and-literary-work` da de baja los tres campos nuevos, y **sólo mientras su campo de origen siga poblado**. Si el origen ya no está —porque el PR de limpieza que lo retira ya corrió—, el campo nuevo pasó a ser la única copia de esas referencias y la reversión aborta en vez de destruirlas.

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/README.md
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/README.md
@@ -12,13 +12,19 @@ Puebla los campos de la página de inicio y del contenido rotativo que referenci
 
 **`storylist-to-collection` y `story-to-literary-work` tienen que estar aplicadas con `--no-dry-run` en el mismo dataset.** Las referencias nuevas se derivan del identificador del documento migrado; si ese documento no existe y la referencia es fuerte, el content lake rechaza la transacción entera al escribir.
 
-El dry-run **no** lo detecta: imprime mutaciones sin llegar al servidor. Por eso la verificación de referencias colgadas de más abajo es un paso obligatorio del procedimiento, no una sugerencia.
+El dry-run **no** lo detecta: imprime mutaciones sin llegar al servidor. Por eso la verificación de referencias colgadas es un paso obligatorio del procedimiento, no una sugerencia.
 
 ## Por qué campos nuevos y no un renombre
 
 El Studio y la aplicación no despliegan a la vez. Si se reusaran los nombres de campo no habría orden seguro: desplegar el código primero lo deja leyendo documentos que todavía referencian el tipo viejo, y migrar primero deja al código todavía desplegado leyendo lo que ya cambió de forma. Con campos nuevos las dos formas conviven y ningún lector se queda sin fuente.
 
 Los campos viejos quedan intactos. Su baja va en un PR de limpieza posterior, cuando ningún lector los consulte.
+
+## Por qué también recorre los borradores
+
+Sólo se sirve el documento publicado, así que migrar un borrador no cambia nada de lo que se lee. Pero **omitirlo sí quita**: publicar reemplaza el documento publicado por el contenido del borrador, y un borrador creado antes de la corrida no trae los campos nuevos. Dejarlos afuera convierte cada publicación pendiente en una pérdida silenciosa de lo ya migrado.
+
+Conviene igual saber cuántos hay en vuelo antes de aplicar (consulta en el censo previo).
 
 ## Cuándo corre
 
@@ -46,46 +52,38 @@ pnpm exec sanity migration run relink-landing-to-collection-and-literary-work \
 
 Orden de datasets: `development` → `staging` → `production`, con censo antes y verificación después de cada uno.
 
-## Censo previo
+## Consultas del procedimiento
 
-```groq
-{
-  'landingPages': count(*[_type == 'landingPage' && !(_id in path('drafts.**'))]),
-  'cards':        count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].cards[]),
-  'latestReads':  count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].latestReads[]),
-  'rotating':     count(*[_type == 'rotatingContent']),
-  'mostRead':     count(*[_type == 'rotatingContent'].mostRead[])
-}
-```
+Las cuatro viven en [`verification-queries.ts`](./verification-queries.ts) como constantes, y su spec las ejecuta contra un dataset con una referencia colgada deliberada. **No están acá como texto a propósito:** las dos primeras versiones de estas consultas estaban inertes —una contaba los nulos en vez de descartarlos, y las dos contaban de más un campo ausente— y ninguna de las dos cosas se veía leyéndolas.
 
-## Verificación posterior
+Para correrlas, importarlas o copiarlas del módulo.
 
-Dos cosas, y las dos importan:
+| Constante                     | Qué responde                                                              | Resultado esperado |
+| ----------------------------- | ------------------------------------------------------------------------- | ------------------ |
+| `DRAFTS_IN_FLIGHT_QUERY`      | Qué borradores hay sin publicar (censo previo)                            | informativo        |
+| `PARITY_QUERY`                | Cuántas referencias tiene cada campo nuevo frente a su origen             | pares iguales      |
+| `PER_DOCUMENT_MISMATCH_QUERY` | Qué documentos tienen un campo nuevo desparejo con su origen              | `[]`               |
+| `DANGLING_QUERY`              | Cuántas referencias nuevas apuntan a un documento inexistente             | `0` en los tres    |
+| `UNREVERTIBLE_QUERY`          | Qué documentos ya no se pueden revertir (antes de revertir, no de migrar) | `[]`               |
 
-```groq
-// 1. Cada campo nuevo tiene tantas referencias como su origen.
-{
-  'cards':        count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].cards[]),
-  'collections':  count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].collections[]),
-  'latestReads':  count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].latestReads[]),
-  'latestWorks':  count(*[_type == 'landingPage' && !(_id in path('drafts.**'))].latestLiteraryWorks[]),
-  'mostRead':     count(*[_type == 'rotatingContent'].mostRead[]),
-  'mostReadWorks':count(*[_type == 'rotatingContent'].mostReadLiteraryWorks[])
-}
-
-// 2. Ninguna referencia nueva quedó colgada. Es la que no se puede omitir: la
-//    derivación produce un identificador bien formado aunque el destino no exista.
-{
-  'collectionsResueltas': count(*[_type == 'landingPage'].collections[]->_id),
-  'latestWorksResueltas': count(*[_type == 'landingPage'].latestLiteraryWorks[]->_id),
-  'mostReadResueltas':    count(*[_type == 'rotatingContent'].mostReadLiteraryWorks[]->_id)
-}
-```
-
-Los conteos de la segunda consulta tienen que coincidir con los de la primera. Si no coinciden, hay referencias apuntando a documentos que no existen y el prerequisito no estaba cumplido.
+`PARITY_QUERY` sola no alcanza: es agregada, y un documento con dos de más compensa a otro con dos de menos. Por eso va acompañada de la de discrepancia por documento.
 
 **Ningún gate de CI detecta un dataset sin migrar:** el job de e2e corre contra `staging` y pasaría en verde igual. Es responsabilidad de quien despliega.
 
 ## Reversión
 
-`revert-relink-landing-to-collection-and-literary-work` da de baja los tres campos nuevos, y **sólo mientras su campo de origen siga poblado**. Si el origen ya no está —porque el PR de limpieza que lo retira ya corrió—, el campo nuevo pasó a ser la única copia de esas referencias y la reversión aborta en vez de destruirlas.
+`revert-relink-landing-to-collection-and-literary-work` da de baja los tres campos nuevos, y sólo cuando su contenido es exactamente lo que esta migración habría escrito. Aborta —sin borrar nada— en dos casos: si el campo de origen ya no está poblado (el campo nuevo pasó a ser la única copia) y si el contenido fue editado después de migrar (borrarlo perdería esa edición).
+
+Como el aborto corta la corrida, conviene listar antes los documentos no revertibles con `UNREVERTIBLE_QUERY`: descubrirlo a mitad de camino deja unos documentos revertidos y otros no.
+
+```bash
+# Dry-run
+pnpm exec sanity migration run revert-relink-landing-to-collection-and-literary-work \
+  --project "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')" \
+  --dataset <destino>
+
+# Aplicar
+pnpm exec sanity migration run revert-relink-landing-to-collection-and-literary-work \
+  --project "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')" \
+  --dataset <destino> --no-dry-run --no-confirm
+```

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/build-relinked-references.spec.ts
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/build-relinked-references.spec.ts
@@ -6,8 +6,8 @@ import {
 	type KeyedReference,
 } from './build-relinked-references';
 
-function reference(key: string, ref: string): KeyedReference {
-	return { _key: key, _type: 'reference', _ref: ref };
+function reference(key: string, ref: string, extra: Partial<KeyedReference> = {}): KeyedReference {
+	return { _key: key, _type: 'reference', _ref: ref, ...extra };
 }
 
 describe('buildCollectionReferences', () => {
@@ -33,12 +33,36 @@ describe('buildCollectionReferences', () => {
 		expect(derived.map(({ _key }) => _key)).toEqual(['b', 'a']);
 	});
 
-	// Es lo que permite re-correr la migración tras el paso del generador de semanas futuras sin que las
-	// referencias ya derivadas acumulen el prefijo una vez por corrida.
-	it('deja intacta una referencia ya derivada', () => {
-		const alreadyDerived = reference('a', 'collection-from-storylist-storylist-verano');
+	// Una referencia débil dice que el destino todavía no está publicado. Sintetizarla taparía un dataset
+	// a medio migrar; perderla haría que el content lake rechace la transacción entera.
+	it('copia la debilidad del origen', () => {
+		const [derived] = buildCollectionReferences([reference('a', 'storylist-verano', { _weak: true })]);
 
-		expect(buildCollectionReferences([alreadyDerived])).toEqual([alreadyDerived]);
+		expect(derived._weak).toBe(true);
+	});
+
+	it('no inventa debilidad donde el origen no la declara', () => {
+		const [derived] = buildCollectionReferences([reference('a', 'storylist-verano')]);
+
+		expect('_weak' in derived).toBe(false);
+	});
+
+	// Es lo que distingue este reapuntado de una copia: el tipo del destino cambia, así que la promesa de
+	// fortalecer al publicar tiene que nombrar el tipo nuevo y no el viejo.
+	it('retraduce al tipo destino la promesa de fortalecer al publicar', () => {
+		const [derived] = buildCollectionReferences([
+			reference('a', 'storylist-verano', {
+				_strengthenOnPublish: { type: 'storylist', template: { id: 'storylist' } },
+			}),
+		]);
+
+		expect(derived._strengthenOnPublish).toEqual({ type: 'collection', template: { id: 'collection' } });
+	});
+
+	it('no inventa la promesa donde el origen no la declara', () => {
+		const [derived] = buildCollectionReferences([reference('a', 'storylist-verano')]);
+
+		expect('_strengthenOnPublish' in derived).toBe(false);
 	});
 });
 
@@ -59,9 +83,17 @@ describe('buildLiteraryWorkReferences', () => {
 		expect(buildLiteraryWorkReferences([])).toEqual([]);
 	});
 
-	it('deja intacta una referencia ya derivada', () => {
-		const alreadyDerived = reference('a', 'lw-from-story-story-el-aleph');
+	it('retraduce al tipo destino la promesa de fortalecer al publicar', () => {
+		const [derived] = buildLiteraryWorkReferences([
+			reference('a', 'story-el-aleph', { _strengthenOnPublish: { type: 'story', template: { id: 'story' } } }),
+		]);
 
-		expect(buildLiteraryWorkReferences([alreadyDerived])).toEqual([alreadyDerived]);
+		expect(derived._strengthenOnPublish).toEqual({ type: 'literaryWork', template: { id: 'literaryWork' } });
+	});
+
+	it('copia la debilidad del origen', () => {
+		const [derived] = buildLiteraryWorkReferences([reference('a', 'story-el-aleph', { _weak: true })]);
+
+		expect(derived._weak).toBe(true);
 	});
 });

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/build-relinked-references.spec.ts
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/build-relinked-references.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	buildCollectionReferences,
+	buildLiteraryWorkReferences,
+	type KeyedReference,
+} from './build-relinked-references';
+
+function reference(key: string, ref: string): KeyedReference {
+	return { _key: key, _type: 'reference', _ref: ref };
+}
+
+describe('buildCollectionReferences', () => {
+	it('apunta al documento de colección derivado de la storylist', () => {
+		expect(buildCollectionReferences([reference('a', 'storylist-verano')])).toEqual([
+			reference('a', 'collection-from-storylist-storylist-verano'),
+		]);
+	});
+
+	it('deriva el borrador conservando el prefijo de path al frente', () => {
+		const [derived] = buildCollectionReferences([reference('a', 'drafts.storylist-verano')]);
+
+		expect(derived._ref).toBe('drafts.collection-from-storylist-storylist-verano');
+	});
+
+	it('devuelve una lista vacía cuando la fuente está ausente', () => {
+		expect(buildCollectionReferences(undefined)).toEqual([]);
+	});
+
+	it('conserva la clave y el orden de la fuente', () => {
+		const derived = buildCollectionReferences([reference('b', 'storylist-uno'), reference('a', 'storylist-dos')]);
+
+		expect(derived.map(({ _key }) => _key)).toEqual(['b', 'a']);
+	});
+
+	// Es lo que permite re-correr la migración tras el paso del generador de semanas futuras sin que las
+	// referencias ya derivadas acumulen el prefijo una vez por corrida.
+	it('deja intacta una referencia ya derivada', () => {
+		const alreadyDerived = reference('a', 'collection-from-storylist-storylist-verano');
+
+		expect(buildCollectionReferences([alreadyDerived])).toEqual([alreadyDerived]);
+	});
+});
+
+describe('buildLiteraryWorkReferences', () => {
+	it('apunta a la obra derivada de la historia', () => {
+		expect(buildLiteraryWorkReferences([reference('a', 'story-el-aleph')])).toEqual([
+			reference('a', 'lw-from-story-story-el-aleph'),
+		]);
+	});
+
+	it('deriva el borrador conservando el prefijo de path al frente', () => {
+		const [derived] = buildLiteraryWorkReferences([reference('a', 'drafts.story-el-aleph')]);
+
+		expect(derived._ref).toBe('drafts.lw-from-story-story-el-aleph');
+	});
+
+	it('devuelve una lista vacía cuando la fuente está vacía', () => {
+		expect(buildLiteraryWorkReferences([])).toEqual([]);
+	});
+
+	it('deja intacta una referencia ya derivada', () => {
+		const alreadyDerived = reference('a', 'lw-from-story-story-el-aleph');
+
+		expect(buildLiteraryWorkReferences([alreadyDerived])).toEqual([alreadyDerived]);
+	});
+});

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/build-relinked-references.ts
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/build-relinked-references.ts
@@ -1,12 +1,16 @@
-import { collectionIdFor, isMigratedCollectionId } from '../storylist-to-collection/build-collection-document';
-import { isMigratedLiteraryWorkId, literaryWorkIdFor } from '../story-to-literary-work/build-literary-work-document';
+import { collectionIdFor } from '../storylist-to-collection/build-collection-document';
+import { literaryWorkIdFor } from '../story-to-literary-work/build-literary-work-document';
 
 /** Una referencia dentro de un array de Sanity: la clave la asigna el editor y sobrevive al reapuntado. */
 export interface KeyedReference {
 	_key: string;
 	_type: 'reference';
 	_ref: string;
+	_weak?: boolean;
+	_strengthenOnPublish?: { type: string; template?: { id: string } };
 }
+
+type TargetType = 'collection' | 'literaryWork';
 
 /**
  * Deriva las referencias del campo nuevo a partir de las del viejo.
@@ -15,23 +19,37 @@ export interface KeyedReference {
  * de replicarse: una segunda noción de "cuál es el documento migrado" podría apuntar al vacío, y las
  * importadas ya contemplan el prefijo de path que marca a los borradores.
  *
- * Conserva el `_key` de origen —es estable y hace trazable de dónde salió cada entrada— y cambia sólo el
- * destino. Un `_ref` ya derivado se deja intacto, para que una segunda corrida no vuelva a prefijarlo.
+ * **La referencia se construye campo por campo y no se spreadea.** El destino cambia de tipo, así que
+ * `_strengthenOnPublish` —que nombra contra qué tipo el Studio debe fortalecer la referencia al
+ * publicarla— tiene que retraducirse: copiarla dejaría una referencia a una obra prometiendo fortalecerse
+ * contra una historia. Es la misma distinción que ya resuelve la migración que creó estos documentos.
+ *
+ * **`_weak` se copia y nunca se sintetiza.** Una referencia débil dice que el destino todavía no está
+ * publicado; debilitar una que el origen tiene fuerte taparía un dataset a medio migrar.
+ *
+ * El `_key` se preserva del origen: es estable, hace trazable de dónde salió cada entrada, y derivarlo
+ * del `_ref` produciría claves duplicadas si un mismo destino aparece dos veces.
  */
 function relink(
 	references: readonly KeyedReference[] | undefined,
 	derive: (id: string) => string,
-	isDerived: (id: string) => boolean,
+	targetType: TargetType,
 ): KeyedReference[] {
-	return (references ?? []).map((reference) =>
-		isDerived(reference._ref) ? reference : { ...reference, _ref: derive(reference._ref) },
-	);
+	return (references ?? []).map((reference) => ({
+		_type: 'reference',
+		_ref: derive(reference._ref),
+		_key: reference._key,
+		...(reference._weak !== undefined ? { _weak: reference._weak } : {}),
+		...(reference._strengthenOnPublish !== undefined
+			? { _strengthenOnPublish: { type: targetType, template: { id: targetType } } }
+			: {}),
+	}));
 }
 
 export function buildCollectionReferences(references: readonly KeyedReference[] | undefined): KeyedReference[] {
-	return relink(references, collectionIdFor, isMigratedCollectionId);
+	return relink(references, collectionIdFor, 'collection');
 }
 
 export function buildLiteraryWorkReferences(references: readonly KeyedReference[] | undefined): KeyedReference[] {
-	return relink(references, literaryWorkIdFor, isMigratedLiteraryWorkId);
+	return relink(references, literaryWorkIdFor, 'literaryWork');
 }

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/build-relinked-references.ts
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/build-relinked-references.ts
@@ -1,0 +1,37 @@
+import { collectionIdFor, isMigratedCollectionId } from '../storylist-to-collection/build-collection-document';
+import { isMigratedLiteraryWorkId, literaryWorkIdFor } from '../story-to-literary-work/build-literary-work-document';
+
+/** Una referencia dentro de un array de Sanity: la clave la asigna el editor y sobrevive al reapuntado. */
+export interface KeyedReference {
+	_key: string;
+	_type: 'reference';
+	_ref: string;
+}
+
+/**
+ * Deriva las referencias del campo nuevo a partir de las del viejo.
+ *
+ * Las derivaciones de `_id` se **importan** de las migraciones que crearon los documentos destino en vez
+ * de replicarse: una segunda noción de "cuál es el documento migrado" podría apuntar al vacío, y las
+ * importadas ya contemplan el prefijo de path que marca a los borradores.
+ *
+ * Conserva el `_key` de origen —es estable y hace trazable de dónde salió cada entrada— y cambia sólo el
+ * destino. Un `_ref` ya derivado se deja intacto, para que una segunda corrida no vuelva a prefijarlo.
+ */
+function relink(
+	references: readonly KeyedReference[] | undefined,
+	derive: (id: string) => string,
+	isDerived: (id: string) => boolean,
+): KeyedReference[] {
+	return (references ?? []).map((reference) =>
+		isDerived(reference._ref) ? reference : { ...reference, _ref: derive(reference._ref) },
+	);
+}
+
+export function buildCollectionReferences(references: readonly KeyedReference[] | undefined): KeyedReference[] {
+	return relink(references, collectionIdFor, isMigratedCollectionId);
+}
+
+export function buildLiteraryWorkReferences(references: readonly KeyedReference[] | undefined): KeyedReference[] {
+	return relink(references, literaryWorkIdFor, isMigratedLiteraryWorkId);
+}

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/index.spec.ts
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/index.spec.ts
@@ -1,0 +1,117 @@
+import { evaluate, parse } from 'groq-js';
+import { describe, expect, it } from 'vitest';
+
+import type { KeyedReference } from './build-relinked-references';
+import migration from './index';
+
+// `defineMigration` conserva el objeto tal cual, así que `migrate.document` es una función pura y es lo
+// único que hace falta ejercitar: decide qué mutación emite cada documento.
+interface FieldPatch {
+	path: string[];
+	op: { type: string; value?: unknown };
+}
+
+const migrateDocument = (doc: Record<string, unknown>) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never) as FieldPatch[];
+};
+
+const reference = (key: string, ref: string): KeyedReference => ({ _key: key, _type: 'reference', _ref: ref });
+
+const landingPage = (overrides: Record<string, unknown> = {}) => ({
+	_id: 'landing-2026-01',
+	_type: 'landingPage',
+	cards: [reference('c1', 'storylist-verano')],
+	latestReads: [reference('l1', 'story-el-aleph')],
+	...overrides,
+});
+
+const rotatingContent = (overrides: Record<string, unknown> = {}) => ({
+	_id: 'rotating-content',
+	_type: 'rotatingContent',
+	mostRead: [reference('m1', 'story-el-aleph')],
+	...overrides,
+});
+
+const patchFor = (patches: FieldPatch[], field: string) => patches.find(({ path }) => path[0] === field);
+
+/** Los destinos escritos sobre un campo, o `undefined` si el campo no se tocó. */
+const writtenRefs = (patches: FieldPatch[], field: string): string[] | undefined =>
+	(patchFor(patches, field)?.op.value as KeyedReference[] | undefined)?.map(({ _ref }) => _ref);
+
+describe('migración de reapuntado de la página de inicio y el contenido rotativo', () => {
+	it('alcanza a los dos tipos de documento que llevan las referencias', () => {
+		expect(migration.documentTypes).toEqual(['landingPage', 'rotatingContent']);
+	});
+
+	// El filtro se ejecuta con el mismo motor que GROQ y no se compara como texto: una aserción textual
+	// pasa igual con un filtro roto mientras el literal coincida.
+	describe('el filtro decide qué entra', () => {
+		const matching = async (...docs: Record<string, unknown>[]) => {
+			const result = await evaluate(parse(`*[${migration.filter}]._id`), { dataset: docs });
+			return (await result.get()) as string[];
+		};
+
+		it('admite un documento publicado', async () => {
+			expect(await matching({ _id: 'publicado', _type: 'landingPage' })).toEqual(['publicado']);
+		});
+
+		it('deja fuera un borrador', async () => {
+			expect(await matching({ _id: 'drafts.borrador', _type: 'landingPage' })).toEqual([]);
+		});
+	});
+
+	describe('página de inicio', () => {
+		it('puebla los dos campos nuevos desde los viejos', () => {
+			const mutations = migrateDocument(landingPage());
+
+			expect(writtenRefs(mutations, 'collections')).toEqual(['collection-from-storylist-storylist-verano']);
+			expect(writtenRefs(mutations, 'latestLiteraryWorks')).toEqual(['lw-from-story-story-el-aleph']);
+		});
+
+		// Escribir una lista vacía marcaría el documento como migrado sin haberlo estado.
+		it('no emite mutación cuando las dos fuentes están vacías', () => {
+			expect(migrateDocument(landingPage({ cards: [], latestReads: undefined }))).toEqual([]);
+		});
+
+		it('puebla solo el campo cuya fuente tiene contenido', () => {
+			const mutations = migrateDocument(landingPage({ latestReads: [] }));
+
+			expect(mutations).toHaveLength(1);
+			expect(writtenRefs(mutations, 'collections')).toBeDefined();
+		});
+
+		// Es lo que hace segura la re-corrida posterior al despliegue del contrato nuevo: una edición hecha
+		// a mano en el Studio sobre el campo nuevo no se pisa con lo derivado del viejo.
+		it('escribe con semántica de backfill y no de sincronización', () => {
+			const [patch] = migrateDocument(landingPage());
+
+			expect(patch.op.type).toBe('setIfMissing');
+		});
+
+		it('conserva la clave de la referencia de origen', () => {
+			const written = (patchFor(migrateDocument(landingPage()), 'collections')?.op.value ?? []) as KeyedReference[];
+
+			expect(written[0]?._key).toBe('c1');
+		});
+	});
+
+	describe('contenido rotativo', () => {
+		it('puebla las obras más leídas desde las historias', () => {
+			expect(writtenRefs(migrateDocument(rotatingContent()), 'mostReadLiteraryWorks')).toEqual([
+				'lw-from-story-story-el-aleph',
+			]);
+		});
+
+		it('no toca los campos de la página de inicio', () => {
+			const mutations = migrateDocument(rotatingContent());
+
+			expect(mutations).toHaveLength(1);
+		});
+
+		it('no emite mutación cuando la fuente está vacía', () => {
+			expect(migrateDocument(rotatingContent({ mostRead: [] }))).toEqual([]);
+		});
+	});
+});

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/index.spec.ts
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/index.spec.ts
@@ -1,4 +1,3 @@
-import { evaluate, parse } from 'groq-js';
 import { describe, expect, it } from 'vitest';
 
 import type { KeyedReference } from './build-relinked-references';
@@ -45,21 +44,19 @@ describe('migración de reapuntado de la página de inicio y el contenido rotati
 		expect(migration.documentTypes).toEqual(['landingPage', 'rotatingContent']);
 	});
 
-	// El filtro se ejecuta con el mismo motor que GROQ y no se compara como texto: una aserción textual
-	// pasa igual con un filtro roto mientras el literal coincida.
-	describe('el filtro decide qué entra', () => {
-		const matching = async (...docs: Record<string, unknown>[]) => {
-			const result = await evaluate(parse(`*[${migration.filter}]._id`), { dataset: docs });
-			return (await result.get()) as string[];
-		};
+	// Los borradores entran a propósito: publicar uno creado antes de la corrida reemplaza al documento
+	// publicado por su contenido, así que dejarlos afuera convierte cada publicación pendiente en una
+	// pérdida silenciosa de lo migrado.
+	it('migra un borrador igual que un documento publicado', () => {
+		const borrador = { ...landingPage(), _id: 'drafts.landing-2026-01' };
 
-		it('admite un documento publicado', async () => {
-			expect(await matching({ _id: 'publicado', _type: 'landingPage' })).toEqual(['publicado']);
-		});
+		expect(writtenRefs(migrateDocument(borrador), 'collections')).toEqual([
+			'collection-from-storylist-storylist-verano',
+		]);
+	});
 
-		it('deja fuera un borrador', async () => {
-			expect(await matching({ _id: 'drafts.borrador', _type: 'landingPage' })).toEqual([]);
-		});
+	it('ignora un tipo de documento que no es ninguno de los dos', () => {
+		expect(migrateDocument({ _id: 'autor-1', _type: 'author' })).toEqual([]);
 	});
 
 	describe('página de inicio', () => {

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/index.ts
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/index.ts
@@ -6,22 +6,19 @@ import {
 	type KeyedReference,
 } from './build-relinked-references';
 
-// El shape mínimo que la migración lee. No se importan los tipos del typegen: declaran los campos nuevos
-// como opcionales y los viejos igual, así que no aportan sobre esto y atan la migración al schema vigente.
-interface LandingPageDocument {
+// El shape mínimo que la migración lee, con los campos de los dos tipos en un solo lugar. No se importan
+// los tipos del typegen: declaran todos los campos como opcionales, así que no aportan sobre esto y atan
+// la migración al schema vigente.
+//
+// `_type` va como `string` y no como unión de literales: el runner tipa el documento como `SanityDocument`,
+// donde es `string`, y acotarlo acá vuelve la función incompatible con la firma que espera.
+interface RelinkableDocument {
 	_id: string;
-	_type: 'landingPage';
+	_type: string;
 	cards?: KeyedReference[];
 	latestReads?: KeyedReference[];
-}
-
-interface RotatingContentDocument {
-	_id: string;
-	_type: 'rotatingContent';
 	mostRead?: KeyedReference[];
 }
-
-type MigratedDocument = LandingPageDocument | RotatingContentDocument;
 
 /**
  * Puebla los campos que referencian colecciones y obras a partir de los que referencian storylists e
@@ -46,7 +43,7 @@ export default defineMigration({
 	// el conteo con el que se verifica la corrida.
 	filter: "!(_id in path('drafts.**'))",
 	migrate: {
-		document(doc: MigratedDocument) {
+		document(doc: RelinkableDocument) {
 			if (doc._type === 'rotatingContent') {
 				const mostReadLiteraryWorks = buildLiteraryWorkReferences(doc.mostRead);
 				return mostReadLiteraryWorks.length > 0

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/index.ts
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/index.ts
@@ -39,16 +39,24 @@ interface RelinkableDocument {
 export default defineMigration({
 	title: 'Reapuntar las referencias de la página de inicio y del contenido rotativo al dominio nuevo',
 	documentTypes: ['landingPage', 'rotatingContent'],
-	// Los borradores quedan fuera: la landing publicada es la única que se sirve, y migrarlos sólo ensucia
-	// el conteo con el que se verifica la corrida.
-	filter: "!(_id in path('drafts.**'))",
+	// Sin filtro: los borradores también se migran. Sólo se sirve el documento publicado, así que migrarlos
+	// no aporta a lo que se lee, pero omitirlos sí quita: publicar un borrador reemplaza al publicado por el
+	// contenido del borrador, y uno creado antes de la corrida no trae los campos nuevos. Dejarlos afuera
+	// convierte cada publicación pendiente en una pérdida silenciosa de lo migrado.
 	migrate: {
 		document(doc: RelinkableDocument) {
+			// Los dos tipos se nombran explícitamente en vez de tratar a `landingPage` como el caso por
+			// defecto: si mañana se suma un tipo a la lista de arriba, el default le escribiría campos que no
+			// tiene en vez de ignorarlo.
 			if (doc._type === 'rotatingContent') {
 				const mostReadLiteraryWorks = buildLiteraryWorkReferences(doc.mostRead);
 				return mostReadLiteraryWorks.length > 0
 					? [at('mostReadLiteraryWorks', setIfMissing(mostReadLiteraryWorks))]
 					: [];
+			}
+
+			if (doc._type !== 'landingPage') {
+				return [];
 			}
 
 			const collections = buildCollectionReferences(doc.cards);

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/index.ts
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/index.ts
@@ -1,0 +1,66 @@
+import { at, defineMigration, setIfMissing } from 'sanity/migrate';
+
+import {
+	buildCollectionReferences,
+	buildLiteraryWorkReferences,
+	type KeyedReference,
+} from './build-relinked-references';
+
+// El shape mínimo que la migración lee. No se importan los tipos del typegen: declaran los campos nuevos
+// como opcionales y los viejos igual, así que no aportan sobre esto y atan la migración al schema vigente.
+interface LandingPageDocument {
+	_id: string;
+	_type: 'landingPage';
+	cards?: KeyedReference[];
+	latestReads?: KeyedReference[];
+}
+
+interface RotatingContentDocument {
+	_id: string;
+	_type: 'rotatingContent';
+	mostRead?: KeyedReference[];
+}
+
+type MigratedDocument = LandingPageDocument | RotatingContentDocument;
+
+/**
+ * Puebla los campos que referencian colecciones y obras a partir de los que referencian storylists e
+ * historias, sin tocar estos últimos.
+ *
+ * **Orden de despliegue:** corre después de desplegar el Studio con los campos nuevos y **antes** de que
+ * la aplicación los lea. Es segura en esa ventana porque no modifica nada que alguien esté leyendo: los
+ * campos nuevos nacen vacíos y nadie los consulta hasta el despliegue que cambia el contrato.
+ *
+ * **Backfill, no sincronización.** Usa `setIfMissing` en lugar de `set` para que una corrida tardía —con
+ * el contrato nuevo ya desplegado y algún campo editado a mano en el Studio— no pise esa edición con lo
+ * derivado del campo viejo. Es lo que la vuelve idempotente y re-corrible, que hace falta porque el
+ * generador de semanas futuras copia hacia adelante sólo los campos viejos hasta ese despliegue.
+ *
+ * Un documento cuya fuente está vacía no produce mutación: escribir una lista vacía lo marcaría como
+ * migrado sin haberlo estado.
+ */
+export default defineMigration({
+	title: 'Reapuntar las referencias de la página de inicio y del contenido rotativo al dominio nuevo',
+	documentTypes: ['landingPage', 'rotatingContent'],
+	// Los borradores quedan fuera: la landing publicada es la única que se sirve, y migrarlos sólo ensucia
+	// el conteo con el que se verifica la corrida.
+	filter: "!(_id in path('drafts.**'))",
+	migrate: {
+		document(doc: MigratedDocument) {
+			if (doc._type === 'rotatingContent') {
+				const mostReadLiteraryWorks = buildLiteraryWorkReferences(doc.mostRead);
+				return mostReadLiteraryWorks.length > 0
+					? [at('mostReadLiteraryWorks', setIfMissing(mostReadLiteraryWorks))]
+					: [];
+			}
+
+			const collections = buildCollectionReferences(doc.cards);
+			const latestLiteraryWorks = buildLiteraryWorkReferences(doc.latestReads);
+
+			return [
+				...(collections.length > 0 ? [at('collections', setIfMissing(collections))] : []),
+				...(latestLiteraryWorks.length > 0 ? [at('latestLiteraryWorks', setIfMissing(latestLiteraryWorks))] : []),
+			];
+		},
+	},
+});

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/verification-queries.spec.ts
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/verification-queries.spec.ts
@@ -1,0 +1,138 @@
+import { evaluate, parse } from 'groq-js';
+import { describe, expect, it } from 'vitest';
+
+import {
+	DANGLING_QUERY,
+	DRAFTS_IN_FLIGHT_QUERY,
+	PARITY_QUERY,
+	PER_DOCUMENT_MISMATCH_QUERY,
+	UNREVERTIBLE_QUERY,
+} from './verification-queries';
+
+const run = async (query: string, dataset: Record<string, unknown>[]) => {
+	const result = await evaluate(parse(query), { dataset });
+	return result.get();
+};
+
+const reference = (key: string, ref: string) => ({ _key: key, _type: 'reference', _ref: ref });
+
+const collection = { _id: 'collection-1', _type: 'collection' };
+const literaryWork = { _id: 'lw-1', _type: 'literaryWork' };
+
+const migratedLanding = (overrides: Record<string, unknown> = {}) => ({
+	_id: 'landing-1',
+	_type: 'landingPage',
+	cards: [reference('c1', 'storylist-1')],
+	collections: [reference('c1', 'collection-1')],
+	latestReads: [reference('l1', 'story-1')],
+	latestLiteraryWorks: [reference('l1', 'lw-1')],
+	...overrides,
+});
+
+describe('consulta de paridad', () => {
+	it('reporta el mismo conteo en el campo nuevo que en su origen', async () => {
+		expect(await run(PARITY_QUERY, [migratedLanding(), collection, literaryWork])).toMatchObject({
+			cards: 1,
+			collections: 1,
+			latestReads: 1,
+			latestWorks: 1,
+		});
+	});
+
+	// Recorrer un campo ausente no da una lista vacía sino `[null]`, así que sin la guarda un documento
+	// sin migrar sumaba uno de más y la paridad daba bien justo cuando no debía.
+	it('cuenta cero, y no uno, en el campo que todavía no se pobló', async () => {
+		const sinPoblar = { _id: 'landing-1', _type: 'landingPage', cards: [reference('c1', 'storylist-1')] };
+		const result = (await run(PARITY_QUERY, [sinPoblar])) as Record<string, number>;
+
+		expect(result.cards).toBe(1);
+		expect(result.collections).toBe(0);
+	});
+});
+
+describe('consulta de referencias colgadas', () => {
+	it('no reporta ninguna cuando todos los destinos existen', async () => {
+		expect(await run(DANGLING_QUERY, [migratedLanding(), collection, literaryWork])).toMatchObject({
+			collections: 0,
+			latestWorks: 0,
+		});
+	});
+
+	// Es el caso que la primera versión de esta consulta no detectaba: contaba los nulos del destino
+	// ausente en vez de descartarlos, así que daba el mismo número con y sin referencias rotas.
+	it('detecta una referencia cuyo destino no existe', async () => {
+		const dataset = [migratedLanding({ collections: [reference('c1', 'collection-inexistente')] }), literaryWork];
+
+		expect(await run(DANGLING_QUERY, dataset)).toMatchObject({ collections: 1, latestWorks: 0 });
+	});
+
+	// El otro lado del mismo defecto: sin la guarda, cada documento que todavía no tiene el campo
+	// aparecía como una referencia colgada, y la verificación fallaba justo cuando todo estaba bien.
+	it('no reporta como colgado un documento que todavía no tiene el campo', async () => {
+		const sinMigrar = { _id: 'landing-2', _type: 'landingPage', cards: [reference('c1', 'storylist-1')] };
+
+		expect(await run(DANGLING_QUERY, [migratedLanding(), collection, literaryWork, sinMigrar])).toMatchObject({
+			collections: 0,
+		});
+	});
+
+	it('detecta una referencia colgada en el contenido rotativo', async () => {
+		const dataset = [
+			{
+				_id: 'rotating-content',
+				_type: 'rotatingContent',
+				mostRead: [reference('m1', 'story-1')],
+				mostReadLiteraryWorks: [reference('m1', 'lw-inexistente')],
+			},
+		];
+
+		expect(await run(DANGLING_QUERY, dataset)).toMatchObject({ mostReadWorks: 1 });
+	});
+});
+
+describe('consulta de discrepancia por documento', () => {
+	it('no nombra a nadie cuando cada documento tiene su paridad', async () => {
+		expect(await run(PER_DOCUMENT_MISMATCH_QUERY, [migratedLanding()])).toEqual([]);
+	});
+
+	// La paridad agregada suma igual con un documento de más y otro de menos: por eso hace falta ésta.
+	it('nombra al documento cuyo campo nuevo tiene menos referencias que su origen', async () => {
+		const dataset = [
+			migratedLanding({ _id: 'con-faltante', collections: [] }),
+			migratedLanding({
+				_id: 'con-sobrante',
+				collections: [reference('c1', 'collection-1'), reference('c2', 'collection-1')],
+			}),
+		];
+
+		expect(await run(PER_DOCUMENT_MISMATCH_QUERY, dataset)).toEqual(['con-faltante', 'con-sobrante']);
+	});
+});
+
+describe('consulta de documentos no revertibles', () => {
+	it('no nombra a nadie mientras el origen siga poblado', async () => {
+		expect(await run(UNREVERTIBLE_QUERY, [migratedLanding()])).toEqual([]);
+	});
+
+	it('nombra al documento cuyo origen ya se retiró', async () => {
+		const sinOrigen = {
+			_id: 'landing-1',
+			_type: 'landingPage',
+			collections: [reference('c1', 'collection-1')],
+		};
+
+		expect(await run(UNREVERTIBLE_QUERY, [sinOrigen])).toEqual(['landing-1']);
+	});
+});
+
+describe('consulta de borradores en vuelo', () => {
+	it('nombra los borradores de los tipos que la migración toca', async () => {
+		const dataset = [
+			migratedLanding(),
+			{ _id: 'drafts.landing-1', _type: 'landingPage' },
+			{ _id: 'drafts.author-1', _type: 'author' },
+		];
+
+		expect(await run(DRAFTS_IN_FLIGHT_QUERY, dataset)).toEqual(['drafts.landing-1']);
+	});
+});

--- a/cms/migrations/relink-landing-to-collection-and-literary-work/verification-queries.ts
+++ b/cms/migrations/relink-landing-to-collection-and-literary-work/verification-queries.ts
@@ -1,0 +1,64 @@
+/**
+ * Las consultas con las que se verifica la corrida, como constantes ejecutables en vez de prosa en el
+ * README.
+ *
+ * El motivo es el mismo por el que el spec de la migración evalúa su `filter` con el motor de GROQ en
+ * lugar de compararlo como texto: una consulta publicada que nadie ejecuta puede estar inerte y aparentar
+ * que verifica. Estas tuvieron dos defectos que sólo aparecieron al ejecutarlas, y ninguno de los dos era
+ * visible leyéndolas.
+ *
+ * **Los dos defectos vienen del mismo lugar:** recorrer un campo ausente. `doc.campo[]` sobre un
+ * documento que no lo declara no produce una lista vacía sino `[null]`, así que:
+ *
+ * - contarlo daba **uno de más** por cada documento sin migrar, y
+ * - filtrarlo por destino inexistente daba un **falso positivo** por cada uno de ellos.
+ *
+ * De ahí que cada conteo lleve su `defined(...)` en el filtro del documento: acota el recorrido a los que
+ * efectivamente tienen el campo.
+ */
+
+/** Paridad entre cada campo nuevo y su origen. Cada campo nuevo debe igualar a su par. */
+export const PARITY_QUERY = `{
+  'cards':          count(*[_type == 'landingPage' && defined(cards)].cards[]),
+  'collections':    count(*[_type == 'landingPage' && defined(collections)].collections[]),
+  'latestReads':    count(*[_type == 'landingPage' && defined(latestReads)].latestReads[]),
+  'latestWorks':    count(*[_type == 'landingPage' && defined(latestLiteraryWorks)].latestLiteraryWorks[]),
+  'mostRead':       count(*[_type == 'rotatingContent' && defined(mostRead)].mostRead[]),
+  'mostReadWorks':  count(*[_type == 'rotatingContent' && defined(mostReadLiteraryWorks)].mostReadLiteraryWorks[])
+}`;
+
+/**
+ * Referencias nuevas que no resuelven. Los tres conteos deben dar `0`.
+ *
+ * `[!defined(@->_id)]` **filtra** los miembros cuyo destino no existe. La forma que compara "conteo
+ * resuelto contra conteo de origen" no sirve: dereferenciar conserva el `null` del destino ausente y
+ * `count()` lo cuenta, así que los dos números coinciden aunque todas las referencias estén colgadas.
+ */
+export const DANGLING_QUERY = `{
+  'collections':   count(*[_type == 'landingPage' && defined(collections)].collections[!defined(@->_id)]),
+  'latestWorks':   count(*[_type == 'landingPage' && defined(latestLiteraryWorks)].latestLiteraryWorks[!defined(@->_id)]),
+  'mostReadWorks': count(*[_type == 'rotatingContent' && defined(mostReadLiteraryWorks)].mostReadLiteraryWorks[!defined(@->_id)])
+}`;
+
+/**
+ * Documentos donde un campo nuevo no tiene tantas referencias como su origen. Debe devolver `[]`.
+ *
+ * La paridad agregada no alcanza: un documento con dos de más y otro con dos de menos suman igual.
+ */
+export const PER_DOCUMENT_MISMATCH_QUERY = `*[
+  (_type == 'landingPage' && (count(cards) != count(collections) || count(latestReads) != count(latestLiteraryWorks))) ||
+  (_type == 'rotatingContent' && count(mostRead) != count(mostReadLiteraryWorks))
+]._id`;
+
+/**
+ * Documentos que la reversión no podría revertir, porque su campo de origen ya no está poblado. Debe
+ * devolver `[]` antes de revertir: si no, la corrida abortaría a mitad de camino, dejando unos documentos
+ * revertidos y otros no.
+ */
+export const UNREVERTIBLE_QUERY = `*[
+  (_type == 'landingPage' && ((defined(collections) && !defined(cards)) || (defined(latestLiteraryWorks) && !defined(latestReads)))) ||
+  (_type == 'rotatingContent' && defined(mostReadLiteraryWorks) && !defined(mostRead))
+]._id`;
+
+/** Borradores en vuelo. Publicar uno creado antes de la corrida pisa el documento migrado con su contenido. */
+export const DRAFTS_IN_FLIGHT_QUERY = `*[_id in path('drafts.**') && _type in ['landingPage', 'rotatingContent']]._id`;

--- a/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.spec.ts
+++ b/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import {
+	buildCollectionReferences,
+	buildLiteraryWorkReferences,
+} from '../relink-landing-to-collection-and-literary-work/build-relinked-references';
 import migration from './index';
 
 const migrateDocument = (doc: Record<string, unknown>) => {
@@ -10,41 +14,56 @@ const migrateDocument = (doc: Record<string, unknown>) => {
 
 const reference = (ref: string) => ({ _key: 'k1', _type: 'reference' as const, _ref: ref });
 
+const cards = [reference('storylist-verano')];
+const latestReads = [reference('story-el-aleph')];
+const mostRead = [reference('story-el-aleph')];
+
+/** Un documento tal como lo dejó la migración de ida: los campos nuevos derivados de los viejos. */
 const relinkedLandingPage = (overrides: Record<string, unknown> = {}) => ({
 	_id: 'landing-2026-01',
-	_type: 'landingPage' as const,
-	cards: [reference('storylist-verano')],
-	latestReads: [reference('story-el-aleph')],
-	collections: [reference('collection-from-storylist-storylist-verano')],
-	latestLiteraryWorks: [reference('lw-from-story-story-el-aleph')],
+	_type: 'landingPage',
+	cards,
+	latestReads,
+	collections: buildCollectionReferences(cards),
+	latestLiteraryWorks: buildLiteraryWorkReferences(latestReads),
+	...overrides,
+});
+
+const relinkedRotatingContent = (overrides: Record<string, unknown> = {}) => ({
+	_id: 'rotating-content',
+	_type: 'rotatingContent',
+	mostRead,
+	mostReadLiteraryWorks: buildLiteraryWorkReferences(mostRead),
 	...overrides,
 });
 
 describe('reversión del reapuntado', () => {
-	it('da de baja los dos campos nuevos de la página de inicio', () => {
-		const patches = migrateDocument(relinkedLandingPage());
+	it('alcanza a los dos tipos de documento que llevan las referencias', () => {
+		expect(migration.documentTypes).toEqual(['landingPage', 'rotatingContent']);
+	});
 
-		expect(patches.map(({ path, op }) => [path[0], op.type])).toEqual([
+	// Recorre los borradores porque es lo que la ida escribió: dejarlos afuera revertiría a medias.
+	it('revierte un borrador igual que un documento publicado', () => {
+		const borrador = { ...relinkedLandingPage(), _id: 'drafts.landing-2026-01' };
+
+		expect(migrateDocument(borrador).map(({ path }) => path[0])).toEqual(['collections', 'latestLiteraryWorks']);
+	});
+
+	it('da de baja los dos campos nuevos de la página de inicio', () => {
+		expect(migrateDocument(relinkedLandingPage()).map(({ path, op }) => [path[0], op.type])).toEqual([
 			['collections', 'unset'],
 			['latestLiteraryWorks', 'unset'],
 		]);
 	});
 
 	it('da de baja las obras más leídas del contenido rotativo', () => {
-		const patches = migrateDocument({
-			_id: 'rotating-content',
-			_type: 'rotatingContent',
-			mostRead: [reference('story-el-aleph')],
-			mostReadLiteraryWorks: [reference('lw-from-story-story-el-aleph')],
-		});
-
-		expect(patches.map(({ path }) => path[0])).toEqual(['mostReadLiteraryWorks']);
+		expect(migrateDocument(relinkedRotatingContent()).map(({ path }) => path[0])).toEqual(['mostReadLiteraryWorks']);
 	});
 
 	it('no produce mutación sobre un documento que nunca se reapuntó', () => {
-		expect(migrateDocument(relinkedLandingPage({ collections: undefined, latestLiteraryWorks: undefined }))).toEqual(
-			[],
-		);
+		const sinReapuntar = { _id: 'landing-2026-02', _type: 'landingPage', cards, latestReads };
+
+		expect(migrateDocument(sinReapuntar)).toEqual([]);
 	});
 
 	// Sin la fuente, el campo nuevo pasó a ser la única copia de esas referencias: darlo de baja las
@@ -54,16 +73,20 @@ describe('reversión del reapuntado', () => {
 	});
 
 	it('aborta si el origen de las obras más leídas ya no está', () => {
-		expect(() =>
-			migrateDocument({
-				_id: 'rotating-content',
-				_type: 'rotatingContent',
-				mostReadLiteraryWorks: [reference('lw-from-story-story-el-aleph')],
-			}),
-		).toThrowError(/mostReadLiteraryWorks/);
+		const sinOrigen = {
+			_id: 'rotating-content',
+			_type: 'rotatingContent',
+			mostReadLiteraryWorks: buildLiteraryWorkReferences(mostRead),
+		};
+
+		expect(() => migrateDocument(sinOrigen)).toThrowError(/mostReadLiteraryWorks/);
 	});
 
-	it('deja fuera los borradores, igual que la migración de ida', () => {
-		expect(migration.filter).toBe("!(_id in path('drafts.**'))");
+	// La ida elige escritura de backfill justamente para no pisar una edición manual. La vuelta tiene que
+	// cuidarla igual, o lo que una respeta la otra lo borra.
+	it('aborta si el contenido fue editado después de migrar', () => {
+		const editado = relinkedLandingPage({ collections: [reference('collection-elegida-a-mano')] });
+
+		expect(() => migrateDocument(editado)).toThrowError(/editado/);
 	});
 });

--- a/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.spec.ts
+++ b/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import migration from './index';
+
+const migrateDocument = (doc: Record<string, unknown>) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never) as { path: string[]; op: { type: string } }[];
+};
+
+const reference = (ref: string) => ({ _key: 'k1', _type: 'reference' as const, _ref: ref });
+
+const relinkedLandingPage = (overrides: Record<string, unknown> = {}) => ({
+	_id: 'landing-2026-01',
+	_type: 'landingPage' as const,
+	cards: [reference('storylist-verano')],
+	latestReads: [reference('story-el-aleph')],
+	collections: [reference('collection-from-storylist-storylist-verano')],
+	latestLiteraryWorks: [reference('lw-from-story-story-el-aleph')],
+	...overrides,
+});
+
+describe('reversión del reapuntado', () => {
+	it('da de baja los dos campos nuevos de la página de inicio', () => {
+		const patches = migrateDocument(relinkedLandingPage());
+
+		expect(patches.map(({ path, op }) => [path[0], op.type])).toEqual([
+			['collections', 'unset'],
+			['latestLiteraryWorks', 'unset'],
+		]);
+	});
+
+	it('da de baja las obras más leídas del contenido rotativo', () => {
+		const patches = migrateDocument({
+			_id: 'rotating-content',
+			_type: 'rotatingContent',
+			mostRead: [reference('story-el-aleph')],
+			mostReadLiteraryWorks: [reference('lw-from-story-story-el-aleph')],
+		});
+
+		expect(patches.map(({ path }) => path[0])).toEqual(['mostReadLiteraryWorks']);
+	});
+
+	it('no produce mutación sobre un documento que nunca se reapuntó', () => {
+		expect(migrateDocument(relinkedLandingPage({ collections: undefined, latestLiteraryWorks: undefined }))).toEqual(
+			[],
+		);
+	});
+
+	// Sin la fuente, el campo nuevo pasó a ser la única copia de esas referencias: darlo de baja las
+	// destruiría, y la reversión dejó de ser una reversión.
+	it('aborta si el campo de origen ya no está poblado', () => {
+		expect(() => migrateDocument(relinkedLandingPage({ cards: [] }))).toThrowError(/collections/);
+	});
+
+	it('aborta si el origen de las obras más leídas ya no está', () => {
+		expect(() =>
+			migrateDocument({
+				_id: 'rotating-content',
+				_type: 'rotatingContent',
+				mostReadLiteraryWorks: [reference('lw-from-story-story-el-aleph')],
+			}),
+		).toThrowError(/mostReadLiteraryWorks/);
+	});
+
+	it('deja fuera los borradores, igual que la migración de ida', () => {
+		expect(migration.filter).toBe("!(_id in path('drafts.**'))");
+	});
+});

--- a/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.ts
+++ b/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.ts
@@ -1,9 +1,11 @@
 import { at, defineMigration, unset } from 'sanity/migrate';
 
 // Mismo shape mínimo que la migración de ida, más los campos nuevos, que son los que esta reversión mira.
+// `_type` va como `string` por el mismo motivo que allá: el runner lo tipa así y acotarlo vuelve la
+// función incompatible con la firma que espera.
 interface RelinkedDocument {
 	_id: string;
-	_type: 'landingPage' | 'rotatingContent';
+	_type: string;
 	cards?: unknown[];
 	latestReads?: unknown[];
 	mostRead?: unknown[];

--- a/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.ts
+++ b/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.ts
@@ -1,0 +1,53 @@
+import { at, defineMigration, unset } from 'sanity/migrate';
+
+// Mismo shape mínimo que la migración de ida, más los campos nuevos, que son los que esta reversión mira.
+interface RelinkedDocument {
+	_id: string;
+	_type: 'landingPage' | 'rotatingContent';
+	cards?: unknown[];
+	latestReads?: unknown[];
+	mostRead?: unknown[];
+	collections?: unknown[];
+	latestLiteraryWorks?: unknown[];
+	mostReadLiteraryWorks?: unknown[];
+}
+
+/** Un campo se puede dar de baja sólo si su fuente sigue en pie: es de donde se vuelve a derivar. */
+function unsetIfSourceSurvives(field: string, source: unknown[] | undefined, value: unknown[] | undefined) {
+	if (!value) {
+		return [];
+	}
+	if (!source || source.length === 0) {
+		throw new Error(
+			`No se puede dar de baja "${field}": su campo de origen ya no está poblado, así que borrarlo destruiría la única copia de esas referencias.`,
+		);
+	}
+	return [at(field, unset())];
+}
+
+/**
+ * Deshace el reapuntado dando de baja los tres campos nuevos.
+ *
+ * **Sólo revierte lo que puede volver a derivarse.** Si el campo viejo ya no está poblado —porque el PR
+ * de limpieza que lo retira ya corrió—, esta reversión dejó de ser reversible: el campo nuevo pasó a ser
+ * la única copia de esas referencias, y borrarlo las destruiría. En ese caso lanza en vez de borrar.
+ *
+ * Es idempotente: un documento sin los campos nuevos no produce mutación.
+ */
+export default defineMigration({
+	title: 'Revertir el reapuntado de referencias de la página de inicio y del contenido rotativo',
+	documentTypes: ['landingPage', 'rotatingContent'],
+	filter: "!(_id in path('drafts.**'))",
+	migrate: {
+		document(doc: RelinkedDocument) {
+			if (doc._type === 'rotatingContent') {
+				return unsetIfSourceSurvives('mostReadLiteraryWorks', doc.mostRead, doc.mostReadLiteraryWorks);
+			}
+
+			return [
+				...unsetIfSourceSurvives('collections', doc.cards, doc.collections),
+				...unsetIfSourceSurvives('latestLiteraryWorks', doc.latestReads, doc.latestLiteraryWorks),
+			];
+		},
+	},
+});

--- a/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.ts
+++ b/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.ts
@@ -1,21 +1,45 @@
 import { at, defineMigration, unset } from 'sanity/migrate';
 
+import {
+	buildCollectionReferences,
+	buildLiteraryWorkReferences,
+	type KeyedReference,
+} from '../relink-landing-to-collection-and-literary-work/build-relinked-references';
+
 // Mismo shape mínimo que la migración de ida, más los campos nuevos, que son los que esta reversión mira.
 // `_type` va como `string` por el mismo motivo que allá: el runner lo tipa así y acotarlo vuelve la
 // función incompatible con la firma que espera.
 interface RelinkedDocument {
 	_id: string;
 	_type: string;
-	cards?: unknown[];
-	latestReads?: unknown[];
-	mostRead?: unknown[];
-	collections?: unknown[];
-	latestLiteraryWorks?: unknown[];
-	mostReadLiteraryWorks?: unknown[];
+	cards?: KeyedReference[];
+	latestReads?: KeyedReference[];
+	mostRead?: KeyedReference[];
+	collections?: KeyedReference[];
+	latestLiteraryWorks?: KeyedReference[];
+	mostReadLiteraryWorks?: KeyedReference[];
 }
 
-/** Un campo se puede dar de baja sólo si su fuente sigue en pie: es de donde se vuelve a derivar. */
-function unsetIfSourceSurvives(field: string, source: unknown[] | undefined, value: unknown[] | undefined) {
+/**
+ * Da de baja un campo sólo si su contenido es exactamente lo que la migración de ida habría escrito.
+ *
+ * Dos cosas distintas lo impiden, y las dos terminan en un aborto en vez de en un borrado:
+ *
+ * - **La fuente ya no está.** El campo nuevo pasó a ser la única copia de esas referencias, así que
+ *   borrarlo no revierte nada: destruye el dato.
+ * - **El contenido no coincide con lo derivable.** Alguien lo editó a mano en el Studio. La ida cuida ese
+ *   caso al escribir con semántica de backfill; la vuelta tiene que cuidarlo igual, o lo que una respeta
+ *   la otra lo borra.
+ *
+ * La comparación reusa el módulo de derivación en vez de reimplementarlo: una segunda noción de "lo que
+ * la ida habría escrito" divergiría, y la reversión pasaría a borrar lo que no escribió.
+ */
+function unsetIfMigrationWroteIt(
+	field: string,
+	source: KeyedReference[] | undefined,
+	value: KeyedReference[] | undefined,
+	derive: (references: readonly KeyedReference[] | undefined) => KeyedReference[],
+) {
 	if (!value) {
 		return [];
 	}
@@ -24,31 +48,47 @@ function unsetIfSourceSurvives(field: string, source: unknown[] | undefined, val
 			`No se puede dar de baja "${field}": su campo de origen ya no está poblado, así que borrarlo destruiría la única copia de esas referencias.`,
 		);
 	}
+	if (JSON.stringify(value) !== JSON.stringify(derive(source))) {
+		throw new Error(
+			`No se puede dar de baja "${field}": su contenido no coincide con lo que la migración escribió, así que fue editado después. Borrarlo perdería esa edición.`,
+		);
+	}
 	return [at(field, unset())];
 }
 
 /**
  * Deshace el reapuntado dando de baja los tres campos nuevos.
  *
- * **Sólo revierte lo que puede volver a derivarse.** Si el campo viejo ya no está poblado —porque el PR
- * de limpieza que lo retira ya corrió—, esta reversión dejó de ser reversible: el campo nuevo pasó a ser
- * la única copia de esas referencias, y borrarlo las destruiría. En ese caso lanza en vez de borrar.
+ * Recorre los borradores igual que la ida, porque es lo que aquélla escribió.
  *
  * Es idempotente: un documento sin los campos nuevos no produce mutación.
  */
 export default defineMigration({
 	title: 'Revertir el reapuntado de referencias de la página de inicio y del contenido rotativo',
 	documentTypes: ['landingPage', 'rotatingContent'],
-	filter: "!(_id in path('drafts.**'))",
 	migrate: {
 		document(doc: RelinkedDocument) {
 			if (doc._type === 'rotatingContent') {
-				return unsetIfSourceSurvives('mostReadLiteraryWorks', doc.mostRead, doc.mostReadLiteraryWorks);
+				return unsetIfMigrationWroteIt(
+					'mostReadLiteraryWorks',
+					doc.mostRead,
+					doc.mostReadLiteraryWorks,
+					buildLiteraryWorkReferences,
+				);
+			}
+
+			if (doc._type !== 'landingPage') {
+				return [];
 			}
 
 			return [
-				...unsetIfSourceSurvives('collections', doc.cards, doc.collections),
-				...unsetIfSourceSurvives('latestLiteraryWorks', doc.latestReads, doc.latestLiteraryWorks),
+				...unsetIfMigrationWroteIt('collections', doc.cards, doc.collections, buildCollectionReferences),
+				...unsetIfMigrationWroteIt(
+					'latestLiteraryWorks',
+					doc.latestReads,
+					doc.latestLiteraryWorks,
+					buildLiteraryWorkReferences,
+				),
 			];
 		},
 	},

--- a/cms/schema.json
+++ b/cms/schema.json
@@ -170,6 +170,36 @@
 		}
 	},
 	{
+		"type": "type",
+		"name": "literaryWork.reference",
+		"value": {
+			"type": "object",
+			"attributes": {
+				"_ref": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string"
+					}
+				},
+				"_type": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string",
+						"value": "reference"
+					}
+				},
+				"_weak": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "boolean"
+					},
+					"optional": true
+				}
+			},
+			"dereferencesTo": "literaryWork"
+		}
+	},
+	{
 		"name": "rotatingContent",
 		"type": "document",
 		"attributes": {
@@ -228,6 +258,28 @@
 						"rest": {
 							"type": "inline",
 							"name": "story.reference"
+						}
+					}
+				},
+				"optional": true
+			},
+			"mostReadLiteraryWorks": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "array",
+					"of": {
+						"type": "object",
+						"attributes": {
+							"_key": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								}
+							}
+						},
+						"rest": {
+							"type": "inline",
+							"name": "literaryWork.reference"
 						}
 					}
 				},
@@ -2230,36 +2282,6 @@
 		}
 	},
 	{
-		"type": "type",
-		"name": "literaryWork.reference",
-		"value": {
-			"type": "object",
-			"attributes": {
-				"_ref": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string"
-					}
-				},
-				"_type": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string",
-						"value": "reference"
-					}
-				},
-				"_weak": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "boolean"
-					},
-					"optional": true
-				}
-			},
-			"dereferencesTo": "literaryWork"
-		}
-	},
-	{
 		"name": "collection",
 		"type": "document",
 		"attributes": {
@@ -3428,6 +3450,36 @@
 		}
 	},
 	{
+		"type": "type",
+		"name": "collection.reference",
+		"value": {
+			"type": "object",
+			"attributes": {
+				"_ref": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string"
+					}
+				},
+				"_type": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string",
+						"value": "reference"
+					}
+				},
+				"_weak": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "boolean"
+					},
+					"optional": true
+				}
+			},
+			"dereferencesTo": "collection"
+		}
+	},
+	{
 		"name": "landingPage",
 		"type": "document",
 		"attributes": {
@@ -3538,6 +3590,50 @@
 						"rest": {
 							"type": "inline",
 							"name": "story.reference"
+						}
+					}
+				},
+				"optional": true
+			},
+			"collections": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "array",
+					"of": {
+						"type": "object",
+						"attributes": {
+							"_key": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								}
+							}
+						},
+						"rest": {
+							"type": "inline",
+							"name": "collection.reference"
+						}
+					}
+				},
+				"optional": true
+			},
+			"latestLiteraryWorks": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "array",
+					"of": {
+						"type": "object",
+						"attributes": {
+							"_key": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								}
+							}
+						},
+						"rest": {
+							"type": "inline",
+							"name": "literaryWork.reference"
 						}
 					}
 				},

--- a/cms/schemas/landingPage.ts
+++ b/cms/schemas/landingPage.ts
@@ -59,7 +59,7 @@ export default defineType({
 		}),
 		defineField({
 			name: 'cards',
-			title: 'Storylists con Tarjetas',
+			title: 'Storylists con Tarjetas (en baja)',
 			type: 'array',
 			of: [
 				defineArrayMember({
@@ -72,7 +72,7 @@ export default defineType({
 		}),
 		defineField({
 			name: 'latestReads',
-			title: 'Últimas novedades',
+			title: 'Últimas novedades (en baja)',
 			type: 'array',
 			of: [
 				defineArrayMember({
@@ -80,6 +80,36 @@ export default defineType({
 					title: 'Historia',
 					type: 'reference',
 					to: [{ type: 'story' }],
+				}),
+			],
+		}),
+		// Los campos nuevos conviven con los de arriba en vez de reemplazarlos: el Studio y la aplicación no
+		// despliegan a la vez, así que reusar el nombre dejaría una ventana en la que un lado lee lo que el
+		// otro todavía no escribe. Sin `required`: durante la convivencia un documento puede tener poblado
+		// un par u otro, y exigirlos rompería la edición de los documentos que todavía no migraron.
+		defineField({
+			name: 'collections',
+			title: 'Colecciones con Tarjetas',
+			type: 'array',
+			of: [
+				defineArrayMember({
+					name: 'collection',
+					title: 'Colección',
+					type: 'reference',
+					to: [{ type: 'collection' }],
+				}),
+			],
+		}),
+		defineField({
+			name: 'latestLiteraryWorks',
+			title: 'Últimas novedades (obras)',
+			type: 'array',
+			of: [
+				defineArrayMember({
+					name: 'literaryWork',
+					title: 'Obra literaria',
+					type: 'reference',
+					to: [{ type: 'literaryWork' }],
 				}),
 			],
 		}),

--- a/cms/schemas/rotatingContent.ts
+++ b/cms/schemas/rotatingContent.ts
@@ -18,7 +18,7 @@ export default defineType({
 		}),
 		defineField({
 			name: 'mostRead',
-			title: 'Lo más leído',
+			title: 'Lo más leído (en baja)',
 			type: 'array',
 			of: [
 				defineArrayMember({
@@ -26,6 +26,21 @@ export default defineType({
 					title: 'Historia',
 					type: 'reference',
 					to: [{ type: 'story' }],
+				}),
+			],
+		}),
+		// Convive con el de arriba por el mismo motivo que los de la página de inicio: el Studio y la
+		// aplicación no despliegan a la vez.
+		defineField({
+			name: 'mostReadLiteraryWorks',
+			title: 'Lo más leído (obras)',
+			type: 'array',
+			of: [
+				defineArrayMember({
+					name: 'literaryWork',
+					title: 'Obra literaria',
+					type: 'reference',
+					to: [{ type: 'literaryWork' }],
 				}),
 			],
 		}),

--- a/docs/CONTENT_UPDATE_STRATEGIES.md
+++ b/docs/CONTENT_UPDATE_STRATEGIES.md
@@ -27,7 +27,7 @@ La aplicación implementa un patrón centralizado llamado **`rotatingContent`** 
 
 Actualmente, este documento almacena:
 
-- **Historias más leídas** (`mostRead`) - Ranking actualizado automáticamente de manera diaria.
+- **Obras más leídas** (`mostReadLiteraryWorks`) - Ranking actualizado automáticamente de manera diaria. Sustituye a `mostRead`, que referenciaba historias y está en baja.
 
 Las funcionalidades relacionadas a contenido rotativo están y deben de ser implementadas a nivel de servidor, a fin de ejecutar procedimientos en intervalos de tiempo dados, regulares o esporádicos, para garantizar que el contenido mostrado en la plataforma esté actualizado y sea coherente con la hoja de ruta de contenido del proyecto.
 
@@ -39,7 +39,9 @@ Las funcionalidades relacionadas a contenido rotativo están y deben de ser impl
 
 Las **historias más leídas** son un ejemplo de contenido dentro del patrón de **contenido rotativo**. Actualmente, mediante el uso de la [Data Export API de Microsoft Clarity](https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-data-export-api), el sistema mantiene un registro de las historias más leídas por los usuarios de La Cuentoneta, tomando una referencia de las historias más leídas en los últimos tres días.
 
-De manera diaria se ejecuta un cron job, definido en `vercel.json` para su ejecución a las 03:30 am (GMT -3), que se encarga, partiendo de esas listas, de alojar en el campo `mostRead` del documento singleton `rotatingContent`, las correspondientes referencias de estas historias, a partir de los documentos `story` de Sanity.
+De manera diaria se ejecuta un cron job, definido en `vercel.json` para su ejecución a las 03:30 am (GMT -3), que se encarga, partiendo de esas listas, de alojar en el documento singleton `rotatingContent` las referencias correspondientes.
+
+El destino de esa escritura pasa a ser `mostReadLiteraryWorks`, con referencias a documentos `literaryWork`. Mientras dure la convivencia de las dos rutas de lectura, el conteo de páginas populares contempla los dos prefijos de URL: leer uno solo dejaría afuera la mitad del tráfico y la lista quedaría subestimada.
 
 ### Ubicación en el Código
 
@@ -55,13 +57,16 @@ El documento singleton `rotatingContent` en Sanity almacena la información de c
 {
   _id: "rotatingContent",
   _type: "rotatingContent",
-  mostRead: Array<StoryReference>  // Historias más leídas (actual)
+  mostReadLiteraryWorks: Array<LiteraryWorkReference>,  // Obras más leídas (vigente)
+  mostRead: Array<StoryReference>                       // Historias más leídas (en baja)
 }
 ```
 
+> **Convivencia de campos.** `mostReadLiteraryWorks` reemplaza a `mostRead` y por un tiempo los dos coexisten. El campo nuevo no reusa el nombre del viejo porque el Studio y la aplicación no despliegan a la vez: reusarlo dejaría una ventana en la que un lado lee lo que el otro todavía no escribe. El campo en baja se retira cuando ningún lector lo consulte.
+
 ### Estructura Extensible del Documento
 
-El documento `rotatingContent` está diseñado para ser **extensible**. La estructura actual solo incluye `mostRead`, pero puede extenderse con nuevos campos sin romper la funcionalidad existente.
+El documento `rotatingContent` está diseñado para ser **extensible**. La estructura actual solo incluye lo más leído, pero puede extenderse con nuevos campos sin romper la funcionalidad existente.
 
 **Ejemplos de campos que podrían agregarse en el futuro:**
 
@@ -69,7 +74,7 @@ El documento `rotatingContent` está diseñado para ser **extensible**. La estru
 {
   _id: "rotatingContent",
   _type: "rotatingContent",
-  mostRead: Array<StoryReference>,           // Historias más leídas (actual)
+  mostReadLiteraryWorks: Array<LiteraryWorkReference>,  // Obras más leídas (vigente)
 
   // Potenciales campos futuros:
   // trending: Array<StoryReference>,       // Historias trending
@@ -111,11 +116,15 @@ Este proceso garantiza que:
     _type: "slug",
     current: "2025-46"
   },
-  campaigns: Array<CampaignReference>,     // Campañas a mostrar
-  cards: Array<CardReference>,             // Tarjetas de contenido
-  latestReads: Array<StoryReference>       // Historias destacadas
+  campaigns: Array<CampaignReference>,               // Campañas a mostrar
+  collections: Array<CollectionReference>,           // Colecciones con tarjetas (vigente)
+  latestLiteraryWorks: Array<LiteraryWorkReference>, // Obras destacadas (vigente)
+  cards: Array<StorylistReference>,                  // Tarjetas de contenido (en baja)
+  latestReads: Array<StoryReference>                 // Historias destacadas (en baja)
 }
 ```
+
+> **Convivencia de campos.** `collections` y `latestLiteraryWorks` reemplazan a `cards` y `latestReads`, por el mismo motivo que en `rotatingContent`. Los cuatro coexisten hasta que se retiren los dos primeros.
 
 ### Nomenclatura de Slugs
 

--- a/docs/CONTENT_UPDATE_STRATEGIES.md
+++ b/docs/CONTENT_UPDATE_STRATEGIES.md
@@ -27,7 +27,7 @@ La aplicación implementa un patrón centralizado llamado **`rotatingContent`** 
 
 Actualmente, este documento almacena:
 
-- **Obras más leídas** (`mostReadLiteraryWorks`) - Ranking actualizado automáticamente de manera diaria. Sustituye a `mostRead`, que referenciaba historias y está en baja.
+- **Lo más leído** - Ranking actualizado automáticamente de manera diaria. Vive hoy en `mostRead`, que referencia historias y está en baja; su reemplazo es `mostReadLiteraryWorks`, ya declarado en el schema y todavía sin escritor.
 
 Las funcionalidades relacionadas a contenido rotativo están y deben de ser implementadas a nivel de servidor, a fin de ejecutar procedimientos en intervalos de tiempo dados, regulares o esporádicos, para garantizar que el contenido mostrado en la plataforma esté actualizado y sea coherente con la hoja de ruta de contenido del proyecto.
 
@@ -41,7 +41,9 @@ Las **historias más leídas** son un ejemplo de contenido dentro del patrón de
 
 De manera diaria se ejecuta un cron job, definido en `vercel.json` para su ejecución a las 03:30 am (GMT -3), que se encarga, partiendo de esas listas, de alojar en el documento singleton `rotatingContent` las referencias correspondientes.
 
-El destino de esa escritura pasa a ser `mostReadLiteraryWorks`, con referencias a documentos `literaryWork`. Mientras dure la convivencia de las dos rutas de lectura, el conteo de páginas populares contempla los dos prefijos de URL: leer uno solo dejaría afuera la mitad del tráfico y la lista quedaría subestimada.
+Hoy escribe en `mostRead`, con referencias a documentos `story`.
+
+> **Pendiente del cambio de contrato.** El destino pasará a ser `mostReadLiteraryWorks`, con referencias a `literaryWork`, y el conteo de páginas populares tendrá que contemplar los dos prefijos de URL mientras las dos rutas de lectura convivan: leer uno solo dejaría afuera la mitad del tráfico y subestimaría la lista. Nada de eso está implementado todavía.
 
 ### Ubicación en el Código
 

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -50,6 +50,13 @@ export type StoryReference = {
 	[internalGroqTypeReferenceTo]?: 'story';
 };
 
+export type LiteraryWorkReference = {
+	_ref: string;
+	_type: 'reference';
+	_weak?: boolean;
+	[internalGroqTypeReferenceTo]?: 'literaryWork';
+};
+
 export type RotatingContent = {
 	_id: string;
 	_type: 'rotatingContent';
@@ -61,6 +68,11 @@ export type RotatingContent = {
 		{
 			_key: string;
 		} & StoryReference
+	>;
+	mostReadLiteraryWorks?: Array<
+		{
+			_key: string;
+		} & LiteraryWorkReference
 	>;
 };
 
@@ -385,13 +397,6 @@ export type Nationality = {
 	};
 };
 
-export type LiteraryWorkReference = {
-	_ref: string;
-	_type: 'reference';
-	_weak?: boolean;
-	[internalGroqTypeReferenceTo]?: 'literaryWork';
-};
-
 export type Collection = {
 	_id: string;
 	_type: 'collection';
@@ -589,6 +594,13 @@ export type StorylistReference = {
 	[internalGroqTypeReferenceTo]?: 'storylist';
 };
 
+export type CollectionReference = {
+	_ref: string;
+	_type: 'reference';
+	_weak?: boolean;
+	[internalGroqTypeReferenceTo]?: 'collection';
+};
+
 export type LandingPage = {
 	_id: string;
 	_type: 'landingPage';
@@ -611,6 +623,16 @@ export type LandingPage = {
 		{
 			_key: string;
 		} & StoryReference
+	>;
+	collections?: Array<
+		{
+			_key: string;
+		} & CollectionReference
+	>;
+	latestLiteraryWorks?: Array<
+		{
+			_key: string;
+		} & LiteraryWorkReference
 	>;
 };
 
@@ -757,6 +779,7 @@ export type AllSanitySchemaTypes =
 	| SanityImageAssetReference
 	| HostAvatar
 	| StoryReference
+	| LiteraryWorkReference
 	| RotatingContent
 	| Tag
 	| Slug
@@ -773,12 +796,12 @@ export type AllSanitySchemaTypes =
 	| NationalityReference
 	| Author
 	| Nationality
-	| LiteraryWorkReference
 	| Collection
 	| Storylist
 	| ContentCampaign
 	| ContentCampaignReference
 	| StorylistReference
+	| CollectionReference
 	| LandingPage
 	| Resource
 	| ResourceType


### PR DESCRIPTION
## Qué hace

Primero de los dos PRs de #2266. Agrega al Studio los campos que referencian **colecciones** y **obras literarias**, y migra hacia ellos las referencias que hoy apuntan a storylists e historias. **No cambia ningún contrato ni ningún lector:** los campos nuevos nacen vacíos, se pueblan por migración y nadie los consulta todavía. El cambio de contrato va en el PR 2.

| Documento | Campo en baja | Campo nuevo |
| --- | --- | --- |
| `landingPage` | `cards` → `storylist` | **`collections`** → `collection` |
| `landingPage` | `latestReads` → `story` | **`latestLiteraryWorks`** → `literaryWork` |
| `rotatingContent` | `mostRead` → `story` | **`mostReadLiteraryWorks`** → `literaryWork` |

## Por qué campos nuevos y no un renombre

El Studio y la aplicación no despliegan a la vez, así que reusar los nombres no tiene orden seguro: desplegar el código primero lo deja leyendo documentos que todavía referencian el tipo viejo, y migrar primero deja al código ya desplegado leyendo lo que cambió de forma. La landing se rompe en los dos órdenes. Con campos nuevos las dos formas conviven y ningún lector se queda sin fuente.

Los campos viejos quedan intactos, con el sufijo "(en baja)" en su título para que quien edita sepa cuál es el vigente. Su retiro va en un PR de limpieza posterior.

## El tamaño real de la migración

El issue hablaba de "el singleton `rotatingContent.mostRead`". Medido contra `production`:

| Campo | Documentos publicados | Referencias |
| --- | --- | --- |
| `landingPage.cards` | 39 | 288 |
| `landingPage.latestReads` | 39 | 222 |
| `rotatingContent.mostRead` | 2 — no es un singleton | 18 |

Más los borradores en vuelo (hay dos en producción), que la migración también recorre: publicar un borrador reemplaza al documento publicado por su contenido, así que uno creado antes de la corrida borraría en silencio lo migrado si quedara afuera.

## Decisiones de la migración

- **Escribe con `setIfMissing`, no con `set`.** Es backfill, no sincronización: una corrida tardía no pisa un campo editado a mano en el Studio. Es lo que la vuelve idempotente y re-corrible — y hay que re-correrla tras el despliegue del PR 2, porque el generador de semanas futuras copia hacia adelante sólo los campos viejos hasta entonces.
- **La referencia se construye campo por campo, no se spreadea:** el destino cambia de tipo, así que `_strengthenOnPublish` se retraduce — copiarla dejaría una referencia a una obra prometiéndole al Studio fortalecerla contra una historia. `_weak` se copia y nunca se sintetiza.
- **Las derivaciones de identificador se importan** de las migraciones que crearon los documentos destino: una segunda noción de "cuál es el documento migrado" podría apuntar al vacío.
- **La reversión sólo da de baja lo que la ida habría escrito exactamente** (comparando contra el propio módulo de derivación). Aborta sin borrar si el origen ya no está poblado o si el contenido fue editado después de migrar.
- **Las consultas de verificación son constantes ejecutables con spec propio**, no prosa: las dos primeras versiones estaban inertes —una contaba los nulos de la dereferencia en vez de descartarlos; recorrer un campo ausente produce `[null]` y sumaba uno de más por documento sin migrar— y ninguno de los dos defectos se veía leyéndolas. El spec las ejecuta contra un dataset con una referencia rota deliberada.

## Plan de pruebas

- **Los once gates de CI, verdes.** Dos se pusieron rojos en el camino y los dos dejaron enseñanza: `studio-build` falló en el primer intento por un acople de tipos con el runner de migraciones que sólo el type-check de `cms/` detecta (corregido: el documento se tipa como lo tipa el runner); `e2e` falló por el dataset —la landing de la semana corriente no existía aún en `staging`— y pasó al re-correr sin tocar nada, confirmando que era ajeno al diff.
- **282 tests del Studio verdes**, incluidos los 35 nuevos de la migración, su reversión, el módulo de derivación y las consultas de verificación.
- **Las consultas de verificación, ejecutadas también contra `production`:** 0 referencias colgadas hoy; los conteos de arriba son la línea de base del censo previo.
- **La migración no se corrió todavía**: corre después del merge y del deploy del Studio, dataset por dataset (`development` → `staging` → `production`), con censo previo y verificación posterior según el `README.md` de la migración. Ningún gate de CI detecta un dataset sin migrar; es responsabilidad de quien despliega.
- La review local corrió completa: sus 14 hallazgos (2 críticos, 7 advertencias, 5 sugerencias) quedaron corregidos en los últimos 4 commits.

Parte de #2266 y de #2265. El `Closes` va en el PR 2, que completa el contrato; cerrarlo acá marcaría resuelto un issue a mitad de camino.
