### PR TITLE
[#2224] - Actualiza los ejemplos de @Injectable en docs/ a la convención @Service()

### DIFF
--- a/docs/DDD_IMPROVEMENTS.md
+++ b/docs/DDD_IMPROVEMENTS.md
@@ -69,7 +69,7 @@ interface StoryRepository {
 }
 
 // 2. Implementación de repositorio (capa de infraestructura)
-@Injectable({ providedIn: 'root' })
+@Service({ autoProvided: false })
 class SanityStoryRepository implements StoryRepository {
 	constructor(private sanityClient: SanityClient) {}
 
@@ -114,7 +114,7 @@ class SanityStoryRepository implements StoryRepository {
 }
 
 // 3. Servicio de aplicación usando inyección (capa de aplicación)
-@Injectable({ providedIn: 'root' })
+@Service({ autoProvided: false })
 class StoryApplicationService {
 	constructor(private storyRepository: StoryRepository) {}
 
@@ -132,7 +132,7 @@ class StoryApplicationService {
 }
 
 // 4. Uso en componentes/servicios frontend
-@Injectable({ providedIn: 'root' })
+@Service()
 class StoryService {
 	constructor(private http: HttpClient) {}
 
@@ -302,7 +302,7 @@ interface EventPublisher {
 	subscribe(eventName: string, handler: (event: DomainEvent) => Promise<void>): void;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 class InMemoryEventPublisher implements EventPublisher {
 	private subscribers: Map<string, ((event: DomainEvent) => Promise<void>)[]> = new Map();
 
@@ -379,7 +379,7 @@ class Story {
 }
 
 // 5. Servicio que publica eventos
-@Injectable({ providedIn: 'root' })
+@Service()
 class StoryApplicationService {
 	constructor(
 		private storyRepository: StoryRepository,
@@ -411,7 +411,7 @@ class StoryApplicationService {
 }
 
 // 6. Suscriptores a eventos
-@Injectable({ providedIn: 'root' })
+@Service()
 class StoryEventHandlers {
 	constructor(
 		private eventPublisher: EventPublisher,
@@ -453,7 +453,7 @@ interface EventStore {
 	getEventsSince(timestamp: Date): Promise<DomainEvent[]>;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 class SanityEventStore implements EventStore {
 	constructor(private sanityClient: SanityClient) {}
 
@@ -621,7 +621,7 @@ class SanityStoryRepository implements StoryRepository {
 }
 
 // 4. Uso desde el servicio de aplicación
-@Injectable({ providedIn: 'root' })
+@Service()
 class StoryApplicationService {
 	constructor(private storyRepository: StoryRepository) {}
 

--- a/docs/specs/communities.md
+++ b/docs/specs/communities.md
@@ -2574,7 +2574,7 @@ const routes: Routes = [
 **Ubicación:** `src/app/providers/community.service.ts`
 
 ```typescript
-@Injectable({ providedIn: 'root' })
+@Service()
 export class CommunityService {
 	private http = inject(HttpClient);
 	private url = `${environment.apiUrl}/api/community`;
@@ -2601,7 +2601,7 @@ export class CommunityService {
 **Ubicación:** `src/app/providers/event.service.ts`
 
 ```typescript
-@Injectable({ providedIn: 'root' })
+@Service()
 export class EventService {
 	private http = inject(HttpClient);
 	private url = `${environment.apiUrl}/api/event`;
@@ -2618,7 +2618,7 @@ export class EventService {
 **Ubicación:** `src/app/providers/blog-entry.service.ts`
 
 ```typescript
-@Injectable({ providedIn: 'root' })
+@Service()
 export class BlogEntryService {
 	private http = inject(HttpClient);
 	private url = `${environment.apiUrl}/api/blog`;
@@ -2636,7 +2636,7 @@ export class BlogEntryService {
 **Ubicación:** `src/app/providers/contest.service.ts`
 
 ```typescript
-@Injectable({ providedIn: 'root' })
+@Service()
 export class ContestService {
 	private http = inject(HttpClient);
 	private url = `${environment.apiUrl}/api/contest`;


### PR DESCRIPTION
## Resumen

Actualiza los 12 ejemplos de código que usaban el decorador viejo `@Injectable({ providedIn: 'root' })` a la convención vigente `@Service()`, para que ningún documento del repo enseñe el decorador viejo.

## Problema

La adopción de `@Service()` como convención para services singleton dejó dos documentos históricos con ejemplos del decorador anterior: `docs/specs/communities.md` (4 ocurrencias) y `docs/DDD_IMPROVEMENTS.md` (8). La convención vive en `.claude/references/angular-state.md`; estos docs de diseño quedaron fuera del alcance del PR que la adoptó porque son referencias históricas, no vivas.

## Cambios

Criterio de correspondencia por ejemplo:

- **`@Service()`** (10): servicios singleton provistos en root sin registro explícito — los cuatro data-access de `communities.md`, y en `DDD_IMPROVEMENTS.md`: `StoryService` frontend, `InMemoryEventPublisher`, `StoryEventHandlers`, `SanityEventStore` y los `StoryApplicationService` de las secciones 2 y 3.
- **`@Service({ autoProvided: false })`** (2): `SanityStoryRepository` y el `StoryApplicationService` de la sección 1 — las dos clases que el propio ejemplo registra explícitamente en el bloque «Configuración en Angular» (`providers: [{ provide: StoryRepository, useClass: ... }, StoryApplicationService]`); una clase provista a mano no se auto-provee.

Verificado: no queda ningún `@Injectable({ providedIn: 'root' })` en `docs/`. Cambio solo de documentación (exento de tests según políticas).

## Fuera de alcance (según el issue)

- Referencias a `providedIn` en contexto de `InjectionToken` (`clean-architecture.md`, skill `aposd-comments-style`): concepto distinto del decorador de service, siguen correctas.
- Menciones de `@Injectable` como superficie de detección de la regla ESLint `component-config-in-class` (en tooling y referencias): nombran el decorador legacy para reconocer archivos viejos, no enseñan su uso.

Closes #2224