### PR TITLE
[#2288] - Puebla el catálogo de colecciones con el listado real

### DIFF
--- a/src/app/pages/collections/collections.page.spec.ts
+++ b/src/app/pages/collections/collections.page.spec.ts
@@ -1,33 +1,198 @@
-import { render, screen } from '@testing-library/angular';
-import { restoreAllMocks, spyOn } from '@test-utils';
+import { render, screen, within } from '@testing-library/angular';
+import { provideRouter } from '@angular/router';
+import { RESPONSE_INIT } from '@angular/core';
+import { NEVER, Observable, of, throwError } from 'rxjs';
 
+import { createCollectionTeaser, type Collection, type CollectionTeaser } from '@models/collection.model';
+import { onoffCollectionsMock, onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
 import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+import { clearAllMocks, restoreAllMocks, spyOn } from '@test-utils';
 
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import type { CollectionApi } from '../../providers/collection.provider';
+import { provideCollectionApiMock } from '../../providers/collection.mock';
 import CollectionsPage from './collections.page';
 
+class StubCatalogCollectionApi implements CollectionApi {
+	constructor(private readonly teasers: readonly CollectionTeaser[]) {}
+
+	public getBySlug(): Observable<Collection> {
+		return throwError(() => new Error('StubCatalogCollectionApi: la página del catálogo no consulta por slug'));
+	}
+
+	public getAll(): Observable<CollectionTeaser[]> {
+		return of([...this.teasers]);
+	}
+}
+
+class FailingCollectionApi implements CollectionApi {
+	public getBySlug(): Observable<Collection> {
+		return throwError(() => new Error('sin catálogo'));
+	}
+
+	public getAll(): Observable<CollectionTeaser[]> {
+		return throwError(() => new Error('sin catálogo'));
+	}
+}
+
+// `NEVER` deja el recurso pendiente, que es la única forma de sostener el esqueleto a la vista.
+class PendingCollectionApi implements CollectionApi {
+	public getBySlug(): Observable<Collection> {
+		return NEVER;
+	}
+
+	public getAll(): Observable<CollectionTeaser[]> {
+		return NEVER;
+	}
+}
+
+const renderPage = (api: CollectionApi) =>
+	render(CollectionsPage, {
+		providers: [provideRouter([]), provideCollectionApiMock(api)],
+	});
+
+// El corpus no tiene títulos con acento inicial, que es lo que el orden tiene que resolver.
+const [canonical] = onoffCollectionTeasersMock;
+const withTitle = (title: string, slug: string): CollectionTeaser =>
+	createCollectionTeaser({
+		_id: `${canonical._id}-${slug}`,
+		slug,
+		title,
+		description: canonical.description,
+		imagery: canonical.imagery,
+		tags: canonical.tags,
+		config: canonical.config,
+		mediaSources: canonical.mediaSources,
+		count: canonical.count,
+	});
+
+const hrefsOf = (testId: string) =>
+	within(screen.getByTestId(testId))
+		.getAllByRole('link')
+		.map((link) => link.getAttribute('href'));
+
 describe('CollectionsPage', () => {
+	beforeEach(() => {
+		clearAllMocks();
+	});
+
 	afterEach(() => restoreAllMocks());
 
-	it('should announce the catalogue with a heading', async () => {
-		await render(CollectionsPage);
+	it('should headline the catalogue with how many collections it lists', async () => {
+		await renderPage(new StubCatalogCollectionApi(onoffCollectionTeasersMock));
 
-		expect(screen.getByRole('heading', { level: 1, name: 'Colecciones' })).toBeInTheDocument();
+		expect(
+			screen.getByRole('heading', { level: 1, name: `${onoffCollectionTeasersMock.length} Colecciones` }),
+		).toBeInTheDocument();
 	});
 
-	it('should set the canonical URL for /collection', async () => {
-		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
+	it('should put the count in singular when the catalogue lists one collection', async () => {
+		await renderPage(new StubCatalogCollectionApi([canonical]));
 
-		await render(CollectionsPage);
-
-		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl('collection'));
+		expect(screen.getByRole('heading', { level: 1, name: '1 Colección' })).toBeInTheDocument();
 	});
 
-	it('should keep itself out of the index while it has nothing to show', async () => {
-		const robotsSpy = spyOn(HeadMetadataDirective.prototype, 'setRobots');
+	it('should render one card per collection in the catalogue', async () => {
+		await renderPage(new StubCatalogCollectionApi(onoffCollectionTeasersMock));
 
-		await render(CollectionsPage);
+		expect(within(screen.getByTestId('collections')).getAllByRole('link')).toHaveLength(
+			onoffCollectionTeasersMock.length,
+		);
+	});
 
-		expect(robotsSpy).toHaveBeenCalledWith('noindex, follow');
+	it('should link every card to the collection detail route', async () => {
+		await renderPage(new StubCatalogCollectionApi(onoffCollectionTeasersMock));
+
+		expect(hrefsOf('collections')).toEqual(
+			expect.arrayContaining(onoffCollectionsMock.map(({ slug }) => `/collection/${slug}`)),
+		);
+	});
+
+	// La colación de la base pondría `Ámbar` detrás de `Zoológico`.
+	it('should order titles with accent folding, not by code point', async () => {
+		const desordenadas = [
+			withTitle('Zoológico', 'zoologico'),
+			withTitle('Ámbar', 'ambar'),
+			withTitle('Bruma', 'bruma'),
+		];
+
+		await renderPage(new StubCatalogCollectionApi(desordenadas));
+
+		expect(hrefsOf('collections')).toEqual(['/collection/ambar', '/collection/bruma', '/collection/zoologico']);
+	});
+
+	it('should show placeholders while the catalogue is on its way', async () => {
+		const { container } = await renderPage(new PendingCollectionApi());
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- el esqueleto no expone rol ni texto: solo se lo puede contar por selector
+		expect(container.querySelectorAll('cuentoneta-collection-teaser-card-skeleton').length).toBeGreaterThan(0);
+		expect(screen.queryByTestId('catalog-empty')).not.toBeInTheDocument();
+	});
+
+	it('should keep the heading when the catalogue comes back empty', async () => {
+		await renderPage(new StubCatalogCollectionApi([]));
+
+		expect(screen.getByRole('heading', { level: 1, name: '0 Colecciones' })).toBeInTheDocument();
+		expect(screen.queryByTestId('collections')).not.toBeInTheDocument();
+	});
+
+	it('should say the catalogue is empty instead of showing placeholders', async () => {
+		const { container } = await renderPage(new StubCatalogCollectionApi([]));
+
+		expect(screen.getByTestId('catalog-empty')).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- el esqueleto no expone rol ni texto: la ausencia solo se afirma por selector
+		expect(container.querySelector('cuentoneta-collection-teaser-card-skeleton')).toBeNull();
+	});
+
+	it('should tell the reader when the catalogue fails to load', async () => {
+		await renderPage(new FailingCollectionApi());
+
+		expect(screen.getByTestId('catalog-error')).toBeInTheDocument();
+		expect(screen.queryByTestId('collections')).not.toBeInTheDocument();
+	});
+
+	describe('metadatos', () => {
+		it('should set the canonical URL for /collection', async () => {
+			const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
+
+			await renderPage(new StubCatalogCollectionApi(onoffCollectionTeasersMock));
+
+			expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl('collection'));
+		});
+
+		it('should keep itself out of the index until it has metadata of its own', async () => {
+			const robotsSpy = spyOn(HeadMetadataDirective.prototype, 'setRobots');
+
+			await renderPage(new StubCatalogCollectionApi(onoffCollectionTeasersMock));
+
+			expect(robotsSpy).toHaveBeenCalledWith('noindex, follow');
+		});
+	});
+
+	describe('código de respuesta', () => {
+		const renderWithResponseInit = (api: CollectionApi, responseInit: { status?: number }) =>
+			render(CollectionsPage, {
+				providers: [
+					provideRouter([]),
+					provideCollectionApiMock(api),
+					{ provide: RESPONSE_INIT, useValue: responseInit },
+				],
+			});
+
+		it('should respond 503 when the catalogue fails', async () => {
+			const responseInit: { status?: number } = {};
+
+			await renderWithResponseInit(new FailingCollectionApi(), responseInit);
+
+			expect(responseInit.status).toBe(503);
+		});
+
+		it('should leave the status untouched when the catalogue resolves', async () => {
+			const responseInit: { status?: number } = {};
+
+			await renderWithResponseInit(new StubCatalogCollectionApi(onoffCollectionTeasersMock), responseInit);
+
+			expect(responseInit.status).toBeUndefined();
+		});
 	});
 });

--- a/src/app/pages/collections/collections.page.stories.ts
+++ b/src/app/pages/collections/collections.page.stories.ts
@@ -1,0 +1,129 @@
+import { applicationConfig, type Meta, type StoryObj } from '@storybook/angular-vite';
+import { provideRouter } from '@angular/router';
+import { NEVER, of, throwError, type Observable } from 'rxjs';
+
+import type { Collection, CollectionTeaser } from '@models/collection.model';
+import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
+
+import { provideCollectionApiMock } from '../../providers/collection.mock';
+import type { CollectionApi } from '../../providers/collection.provider';
+import CollectionsPage from './collections.page';
+
+const catalogues = {
+	corpus: onoffCollectionTeasersMock,
+	empty: [] as readonly CollectionTeaser[],
+} as const;
+
+type Scenario = keyof typeof catalogues | 'loading' | 'failure';
+
+class StubScenarioCollectionApi implements CollectionApi {
+	constructor(private readonly scenario: Scenario) {}
+
+	public getBySlug(): Observable<Collection> {
+		return throwError(() => new Error('El catálogo no consulta por slug'));
+	}
+
+	public getAll(): Observable<CollectionTeaser[]> {
+		if (this.scenario === 'failure') {
+			return throwError(() => new Error('sin catálogo'));
+		}
+		// `NEVER` deja el recurso pendiente, que es la única forma de sostener el esqueleto a la vista.
+		if (this.scenario === 'loading') {
+			return NEVER;
+		}
+		return of([...catalogues[this.scenario]]);
+	}
+}
+
+type CollectionsPageArgs = { scenario: Scenario };
+
+const meta: Meta<CollectionsPageArgs> = {
+	component: CollectionsPage,
+	title: 'Páginas/CollectionsPage',
+	// Uno por render: la página de autodocs monta todas las entradas a la vez y una instancia común
+	// dejaría que el escenario de una resolviera dentro de otra.
+	decorators: [
+		(story, context) =>
+			applicationConfig({
+				providers: [
+					provideRouter([]),
+					provideCollectionApiMock(new StubScenarioCollectionApi((context.args as CollectionsPageArgs).scenario)),
+				],
+			})(story, context),
+	],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>El catálogo de colecciones, <strong>CollectionsPage</strong>, montado sobre el corpus de Onoff. Como el resto de las entradas bajo <strong>Páginas</strong>, no cataloga un componente sino el ensamblado completo: el encabezado con el conteo y la lista de tarjetas que llevan al detalle.</p><p>El único control elige el escenario del catálogo, que es lo único que mueve la página desde afuera: no recibe parámetros de ruta.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-collectionteasercard--docs" target="_top"><strong>CollectionTeaserCard</strong></a>, la misma tarjeta que enlaza a <a href="./?path=/docs/páginas-collectionpage--docs" target="_top"><strong>CollectionPage</strong></a>, y de su esqueleto.</p><p>El orden no es el que entrega el backend: se resuelve en la página con colación en español, porque la base compara por punto de código y mandaría al final del catálogo todo título que empiece con acento o eñe.</p><p>El encabezado fijo de la aplicación no se monta en el catálogo, así que el margen superior de la página se ve como espacio en blanco.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		scenario: {
+			name: 'Catálogo',
+			control: { type: 'inline-radio' },
+			options: ['corpus', 'loading', 'empty', 'failure'],
+			table: { type: { summary: "'corpus' | 'loading' | 'empty' | 'failure'" } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<CollectionsPageArgs>;
+
+export const Playground: Story = {
+	args: { scenario: 'corpus' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El catálogo con el control vivo. Cambiá <strong>Catálogo</strong> para recorrer los cuatro estados, y en particular para alternar entre <strong>corpus</strong> y <strong>loading</strong>: la lista real y la de esqueletos ocupan el mismo lugar, así que la alineación entre las dos se puede evaluar de un vistazo.</p>`,
+			},
+		},
+	},
+};
+
+export const CatalogoDelCorpus: Story = {
+	args: { scenario: 'corpus' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Las colecciones del corpus, tal como las sirve el backend.</p><p><strong>Usos:</strong> mirar la tarjeta con datos reales.</p>`,
+			},
+		},
+	},
+};
+
+export const CatalogoCargando: Story = {
+	args: { scenario: 'loading' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El catálogo mientras carga: la lista de esqueletos, en el mismo lugar y con la misma geometría que la lista real. Alternar con <strong>corpus</strong> desde el control de <strong>Playground</strong> es lo que permite verificar que una no salte respecto de la otra.</p><p>En la aplicación servida este estado no llega al HTML: el recurso bloquea el render del servidor. Se ve al navegar dentro de la aplicación.</p>`,
+			},
+		},
+	},
+};
+
+export const CatalogoVacio: Story = {
+	args: { scenario: 'empty' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Un catálogo que resolvió sin colecciones. Lo dice con todas las letras en vez de quedarse con los esqueletos puestos: un catálogo vacío y un catálogo cargando significan cosas opuestas y no pueden verse igual.</p>`,
+			},
+		},
+	},
+};
+
+export const CatalogoQueFalla: Story = {
+	args: { scenario: 'failure' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El catálogo no se pudo cargar. Se distingue del catálogo vacío a propósito: sin el mensaje, la página afirmaría que no hay colecciones cuando lo que hubo fue un fallo.</p><p>En la aplicación servida, además, la respuesta sale con código 503 para que el borde no cachee el fallo como si fuera la página.</p>`,
+			},
+		},
+	},
+};

--- a/src/app/pages/collections/collections.page.ts
+++ b/src/app/pages/collections/collections.page.ts
@@ -1,29 +1,86 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, effect, inject, RESPONSE_INIT } from '@angular/core';
 
 import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+import { ssrBlockingRxResource } from '@app-utils/ssr-resource';
+
+import { CollectionTeaserCard } from '@components/collection-teaser-card/collection-teaser-card';
+import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
 
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { CollectionApi } from '../../providers/collection.provider';
 
 @Component({
 	selector: 'cuentoneta-collections',
 	template: `
 		<!-- El encabezado es fijo: sin el margen superior, la página arranca debajo de él. -->
-		<main class="mx-auto mt-header-height flex w-full max-w-310 flex-col px-4 pt-8 pb-16">
-			<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">Colecciones</h1>
+		<main class="mx-auto mt-header-height flex w-full max-w-310 flex-col gap-12 px-4 pt-8 pb-16">
+			<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">
+				{{ collections().length }} {{ collections().length === 1 ? 'Colección' : 'Colecciones' }}
+			</h1>
+
+			@if (loading()) {
+				<section class="flex flex-col gap-8" aria-busy="true">
+					@for (placeholder of [1, 2, 3, 4]; track placeholder) {
+						<cuentoneta-collection-teaser-card-skeleton class="w-full" />
+					}
+				</section>
+			} @else if (failed()) {
+				<p class="font-inter text-base text-neutral-700" data-testid="catalog-error">
+					No pudimos cargar las colecciones. Probá de nuevo en un rato.
+				</p>
+			} @else if (collections().length > 0) {
+				<section class="flex flex-col gap-8" data-testid="collections">
+					@for (collection of collections(); track collection.slug) {
+						<cuentoneta-collection-teaser-card [collection]="collection" class="w-full" />
+					}
+				</section>
+			} @else {
+				<p class="font-inter text-base text-neutral-700" data-testid="catalog-empty">
+					Todavía no hay colecciones publicadas.
+				</p>
+			}
 		</main>
 	`,
 	hostDirectives: [HeadMetadataDirective],
+	imports: [CollectionTeaserCard, CollectionTeaserCardSkeletonComponent],
 })
 export default class CollectionsPage {
+	private readonly collectionApi = inject(CollectionApi);
 	private readonly metaTagsDirective = inject(HeadMetadataDirective);
+	private readonly responseInit = inject(RESPONSE_INIT, { optional: true });
+
+	private readonly catalogResource = ssrBlockingRxResource({
+		stream: () => this.collectionApi.getAll(),
+		defaultValue: [],
+	});
+
+	// El `order(title asc)` de la query compara por punto de código: manda al final todo título con
+	// acento o eñe inicial, y Sanity no expone colación con plegado.
+	private readonly collator = new Intl.Collator('es');
+
+	protected readonly collections = computed(() => {
+		const catalog = this.catalogResource.hasValue() ? this.catalogResource.value() : [];
+		return [...catalog].sort((first, second) => this.collator.compare(first.title, second.title));
+	});
+
+	protected readonly failed = computed(() => this.catalogResource.status() === 'error');
+
+	protected readonly loading = computed(() => this.catalogResource.isLoading());
+
+	// Un fallo transitorio no puede salir 200: el borde lo cachearía como si fuera la página. No hay
+	// rama 404 — un catálogo no deja de existir.
+	private readonly respondErrorStatusEffect = effect(() => {
+		if (!this.catalogResource.error() || !this.responseInit) {
+			return;
+		}
+		this.responseInit.status = 503;
+	});
 
 	constructor() {
 		this.updateMetaTags();
 	}
 
-	// Todavía no hay catálogo que mostrar. Se sirve `noindex` hasta que lo haya, para no gastar rastreo en
-	// una página vacía ni arriesgar que quede indexada así; `follow` porque los enlaces que aparezcan sí
-	// interesan.
+	// TODO(#2288): quitar el `noindex` al sumar los metadatos propios y los datos estructurados.
 	private updateMetaTags() {
 		this.metaTagsDirective.setTitle('Colecciones');
 		this.metaTagsDirective.setDefaultDescription();

--- a/src/app/pages/collections/collections.page.ts
+++ b/src/app/pages/collections/collections.page.ts
@@ -12,7 +12,7 @@ import { CollectionApi } from '../../providers/collection.provider';
 @Component({
 	selector: 'cuentoneta-collections',
 	template: `
-		<!-- El encabezado es fijo: sin el margen superior, la página arranca debajo de él. -->
+		<!-- TODO(#2348): el despeje del encabezado fijo pasa al shell; hoy cada página lo repite. -->
 		<main class="mx-auto mt-header-height flex w-full max-w-310 flex-col gap-12 px-4 pt-8 pb-16">
 			<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">
 				{{ collections().length }} {{ collections().length === 1 ? 'Colección' : 'Colecciones' }}


### PR DESCRIPTION
Tercera rebanada de #2288. Su base era la rama de #2341, ya mergeada: GitHub la reapuntó sola a `develop`, así que el diff de este PR es solo lo suyo — tres archivos, todos de la página del catálogo.

## Qué entra

- El recurso del catálogo, **bloqueante para el render del servidor**: el HTML sale con la lista puesta y no con esqueletos.
- El orden, resuelto en la página.
- Los cuatro estados —lista, carga, vacío y fallo— con su spec y sus stories.

## Dos decisiones que conviene mirar

**El orden no va en la query.** La base compara por punto de código, así que `order(title asc)` manda al final del catálogo todo título que empiece con acento o eñe, y Sanity no expone colación con plegado. Se ordena en la página con `Intl.Collator('es')`. El spec lo fija con un caso que la colación de la base reprobaría: `Ámbar` antes que `Bruma` y `Zoológico`.

**Vacío y fallo son estados distintos, y ninguno es «cargando».** Un catálogo que resolvió sin colecciones dice que no hay colecciones publicadas; uno que falló dice que falló y además responde **503**, para que el borde no cachee un fallo transitorio como si fuera la página. Quedarse con los esqueletos puestos en cualquiera de los dos casos afirmaría algo falso. No hay rama 404: un catálogo no deja de existir.

## Lo que no entra

Sigue en `noindex, follow`, con un `TODO` que nombra el issue. Los metadatos propios, el JSON-LD, el sitemap y la entrada en el menú son #2345. El filtrado, #2346.

## Verificación

Los once gates en verde sobre este PR. En local, además, `pnpm test` completo (195 archivos, 2375 casos), `storybook:build`, `tsc --noEmit` y `lint`.

Parte de #2288.
