### PR TITLE
[#2288] - Declara la ruta del catálogo de colecciones con una página mínima

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -47,6 +47,10 @@ export const serverRoutes: Array<ServerRoute> = [
 		renderMode: RenderMode.Server,
 	},
 	{
+		path: AppRoutes.Collection,
+		renderMode: RenderMode.Server,
+	},
+	{
 		path: '**',
 		renderMode: RenderMode.Prerender,
 	},

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -51,6 +51,10 @@ export const appRoutes: Routes = [
 		loadComponent: () => import('./pages/collection/collection.page'),
 	},
 	{
+		path: AppRoutes.Collection,
+		loadComponent: () => import('./pages/collections/collections.page'),
+	},
+	{
 		path: AppRoutes.About,
 		loadComponent: () => import('./pages/about/about.component'),
 	},

--- a/src/app/pages/collections/collections.page.spec.ts
+++ b/src/app/pages/collections/collections.page.spec.ts
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/angular';
+import { restoreAllMocks, spyOn } from '@test-utils';
+
+import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import CollectionsPage from './collections.page';
+
+describe('CollectionsPage', () => {
+	afterEach(() => restoreAllMocks());
+
+	it('should announce the catalogue with a heading', async () => {
+		await render(CollectionsPage);
+
+		expect(screen.getByRole('heading', { level: 1, name: 'Colecciones' })).toBeInTheDocument();
+	});
+
+	it('should set the canonical URL for /collection', async () => {
+		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
+
+		await render(CollectionsPage);
+
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl('collection'));
+	});
+
+	it('should keep itself out of the index while it has nothing to show', async () => {
+		const robotsSpy = spyOn(HeadMetadataDirective.prototype, 'setRobots');
+
+		await render(CollectionsPage);
+
+		expect(robotsSpy).toHaveBeenCalledWith('noindex, follow');
+	});
+});

--- a/src/app/pages/collections/collections.page.ts
+++ b/src/app/pages/collections/collections.page.ts
@@ -1,0 +1,33 @@
+import { Component, inject } from '@angular/core';
+
+import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+
+@Component({
+	selector: 'cuentoneta-collections',
+	template: `
+		<!-- El encabezado es fijo: sin el margen superior, la página arranca debajo de él. -->
+		<main class="mx-auto mt-header-height flex w-full max-w-310 flex-col px-4 pt-8 pb-16">
+			<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">Colecciones</h1>
+		</main>
+	`,
+	hostDirectives: [HeadMetadataDirective],
+})
+export default class CollectionsPage {
+	private readonly metaTagsDirective = inject(HeadMetadataDirective);
+
+	constructor() {
+		this.updateMetaTags();
+	}
+
+	// Todavía no hay catálogo que mostrar. Se sirve `noindex` hasta que lo haya, para no gastar rastreo en
+	// una página vacía ni arriesgar que quede indexada así; `follow` porque los enlaces que aparezcan sí
+	// interesan.
+	private updateMetaTags() {
+		this.metaTagsDirective.setTitle('Colecciones');
+		this.metaTagsDirective.setDefaultDescription();
+		this.metaTagsDirective.setCanonicalUrl(buildCanonicalUrl('collection'));
+		this.metaTagsDirective.setRobots('noindex, follow');
+	}
+}


### PR DESCRIPTION
Primera de las rebanadas en que se divide #2288. La PR #2309 queda abierta como referencia del destino, congelada: nada de lo que hay acá sale de un cherry-pick automático, cada rebanada se rearma para que se sostenga sola.

## Qué entra

- La ruta `/collection` en `app.routes.ts` y `app.routes.server.ts`, en `RenderMode.Server`.
- `CollectionsPage`: encabezado y metadatos, nada más.
- Su spec.

## La decisión que no se podía postergar

El guardrail `seo-host-directives.spec.ts` cruza el modo de render con el código del componente y exige que toda ruta indexable declare sus directivas de SEO. Declarar la ruta obliga entonces a decidir la indexabilidad en esta misma rebanada.

Sale `noindex, follow`, que además es lo correcto por sí mismo: una página sin contenido no debería gastar presupuesto de rastreo ni arriesgarse a quedar indexada vacía —cuesta más sacarla del índice que no entrar—, y `follow` deja que se sigan los enlaces que aparezcan. Por el mismo motivo la URL **no** se suma al sitemap ni al menú de navegación: no hay nada que ofrecer todavía.

La rebanada de SEO da vuelta las tres cosas a la vez, cuando la página ya diga algo.

## Rebanadas siguientes

1. **Esta** — ruta y página mínima.
2. Objetivo clickeable de `CollectionTeaserCard` (independiente, base `develop`).
3. Catálogo con datos: recurso bloqueante de SSR, orden con colación española, estados de carga, vacío y error.
4. SEO: meta tags, JSON-LD, sitemap, e2e de indexado y entrada en el menú.
5. Filtrado por facetas.

## Verificación

`pnpm test` completo en verde (195 archivos, 2365 casos), `tsc --noEmit` y `lint` limpios.

Parte de #2288.
