### PR TITLE
[#2310] - Un cierre en el mismo frame que la apertura deja el drawer abierto

### DIFF
--- a/src/app/components/drawer/drawer-transition.directive.spec.ts
+++ b/src/app/components/drawer/drawer-transition.directive.spec.ts
@@ -81,4 +81,24 @@ describe('DrawerTransitionDirective', () => {
 		expect(firstComplete).toHaveBeenCalledTimes(1);
 		expect(secondComplete).toHaveBeenCalledTimes(1);
 	});
+
+	it('should reopen normally after a close that landed before the entry frame ran', () => {
+		useFakeTimers();
+
+		directive.open(dialog);
+		directive.close(dialog, () => {});
+		directive.open(dialog);
+
+		expect(dialog.open).toBe(true);
+		expect(directive.isTransitionedIn()).toBe(false);
+
+		runOnlyPendingTimers();
+		expect(directive.isTransitionedIn()).toBe(true);
+
+		let completed = false;
+		directive.close(dialog, () => (completed = true));
+		dialog.dispatchEvent(new Event('transitionend'));
+		expect(dialog.open).toBe(false);
+		expect(completed).toBe(true);
+	});
 });

--- a/src/app/components/drawer/drawer-transition.directive.spec.ts
+++ b/src/app/components/drawer/drawer-transition.directive.spec.ts
@@ -80,6 +80,22 @@ describe('DrawerTransitionDirective', () => {
 		expect(secondComplete).toHaveBeenCalledTimes(1);
 	});
 
+	it('should drop a pending entry frame when close lands on an externally closed dialog', () => {
+		useFakeTimers();
+
+		const onComplete = fn();
+		directive.open(dialog);
+		dialog.close();
+		directive.close(dialog, onComplete);
+
+		expect(onComplete).toHaveBeenCalledTimes(1);
+
+		// El frame huérfano no reabre el estado sobre el diálogo ya cerrado.
+		runOnlyPendingTimers();
+		expect(directive.isTransitionedIn()).toBe(false);
+		expect(dialog.open).toBe(false);
+	});
+
 	it('should reopen normally after a close that landed before the entry frame ran', () => {
 		useFakeTimers();
 

--- a/src/app/components/drawer/drawer-transition.directive.spec.ts
+++ b/src/app/components/drawer/drawer-transition.directive.spec.ts
@@ -62,4 +62,23 @@ describe('DrawerTransitionDirective', () => {
 		expect(directive.isTransitionedIn()).toBe(false);
 		expect(onComplete).toHaveBeenCalledTimes(1);
 	});
+
+	it('should complete a late close immediately without leaving transition listeners behind', () => {
+		useFakeTimers();
+
+		const firstComplete = fn();
+		const secondComplete = fn();
+		directive.open(dialog);
+		directive.close(dialog, firstComplete);
+		expect(dialog.open).toBe(false);
+
+		// Un cierre tardío sobre el diálogo ya cerrado se resuelve de una vez: no apila un listener
+		// de `transitionend` que nunca llegaría a dispararse con naturalidad.
+		directive.close(dialog, secondComplete);
+		expect(secondComplete).toHaveBeenCalledTimes(1);
+
+		dialog.dispatchEvent(new Event('transitionend'));
+		expect(firstComplete).toHaveBeenCalledTimes(1);
+		expect(secondComplete).toHaveBeenCalledTimes(1);
+	});
 });

--- a/src/app/components/drawer/drawer-transition.directive.spec.ts
+++ b/src/app/components/drawer/drawer-transition.directive.spec.ts
@@ -1,3 +1,5 @@
+import { fn, runOnlyPendingTimers, useFakeTimers, useRealTimers } from '@test-utils';
+
 import { DrawerTransitionDirective } from './drawer-transition.directive';
 
 const nextFrame = (): Promise<void> => new Promise((resolve) => requestAnimationFrame(() => resolve()));
@@ -12,7 +14,10 @@ describe('DrawerTransitionDirective', () => {
 		document.body.appendChild(dialog);
 	});
 
-	afterEach(() => dialog.remove());
+	afterEach(() => {
+		useRealTimers();
+		dialog.remove();
+	});
 
 	it('should open the dialog and flag the transition on the next frame', async () => {
 		directive.open(dialog);
@@ -36,5 +41,25 @@ describe('DrawerTransitionDirective', () => {
 		dialog.dispatchEvent(new Event('transitionend'));
 		expect(dialog.open).toBe(false);
 		expect(completed).toBe(true);
+	});
+
+	it('should close synchronously when close arrives before the entry frame runs', () => {
+		useFakeTimers();
+
+		const onComplete = fn();
+		directive.open(dialog);
+		directive.close(dialog, onComplete);
+
+		expect(dialog.open).toBe(false);
+		expect(onComplete).toHaveBeenCalledTimes(1);
+		expect(directive.isTransitionedIn()).toBe(false);
+
+		// El frame diferido quedó cancelado: correrlo no reabre el panel, y el cierre no deja
+		// ningún listener de `transitionend` colgado que dispare una segunda finalización.
+		runOnlyPendingTimers();
+		dialog.dispatchEvent(new Event('transitionend'));
+		expect(dialog.open).toBe(false);
+		expect(directive.isTransitionedIn()).toBe(false);
+		expect(onComplete).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/app/components/drawer/drawer-transition.directive.spec.ts
+++ b/src/app/components/drawer/drawer-transition.directive.spec.ts
@@ -85,8 +85,9 @@ describe('DrawerTransitionDirective', () => {
 	it('should reopen normally after a close that landed before the entry frame ran', () => {
 		useFakeTimers();
 
+		const firstComplete = fn();
 		directive.open(dialog);
-		directive.close(dialog, () => {});
+		directive.close(dialog, firstComplete);
 		directive.open(dialog);
 
 		expect(dialog.open).toBe(true);
@@ -100,5 +101,6 @@ describe('DrawerTransitionDirective', () => {
 		dialog.dispatchEvent(new Event('transitionend'));
 		expect(dialog.open).toBe(false);
 		expect(completed).toBe(true);
+		expect(firstComplete).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/app/components/drawer/drawer-transition.directive.spec.ts
+++ b/src/app/components/drawer/drawer-transition.directive.spec.ts
@@ -54,8 +54,7 @@ describe('DrawerTransitionDirective', () => {
 		expect(onComplete).toHaveBeenCalledTimes(1);
 		expect(directive.isTransitionedIn()).toBe(false);
 
-		// El frame diferido quedó cancelado: correrlo no reabre el panel, y el cierre no deja
-		// ningún listener de `transitionend` colgado que dispare una segunda finalización.
+		// El frame cancelado no reabre ni completa de más.
 		runOnlyPendingTimers();
 		dialog.dispatchEvent(new Event('transitionend'));
 		expect(dialog.open).toBe(false);
@@ -72,8 +71,7 @@ describe('DrawerTransitionDirective', () => {
 		directive.close(dialog, firstComplete);
 		expect(dialog.open).toBe(false);
 
-		// Un cierre tardío sobre el diálogo ya cerrado se resuelve de una vez: no apila un listener
-		// de `transitionend` que nunca llegaría a dispararse con naturalidad.
+		// Sobre diálogo cerrado no se apilan listeners.
 		directive.close(dialog, secondComplete);
 		expect(secondComplete).toHaveBeenCalledTimes(1);
 

--- a/src/app/components/drawer/drawer-transition.directive.ts
+++ b/src/app/components/drawer/drawer-transition.directive.ts
@@ -1,17 +1,5 @@
 import { Directive, signal } from '@angular/core';
 
-/** Handle centinela de "sin frame pendiente": `cancelAnimationFrame` lo descarta sin efecto (spec WHATWG). */
-const NO_PENDING_FRAME = -1;
-
-/**
- * Fase del drawer al momento de pedir un cierre. `alreadyClosed`: el diálogo ya está cerrado (cierre
- * idempotente). `entryPending`: la apertura difirió su estado un frame y ese frame sigue vivo. `settled`:
- * la entrada asentó y hay transición que orquestar para la salida.
- */
-type DrawerClosePhase = 'alreadyClosed' | 'entryPending' | 'settled';
-
-type DrawerCloseStrategy = (element: HTMLDialogElement, onComplete: () => void) => void;
-
 /**
  * Orquesta la transición de entrada/salida del drawer. Expone `isTransitionedIn` como signal para que
  * `DrawerComponent` maneje el atributo `data-open` de forma declarativa en la plantilla; solo el timing de
@@ -23,53 +11,40 @@ export class DrawerTransitionDirective {
 	private readonly _isTransitionedIn = signal(false);
 	public readonly isTransitionedIn = this._isTransitionedIn.asReadonly();
 
-	/** Handle del frame diferido de la apertura; `NO_PENDING_FRAME` cuando no hay ninguno pendiente. */
-	private pendingEntryFrame = NO_PENDING_FRAME;
-
-	// Estrategias de cierre indexadas por fase: el mapa hace exhaustivo el manejo de fases a nivel de
-	// tipos (una fase nueva sin estrategia no compila) y reemplaza el branching por una lookup O(1).
-	private readonly closeStrategies: Record<DrawerClosePhase, DrawerCloseStrategy> = {
-		alreadyClosed: (_element, onComplete) => onComplete(),
-		entryPending: (element, onComplete) => {
-			cancelAnimationFrame(this.pendingEntryFrame);
-			this.pendingEntryFrame = NO_PENDING_FRAME;
-			element.close();
-			onComplete();
-		},
-		settled: (element, onComplete) => {
-			this._isTransitionedIn.set(false);
-			const handler = (event: Event): void => {
-				if (event.target !== element) {
-					return;
-				}
-				element.removeEventListener('transitionend', handler);
-				element.close();
-				onComplete();
-			};
-			element.addEventListener('transitionend', handler);
-		},
-	};
+	private pendingEntryFrame: number | null = null;
 
 	/** Abre el diálogo y dispara el slide-in después de un frame (para que el navegador aplique primero el estado cerrado). */
 	public open(element: HTMLDialogElement): void {
 		element.showModal();
 		this.pendingEntryFrame = requestAnimationFrame(() => {
-			this.pendingEntryFrame = NO_PENDING_FRAME;
+			this.pendingEntryFrame = null;
 			this._isTransitionedIn.set(true);
 		});
 	}
 
-	/**
-	 * Cierra el drawer con la estrategia de su fase vigente, y llama a `onComplete` al terminar. Es idempotente
-	 * en cualquier instante posterior a `open()`: sobre un diálogo ya cerrado completa de una vez, sin apilar
-	 * listeners; si la apertura todavía no asentó, cierra de forma síncrona —la salida no tendría transición que
-	 * esperar, y dejar el frame vivo reabriría el panel tras el cierre—.
-	 */
+	/** Dispara la salida y llama a `onComplete` al terminar; válido en cualquier instante posterior a `open()`. */
 	public close(element: HTMLDialogElement, onComplete: () => void): void {
-		this.closeStrategies[this.closePhaseOf(element)](element, onComplete);
-	}
-
-	private closePhaseOf(element: HTMLDialogElement): DrawerClosePhase {
-		return !element.open ? 'alreadyClosed' : this.pendingEntryFrame === NO_PENDING_FRAME ? 'settled' : 'entryPending';
+		if (!element.open) {
+			onComplete();
+			return;
+		}
+		if (this.pendingEntryFrame !== null) {
+			// La entrada aún no asentó: no hay transición que esperar y el frame vivo reabriría el panel.
+			cancelAnimationFrame(this.pendingEntryFrame);
+			this.pendingEntryFrame = null;
+			element.close();
+			onComplete();
+			return;
+		}
+		this._isTransitionedIn.set(false);
+		const handler = (event: Event): void => {
+			if (event.target !== element) {
+				return;
+			}
+			element.removeEventListener('transitionend', handler);
+			element.close();
+			onComplete();
+		};
+		element.addEventListener('transitionend', handler);
 	}
 }

--- a/src/app/components/drawer/drawer-transition.directive.ts
+++ b/src/app/components/drawer/drawer-transition.directive.ts
@@ -25,6 +25,12 @@ export class DrawerTransitionDirective {
 	/** Dispara la salida y llama a `onComplete` al terminar; válido en cualquier instante posterior a `open()`. */
 	public close(element: HTMLDialogElement, onComplete: () => void): void {
 		if (!element.open) {
+			// Cierre por fuera de la directiva (p. ej. `form method=dialog`): limpia el frame y el estado.
+			if (this.pendingEntryFrame !== null) {
+				cancelAnimationFrame(this.pendingEntryFrame);
+				this.pendingEntryFrame = null;
+			}
+			this._isTransitionedIn.set(false);
 			onComplete();
 			return;
 		}

--- a/src/app/components/drawer/drawer-transition.directive.ts
+++ b/src/app/components/drawer/drawer-transition.directive.ts
@@ -11,14 +11,31 @@ export class DrawerTransitionDirective {
 	private readonly _isTransitionedIn = signal(false);
 	public readonly isTransitionedIn = this._isTransitionedIn.asReadonly();
 
+	/** Frame diferido de la apertura; `null` una vez que corrió o fue cancelado por un cierre temprano. */
+	private pendingEntryFrame: number | null = null;
+
 	/** Abre el diálogo y dispara el slide-in después de un frame (para que el navegador aplique primero el estado cerrado). */
 	public open(element: HTMLDialogElement): void {
 		element.showModal();
-		requestAnimationFrame(() => this._isTransitionedIn.set(true));
+		this.pendingEntryFrame = requestAnimationFrame(() => {
+			this.pendingEntryFrame = null;
+			this._isTransitionedIn.set(true);
+		});
 	}
 
-	/** Dispara la transición de salida y llama a `onComplete` recién después de `transitionend`. */
+	/**
+	 * Dispara la transición de salida y llama a `onComplete` recién después de `transitionend`. Si la apertura
+	 * todavía no asentó (frame diferido pendiente), cierra de forma síncrona: la salida no tendría transición que
+	 * esperar —el estado de entrada ya era `false`—, y dejar el frame vivo reabriría el panel tras el cierre.
+	 */
 	public close(element: HTMLDialogElement, onComplete: () => void): void {
+		if (this.pendingEntryFrame !== null) {
+			cancelAnimationFrame(this.pendingEntryFrame);
+			this.pendingEntryFrame = null;
+			element.close();
+			onComplete();
+			return;
+		}
 		this._isTransitionedIn.set(false);
 		const handler = (event: Event): void => {
 			if (event.target !== element) {

--- a/src/app/components/drawer/drawer-transition.directive.ts
+++ b/src/app/components/drawer/drawer-transition.directive.ts
@@ -24,11 +24,16 @@ export class DrawerTransitionDirective {
 	}
 
 	/**
-	 * Dispara la transición de salida y llama a `onComplete` recién después de `transitionend`. Si la apertura
-	 * todavía no asentó (frame diferido pendiente), cierra de forma síncrona: la salida no tendría transición que
-	 * esperar —el estado de entrada ya era `false`—, y dejar el frame vivo reabriría el panel tras el cierre.
+	 * Dispara la transición de salida y llama a `onComplete` recién después de `transitionend`. Es idempotente:
+	 * sobre un diálogo ya cerrado completa de una vez, sin apilar listeners. Si la apertura todavía no asentó
+	 * (frame diferido pendiente), cierra de forma síncrona: la salida no tendría transición que esperar —el
+	 * estado de entrada ya era `false`—, y dejar el frame vivo reabriría el panel tras el cierre.
 	 */
 	public close(element: HTMLDialogElement, onComplete: () => void): void {
+		if (!element.open) {
+			onComplete();
+			return;
+		}
 		if (this.pendingEntryFrame !== null) {
 			cancelAnimationFrame(this.pendingEntryFrame);
 			this.pendingEntryFrame = null;

--- a/src/app/components/drawer/drawer-transition.directive.ts
+++ b/src/app/components/drawer/drawer-transition.directive.ts
@@ -1,5 +1,17 @@
 import { Directive, signal } from '@angular/core';
 
+/** Handle centinela de "sin frame pendiente": `cancelAnimationFrame` lo descarta sin efecto (spec WHATWG). */
+const NO_PENDING_FRAME = -1;
+
+/**
+ * Fase del drawer al momento de pedir un cierre. `alreadyClosed`: el diálogo ya está cerrado (cierre
+ * idempotente). `entryPending`: la apertura difirió su estado un frame y ese frame sigue vivo. `settled`:
+ * la entrada asentó y hay transición que orquestar para la salida.
+ */
+type DrawerClosePhase = 'alreadyClosed' | 'entryPending' | 'settled';
+
+type DrawerCloseStrategy = (element: HTMLDialogElement, onComplete: () => void) => void;
+
 /**
  * Orquesta la transición de entrada/salida del drawer. Expone `isTransitionedIn` como signal para que
  * `DrawerComponent` maneje el atributo `data-open` de forma declarativa en la plantilla; solo el timing de
@@ -11,45 +23,53 @@ export class DrawerTransitionDirective {
 	private readonly _isTransitionedIn = signal(false);
 	public readonly isTransitionedIn = this._isTransitionedIn.asReadonly();
 
-	/** Frame diferido de la apertura; `null` una vez que corrió o fue cancelado por un cierre temprano. */
-	private pendingEntryFrame: number | null = null;
+	/** Handle del frame diferido de la apertura; `NO_PENDING_FRAME` cuando no hay ninguno pendiente. */
+	private pendingEntryFrame = NO_PENDING_FRAME;
+
+	// Estrategias de cierre indexadas por fase: el mapa hace exhaustivo el manejo de fases a nivel de
+	// tipos (una fase nueva sin estrategia no compila) y reemplaza el branching por una lookup O(1).
+	private readonly closeStrategies: Record<DrawerClosePhase, DrawerCloseStrategy> = {
+		alreadyClosed: (_element, onComplete) => onComplete(),
+		entryPending: (element, onComplete) => {
+			cancelAnimationFrame(this.pendingEntryFrame);
+			this.pendingEntryFrame = NO_PENDING_FRAME;
+			element.close();
+			onComplete();
+		},
+		settled: (element, onComplete) => {
+			this._isTransitionedIn.set(false);
+			const handler = (event: Event): void => {
+				if (event.target !== element) {
+					return;
+				}
+				element.removeEventListener('transitionend', handler);
+				element.close();
+				onComplete();
+			};
+			element.addEventListener('transitionend', handler);
+		},
+	};
 
 	/** Abre el diálogo y dispara el slide-in después de un frame (para que el navegador aplique primero el estado cerrado). */
 	public open(element: HTMLDialogElement): void {
 		element.showModal();
 		this.pendingEntryFrame = requestAnimationFrame(() => {
-			this.pendingEntryFrame = null;
+			this.pendingEntryFrame = NO_PENDING_FRAME;
 			this._isTransitionedIn.set(true);
 		});
 	}
 
 	/**
-	 * Dispara la transición de salida y llama a `onComplete` recién después de `transitionend`. Es idempotente:
-	 * sobre un diálogo ya cerrado completa de una vez, sin apilar listeners. Si la apertura todavía no asentó
-	 * (frame diferido pendiente), cierra de forma síncrona: la salida no tendría transición que esperar —el
-	 * estado de entrada ya era `false`—, y dejar el frame vivo reabriría el panel tras el cierre.
+	 * Cierra el drawer con la estrategia de su fase vigente, y llama a `onComplete` al terminar. Es idempotente
+	 * en cualquier instante posterior a `open()`: sobre un diálogo ya cerrado completa de una vez, sin apilar
+	 * listeners; si la apertura todavía no asentó, cierra de forma síncrona —la salida no tendría transición que
+	 * esperar, y dejar el frame vivo reabriría el panel tras el cierre—.
 	 */
 	public close(element: HTMLDialogElement, onComplete: () => void): void {
-		if (!element.open) {
-			onComplete();
-			return;
-		}
-		if (this.pendingEntryFrame !== null) {
-			cancelAnimationFrame(this.pendingEntryFrame);
-			this.pendingEntryFrame = null;
-			element.close();
-			onComplete();
-			return;
-		}
-		this._isTransitionedIn.set(false);
-		const handler = (event: Event): void => {
-			if (event.target !== element) {
-				return;
-			}
-			element.removeEventListener('transitionend', handler);
-			element.close();
-			onComplete();
-		};
-		element.addEventListener('transitionend', handler);
+		this.closeStrategies[this.closePhaseOf(element)](element, onComplete);
+	}
+
+	private closePhaseOf(element: HTMLDialogElement): DrawerClosePhase {
+		return !element.open ? 'alreadyClosed' : this.pendingEntryFrame === NO_PENDING_FRAME ? 'settled' : 'entryPending';
 	}
 }

--- a/src/app/components/drawer/drawer.component.spec.ts
+++ b/src/app/components/drawer/drawer.component.spec.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { render, screen } from '@testing-library/angular';
 import userEvent, { type UserEvent } from '@testing-library/user-event';
 
@@ -13,9 +14,9 @@ import { DrawerTrackerService } from './drawer-tracker.service';
 	template: `
 		<button (click)="drawer.open()" type="button">Abrir</button>
 		<cuentoneta-drawer
-			(opened)="openedCount = openedCount + 1"
-			(closed)="closedCount = closedCount + 1"
-			(afterClosed)="afterClosedCount = afterClosedCount + 1"
+			(opened)="openedCount = openedCount + 1; mark('opened')"
+			(closed)="closedCount = closedCount + 1; mark('closed')"
+			(afterClosed)="afterClosedCount = afterClosedCount + 1; mark('afterClosed')"
 			[direction]="direction"
 			[title]="title"
 			[description]="description"
@@ -44,6 +45,11 @@ class HostComponent {
 	public openedCount = 0;
 	public closedCount = 0;
 	public afterClosedCount = 0;
+	public readonly eventLog: string[] = [];
+
+	public mark(eventName: string): void {
+		this.eventLog.push(eventName);
+	}
 }
 
 const getDialog = (): HTMLDialogElement => screen.getByRole('dialog', { hidden: true }) as HTMLDialogElement;
@@ -88,6 +94,20 @@ describe('DrawerComponent', () => {
 		dialog.dispatchEvent(new Event('transitionend'));
 		expect(dialog.open).toBe(false);
 		expect(fixture.componentInstance.afterClosedCount).toBe(1);
+	});
+
+	it('should emit closed before afterClosed when close arrives in the same frame as open', async () => {
+		const { fixture } = await render(HostComponent);
+		const drawer = fixture.debugElement.query(By.directive(DrawerComponent)).componentInstance as DrawerComponent;
+
+		// Ambas llamadas en la misma tarea: garantiza que el cierre aterriza antes del frame diferido
+		// de la apertura, sin depender del scheduling real de `requestAnimationFrame`.
+		drawer.open();
+		drawer.close();
+
+		expect(fixture.componentInstance.closedCount).toBe(1);
+		expect(fixture.componentInstance.afterClosedCount).toBe(1);
+		expect(fixture.componentInstance.eventLog).toEqual(['opened', 'closed', 'afterClosed']);
 	});
 
 	it('should emit closed and afterClosed only once when close is triggered repeatedly mid-transition', async () => {

--- a/src/app/components/drawer/drawer.component.spec.ts
+++ b/src/app/components/drawer/drawer.component.spec.ts
@@ -100,8 +100,7 @@ describe('DrawerComponent', () => {
 		const { fixture } = await render(HostComponent);
 		const drawer = fixture.debugElement.query(By.css('cuentoneta-drawer')).injector.get(DrawerComponent);
 
-		// Ambas llamadas en la misma tarea: garantiza que el cierre aterriza antes del frame diferido
-		// de la apertura, sin depender del scheduling real de `requestAnimationFrame`.
+		// Misma tarea: el cierre cae antes del frame de entrada.
 		drawer.open();
 		drawer.close();
 

--- a/src/app/components/drawer/drawer.component.spec.ts
+++ b/src/app/components/drawer/drawer.component.spec.ts
@@ -98,7 +98,7 @@ describe('DrawerComponent', () => {
 
 	it('should emit closed before afterClosed when close arrives in the same frame as open', async () => {
 		const { fixture } = await render(HostComponent);
-		const drawer = fixture.debugElement.query(By.directive(DrawerComponent)).componentInstance as DrawerComponent;
+		const drawer = fixture.debugElement.query(By.css('cuentoneta-drawer')).injector.get(DrawerComponent);
 
 		// Ambas llamadas en la misma tarea: garantiza que el cierre aterriza antes del frame diferido
 		// de la apertura, sin depender del scheduling real de `requestAnimationFrame`.

--- a/src/app/components/drawer/drawer.component.ts
+++ b/src/app/components/drawer/drawer.component.ts
@@ -169,8 +169,7 @@ export class DrawerComponent {
 		}
 		this.isClosing.set(true);
 		this.tracker.unregister(this);
-		// `closed` se emite antes de delegar el cierre: si la transición completa de forma síncrona
-		// (apertura sin asentar), `afterClosed` correría dentro de esa llamada y quedaría adelantado.
+		// Primero `closed`: el cierre síncrono resuelve `afterClosed` dentro de `transition.close`.
 		this.closed.emit();
 		this.transition.close(dialog, () => {
 			this.isClosing.set(false);

--- a/src/app/components/drawer/drawer.component.ts
+++ b/src/app/components/drawer/drawer.component.ts
@@ -169,10 +169,12 @@ export class DrawerComponent {
 		}
 		this.isClosing.set(true);
 		this.tracker.unregister(this);
+		// `closed` se emite antes de delegar el cierre: si la transición completa de forma síncrona
+		// (apertura sin asentar), `afterClosed` correría dentro de esa llamada y quedaría adelantado.
+		this.closed.emit();
 		this.transition.close(dialog, () => {
 			this.isClosing.set(false);
 			this.afterClosed.emit();
 		});
-		this.closed.emit();
 	}
 }


### PR DESCRIPTION
## Descripción

Hace válido el cierre del drawer en cualquier instante posterior a la apertura, sin depender de que el frame diferido por `requestAnimationFrame` ya haya corrido.

## Problema

`DrawerTransitionDirective.open()` abre el diálogo y difiere el estado de entrada un frame. Un `close()` que llegaba antes de ese frame ponía el estado en `false` —que ya era `false`—, así que ninguna clase cambiaba, ninguna transición arrancaba y el `transitionend` que el cierre esperaba para completarse nunca llegaba; peor aún, el callback diferido corría después y reabría el panel, dejándolo abierto en modal con un listener de transición colgado.

Una persona no puede tipear dentro de esa ventana de un frame, pero sí la alcanzan los cierres programáticos (una navegación que cierra el panel al salir, un `close()` disparado por un efecto) y cualquier test que abra y cierre sin esperar la transición de entrada.

## Cambios

- **`DrawerTransitionDirective`**: guarda el handle del frame diferido. Si `close()` llega con la apertura todavía sin asentar, cancela el frame y cierra de forma síncrona (`element.close()` + `onComplete()`), sin registrar listener de transición. Además es idempotente: sobre un diálogo ya cerrado completa de una vez, sin apilar listeners huérfanos.
- **Despacho del cierre**: branching secuencial con early-returns (diálogo ya cerrado → completa y limpia el frame pendiente; entrada sin asentar → cierre síncrono con `cancelAnimationFrame`; resto → salida por `transitionend`); el frame pendiente se modela como `number | null` (`null` = sin entrada pendiente).
- **`DrawerComponent`**: emite `closed` antes de delegar a la directiva, de modo que el orden `closed → afterClosed` queda garantizado en ambos caminos (en el síncrono, `afterClosed` correría dentro de la llamada y quedaría adelantado).
- **Tests**: regresión de la carrera (abrir y cerrar en el mismo frame, con fake timers), cierre tardío idempotente, ciclo completo de re-apertura tras cierre temprano, e invariante de orden de emisiones en el componente. Todos verificados en rojo contra la implementación previa cuando aplica.

## Evidencia visual (Storybook, Chromium real)

Estado cerrado inicial del panel:

![Drawer cerrado](https://x0.at/Ym6l.png)

Drawer abierto desde la derecha, con backdrop y botón de cierre:

![Drawer abierto](https://x0.at/Lv3J.png)

Tras ejecutar apertura y cierre **en la misma tarea de JavaScript** —la carrera del issue— el panel desaparece de inmediato: la página vuelve a un estado idéntico al cerrado inicial, sin modal atascado ni foco atrapado:

![Drawer cerrado tras la carrera](https://x0.at/Ym6l.png)

La corrida instrumentada de la carrera, sobre la story `Derecha`:

```json
{
  "classicOpen": true,
  "classicFullyClosed": true,
  "raceDuring": true,
  "raceImmediatelyAfter": false,
  "raceAfterMicrotasks": false,
  "raceAfterFrames": false
}
```

Con la implementación previa, `raceImmediatelyAfter` y `raceAfterFrames` quedaban en `true` para siempre: el panel no se podía cerrar.

## Nota sobre el gate e2e

El check `e2e` está en rojo por `e2e/seo/home.spec.ts:94` (timeout esperando enlaces `/story/` en la home, chromium + firefox). Es un fallo **heredado de `develop`**: el run de la integración de hoy en `develop` lo reproduce igual (run 32678174893), al igual que otras ramas activas, y la home no monta el drawer — este PR no toca ninguna superficie que ese spec ejercite.

Closes #2310.

## Plan de pruebas

- [x] Test de regresión unitario que abre y cierra sin esperar la transición de entrada; verificado en rojo contra la implementación previa y en verde con el fix.
- [x] Tests de idempotencia de cierre tardío, re-apertura tras cierre temprano y orden `closed → afterClosed` (verificados en rojo según corresponda).
- [x] `pnpm test` (suite completa) en verde tras cada commit.
- [x] `pnpm lint`, `pnpm stylelint`, `pnpm check:agents` y `tsc --noEmit` en verde.
- [x] Verificación visual en Storybook (Chromium): ciclo clásico de apertura/cierre y carrera de mismo-frame, con capturas adjuntas arriba.
- [ ] Gates de CI del PR en verde — todos en verde salvo `e2e`, con el rojo heredado de `develop` documentado arriba.

