### PR TITLE
[#2236] - Quita los residuos de Jest de la configuración de TypeScript

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -7,5 +7,5 @@
 	},
 	"files": ["src/main.ts", "src/main.server.ts", "src/server.ts"],
 	"include": ["src/**/*.d.ts"],
-	"exclude": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "**/*.stories.ts", "**/*.stories.js"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "**/*.stories.ts", "**/*.stories.js"]
 }

--- a/tsconfig.editor.json
+++ b/tsconfig.editor.json
@@ -2,7 +2,7 @@
 	"extends": "./tsconfig.json",
 	"include": ["src/**/*.ts"],
 	"compilerOptions": {
-		"types": ["jest", "node"]
+		"types": ["vitest/globals", "node"]
 	},
-	"exclude": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "**/*.stories.ts", "**/*.stories.js"]
+	"exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "**/*.stories.ts", "**/*.stories.js"]
 }


### PR DESCRIPTION
### Problema

El PR #2234 alineó la documentación con Vitest, pero dejó fuera los residuos equivalentes en la configuración de TypeScript detectados durante su review:

- `tsconfig.editor.json` declaraba `"types": ["jest"]` para un paquete desinstalado → `TS2688: Cannot find type definition file for 'jest'` en el editor.
- `tsconfig.editor.json` y `tsconfig.app.json` excluyen un `jest.config.ts` que no existe en el repositorio.

### Solución

- Reemplaza `"jest"` por `"vitest/globals"` en `tsconfig.editor.json`: los globals de la suite quedan tipados en cualquier camino por el que un spec entre al programa del editor. Mismo patrón que ya aplican `tsconfig.spec.json` y `tsconfig.typecheck.json`.
- Saca `"jest.config.ts"` de los `exclude` de ambos tsconfigs (el archivo no existe; verificado con glob). Es la cola que quedó fuera de la limpieza de Jest/Cypress anunciada en el CHANGELOG de 2.10.0.

### Verificación

- `pnpm typecheck` verde.
- `tsc -p tsconfig.editor.json --noEmit` exit 0 — equivalente a la compilación que resuelve el editor al abrir un archivo de `src/`.
- Scan completo: ningún otro residuo de Jest en configs de TS ni en el resto de la configuración (`@testing-library/jest-dom` es intencional, se consume vía `src/test-setup.ts`).

Closes #2236
