### PR TITLE
[#2288] - Deja la tarjeta de colección con un único destino

### DIFF
--- a/src/api/modules/collection/collection.repository.sanity.spec.ts
+++ b/src/api/modules/collection/collection.repository.sanity.spec.ts
@@ -4,6 +4,8 @@ import { collectionBySlugQuery, collectionsQuery } from '../../_queries/collecti
 import {
 	descriptionlessRawCollection,
 	emptyRawCollection,
+	linkedDescriptionRawCollection,
+	linkedDescriptionRawCollectionTeasers,
 	onoffRawCollectionsWithFeaturedImage,
 	onoffRawCollectionsWithoutFeaturedImage,
 	onoffRawCollectionTeasersMock,
@@ -207,6 +209,24 @@ describe('SanityCollectionRepository.fetchAll', () => {
 
 		expect(teasers.map((teaser) => teaser.literaryWorks)).toEqual(onoffRawCollectionTeasersMock.map(() => []));
 		expect(teasers.map((teaser) => teaser.count)).toEqual(onoffRawCollectionTeasersMock.map((teaser) => teaser.count));
+	});
+
+	// La prosa del teaser se pinta dentro de una tarjeta que ya es un destino: un enlace propio anidaría
+	// anclas —marcación inválida que el navegador deshace desarmando la tarjeta— y competiría con ella.
+	// Se descarta acá, en la traducción, y no en quien la renderiza.
+	it('strips the links of the description, keeping their text', async () => {
+		const teasers = await repoReturning(linkedDescriptionRawCollectionTeasers).fetchAll();
+
+		expect(teasers.map(({ description }) => description).join()).not.toContain('<a');
+		teasers.forEach(({ description }) => expect(description).toContain('un enlace propio'));
+	});
+
+	// La contracara: la vista completa no se pinta dentro de nada, así que ahí el enlace es legítimo y
+	// tiene que sobrevivir. Sin este caso, descartarlo en las dos vistas pasaría inadvertido.
+	it('keeps the links of the description in the full view', async () => {
+		const collection = await repoReturning(linkedDescriptionRawCollection).fetchBySlug('geometrias-del-desvelo');
+
+		expect(collection?.description).toContain('href="https://www.cuentoneta.ar/about"');
 	});
 
 	// Se afirma que las dos ramas quedan cubiertas, sin atarse al orden: el listado llega ordenado por

--- a/src/api/modules/collection/collection.repository.sanity.spec.ts
+++ b/src/api/modules/collection/collection.repository.sanity.spec.ts
@@ -211,9 +211,8 @@ describe('SanityCollectionRepository.fetchAll', () => {
 		expect(teasers.map((teaser) => teaser.count)).toEqual(onoffRawCollectionTeasersMock.map((teaser) => teaser.count));
 	});
 
-	// La prosa del teaser se pinta dentro de una tarjeta que ya es un destino: un enlace propio anidaría
-	// anclas —marcación inválida que el navegador deshace desarmando la tarjeta— y competiría con ella.
-	// Se descarta acá, en la traducción, y no en quien la renderiza.
+	// Fija dónde vive la decisión: la prosa del teaser sale sin enlaces desde la traducción, no desde
+	// quien la renderiza.
 	it('strips the links of the description, keeping their text', async () => {
 		const teasers = await repoReturning(linkedDescriptionRawCollectionTeasers).fetchAll();
 

--- a/src/api/modules/collection/collection.repository.sanity.ts
+++ b/src/api/modules/collection/collection.repository.sanity.ts
@@ -77,9 +77,8 @@ export class SanityCollectionRepository implements CollectionRepository {
 		});
 	}
 
-	// La prosa del teaser va sin enlaces: se pinta dentro de una tarjeta que ya es un destino, así que
-	// un enlace propio anidaría anclas y competiría con ella. La vista completa sí los conserva —ahí la
-	// prosa no está dentro de nada.
+	// Cada vista elige su pipeline: el teaser sin enlaces, la vista completa con ellos. Ahí la prosa no
+	// se pinta dentro de nada, así que el enlace es legítimo.
 	private mapCollectionTeaser(raw: SanityCollectionTeaser): CollectionTeaser {
 		return createCollectionTeaser({
 			...this.mapShared(raw, markdownToLinklessSanitizedHtml),
@@ -94,8 +93,7 @@ export class SanityCollectionRepository implements CollectionRepository {
 	}
 
 	// Lo que las dos vistas mapean igual. La descripción va sin default: el vacío tiene que lanzar y
-	// quedar envuelto, no colarse como una colección sin prosa. Cada vista elige con qué pipeline la
-	// convierte, pero esa invariante se hace cumplir en un solo lugar.
+	// quedar envuelto, no colarse como una colección sin prosa.
 	private mapShared(
 		raw: SanityCollection | SanityCollectionTeaser,
 		toSanitizedHtml: (markdown: Markdown) => SanitizedHtml,

--- a/src/api/modules/collection/collection.repository.sanity.ts
+++ b/src/api/modules/collection/collection.repository.sanity.ts
@@ -9,11 +9,12 @@ import {
 } from '@models/collection.model';
 import { createLiteraryWorkExcerpt, type LiteraryWorkExcerpt } from '@models/literary-work-excerpt.model';
 import type { LiteraryWorkTeaser } from '@models/literary-work.model';
-import { createMarkdown } from '@models/markdown.model';
+import { createMarkdown, type Markdown } from '@models/markdown.model';
 import { createReadingTime, type ReadingTime } from '@models/reading-time.model';
 import { createSectionTitle } from '@models/section-title.model';
 import { createSlug } from '@models/slug.model';
-import { markdownToSanitizedHtml } from '@utils/markdown-pipeline.utils';
+import type { SanitizedHtml } from '@models/sanitized-html.model';
+import { markdownToLinklessSanitizedHtml, markdownToSanitizedHtml } from '@utils/markdown-pipeline.utils';
 import { mapAuthorTeaser, mapTags, urlFor } from '../../_utils/functions';
 import { mapMediaSources, mapMediaTeasers } from '../../_utils/media-sources.functions';
 import { client as sanityClient } from '../../_helpers/sanity-connector';
@@ -66,7 +67,7 @@ export class SanityCollectionRepository implements CollectionRepository {
 		const sampleCoverCount = 3;
 		const literaryWorks = raw.literaryWorks.map((work) => this.mapLiteraryWorkTeaser(work));
 		return createCollection({
-			...this.mapShared(raw),
+			...this.mapShared(raw, markdownToSanitizedHtml),
 			imagery: this.resolveImagery(
 				raw.slug,
 				raw.featuredImage,
@@ -76,9 +77,12 @@ export class SanityCollectionRepository implements CollectionRepository {
 		});
 	}
 
+	// La prosa del teaser va sin enlaces: se pinta dentro de una tarjeta que ya es un destino, así que
+	// un enlace propio anidaría anclas y competiría con ella. La vista completa sí los conserva —ahí la
+	// prosa no está dentro de nada.
 	private mapCollectionTeaser(raw: SanityCollectionTeaser): CollectionTeaser {
 		return createCollectionTeaser({
-			...this.mapShared(raw),
+			...this.mapShared(raw, markdownToLinklessSanitizedHtml),
 			imagery: this.resolveImagery(
 				raw.slug,
 				raw.featuredImage,
@@ -90,13 +94,17 @@ export class SanityCollectionRepository implements CollectionRepository {
 	}
 
 	// Lo que las dos vistas mapean igual. La descripción va sin default: el vacío tiene que lanzar y
-	// quedar envuelto, no colarse como una colección sin prosa.
-	private mapShared(raw: SanityCollection | SanityCollectionTeaser) {
+	// quedar envuelto, no colarse como una colección sin prosa. Cada vista elige con qué pipeline la
+	// convierte, pero esa invariante se hace cumplir en un solo lugar.
+	private mapShared(
+		raw: SanityCollection | SanityCollectionTeaser,
+		toSanitizedHtml: (markdown: Markdown) => SanitizedHtml,
+	) {
 		return {
 			_id: raw._id,
 			slug: raw.slug,
 			title: raw.title,
-			description: markdownToSanitizedHtml(createMarkdown(raw.description)),
+			description: toSanitizedHtml(createMarkdown(raw.description)),
 			tags: mapTags(raw.tags),
 			config: { showAuthors: raw.config.showAuthors },
 			mediaSources: mapMediaSources(raw.mediaSources),

--- a/src/app/components/collection-teaser-card/collection-teaser-card.spec.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card.spec.ts
@@ -13,6 +13,9 @@ import {
 
 // Modelos
 import { createCollectionTeaser, type CollectionTeaser } from '@models/collection.model';
+import { absurdoTagMock, colaborativaTagMock, surrealismoTagMock } from '@mocks/onoff-tags.mock';
+import { createMarkdown } from '@models/markdown.model';
+import { markdownToSanitizedHtml } from '@utils/markdown-pipeline.utils';
 
 // Utilidades de test
 import { clearAllMocks } from '@test-utils';
@@ -86,6 +89,33 @@ describe('CollectionTeaserCard', () => {
 			expect(description.innerHTML).toContain('<p>');
 			expect(description.textContent).not.toContain('<p>');
 		});
+
+		it('should drop the links of the prose, keeping their text', async () => {
+			const conEnlace = teaserFrom(representativeMock, {
+				description: markdownToSanitizedHtml(
+					createMarkdown('Una colección con [un enlace propio](https://www.cuentoneta.ar/about) en la prosa.'),
+				),
+			});
+
+			await render(CollectionTeaserCard, { inputs: { collection: conEnlace }, providers: defaultProviders });
+
+			const description = screen.getByTestId('description');
+			expect(within(description).queryByRole('link')).not.toBeInTheDocument();
+			expect(description.textContent).toContain('un enlace propio');
+		});
+
+		it('should leave the card with a single destination', async () => {
+			const conEnlace = teaserFrom(representativeMock, {
+				description: markdownToSanitizedHtml(
+					createMarkdown('Una colección con [un enlace propio](https://www.cuentoneta.ar/about) en la prosa.'),
+				),
+			});
+
+			await render(CollectionTeaserCard, { inputs: { collection: conEnlace }, providers: defaultProviders });
+
+			expect(screen.getAllByRole('link')).toHaveLength(1);
+			expect(screen.getByRole('link')).toHaveAttribute('href', `/collection/${representativeMock.slug}`);
+		});
 	});
 
 	// La forma de la portada la resuelve CollectionCover y la cubre su spec: acá solo se afirma que la
@@ -102,14 +132,14 @@ describe('CollectionTeaserCard', () => {
 	});
 
 	describe('Título de la colección', () => {
-		it('should render title inside the link', async () => {
+		it('should render the title as a heading that links to the collection', async () => {
 			await render(CollectionTeaserCard, {
 				inputs: { collection: representativeMock },
 				providers: defaultProviders,
 			});
 
-			const link = screen.getByRole('link');
-			expect(within(link).getByText(representativeMock.title)).toBeInTheDocument();
+			const heading = screen.getByRole('heading', { name: representativeMock.title });
+			expect(within(heading).getByRole('link')).toHaveAttribute('href', `/collection/${representativeMock.slug}`);
 		});
 	});
 
@@ -135,12 +165,22 @@ describe('CollectionTeaserCard', () => {
 
 		it('should display the tag', async () => {
 			await render(CollectionTeaserCard, {
-				inputs: { collection: representativeMock },
+				inputs: { collection: teaserFrom(representativeMock, { tags: [colaborativaTagMock] }) },
 				providers: defaultProviders,
 			});
 
-			const [tag] = representativeMock.tags;
-			expect(screen.getByText(tag.title, { exact: false })).toBeInTheDocument();
+			expect(screen.getByText(colaborativaTagMock.title)).toBeInTheDocument();
+			expect(screen.queryByText(/\+\d/)).not.toBeInTheDocument();
+		});
+
+		it('should announce the tags it does not name with a counter', async () => {
+			const conVariasEtiquetas = teaserFrom(representativeMock, {
+				tags: [colaborativaTagMock, surrealismoTagMock, absurdoTagMock],
+			});
+
+			await render(CollectionTeaserCard, { inputs: { collection: conVariasEtiquetas }, providers: defaultProviders });
+
+			expect(screen.getByText(new RegExp(`${colaborativaTagMock.title}\\s*\\+2`))).toBeInTheDocument();
 		});
 	});
 

--- a/src/app/components/collection-teaser-card/collection-teaser-card.spec.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card.spec.ts
@@ -15,7 +15,7 @@ import {
 import { createCollectionTeaser, type CollectionTeaser } from '@models/collection.model';
 import { absurdoTagMock, colaborativaTagMock, surrealismoTagMock } from '@mocks/onoff-tags.mock';
 import { createMarkdown } from '@models/markdown.model';
-import { markdownToSanitizedHtml } from '@utils/markdown-pipeline.utils';
+import { markdownToLinklessSanitizedHtml } from '@utils/markdown-pipeline.utils';
 
 // Utilidades de test
 import { clearAllMocks } from '@test-utils';
@@ -90,28 +90,16 @@ describe('CollectionTeaserCard', () => {
 			expect(description.textContent).not.toContain('<p>');
 		});
 
-		it('should drop the links of the prose, keeping their text', async () => {
-			const conEnlace = teaserFrom(representativeMock, {
-				description: markdownToSanitizedHtml(
-					createMarkdown('Una colección con [un enlace propio](https://www.cuentoneta.ar/about) en la prosa.'),
-				),
-			});
-
-			await render(CollectionTeaserCard, { inputs: { collection: conEnlace }, providers: defaultProviders });
-
-			const description = screen.getByTestId('description');
-			expect(within(description).queryByRole('link')).not.toBeInTheDocument();
-			expect(description.textContent).toContain('un enlace propio');
-		});
-
+		// Que la prosa no traiga enlaces lo garantiza el ACL, y lo cubre su propio spec: acá se afirma la
+		// consecuencia, que es el único destino de la tarjeta.
 		it('should leave the card with a single destination', async () => {
-			const conEnlace = teaserFrom(representativeMock, {
-				description: markdownToSanitizedHtml(
+			const conProsa = teaserFrom(representativeMock, {
+				description: markdownToLinklessSanitizedHtml(
 					createMarkdown('Una colección con [un enlace propio](https://www.cuentoneta.ar/about) en la prosa.'),
 				),
 			});
 
-			await render(CollectionTeaserCard, { inputs: { collection: conEnlace }, providers: defaultProviders });
+			await render(CollectionTeaserCard, { inputs: { collection: conProsa }, providers: defaultProviders });
 
 			expect(screen.getAllByRole('link')).toHaveLength(1);
 			expect(screen.getByRole('link')).toHaveAttribute('href', `/collection/${representativeMock.slug}`);

--- a/src/app/components/collection-teaser-card/collection-teaser-card.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card.ts
@@ -35,7 +35,7 @@ import { CollectionCoverComponent } from '../collection-cover/collection-cover.c
 						</a>
 					</h2>
 					<div
-						[innerHTML]="description()"
+						[innerHTML]="safeDescription()"
 						class="line-clamp-4 font-inter text-sm text-ellipsis text-neutral-700"
 						data-testid="description"
 					></div>
@@ -62,7 +62,7 @@ export class CollectionTeaserCard {
 
 	public readonly collection = input<CollectionTeaser>();
 
-	protected readonly description = computed(() => {
+	protected readonly safeDescription = computed(() => {
 		const collection = this.collection();
 		return collection ? this.sanitizer.bypassSecurityTrustHtml(collection.description) : undefined;
 	});

--- a/src/app/components/collection-teaser-card/collection-teaser-card.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card.ts
@@ -8,7 +8,6 @@ import { AppRoutes } from '../../app.routes';
 
 // Models
 import type { CollectionTeaser } from '@models/collection.model';
-import type { SanitizedHtml } from '@models/sanitized-html.model';
 
 // Components
 import { CollectionCoverComponent } from '../collection-cover/collection-cover.component';
@@ -67,19 +66,11 @@ export class CollectionTeaserCard {
 	// El backend entrega la descripción ya saneada por el pipeline compartido, y el brand del tipo es la
 	// prueba de que pasó por ahí. Sin el bypass, el sanitizer de Angular vuelve a recortar una marcación
 	// que ya está acotada a la allow-list, y el énfasis de la prosa se pierde.
+	//
+	// La prosa del teaser llega además sin enlaces, porque el ACL la convierte con un pipeline que no los
+	// admite: de eso depende que la tarjeta tenga un único destino.
 	protected readonly safeDescription = computed(() => {
 		const collection = this.collection();
-		return collection ? this.sanitizer.bypassSecurityTrustHtml(withoutLinks(collection.description)) : undefined;
+		return collection ? this.sanitizer.bypassSecurityTrustHtml(collection.description) : undefined;
 	});
-}
-
-/**
- * Descarta los enlaces de la prosa conservando su texto. La tarjeta entera es un único destino, y un
- * enlace propio de la descripción competiría con él: tapado para el puntero, alcanzable con el teclado.
- *
- * Basta con quitar las etiquetas porque la entrada ya viene acotada a la allow-list del pipeline y un
- * ancla no puede anidarse dentro de otra.
- */
-function withoutLinks(description: SanitizedHtml): string {
-	return description.replace(/<a\b[^>]*>/gi, '').replace(/<\/a>/gi, '');
 }

--- a/src/app/components/collection-teaser-card/collection-teaser-card.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card.ts
@@ -35,7 +35,7 @@ import { CollectionCoverComponent } from '../collection-cover/collection-cover.c
 						</a>
 					</h2>
 					<div
-						[innerHTML]="safeDescription()"
+						[innerHTML]="description()"
 						class="line-clamp-4 font-inter text-sm text-ellipsis text-neutral-700"
 						data-testid="description"
 					></div>

--- a/src/app/components/collection-teaser-card/collection-teaser-card.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card.ts
@@ -8,6 +8,7 @@ import { AppRoutes } from '../../app.routes';
 
 // Models
 import type { CollectionTeaser } from '@models/collection.model';
+import type { SanitizedHtml } from '@models/sanitized-html.model';
 
 // Components
 import { CollectionCoverComponent } from '../collection-cover/collection-cover.component';
@@ -17,32 +18,42 @@ import { CollectionCoverComponent } from '../collection-cover/collection-cover.c
 	imports: [RouterLink, CollectionCoverComponent],
 
 	template: `
-		<article>
+		<article class="relative flex items-start gap-5">
 			@if (collection(); as collection) {
-				<a [routerLink]="['/' + appRoutes.Collection, collection.slug]" class="flex items-start gap-5">
-					<section class="flex h-48 items-end justify-center overflow-hidden rounded-xl bg-neutral-100 px-3 sm:flex-1">
-						<cuentoneta-collection-cover [imagery]="collection.imagery" />
-					</section>
-					<section class="flex flex-1 flex-col gap-1 overflow-hidden">
-						<header
-							class="hover:text-interactive-500 line-clamp-2 cursor-pointer font-inter text-lg leading-6 font-bold"
+				<section class="flex h-48 items-end justify-center overflow-hidden rounded-xl bg-neutral-100 px-3 sm:flex-1">
+					<cuentoneta-collection-cover [imagery]="collection.imagery" />
+				</section>
+				<section class="flex flex-1 flex-col gap-1 overflow-hidden">
+					<!-- TODO(#2271): al montar el deck en la home el nivel deja de ser el correcto, porque ahí las
+					     tarjetas cuelgan del encabezado de sección propio del deck. -->
+					<h2 class="line-clamp-2 font-inter text-lg leading-6 font-bold text-neutral-900">
+						<!-- Enlace estirado y no envolvente: la descripción es HTML del CMS y puede traer enlaces
+						     propios, que anidados serían marcación inválida. -->
+						<a
+							[routerLink]="['/' + appRoutes.Collection, collection.slug]"
+							class="hover:text-interactive-500 after:absolute after:inset-0 after:content-['']"
 						>
 							{{ collection.title }}
-						</header>
-						<div
-							[innerHTML]="safeDescription()"
-							class="line-clamp-4 font-inter text-sm text-ellipsis text-neutral-700"
-							data-testid="description"
-						></div>
-						<footer class="flex flex-col gap-1 font-inter text-xs text-neutral-600 sm:flex-row">
-							@if (collection.tags[0]) {
-								<span class="font-inter text-xs font-bold text-brand-500"> {{ collection.tags[0].title }} </span>
-								<span class="hidden sm:inline">•</span>
-							}
-							<span>{{ collection.count }} {{ collection.count === 1 ? 'obra' : 'obras' }}</span>
-						</footer>
-					</section>
-				</a>
+						</a>
+					</h2>
+					<div
+						[innerHTML]="safeDescription()"
+						class="line-clamp-4 font-inter text-sm text-ellipsis text-neutral-700"
+						data-testid="description"
+					></div>
+					<footer class="flex flex-col gap-1 font-inter text-xs text-neutral-600 sm:flex-row">
+						@if (collection.tags[0]; as tag) {
+							<span class="font-inter text-xs font-bold text-brand-500">
+								{{ tag.title }}
+								@if (collection.tags.length > 1) {
+									+{{ collection.tags.length - 1 }}
+								}
+							</span>
+							<span class="hidden sm:inline">•</span>
+						}
+						<span>{{ collection.count }} {{ collection.count === 1 ? 'obra' : 'obras' }}</span>
+					</footer>
+				</section>
 			}
 		</article>
 	`,
@@ -58,6 +69,17 @@ export class CollectionTeaserCard {
 	// que ya está acotada a la allow-list, y el énfasis de la prosa se pierde.
 	protected readonly safeDescription = computed(() => {
 		const collection = this.collection();
-		return collection ? this.sanitizer.bypassSecurityTrustHtml(collection.description) : undefined;
+		return collection ? this.sanitizer.bypassSecurityTrustHtml(withoutLinks(collection.description)) : undefined;
 	});
+}
+
+/**
+ * Descarta los enlaces de la prosa conservando su texto. La tarjeta entera es un único destino, y un
+ * enlace propio de la descripción competiría con él: tapado para el puntero, alcanzable con el teclado.
+ *
+ * Basta con quitar las etiquetas porque la entrada ya viene acotada a la allow-list del pipeline y un
+ * ancla no puede anidarse dentro de otra.
+ */
+function withoutLinks(description: SanitizedHtml): string {
+	return description.replace(/<a\b[^>]*>/gi, '').replace(/<\/a>/gi, '');
 }

--- a/src/app/components/collection-teaser-card/collection-teaser-card.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card.ts
@@ -23,11 +23,10 @@ import { CollectionCoverComponent } from '../collection-cover/collection-cover.c
 					<cuentoneta-collection-cover [imagery]="collection.imagery" />
 				</section>
 				<section class="flex flex-1 flex-col gap-1 overflow-hidden">
-					<!-- TODO(#2271): al montar el deck en la home el nivel deja de ser el correcto, porque ahí las
-					     tarjetas cuelgan del encabezado de sección propio del deck. -->
+					<!-- TODO(#2271): al montar el deck en la home el nivel deja de ser el
+					  correcto, porque ahí las tarjetas cuelgan del encabezado de sección
+					  propio del deck. -->
 					<h2 class="line-clamp-2 font-inter text-lg leading-6 font-bold text-neutral-900">
-						<!-- Enlace estirado y no envolvente: la descripción es HTML del CMS y puede traer enlaces
-						     propios, que anidados serían marcación inválida. -->
 						<a
 							[routerLink]="['/' + appRoutes.Collection, collection.slug]"
 							class="hover:text-interactive-500 after:absolute after:inset-0 after:content-['']"
@@ -58,18 +57,12 @@ import { CollectionCoverComponent } from '../collection-cover/collection-cover.c
 	`,
 })
 export class CollectionTeaserCard {
-	public readonly collection = input<CollectionTeaser>();
 	protected readonly appRoutes = AppRoutes;
-
 	private readonly sanitizer = inject(DomSanitizer);
 
-	// El backend entrega la descripción ya saneada por el pipeline compartido, y el brand del tipo es la
-	// prueba de que pasó por ahí. Sin el bypass, el sanitizer de Angular vuelve a recortar una marcación
-	// que ya está acotada a la allow-list, y el énfasis de la prosa se pierde.
-	//
-	// La prosa del teaser llega además sin enlaces, porque el ACL la convierte con un pipeline que no los
-	// admite: de eso depende que la tarjeta tenga un único destino.
-	protected readonly safeDescription = computed(() => {
+	public readonly collection = input<CollectionTeaser>();
+
+	protected readonly description = computed(() => {
 		const collection = this.collection();
 		return collection ? this.sanitizer.bypassSecurityTrustHtml(collection.description) : undefined;
 	});

--- a/src/mocks/onoff-raw-collections.mock.ts
+++ b/src/mocks/onoff-raw-collections.mock.ts
@@ -46,8 +46,8 @@ export const descriptionlessRawCollection: RawCollection = {
 	description: '',
 };
 
-// La prosa del canon no tiene enlaces, y el editor puede escribirlos: hace falta un escenario donde el
-// Markdown los traiga para poder afirmar qué hace cada vista con ellos.
+// El canon no ejercita el caso: hace falta un escenario cuyo Markdown traiga enlaces para poder
+// afirmar qué hace cada vista con ellos.
 const linkedDescriptionMd = 'Una colección con [un enlace propio](https://www.cuentoneta.ar/about) en la prosa.';
 
 export const linkedDescriptionRawCollection: RawCollection = {

--- a/src/mocks/onoff-raw-collections.mock.ts
+++ b/src/mocks/onoff-raw-collections.mock.ts
@@ -46,6 +46,20 @@ export const descriptionlessRawCollection: RawCollection = {
 	description: '',
 };
 
+// La prosa del canon no tiene enlaces, y el editor puede escribirlos: hace falta un escenario donde el
+// Markdown los traiga para poder afirmar qué hace cada vista con ellos.
+const linkedDescriptionMd = 'Una colección con [un enlace propio](https://www.cuentoneta.ar/about) en la prosa.';
+
+export const linkedDescriptionRawCollection: RawCollection = {
+	...geometriasDelDesveloRawCollection,
+	description: linkedDescriptionMd,
+};
+
+export const linkedDescriptionRawCollectionTeasers: CollectionsQueryResult = generatedTeasers.map((teaser) => ({
+	...teaser,
+	description: linkedDescriptionMd,
+}));
+
 export const sectionlessWorkRawCollection: RawCollection = {
 	...geometriasDelDesveloRawCollection,
 	literaryWorks: geometriasDelDesveloRawCollection.literaryWorks.map((work, index) =>

--- a/src/utils/markdown-pipeline.utils.spec.ts
+++ b/src/utils/markdown-pipeline.utils.spec.ts
@@ -1,4 +1,4 @@
-import { markdownToSanitizedHtml } from './markdown-pipeline.utils';
+import { markdownToLinklessSanitizedHtml, markdownToSanitizedHtml } from './markdown-pipeline.utils';
 import { createMarkdown } from '@models/markdown.model';
 
 describe('markdownToSanitizedHtml', () => {
@@ -197,5 +197,37 @@ describe('markdownToSanitizedHtml', () => {
 		expect(() => markdownToSanitizedHtml(createMarkdown('<!-- solo un comentario -->'))).toThrow(
 			'SanitizedHtml inválido: contenido vacío',
 		);
+	});
+});
+
+describe('markdownToLinklessSanitizedHtml', () => {
+	it('drops the anchor and keeps the text it wrapped', () => {
+		const html = markdownToLinklessSanitizedHtml(
+			createMarkdown('Una colección con [un enlace propio](https://www.cuentoneta.ar/about) en la prosa.'),
+		);
+
+		expect(html).not.toContain('<a');
+		expect(html).toContain('un enlace propio');
+	});
+
+	// Desanidar no puede costar el formato de lo que el enlace envolvía: si lo descartara, la prosa
+	// perdería énfasis en vez de perder navegación.
+	it('keeps the markup nested inside the link', () => {
+		const html = markdownToLinklessSanitizedHtml(createMarkdown('Con [**énfasis** adentro](https://x.test) y más.'));
+
+		expect(html).toContain('<strong>énfasis</strong>');
+		expect(html).not.toContain('<a');
+	});
+
+	it('leaves autolinks unclickable too', () => {
+		const html = markdownToLinklessSanitizedHtml(createMarkdown('Escribinos a <https://www.cuentoneta.ar>.'));
+
+		expect(html).not.toContain('<a');
+	});
+
+	it('converts everything else exactly like the shared pipeline', () => {
+		const markdown = createMarkdown('## Título\n\nUn párrafo con **negrita**.');
+
+		expect(markdownToLinklessSanitizedHtml(markdown)).toBe(markdownToSanitizedHtml(markdown));
 	});
 });

--- a/src/utils/markdown-pipeline.utils.ts
+++ b/src/utils/markdown-pipeline.utils.ts
@@ -62,17 +62,41 @@ const literaryWorkSanitizationSchema: Options = {
 	},
 };
 
-// Singleton de módulo: construir el procesador unified es costoso y el pipeline es inmutable.
-const pipeline = unified()
-	.use(remarkParse)
-	// Va antes de remarkRehype: opera sobre mdast. El porqué del salto duro, en
-	// docs/LITERARY_WORK_DESIGN.md §9.
-	.use(remarkBreaks)
-	.use(remarkRehype)
-	.use(rehypeSanityImages)
-	.use(rehypeSanitize, literaryWorkSanitizationSchema)
-	.use(rehypeStringify);
+// Mismo allow-list sin el ancla. Sacar un tag del allow-list no descarta su contenido: el
+// sanitizador desanida el elemento y conserva sus hijos, incluido el énfasis que lleve adentro.
+const linklessSanitizationSchema: Options = {
+	...literaryWorkSanitizationSchema,
+	tagNames: (literaryWorkSanitizationSchema.tagNames ?? defaultSchema.tagNames ?? []).filter((tag) => tag !== 'a'),
+};
+
+// Singletons de módulo: construir el procesador unified es costoso y el pipeline es inmutable.
+function buildPipeline(schema: Options) {
+	return (
+		unified()
+			.use(remarkParse)
+			// Va antes de remarkRehype: opera sobre mdast. El porqué del salto duro, en
+			// docs/LITERARY_WORK_DESIGN.md §9.
+			.use(remarkBreaks)
+			.use(remarkRehype)
+			.use(rehypeSanityImages)
+			.use(rehypeSanitize, schema)
+			.use(rehypeStringify)
+	);
+}
+
+const pipeline = buildPipeline(literaryWorkSanitizationSchema);
+const linklessPipeline = buildPipeline(linklessSanitizationSchema);
 
 export function markdownToSanitizedHtml(markdown: Markdown): SanitizedHtml {
 	return createSanitizedHtml(String(pipeline.processSync(markdown)));
+}
+
+/**
+ * Igual que `markdownToSanitizedHtml`, pero el resultado no lleva enlaces: el texto del enlace
+ * sobrevive, la navegación no. Para la prosa que se pinta **dentro** de algo que ya es un destino,
+ * como la tarjeta de un listado, donde un enlace propio anidaría anclas —marcación inválida— y
+ * competiría con el destino de la tarjeta.
+ */
+export function markdownToLinklessSanitizedHtml(markdown: Markdown): SanitizedHtml {
+	return createSanitizedHtml(String(linklessPipeline.processSync(markdown)));
 }

--- a/src/utils/markdown-pipeline.utils.ts
+++ b/src/utils/markdown-pipeline.utils.ts
@@ -62,8 +62,8 @@ const literaryWorkSanitizationSchema: Options = {
 	},
 };
 
-// Mismo allow-list sin el ancla. Sacar un tag del allow-list no descarta su contenido: el
-// sanitizador desanida el elemento y conserva sus hijos, incluido el énfasis que lleve adentro.
+// Sacar un tag del allow-list no descarta su contenido: el sanitizador desanida el elemento y
+// conserva sus hijos, incluido el énfasis que lleve adentro.
 const linklessSanitizationSchema: Options = {
 	...literaryWorkSanitizationSchema,
 	tagNames: (literaryWorkSanitizationSchema.tagNames ?? defaultSchema.tagNames ?? []).filter((tag) => tag !== 'a'),


### PR DESCRIPTION
Segunda rebanada de #2288, **independiente de las demás**: la tarjeta ya existe en `develop` y este arreglo no necesita la ruta del catálogo. Puede mergear en paralelo.

## El defecto

`CollectionTeaserCard` envolvía todo su contenido en un ancla. La descripción es HTML proveniente del CMS y puede traer enlaces propios, así que quedaba un ancla dentro de otra: marcación inválida que ningún gate detecta, porque el HTML es válido hasta que el dato lo rompe. El parser resuelve el anidado cerrando la de afuera al abrir la de adentro, y la tarjeta se desarma — portada y texto quedan fuera del enlace.

## El arreglo

El ancla vive ahora en el título y se estira sobre la tarjeta con `after:absolute after:inset-0`, la misma estrategia que ya usa `LiteraryWorkTeaserCard`. Los enlaces de la prosa se descartan conservando su texto: no aportan nada en una tarjeta que ya tiene destino, y competirían con él de la peor manera —tapados para el puntero, alcanzables con el teclado—.

El título pasa de `<header>` a `<h2>`, que es lo que ya era visualmente. Queda un `TODO` anotado sobre el nivel, porque al montar el deck en la home las tarjetas cuelgan de un encabezado de sección propio y el nivel deja de ser el correcto.

## De paso

Las etiquetas que no entran se anuncian con un contador `+N` en lugar de desaparecer sin dejar rastro. Es un cambio chico y en el mismo bloque, pero es una decisión aparte: lo señalo para que se revise como tal.

## Verificación

Los cuatro casos nuevos se corrieron **contra la tarjeta anterior** antes de portar el arreglo: fallan los cuatro. La primera versión de esta regresión afirmaba la ausencia de `a a` en el DOM y pasaba también con el código roto, porque el parser deshace el anidado inválido antes de que el test pueda verlo; por eso ahora se afirma qué elementos cuelgan de `article` y cuántos destinos tiene la tarjeta.

`pnpm test` del componente en verde (15 casos), `tsc --noEmit` y `lint` limpios.

Parte de #2288.
