### PR TITLE
[#1790] - Adoptar utilidades de tiempo con Vitest (fakeAsync/flush) y TestBed.getLastFixture()

### DIFF
--- a/src/app/directives/portable-text-parser/portable-text-parser.directive.spec.ts
+++ b/src/app/directives/portable-text-parser/portable-text-parser.directive.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, signal } from '@angular/core';
 import { storyMock } from '@mocks/story.mock';
 import { storylistMock } from '@mocks/storylist.mock';
@@ -20,16 +20,16 @@ class TestComponent {
 
 describe('PortableTextDirective', () => {
 	let component: TestComponent;
-	let fixture: ComponentFixture<TestComponent>;
+	const fixture = (): ComponentFixture<TestComponent> => TestBed.getLastFixture<TestComponent>();
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
 			imports: [TestComponent, PortableTextDirective],
 		}).compileComponents();
 
-		fixture = TestBed.createComponent(TestComponent);
-		component = fixture.componentInstance;
-		fixture.detectChanges();
+		TestBed.createComponent(TestComponent);
+		component = fixture().componentInstance;
+		fixture().detectChanges();
 	});
 
 	it('should create', () => {
@@ -39,18 +39,18 @@ describe('PortableTextDirective', () => {
 	describe('story content formatting', () => {
 		it('should format story title in bold and italics', () => {
 			component.content.set(storyMock.summary);
-			fixture.detectChanges();
+			fixture().detectChanges();
 
-			const container = fixture.nativeElement.querySelector('article');
+			const container = fixture().nativeElement.querySelector('article');
 			const boldItalicElement = container.querySelector('b i');
 			expect(boldItalicElement?.textContent).toBe('El espejo del tiempo');
 		});
 
 		it('should format book collection title in italics', () => {
 			component.content.set(storyMock.summary);
-			fixture.detectChanges();
+			fixture().detectChanges();
 
-			const container = fixture.nativeElement.querySelector('article') as HTMLElement;
+			const container = fixture().nativeElement.querySelector('article') as HTMLElement;
 			const italicElements = container.querySelectorAll('i');
 			const collectionTitle = Array.from(italicElements).some((el) => el.textContent === 'Ecos del Silencio');
 			expect(collectionTitle).toBeTruthy();
@@ -77,9 +77,9 @@ describe('PortableTextDirective', () => {
 
 		it('should format links correctly', () => {
 			component.content.set(markedUpBlock);
-			fixture.detectChanges();
+			fixture().detectChanges();
 
-			const container = fixture.nativeElement.querySelector('article');
+			const container = fixture().nativeElement.querySelector('article');
 			const link = container.querySelector('a');
 
 			expect(link).toBeTruthy();
@@ -90,9 +90,9 @@ describe('PortableTextDirective', () => {
 
 		it('should format show title in italics', () => {
 			component.content.set(markedUpBlock);
-			fixture.detectChanges();
+			fixture().detectChanges();
 
-			const container = fixture.nativeElement.querySelector('article') as HTMLElement;
+			const container = fixture().nativeElement.querySelector('article') as HTMLElement;
 			const italicElements = container.querySelectorAll('i');
 			const showTitle = Array.from(italicElements).some((el) => el.textContent === 'Le Ble Chateau');
 			expect(showTitle).toBeTruthy();
@@ -115,9 +115,9 @@ describe('PortableTextDirective', () => {
 					_key: '',
 				},
 			]);
-			fixture.detectChanges();
+			fixture().detectChanges();
 
-			const container = fixture.nativeElement.querySelector('article');
+			const container = fixture().nativeElement.querySelector('article');
 			expect(container.querySelectorAll('br').length).toEqual(2);
 		});
 	});
@@ -140,9 +140,9 @@ describe('PortableTextDirective', () => {
 			};
 			component.content.set([paragraph]);
 			component.classes.set('');
-			fixture.detectChanges();
+			fixture().detectChanges();
 
-			const target = fixture.nativeElement.querySelector('p') as HTMLElement;
+			const target = fixture().nativeElement.querySelector('p') as HTMLElement;
 			expect(target).toHaveClass(expectedClass);
 		});
 
@@ -156,9 +156,9 @@ describe('PortableTextDirective', () => {
 			};
 			component.content.set([paragraph]);
 			component.classes.set('');
-			fixture.detectChanges();
+			fixture().detectChanges();
 
-			const target = fixture.nativeElement.querySelector('p') as HTMLElement;
+			const target = fixture().nativeElement.querySelector('p') as HTMLElement;
 			expect(target.className).toBe('');
 		});
 	});
@@ -166,9 +166,9 @@ describe('PortableTextDirective', () => {
 	describe('class handling', () => {
 		it('should apply custom classes', () => {
 			component.classes.set('custom-class test-class');
-			fixture.detectChanges();
+			fixture().detectChanges();
 
-			const container = fixture.nativeElement.querySelector('article') as HTMLElement;
+			const container = fixture().nativeElement.querySelector('article') as HTMLElement;
 			const classes = container.querySelectorAll('p');
 
 			classes.forEach((el) => {
@@ -179,9 +179,9 @@ describe('PortableTextDirective', () => {
 
 		it('should handle class updates', () => {
 			component.classes.set('initial-class');
-			fixture.detectChanges();
+			fixture().detectChanges();
 
-			const container = fixture.nativeElement.querySelector('article') as HTMLElement;
+			const container = fixture().nativeElement.querySelector('article') as HTMLElement;
 			const classes = container.querySelectorAll('p');
 
 			classes.forEach((el) => {
@@ -189,7 +189,7 @@ describe('PortableTextDirective', () => {
 			});
 
 			component.classes.set('updated-class');
-			fixture.detectChanges();
+			fixture().detectChanges();
 
 			classes.forEach((el) => {
 				expect(el).not.toHaveClass('initial-class');
@@ -201,15 +201,15 @@ describe('PortableTextDirective', () => {
 	describe('content updates', () => {
 		it('should update content when signal changes', () => {
 			component.content.set(storyMock.summary);
-			fixture.detectChanges();
+			fixture().detectChanges();
 
-			let container = fixture.nativeElement.querySelector('article');
+			let container = fixture().nativeElement.querySelector('article');
 			expect(container).toHaveTextContent('El espejo del tiempo');
 
 			component.content.set(storylistMock.description);
-			fixture.detectChanges();
+			fixture().detectChanges();
 
-			container = fixture.nativeElement.querySelector('article');
+			container = fixture().nativeElement.querySelector('article');
 			expect(container).not.toHaveTextContent('El espejo del tiempo');
 		});
 	});

--- a/src/app/pages/author/author.component.spec.ts
+++ b/src/app/pages/author/author.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { render, screen, within } from '@testing-library/angular';
 import AuthorComponent from './author.component';
@@ -9,16 +9,15 @@ import { withoutUrl } from '@testing/resource-without-url';
 
 describe.skip('AuthorComponent', () => {
 	let component: AuthorComponent;
-	let fixture: ComponentFixture<AuthorComponent>;
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
 			imports: [AuthorComponent],
 		}).compileComponents();
 
-		fixture = TestBed.createComponent(AuthorComponent);
-		component = fixture.componentInstance;
-		fixture.detectChanges();
+		TestBed.createComponent(AuthorComponent);
+		component = TestBed.getLastFixture<AuthorComponent>().componentInstance;
+		TestBed.getLastFixture<AuthorComponent>().detectChanges();
 	});
 
 	it('should create', () => {


### PR DESCRIPTION
## Descripción

Adopta `TestBed.getLastFixture()` en los únicos dos specs del repo que usan `TestBed.createComponent`, eliminando el estado mutable `let fixture` a nivel describe:

- `portable-text-parser.directive.spec.ts`: acceso vía un accessor local tipado (`const fixture = () => TestBed.getLastFixture<TestComponent>()`).
- `author.component.spec.ts`: llamadas directas en el `beforeEach`; el bloque `describe.skip` se conserva tal cual.

La otra mitad del issue — adoptar `fakeAsync`/`flush`/`waitForAsync` sobre Vitest — queda **descartada** tras el doble chequeo contra la documentación oficial y el estado del repo:

1. Habilitarlas exige el polyfill `zone.js/plugins/vitest-patch`, que la [guía oficial de migración a Vitest](https://angular.dev/guide/testing/migrating-to-vitest) desaconseja fuertemente: recomienda convertir las suites a async nativo + fake timers de Vitest como "the established approach".
2. Reintroducir zone.js contradice el TestBed zoneless del proyecto (`src/test-setup.ts`, `ZonelessTestModule`).
3. No hay ningún spec usando `fakeAsync` hoy; el control de tiempo ya corre con los wrappers de `@test-utils` sobre fake timers nativos.

Closes #1790.

## Plan de pruebas

- Corrida targeteada de ambos specs con Vitest: **16 passed, 1 skipped** (el skip del bloque conservado).
- Suite completa `pnpm test`: verde en local.
- `pnpm typecheck` y `pnpm lint`: verdes en local.
- Los once gates de CI en verde sobre el commit final: [run 32585951446](https://github.com/cuentoneta/cuentoneta/actions/runs/32585951446) (build, e2e, lint, storybook, studio-build, stylelint, test, typecheck, check-agents), más `check-findings` ([run 32585951427](https://github.com/cuentoneta/cuentoneta/actions/runs/32585951427)) y `guard-config` ([run 32585951450](https://github.com/cuentoneta/cuentoneta/actions/runs/32585951450)).
