### PR TITLE
[#2304] - Quitar el nombre accesible de las barras de carga, que se repite en cada una

### DIFF
--- a/src/app/components/skeleton/skeleton.component.spec.ts
+++ b/src/app/components/skeleton/skeleton.component.spec.ts
@@ -3,9 +3,22 @@ import { render, screen } from '@testing-library/angular';
 import { SkeletonAppearance, SkeletonComponent } from './skeleton.component';
 
 describe('SkeletonComponent', () => {
-	it('should expose role="status" with the loading label for assistive technology', async () => {
+	it('should expose role="status" and aria-busy without an accessible name', async () => {
 		await render(SkeletonComponent);
-		expect(screen.getByRole('status', { name: 'Cargando' })).toHaveAttribute('aria-busy', 'true');
+		const bar = screen.getByRole('status');
+		expect(bar).toHaveAttribute('aria-busy', 'true');
+		expect(bar).not.toHaveAttribute('aria-label');
+	});
+
+	it('should not expose an accessible name on any bar when rendered multiple times', async () => {
+		await render('<cuentoneta-skeleton /><cuentoneta-skeleton /><cuentoneta-skeleton />', {
+			imports: [SkeletonComponent],
+		});
+		const bars = screen.getAllByRole('status');
+		expect(bars).toHaveLength(3);
+		for (const bar of bars) {
+			expect(bar).not.toHaveAttribute('aria-label');
+		}
 	});
 
 	it('should animate with animate-pulse on the host', async () => {

--- a/src/app/components/skeleton/skeleton.component.spec.ts
+++ b/src/app/components/skeleton/skeleton.component.spec.ts
@@ -14,11 +14,8 @@ describe('SkeletonComponent', () => {
 		await render('<cuentoneta-skeleton /><cuentoneta-skeleton /><cuentoneta-skeleton />', {
 			imports: [SkeletonComponent],
 		});
-		const bars = screen.getAllByRole('status');
-		expect(bars).toHaveLength(3);
-		for (const bar of bars) {
-			expect(bar).not.toHaveAttribute('aria-label');
-		}
+		expect(screen.getAllByRole('status')).toHaveLength(3);
+		expect(screen.queryAllByRole('status', { name: /.+/ })).toEqual([]);
 	});
 
 	it('should animate with animate-pulse on the host', async () => {

--- a/src/app/components/skeleton/skeleton.component.ts
+++ b/src/app/components/skeleton/skeleton.component.ts
@@ -14,6 +14,9 @@ export type SkeletonAppearance = (typeof SkeletonAppearance)[keyof typeof Skelet
  * forma: `line` agrega un radio chico, `circle` fuerza un avatar redondo y `square` deja el radio en
  * manos del consumidor (no impone ninguno) para evitar colisiones de cascada con su clase `rounded-*`.
  * Para varias barras, el consumidor repite el elemento con `@for`.
+ *
+ * Declara `role="status"` y `aria-busy`, pero deliberadamente ningún nombre accesible: como cada
+ * barra se repite por pantalla, un nombre propio haría que cada instancia se anunciara por separado.
  */
 @Component({
 	selector: 'cuentoneta-skeleton',
@@ -21,7 +24,6 @@ export type SkeletonAppearance = (typeof SkeletonAppearance)[keyof typeof Skelet
 	host: {
 		role: 'status',
 		'aria-busy': 'true',
-		'aria-label': 'Cargando',
 		class: 'block animate-pulse',
 		'[class.rounded]': "appearance() === 'line'",
 		'[class.rounded-full]': "appearance() === 'circle'",


### PR DESCRIPTION
## Descripción

Retira el `aria-label: 'Cargando'` del host de `SkeletonComponent`. El componente conservaba `role="status"` y `aria-busy="true"`, pero el nombre accesible convertía cada barra en una región que se anuncia a sí misma; como los consumidores repiten la barra para dibujar varias, una pantalla de carga emitía tantas regiones «Cargando» como barras dibuje (la silueta de lectura ronda las quince).

El rol y el estado de ocupado describen correctamente lo que la barra es; una región de estado sin contenido no se anuncia a sí misma, así que la repetición desaparece sin perder la semántica.

Closes #2304.

## Cambios

- `skeleton.component.ts`: quita `'aria-label': 'Cargando'` del objeto `host`; el JSDoc existente registra la omisión deliberada para evitar su reposición futura.
- `skeleton.component.spec.ts`: la aserción que consultaba por nombre ahora afirma rol + `aria-busy` + ausencia de `aria-label`; se agrega un test multi-barra que afirma, vía consulta por rol filtrada por nombre accesible (`queryAllByRole('status', { name: /.+/ })`), que **ninguna** instancia expone nombre — cubre cualquier fuente de nombre (`aria-label`, `aria-labelledby`, `title`, contenido interno), no solo el atributo.
- No se tocan los controles `name: 'Cargando'` de las stories (son el rótulo del control real↔esqueleto de Storybook, no nombres accesibles).

## Verificación contra el árbol de accesibilidad

- Story `Componentes V3/Skeleton → Multiple Lines`: 3 barras en pantalla → el árbol de accesibilidad del navegador muestra 3 nodos `status` **sin nombre**, con `aria-busy="true"` presente y `aria-label` ausente.
- Las stories de ReadPage renderizan contenido mockeado (sin silueta de carga); la silueta de lectura (`read-page-skeleton`) compone exclusivamente barras `<cuentoneta-skeleton>` sin etiquetas propias, así que ninguna instancia puede anunciarse por separado.
- Respaldo de la decisión en la referencia ARIA de MDN: *«Some screen readers announce the name of a status element before announcing its contents»* (el defecto corregido) y *«Naming a status is not required so if nothing is appropriate both these attributes can be omitted»* — [MDN: status role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/status_role).

### Evidencia visual

Capturas de Storybook con anotación superpuesta (conteo de barras y de instancias con nombre accesible, calculado en vivo sobre el DOM):

![Múltiples barras de skeleton, sin nombre accesible](https://x0.at/KgoT.png)

![Esqueleto de tarjeta de autor: composición real con seis barras, ninguna con nombre](https://x0.at/8MdR.png)

## Plan de pruebas

- **Unitarios:** el spec del componente afirma el contrato nuevo — `role="status"` + `aria-busy="true"`, ausencia de `aria-label` — y un caso multi-barra donde ninguna instancia expone nombre. Verde local y en CI (gate `test`).
- **Gates locales corridos en la sesión:** `typecheck`, `lint`, `stylelint`, `test`, `check:agents` — todos verdes.
- **Gates de CI sobre este commit:** `build`, `storybook`, `studio-build`, `lint`, `stylelint`, `typecheck`, `test`, `check-agents`, `check-findings`, `guard-config` — verdes.
- **Árbol de accesibilidad:** story `Componentes V3/Skeleton → Multiple Lines` inspeccionada en navegador — tres nodos `status` sin nombre accesible, con `aria-busy="true"`.
- **e2e:** rojo por un problema preexistente en `develop` — falta el contenido de la landing page en el dataset de staging que consume E2E (`Landing page content not found`, mismo fallo en las corridas 32749909741 y 32678174893 de develop). Ajeno a este diff: se relanzará cuando el dataset se repare.
