### PR TITLE
[#2097] - Dar entrada de catálogo a CollectionTeasersDeck

### DIFF
--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.spec.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.spec.ts
@@ -9,30 +9,7 @@ import { CollectionTeaserCard } from '@components/collection-teaser-card/collect
 import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
 
 // Mocks
-import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
-
-// Modelos
-import { createCollectionTeaser, type CollectionTeaser } from '@models/collection.model';
-
-// El canon trae dos colecciones y el deck necesita más para ejercitar la grilla y los skeletons. Las
-// adicionales pasan por la factory, no por spread: el agregado está congelado y armarlo a mano
-// saltearía las invariantes que la factory existe para hacer cumplir.
-function teasersOfLength(count: number): CollectionTeaser[] {
-	const [base] = onoffCollectionTeasersMock;
-	return Array.from({ length: count }, (_, index) =>
-		createCollectionTeaser({
-			_id: `${base._id}-${index + 1}`,
-			slug: `${base.slug}-${index + 1}`,
-			title: `Colección ${index + 1}`,
-			description: base.description,
-			imagery: base.imagery,
-			tags: base.tags,
-			config: base.config,
-			mediaSources: base.mediaSources,
-			count: base.count,
-		}),
-	);
-}
+import { onoffCollectionTeasersMock, onoffCollectionTeasersOfLength } from '@mocks/onoff-collections.mock';
 
 describe('CollectionTeasersDeck', () => {
 	const defaultProviders = [provideRouter([])];
@@ -63,7 +40,7 @@ describe('CollectionTeasersDeck', () => {
 	describe('Comportamiento del bloque defer', () => {
 		it('should render one skeleton per grid slot while loading', async () => {
 			const { fixture } = await render(CollectionTeasersDeck, {
-				inputs: { teasers: teasersOfLength(4) },
+				inputs: { teasers: onoffCollectionTeasersOfLength(4) },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
@@ -76,7 +53,7 @@ describe('CollectionTeasersDeck', () => {
 
 		it('should render one card per teaser when data is available', async () => {
 			const { fixture } = await render(CollectionTeasersDeck, {
-				inputs: { teasers: teasersOfLength(3) },
+				inputs: { teasers: onoffCollectionTeasersOfLength(3) },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
@@ -90,7 +67,7 @@ describe('CollectionTeasersDeck', () => {
 		});
 
 		it('should link each card to the collection page', async () => {
-			const [teaser] = teasersOfLength(1);
+			const [teaser] = onoffCollectionTeasersOfLength(1);
 			const { fixture } = await render(CollectionTeasersDeck, {
 				inputs: { teasers: [teaser] },
 				providers: defaultProviders,
@@ -105,7 +82,7 @@ describe('CollectionTeasersDeck', () => {
 
 		it('should transition from loading to complete state', async () => {
 			const { fixture } = await render(CollectionTeasersDeck, {
-				inputs: { teasers: teasersOfLength(4) },
+				inputs: { teasers: onoffCollectionTeasersOfLength(4) },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
@@ -47,7 +47,7 @@ export const Primary: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Colecciones derivadas del canon de Onoff mediante el selector del agregador de mocks; la grilla arma una fila por cada dos tarjetas desde viewport <code>sm</code>.</p><p><strong>Usos:</strong> la grilla de colecciones del Design System v3 (todavía sin consumidor en páginas).</p>`,
+				story: `<p>Colecciones derivadas del canon de Onoff mediante el selector del agregador de mocks; la grilla arma una fila por cada dos tarjetas desde viewport <code>sm</code>.</p><p>Las cuatro salen de la misma colección canónica, así que comparten portada, prosa y etiqueta: la grilla se ve más pareja de lo que se verá con contenido real, y no ejercita portadas dispares ni descripciones de largo distinto. Se corrige al ampliar el corpus con colecciones propias.</p><p><strong>Usos:</strong> la grilla de colecciones del Design System v3 (todavía sin consumidor en páginas).</p>`,
 			},
 		},
 	},

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
@@ -1,0 +1,128 @@
+import { argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
+
+import { CollectionTeasersDeck } from './collection-teasers-deck';
+import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
+import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
+import { createCollectionTeaser, type CollectionTeaser } from '@models/collection.model';
+
+// El agregado de dominio está congelado: los teasers adicionales salen de la factory del modelo,
+// no de un spread, para no saltear las invariantes que ella hace cumplir.
+function teasersOfLength(count: number): CollectionTeaser[] {
+	const [base] = onoffCollectionTeasersMock;
+	return Array.from({ length: count }, (_, index) =>
+		createCollectionTeaser({
+			_id: `${base._id}-${index + 1}`,
+			slug: `${base.slug}-${index + 1}`,
+			title: `Colección ${index + 1}`,
+			description: base.description,
+			imagery: base.imagery,
+			tags: base.tags,
+			config: base.config,
+			mediaSources: base.mediaSources,
+			count: base.count,
+		}),
+	);
+}
+
+const meta: Meta<CollectionTeasersDeck> = {
+	component: CollectionTeasersDeck,
+	title: 'Componentes V3/CollectionTeasersDeck',
+	tags: ['autodocs'],
+	decorators: [
+		moduleMetadata({
+			imports: [CollectionTeaserCardSkeletonComponent],
+		}),
+	],
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>El <strong>CollectionTeasersDeck</strong> es el bloque de sección que agrupa colecciones en el Design System v3: encabezado "Colecciones" con subtítulo y grilla responsiva de una columna en mobile y dos desde <code>sm</code>, con una tarjeta por colección resuelta por <a href="./?path=/docs/componentes-v3-collectionteasercard--docs" target="_top"><strong>CollectionTeaserCard</strong></a>.</p><p>Está tipado contra el modelo de dominio <strong>Collection</strong> vía su proyección <code>CollectionTeaser</code>; mientras difiere la carga dibuja cuatro skeletons de <strong>CollectionTeaserCardSkeleton</strong> dentro de su bloque <code>@defer</code>, y sin colecciones queda solo el encabezado.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		teasers: {
+			control: { type: 'object' },
+			description: 'Colecciones a mostrar en la grilla; vacío deja solo el encabezado',
+			table: { type: { summary: 'readonly CollectionTeaser[]' }, defaultValue: { summary: '[]' } },
+		},
+	},
+};
+export default meta;
+
+export const Primary: StoryObj<CollectionTeasersDeck> = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-collection-teasers-deck ${argsToTemplate(args)} />`,
+	}),
+	args: {
+		teasers: teasersOfLength(4),
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Cuatro colecciones derivadas del canon de Onoff con la factory del dominio: dos filas de tarjetas desde viewport <code>sm</code>.</p><p><strong>Usos:</strong> la grilla de colecciones del Design System v3 (todavía sin consumidor en páginas).</p>`,
+			},
+		},
+	},
+};
+
+// La rama de carga replica el shell del deck (encabezado + grilla internos): es lo que el usuario
+// ve mientras corre el @defer, y replicarlo completo mantiene 1:1 el alto contra el estado real.
+export const Estados: StoryObj<CollectionTeasersDeck & { loading: boolean }> = {
+	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
+	render: (args) => ({
+		props: args,
+		template: `
+			@if (loading) {
+				<div class="flex flex-col gap-8">
+					<div class="flex items-center justify-between">
+						<div class="flex flex-col content-between gap-1">
+							<h2 class="font-inter text-2xl font-bold">Colecciones</h2>
+							<div class="font-inter text-sm text-neutral-600">Obras agrupadas por temas, estilos y universos en común</div>
+						</div>
+					</div>
+					<section class="mb-8 grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2">
+						<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
+						<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
+						<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
+						<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
+					</section>
+				</div>
+			} @else {
+				<cuentoneta-collection-teasers-deck [teasers]="teasers" />
+			}
+		`,
+	}),
+	args: {
+		loading: true,
+		teasers: teasersOfLength(4),
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Activá/desactivá "Cargando" para alternar entre el estado real y el estado de carga del deck: encabezado fijo más cuatro skeletons, idénticos a los que dibuja su bloque @defer.',
+			},
+		},
+	},
+};
+
+export const Vacia: StoryObj<CollectionTeasersDeck> = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-collection-teasers-deck ${argsToTemplate(args)} />`,
+	}),
+	args: {
+		teasers: [],
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Sin colecciones el @defer no dispara: queda el encabezado de sección, sin tarjetas ni skeletons. Es el valor default del input teasers.',
+			},
+		},
+	},
+};

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
@@ -2,27 +2,7 @@ import { argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angul
 
 import { CollectionTeasersDeck } from './collection-teasers-deck';
 import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
-import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
-import { createCollectionTeaser, type CollectionTeaser } from '@models/collection.model';
-
-// El agregado de dominio está congelado: los teasers adicionales salen de la factory del modelo,
-// no de un spread, para no saltear las invariantes que ella hace cumplir.
-function teasersOfLength(count: number): CollectionTeaser[] {
-	const [base] = onoffCollectionTeasersMock;
-	return Array.from({ length: count }, (_, index) =>
-		createCollectionTeaser({
-			_id: `${base._id}-${index + 1}`,
-			slug: `${base.slug}-${index + 1}`,
-			title: `Colección ${index + 1}`,
-			description: base.description,
-			imagery: base.imagery,
-			tags: base.tags,
-			config: base.config,
-			mediaSources: base.mediaSources,
-			count: base.count,
-		}),
-	);
-}
+import { onoffCollectionTeasersOfLength } from '@mocks/onoff-collections.mock';
 
 const meta: Meta<CollectionTeasersDeck> = {
 	component: CollectionTeasersDeck,
@@ -57,7 +37,7 @@ export const Primary: StoryObj<CollectionTeasersDeck> = {
 		template: `<cuentoneta-collection-teasers-deck ${argsToTemplate(args)} />`,
 	}),
 	args: {
-		teasers: teasersOfLength(4),
+		teasers: onoffCollectionTeasersOfLength(4),
 	},
 	parameters: {
 		docs: {
@@ -97,7 +77,7 @@ export const Estados: StoryObj<CollectionTeasersDeck & { loading: boolean }> = {
 	}),
 	args: {
 		loading: true,
-		teasers: teasersOfLength(4),
+		teasers: onoffCollectionTeasersOfLength(4),
 	},
 	parameters: {
 		docs: {

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
@@ -4,6 +4,10 @@ import { CollectionTeasersDeck } from './collection-teasers-deck';
 import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
 import { onoffCollectionTeasersOfLength } from '@mocks/onoff-collections.mock';
 
+// Un solo dataset compartido por todas las stories: mismas colecciones en cada estado hace que el
+// switch del catálogo compare siempre lo mismo.
+const deckTeasers = onoffCollectionTeasersOfLength(4);
+
 const meta: Meta<CollectionTeasersDeck> = {
 	component: CollectionTeasersDeck,
 	title: 'Componentes V3/CollectionTeasersDeck',
@@ -17,7 +21,7 @@ const meta: Meta<CollectionTeasersDeck> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>El <strong>CollectionTeasersDeck</strong> es el bloque de sección que agrupa colecciones en el Design System v3: encabezado "Colecciones" con subtítulo y grilla responsiva de una columna en mobile y dos desde <code>sm</code>, con una tarjeta por colección resuelta por <a href="./?path=/docs/componentes-v3-collectionteasercard--docs" target="_top"><strong>CollectionTeaserCard</strong></a>.</p><p>Está tipado contra el modelo de dominio <strong>Collection</strong> vía su proyección <code>CollectionTeaser</code>; mientras difiere la carga dibuja cuatro skeletons de <strong>CollectionTeaserCardSkeleton</strong> dentro de su bloque <code>@defer</code>, y sin colecciones queda solo el encabezado.</p></div>`,
+				component: `<div><p>El <strong>CollectionTeasersDeck</strong> es el bloque de sección que agrupa colecciones en el Design System v3: encabezado "Colecciones" con subtítulo y grilla responsiva de una columna en mobile y dos desde <code>sm</code>, con una tarjeta por colección resuelta por <a href="./?path=/docs/componentes-v3-collectionteasercard--docs" target="_top"><strong>CollectionTeaserCard</strong></a>.</p><p>Está tipado contra el modelo de dominio <strong>Collection</strong> vía su proyección <code>CollectionTeaser</code>; mientras difiere la carga dibuja los skeletons de <strong>CollectionTeaserCardSkeleton</strong> dentro de su bloque <code>@defer</code>, y sin colecciones queda solo el encabezado.</p></div>`,
 			},
 		},
 	},
@@ -30,19 +34,20 @@ const meta: Meta<CollectionTeasersDeck> = {
 	},
 };
 export default meta;
+type Story = StoryObj<CollectionTeasersDeck>;
 
-export const Primary: StoryObj<CollectionTeasersDeck> = {
+export const Primary: Story = {
 	render: (args) => ({
 		props: args,
 		template: `<cuentoneta-collection-teasers-deck ${argsToTemplate(args)} />`,
 	}),
 	args: {
-		teasers: onoffCollectionTeasersOfLength(4),
+		teasers: deckTeasers,
 	},
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Cuatro colecciones derivadas del canon de Onoff con la factory del dominio: dos filas de tarjetas desde viewport <code>sm</code>.</p><p><strong>Usos:</strong> la grilla de colecciones del Design System v3 (todavía sin consumidor en páginas).</p>`,
+				story: `<p>Colecciones derivadas del canon de Onoff mediante el selector del agregador de mocks; la grilla arma una fila por cada dos tarjetas desde viewport <code>sm</code>.</p><p><strong>Usos:</strong> la grilla de colecciones del Design System v3 (todavía sin consumidor en páginas).</p>`,
 			},
 		},
 	},
@@ -50,6 +55,8 @@ export const Primary: StoryObj<CollectionTeasersDeck> = {
 
 // La rama de carga replica el shell del deck (encabezado + grilla internos): es lo que el usuario
 // ve mientras corre el @defer, y replicarlo completo mantiene 1:1 el alto contra el estado real.
+// Bindings explícitos (no argsToTemplate) porque loading no es un input del componente, y
+// argsToTemplate generaría [loading]="loading" contra un destino inexistente.
 export const Estados: StoryObj<CollectionTeasersDeck & { loading: boolean }> = {
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
 	render: (args) => ({
@@ -64,10 +71,9 @@ export const Estados: StoryObj<CollectionTeasersDeck & { loading: boolean }> = {
 						</div>
 					</div>
 					<section class="mb-8 grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2">
-						<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
-						<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
-						<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
-						<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
+						@for (_ of teasers; track $index) {
+							<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
+						}
 					</section>
 				</div>
 			} @else {
@@ -77,19 +83,19 @@ export const Estados: StoryObj<CollectionTeasersDeck & { loading: boolean }> = {
 	}),
 	args: {
 		loading: true,
-		teasers: onoffCollectionTeasersOfLength(4),
+		teasers: deckTeasers,
 	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					'Activá/desactivá "Cargando" para alternar entre el estado real y el estado de carga del deck: encabezado fijo más cuatro skeletons, idénticos a los que dibuja su bloque @defer.',
+					'Activá/desactivá "Cargando" para alternar entre el estado real y el estado de carga del deck: encabezado fijo más un esqueleto por slot de la grilla —iterando los mismos datos, la paridad con la rama real vale por construcción—.',
 			},
 		},
 	},
 };
 
-export const Vacia: StoryObj<CollectionTeasersDeck> = {
+export const Vacia: Story = {
 	render: (args) => ({
 		props: args,
 		template: `<cuentoneta-collection-teasers-deck ${argsToTemplate(args)} />`,

--- a/src/mocks/onoff-collections.mock.ts
+++ b/src/mocks/onoff-collections.mock.ts
@@ -125,6 +125,11 @@ export const onoffCollectionTeasersMock: CollectionTeaser[] = onoffCollectionsMo
 // Los teasers extra se derivan del primero del canon y pasan uno a uno por la factory del teaser:
 // el agregado está congelado, así que armarlos por spread saltearía las invariantes que esa
 // factory existe para hacer cumplir.
+//
+// TODO(#2333): tomar colecciones reales del corpus en vez de repetir una.
+// Al salir todos del mismo canónico comparten portada, prosa, etiqueta y conteo de obras, y sólo se
+// distinguen por un título correlativo. Una grilla así se ve homogénea de un modo que ningún catálogo
+// real es: no muestra portadas dispares, ni descripciones de largo distinto, ni el recorte del título.
 export function onoffCollectionTeasersOfLength(count: number): CollectionTeaser[] {
 	const [base] = onoffCollectionTeasersMock;
 	return Array.from({ length: count }, (_, index) =>

--- a/src/mocks/onoff-collections.mock.ts
+++ b/src/mocks/onoff-collections.mock.ts
@@ -121,3 +121,23 @@ export const inventarioDeLasPasionesCollectionTeaserMock: CollectionTeaser = toT
 );
 
 export const onoffCollectionTeasersMock: CollectionTeaser[] = onoffCollectionsMock.map(toTeaser);
+
+// Los teasers extra se derivan del primero del canon y pasan uno a uno por la factory del teaser:
+// el agregado está congelado, así que armarlos por spread saltearía las invariantes que esa
+// factory existe para hacer cumplir.
+export function onoffCollectionTeasersOfLength(count: number): CollectionTeaser[] {
+	const [base] = onoffCollectionTeasersMock;
+	return Array.from({ length: count }, (_, index) =>
+		createCollectionTeaser({
+			_id: `${base._id}-${index + 1}`,
+			slug: `${base.slug}-${index + 1}`,
+			title: `Colección ${index + 1}`,
+			description: base.description,
+			imagery: base.imagery,
+			tags: base.tags,
+			config: base.config,
+			mediaSources: base.mediaSources,
+			count: base.count,
+		}),
+	);
+}


### PR DESCRIPTION
## Descripción

Da entrada de catálogo a `CollectionTeasersDeck` con su archivo de stories de Storybook (`src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts`), deuda preexistente detectada por el censo de componentes. El comportamiento ya estaba cubierto por el spec; acá solo se agrega catálogo.

Como el deck dibuja el skeleton en su propia plantilla (bloque `@defer/@loading`), la story `Estados` expone el control booleano **"Cargando"** que alterna real↔skeleton en el mismo slot: la rama de carga replica el shell completo del deck (encabezado + grilla interna) para que la comparación de alto y alineación contra el estado real sea 1:1. La grilla se ejercita con cuatro teasers derivados del canon vía el selector `onoffCollectionTeasersOfLength` —consolidado en el agregador de mocks, que ya consumía el spec— para emparejar los slots con los skeletons del `@loading`.

## Stories

- `Primary`: grilla poblada 2×2 (cuatro colecciones derivadas del canon).
- `Estados`: estado intercambiable real↔skeleton (control "Cargando", default en carga).
- `Vacia`: input default vacío — el `@defer` no dispara; queda solo el encabezado de sección, sin tarjetas ni skeletons.

## Capturas

**Primary** — grilla 2×2 con las cuatro colecciones derivadas del canon:

![Primary](https://github.com/user-attachments/assets/7d911a0e-dc6a-4e17-87e1-3a401b734404)

**Estados — "Cargando" activo**: encabezado fijo más un esqueleto por slot de la grilla, iterando los mismos datos de la rama real (paridad 1:1 por construcción):

![Estados con skeletons](https://github.com/user-attachments/assets/cff67af8-b04e-4964-b7a3-b6127ef887f8)

**Estados — "Cargando" desactivado**: el mismo slot muestra el deck real:

![Estados real](https://github.com/user-attachments/assets/3dd0af75-abc1-43e2-9f10-308c1408b577)

**Vacia** — input default: el `@defer` no dispara y queda solo el encabezado:

![Vacia](https://github.com/user-attachments/assets/921b5119-b14e-4cbe-a6a6-beead079ea53)

**Autodocs** — descripción del componente con los nombres en negrita y el enlace a la autodoc de `CollectionTeaserCard`:

![Autodocs](https://github.com/user-attachments/assets/a47e1d6c-03c2-4b8f-a3f0-91860062cf2f)

Closes #2097.

## Plan de pruebas

- Tier local verde tras cada commit: `typecheck`, `lint`, `stylelint`, `test`, `check-agents`.
- Los once gates de CI verdes sobre el commit final (`a2288ca4`), incluidos `storybook`, `build` y `e2e`.
- Verificación manual en Storybook dev (la única que monta las stories): `Primary` renderiza encabezado + 4 tarjetas con sus links; `Estados` alterna skeletons ↔ deck real con el control "Cargando"; `Vacia` deja solo el encabezado; la autodoc renderiza la descripción de una línea y su enlace a la autodoc de `CollectionTeaserCard` resuelve a la página existente.
