### PR TITLE
[#2288] - Suma el filtrado por facetas al catálogo de colecciones

### DIFF
--- a/src/app/components/collection-filters/collection-filters.component.spec.ts
+++ b/src/app/components/collection-filters/collection-filters.component.spec.ts
@@ -54,6 +54,15 @@ describe('CollectionFiltersComponent', () => {
 		expect(facetFor(cuentoTagMock, 1)).toBeInTheDocument();
 	});
 
+	// El nombre no puede salir del `legend`: si contiene un botón, el `fieldset` queda sin nombrar. Este
+	// caso fija el cableado, no el cómputo — happy-dom es más permisivo que el navegador y no reprodujo
+	// el fallo que se ve en Chrome.
+	it('should name the category group', async () => {
+		await renderFilters();
+
+		expect(screen.getByRole('group', { name: 'Categoría' })).toBeInTheDocument();
+	});
+
 	it('should offer each tag once, however many collections carry it', async () => {
 		await renderFilters();
 

--- a/src/app/components/collection-filters/collection-filters.component.spec.ts
+++ b/src/app/components/collection-filters/collection-filters.component.spec.ts
@@ -1,0 +1,127 @@
+import { render, screen, within } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
+import { createCollectionTeaser, type CollectionTeaser } from '@models/collection.model';
+import type { Tag } from '@models/tag.model';
+import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
+import { colaborativaTagMock, cuentoTagMock, surrealismoTagMock } from '@mocks/onoff-tags.mock';
+import { clearAllMocks, fn } from '@test-utils';
+
+import { CollectionFiltersComponent } from './collection-filters.component';
+
+const [canonical] = onoffCollectionTeasersMock;
+const conEtiquetas = (slug: string, tags: readonly Tag[]): CollectionTeaser =>
+	createCollectionTeaser({
+		_id: `${canonical._id}-${slug}`,
+		slug,
+		title: slug,
+		description: canonical.description,
+		imagery: canonical.imagery,
+		tags,
+		config: canonical.config,
+		mediaSources: canonical.mediaSources,
+		count: canonical.count,
+	});
+
+const collections = [
+	conEtiquetas('una', [colaborativaTagMock, surrealismoTagMock]),
+	conEtiquetas('otra', [colaborativaTagMock]),
+	conEtiquetas('tercera', [colaborativaTagMock, cuentoTagMock]),
+];
+
+const renderFilters = async (selected: readonly string[] = []) => {
+	const toggled = fn();
+	const cleared = fn();
+	const view = await render(CollectionFiltersComponent, {
+		inputs: { collections, selected },
+		on: { toggled, cleared },
+	});
+	return { ...view, toggled, cleared };
+};
+
+const facetFor = (tag: Tag, count: number) => screen.getByLabelText(`${tag.title} (${count})`);
+
+describe('CollectionFiltersComponent', () => {
+	beforeEach(() => {
+		clearAllMocks();
+	});
+
+	it('should count each tag over the collections it receives', async () => {
+		await renderFilters();
+
+		expect(facetFor(colaborativaTagMock, 3)).toBeInTheDocument();
+		expect(facetFor(surrealismoTagMock, 1)).toBeInTheDocument();
+		expect(facetFor(cuentoTagMock, 1)).toBeInTheDocument();
+	});
+
+	it('should offer each tag once, however many collections carry it', async () => {
+		await renderFilters();
+
+		expect(within(screen.getByRole('group')).getAllByRole('checkbox')).toHaveLength(3);
+	});
+
+	it('should emit the tag whose facet is activated', async () => {
+		const { toggled } = await renderFilters();
+
+		await userEvent.click(facetFor(surrealismoTagMock, 1));
+
+		expect(toggled).toHaveBeenCalledWith(surrealismoTagMock);
+	});
+
+	it('should check the facets named in the selection', async () => {
+		await renderFilters([colaborativaTagMock.slug]);
+
+		expect(facetFor(colaborativaTagMock, 3)).toBeChecked();
+		expect(facetFor(surrealismoTagMock, 1)).not.toBeChecked();
+	});
+
+	describe('filtros en uso', () => {
+		it('should show a chip for each selected tag', async () => {
+			await renderFilters([colaborativaTagMock.slug]);
+
+			const chips = within(screen.getByTestId('active-filters')).getAllByRole('button');
+			expect(chips).toHaveLength(1);
+			expect(chips[0]).toHaveAccessibleName(`Quitar el filtro ${colaborativaTagMock.title}`);
+		});
+
+		it('should emit the tag whose chip is dismissed', async () => {
+			const { toggled } = await renderFilters([colaborativaTagMock.slug]);
+
+			await userEvent.click(screen.getByRole('button', { name: `Quitar el filtro ${colaborativaTagMock.title}` }));
+
+			expect(toggled).toHaveBeenCalledWith(colaborativaTagMock);
+		});
+
+		it('should emit once when asked to clear everything', async () => {
+			const { cleared } = await renderFilters([colaborativaTagMock.slug, surrealismoTagMock.slug]);
+
+			await userEvent.click(screen.getByRole('button', { name: 'Limpiar filtros' }));
+
+			expect(cleared).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it('should offer nothing to clear while nothing is selected', async () => {
+		await renderFilters();
+
+		expect(screen.queryByRole('button', { name: 'Limpiar filtros' })).not.toBeInTheDocument();
+		expect(screen.queryByTestId('active-filters')).not.toBeInTheDocument();
+	});
+
+	it('should collapse the category group without losing what is selected', async () => {
+		await renderFilters([colaborativaTagMock.slug]);
+
+		await userEvent.click(screen.getByRole('button', { name: /Categoría/ }));
+
+		expect(screen.getByRole('button', { name: /Categoría/ })).toHaveAttribute('aria-expanded', 'false');
+		expect(screen.queryByLabelText(`${surrealismoTagMock.title} (1)`)).not.toBeInTheDocument();
+		expect(screen.getByTestId('active-filters')).toBeInTheDocument();
+	});
+
+	it('should keep its heading when there are no tags to offer', async () => {
+		await render(CollectionFiltersComponent, { inputs: { collections: [], selected: [] } });
+
+		expect(screen.getByRole('heading', { name: 'Filtros' })).toBeInTheDocument();
+		expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+	});
+});

--- a/src/app/components/collection-filters/collection-filters.component.stories.ts
+++ b/src/app/components/collection-filters/collection-filters.component.stories.ts
@@ -1,0 +1,112 @@
+import { argsToTemplate, type Meta, type StoryObj } from '@storybook/angular-vite';
+
+import { createCollectionTeaser, type CollectionTeaser } from '@models/collection.model';
+import type { Tag } from '@models/tag.model';
+import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
+import { absurdoTagMock, colaborativaTagMock, cuentoTagMock, surrealismoTagMock } from '@mocks/onoff-tags.mock';
+
+import { CollectionFiltersComponent } from './collection-filters.component';
+
+// El corpus no reparte sus etiquetas de forma que se vean conteos distintos entre facetas, así que
+// las colecciones se derivan del canon con la combinación que hace falta mirar.
+const [canonical] = onoffCollectionTeasersMock;
+const conEtiquetas = (slug: string, tags: readonly Tag[]): CollectionTeaser =>
+	createCollectionTeaser({
+		_id: `${canonical._id}-${slug}`,
+		slug,
+		title: slug,
+		description: canonical.description,
+		imagery: canonical.imagery,
+		tags,
+		config: canonical.config,
+		mediaSources: canonical.mediaSources,
+		count: canonical.count,
+	});
+
+const catalogo: readonly CollectionTeaser[] = [
+	conEtiquetas('una', [colaborativaTagMock, surrealismoTagMock]),
+	conEtiquetas('otra', [colaborativaTagMock, cuentoTagMock]),
+	conEtiquetas('tercera', [colaborativaTagMock]),
+	conEtiquetas('cuarta', [cuentoTagMock, absurdoTagMock]),
+];
+
+const meta: Meta<CollectionFiltersComponent> = {
+	component: CollectionFiltersComponent,
+	title: 'Componentes V3/CollectionFilters',
+	render: (args) => ({
+		props: args,
+		template: `<div class="w-50"><cuentoneta-collection-filters ${argsToTemplate(args)} /></div>`,
+	}),
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>La columna de filtros del catálogo, <strong>CollectionFilters</strong>. Cuenta las etiquetas de las colecciones que recibe y ofrece una faceta por cada una, con cuántas la llevan.</p><p>No decide nada sobre el filtrado: avisa qué etiqueta se tocó y quién lo consume resuelve qué hacer. La selección entra como dato, así que el panel nunca discrepa de lo que la página está mostrando.</p><p>Recibe las colecciones <strong>a la vista</strong>, no el catálogo entero: de ahí que al elegir una etiqueta las demás bajen su número y las que no conviven con ella desaparezcan. Como toda faceta ofrecida tiene al menos una colección detrás, no hay forma de vaciar el listado eligiendo filtros.</p><p>Los chips de lo elegido salen de las mismas facetas, y lo único que resuelve por su cuenta es si el grupo está plegado.</p><p>Se usa en <a href="./?path=/docs/páginas-collectionspage--docs" target="_top"><strong>CollectionsPage</strong></a>.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		collections: { name: 'Colecciones a la vista', table: { type: { summary: 'readonly CollectionTeaser[]' } } },
+		selected: { name: 'Etiquetas elegidas', table: { type: { summary: 'readonly string[]' } } },
+		toggled: { action: 'toggled' },
+		cleared: { action: 'cleared' },
+	},
+};
+
+export default meta;
+type Story = StoryObj<CollectionFiltersComponent>;
+
+export const Playground: Story = {
+	args: { collections: catalogo, selected: [] },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El panel con los controles vivos. Los eventos salen por el panel de <strong>Actions</strong>: la etiqueta viaja entera en <code>toggled</code>, así que quien escucha no tiene que resolver el slug contra nada.</p><p>Agregá una etiqueta a <strong>Etiquetas elegidas</strong> para ver cómo cambian los conteos y aparecen los chips.</p>`,
+			},
+		},
+	},
+};
+
+export const SinFiltrosElegidos: Story = {
+	args: { collections: catalogo, selected: [] },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El estado de arranque: una faceta por etiqueta del catálogo y nada elegido. Sin selección no hay chips ni acceso a limpiar, porque no habría qué limpiar.</p>`,
+			},
+		},
+	},
+};
+
+export const ConFiltrosElegidos: Story = {
+	args: { collections: catalogo, selected: [colaborativaTagMock.slug, cuentoTagMock.slug] },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Con dos etiquetas elegidas aparecen sus chips y el acceso a limpiar todo.</p><p><strong>Usos:</strong> evaluar cómo conviven los chips con el encabezado cuando el nombre de la etiqueta es largo, y cuándo pasan a una segunda línea.</p>`,
+			},
+		},
+	},
+};
+
+export const UnaSolaColeccionALaVista: Story = {
+	args: { collections: [catalogo[2]], selected: [colaborativaTagMock.slug] },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Al que se llega filtrando por una etiqueta que no convive con ninguna otra: queda su propia faceta y nada más. Es el estado que hace visible por qué elegir filtros no puede vaciar el listado.</p>`,
+			},
+		},
+	},
+};
+
+export const CatalogoSinEtiquetas: Story = {
+	args: { collections: [], selected: [] },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Sin colecciones que contar el grupo queda vacío, pero el encabezado se conserva: la columna no desaparece ni cambia de ancho.</p>`,
+			},
+		},
+	},
+};

--- a/src/app/components/collection-filters/collection-filters.component.ts
+++ b/src/app/components/collection-filters/collection-filters.component.ts
@@ -1,0 +1,145 @@
+import { Component, computed, input, output, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { faSolidCheck, faSolidChevronDown, faSolidXmark } from '@ng-icons/font-awesome/solid';
+
+import type { CollectionTeaser } from '@models/collection.model';
+import type { Tag } from '@models/tag.model';
+
+interface CollectionFacet {
+	readonly tag: Tag;
+	readonly count: number;
+	readonly selected: boolean;
+}
+
+@Component({
+	selector: 'cuentoneta-collection-filters',
+	providers: [provideIcons({ faSolidCheck, faSolidChevronDown, faSolidXmark })],
+	imports: [NgIcon],
+	host: { class: 'flex flex-col gap-6' },
+	template: `
+		<div class="flex items-center justify-between">
+			<h2 class="font-inter text-base leading-6 font-bold text-neutral-900">Filtros</h2>
+			@if (selectedTags().length > 0) {
+				<button
+					(click)="cleared.emit()"
+					type="button"
+					class="cursor-pointer font-inter text-xs leading-4 font-semibold text-neutral-900 underline hover:text-brand-500"
+				>
+					Limpiar filtros
+				</button>
+			}
+		</div>
+
+		@if (selectedTags().length > 0) {
+			<ul class="flex list-none flex-wrap gap-2" data-testid="active-filters">
+				@for (tag of selectedTags(); track tag.slug) {
+					<li>
+						<button
+							(click)="toggled.emit(tag)"
+							[attr.aria-label]="'Quitar el filtro ' + tag.title"
+							type="button"
+							class="flex cursor-pointer items-center gap-1 rounded-full bg-brand-100 px-2.5 py-1.5 font-inter text-[10px] leading-[14px] font-semibold text-brand-500"
+						>
+							{{ tag.title }}
+							<ng-icon name="faSolidXmark" size="14" aria-hidden="true" />
+						</button>
+					</li>
+				}
+			</ul>
+		}
+
+		<!-- No es \`fieldset\`/\`legend\`: el legend queda fuera del flujo flex y la separación con la lista no
+		     se aplica. -->
+		<div class="flex flex-col gap-3" role="group" aria-labelledby="category-group-label">
+			<div>
+				<button
+					(click)="toggleCategoryGroup()"
+					[attr.aria-expanded]="isCategoryGroupOpen()"
+					aria-controls="category-facets"
+					id="category-group-label"
+					type="button"
+					class="flex cursor-pointer items-center gap-1 font-inter text-sm leading-5 font-semibold text-neutral-900"
+				>
+					Categoría
+					<!-- El diseño dibuja el trazo chico y centrado dentro de una caja de 24, no llenándola. -->
+					<span class="flex size-6 items-center justify-center">
+						<ng-icon
+							[class.-rotate-90]="!isCategoryGroupOpen()"
+							name="faSolidChevronDown"
+							size="12"
+							aria-hidden="true"
+							class="transition-transform"
+						/>
+					</span>
+				</button>
+			</div>
+			@if (isCategoryGroupOpen()) {
+				<ul class="flex list-none flex-col gap-2.5" id="category-facets">
+					@for (facet of facets(); track facet.tag.slug) {
+						<li class="flex items-center gap-1.5">
+							<span class="relative flex size-5 shrink-0 items-center justify-center">
+								<input
+									(change)="toggled.emit(facet.tag)"
+									[checked]="facet.selected"
+									[id]="'facet-' + facet.tag.slug"
+									class="peer size-5 cursor-pointer appearance-none rounded border-2 border-neutral-300 bg-white checked:border-brand-500 checked:bg-brand-500"
+									type="checkbox"
+								/>
+								<!-- Aparte y no como \`::after\`: en un elemento reemplazado no se renderiza. El color va por
+								     estilo porque la utilidad no resuelve sobre el host del icono. -->
+								<ng-icon
+									[style.color]="'var(--color-white)'"
+									name="faSolidCheck"
+									size="12"
+									aria-hidden="true"
+									class="pointer-events-none absolute hidden peer-checked:block"
+								/>
+							</span>
+							<label
+								[for]="'facet-' + facet.tag.slug"
+								class="cursor-pointer font-inter text-xs leading-4 font-medium text-neutral-900"
+							>
+								{{ facet.tag.title }} ({{ facet.count }})
+							</label>
+						</li>
+					}
+				</ul>
+			}
+		</div>
+	`,
+})
+export class CollectionFiltersComponent {
+	/** Las colecciones sobre las que se cuentan las facetas: las que están a la vista, no el catálogo. */
+	public readonly collections = input.required<readonly CollectionTeaser[]>();
+	public readonly selected = input.required<readonly string[]>();
+
+	public readonly toggled = output<Tag>();
+	public readonly cleared = output<void>();
+
+	private readonly collator = new Intl.Collator('es');
+
+	protected readonly facets = computed<readonly CollectionFacet[]>(() => {
+		const selected = new Set(this.selected());
+		const counts = new Map<string, CollectionFacet>();
+		for (const collection of this.collections()) {
+			for (const tag of collection.tags) {
+				const seen = counts.get(tag.slug);
+				counts.set(tag.slug, { tag, count: (seen?.count ?? 0) + 1, selected: selected.has(tag.slug) });
+			}
+		}
+		return [...counts.values()].sort((first, second) => this.collator.compare(first.tag.title, second.tag.title));
+	});
+
+	protected readonly selectedTags = computed(() =>
+		this.facets()
+			.filter((facet) => facet.selected)
+			.map((facet) => facet.tag),
+	);
+
+	private readonly categoryGroupOpen = signal(true);
+	protected readonly isCategoryGroupOpen = this.categoryGroupOpen.asReadonly();
+
+	protected toggleCategoryGroup(): void {
+		this.categoryGroupOpen.update((open) => !open);
+	}
+}

--- a/src/app/components/collection-filters/collection-filters.component.ts
+++ b/src/app/components/collection-filters/collection-filters.component.ts
@@ -48,33 +48,34 @@ interface CollectionFacet {
 			</ul>
 		}
 
-		<!-- No es \`fieldset\`/\`legend\`: el legend queda fuera del flujo flex y la separación con la lista no
-		     se aplica. -->
-		<div class="flex flex-col gap-3" role="group" aria-labelledby="category-group-label">
-			<div>
+		<!-- El nombre va por \`aria-label\` y no por el \`legend\`: un legend que contiene un botón deja al
+		     \`fieldset\` sin nombre. Por eso el rótulo se repite, y las dos copias salen del mismo campo.
+		     La separación con la lista tampoco puede venir de \`gap\` —el legend no es flex item—, así que la
+		     lleva la lista y se va con ella al plegar. -->
+		<fieldset [attr.aria-label]="categoryLabel" class="min-w-0">
+			<legend>
 				<button
 					(click)="toggleCategoryGroup()"
 					[attr.aria-expanded]="isCategoryGroupOpen()"
 					aria-controls="category-facets"
-					id="category-group-label"
 					type="button"
 					class="flex cursor-pointer items-center gap-1 font-inter text-sm leading-5 font-semibold text-neutral-900"
 				>
-					Categoría
-					<!-- El diseño dibuja el trazo chico y centrado dentro de una caja de 24, no llenándola. -->
-					<span class="flex size-6 items-center justify-center">
+					{{ categoryLabel }}
+					<!-- El diseño dibuja el trazo chico y centrado dentro de una caja de 24, no llenándola. El
+					     \`aria-hidden\` va acá y no solo en el icono: adentro del botón, el icono le borra el nombre. -->
+					<span aria-hidden="true" class="flex size-6 items-center justify-center">
 						<ng-icon
 							[class.-rotate-90]="!isCategoryGroupOpen()"
 							name="faSolidChevronDown"
 							size="12"
-							aria-hidden="true"
 							class="transition-transform"
 						/>
 					</span>
 				</button>
-			</div>
+			</legend>
 			@if (isCategoryGroupOpen()) {
-				<ul class="flex list-none flex-col gap-2.5" id="category-facets">
+				<ul class="mt-3 flex list-none flex-col gap-2.5" id="category-facets">
 					@for (facet of facets(); track facet.tag.slug) {
 						<li class="flex items-center gap-1.5">
 							<span class="relative flex size-5 shrink-0 items-center justify-center">
@@ -105,7 +106,7 @@ interface CollectionFacet {
 					}
 				</ul>
 			}
-		</div>
+		</fieldset>
 	`,
 })
 export class CollectionFiltersComponent {
@@ -115,6 +116,8 @@ export class CollectionFiltersComponent {
 
 	public readonly toggled = output<Tag>();
 	public readonly cleared = output<void>();
+
+	protected readonly categoryLabel = 'Categoría';
 
 	private readonly collator = new Intl.Collator('es');
 

--- a/src/app/pages/collections/collections.page.spec.ts
+++ b/src/app/pages/collections/collections.page.spec.ts
@@ -1,15 +1,21 @@
 import { render, screen, within } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 import { provideRouter } from '@angular/router';
 import { RESPONSE_INIT } from '@angular/core';
-import { NEVER, Observable, of, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 
-import { createCollectionTeaser, type Collection, type CollectionTeaser } from '@models/collection.model';
-import { onoffCollectionsMock, onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
-import { clearAllMocks } from '@test-utils';
+import CollectionsPage from './collections.page';
 
 import type { CollectionApi } from '../../providers/collection.provider';
 import { provideCollectionApiMock } from '../../providers/collection.mock';
-import CollectionsPage from './collections.page';
+
+import { createCollectionTeaser, type Collection, type CollectionTeaser } from '@models/collection.model';
+import type { Tag } from '@models/tag.model';
+
+import { onoffCollectionsMock, onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
+import { colaborativaTagMock, surrealismoTagMock } from '@mocks/onoff-tags.mock';
+
+import { clearAllMocks } from '@test-utils';
 
 class StubCatalogCollectionApi implements CollectionApi {
 	constructor(private readonly teasers: readonly CollectionTeaser[]) {}
@@ -33,17 +39,6 @@ class FailingCollectionApi implements CollectionApi {
 	}
 }
 
-// `NEVER` deja el recurso pendiente, que es la única forma de sostener el esqueleto a la vista.
-class PendingCollectionApi implements CollectionApi {
-	public getBySlug(): Observable<Collection> {
-		return NEVER;
-	}
-
-	public getAll(): Observable<CollectionTeaser[]> {
-		return NEVER;
-	}
-}
-
 const renderPage = (api: CollectionApi) =>
 	render(CollectionsPage, {
 		providers: [provideRouter([]), provideCollectionApiMock(api)],
@@ -63,11 +58,6 @@ const withTitle = (title: string, slug: string): CollectionTeaser =>
 		mediaSources: canonical.mediaSources,
 		count: canonical.count,
 	});
-
-const hrefsOf = (testId: string) =>
-	within(screen.getByTestId(testId))
-		.getAllByRole('link')
-		.map((link) => link.getAttribute('href'));
 
 describe('CollectionsPage', () => {
 	beforeEach(() => {
@@ -99,9 +89,10 @@ describe('CollectionsPage', () => {
 	it('should link every card to the collection detail route', async () => {
 		await renderPage(new StubCatalogCollectionApi(onoffCollectionTeasersMock));
 
-		expect(hrefsOf('collections')).toEqual(
-			expect.arrayContaining(onoffCollectionsMock.map(({ slug }) => `/collection/${slug}`)),
-		);
+		const hrefs = within(screen.getByTestId('collections'))
+			.getAllByRole('link')
+			.map((link) => link.getAttribute('href'));
+		expect(hrefs).toEqual(expect.arrayContaining(onoffCollectionsMock.map(({ slug }) => `/collection/${slug}`)));
 	});
 
 	// La colación de la base pondría `Ámbar` detrás de `Zoológico`.
@@ -114,15 +105,10 @@ describe('CollectionsPage', () => {
 
 		await renderPage(new StubCatalogCollectionApi(desordenadas));
 
-		expect(hrefsOf('collections')).toEqual(['/collection/ambar', '/collection/bruma', '/collection/zoologico']);
-	});
-
-	it('should show placeholders while the catalogue is on its way', async () => {
-		const { container } = await renderPage(new PendingCollectionApi());
-
-		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- el esqueleto no expone rol ni texto: solo se lo puede contar por selector
-		expect(container.querySelectorAll('cuentoneta-collection-teaser-card-skeleton').length).toBeGreaterThan(0);
-		expect(screen.queryByTestId('catalog-empty')).not.toBeInTheDocument();
+		const hrefs = within(screen.getByTestId('collections'))
+			.getAllByRole('link')
+			.map((link) => link.getAttribute('href'));
+		expect(hrefs).toEqual(['/collection/ambar', '/collection/bruma', '/collection/zoologico']);
 	});
 
 	it('should keep the heading when the catalogue comes back empty', async () => {
@@ -145,6 +131,100 @@ describe('CollectionsPage', () => {
 
 		expect(screen.getByTestId('catalog-error')).toBeInTheDocument();
 		expect(screen.queryByTestId('collections')).not.toBeInTheDocument();
+	});
+
+	describe('filtros', () => {
+		const conEtiquetas = (slug: string, tags: readonly Tag[]): CollectionTeaser =>
+			createCollectionTeaser({
+				_id: `${canonical._id}-${slug}`,
+				slug,
+				title: slug,
+				description: canonical.description,
+				imagery: canonical.imagery,
+				tags,
+				config: canonical.config,
+				mediaSources: canonical.mediaSources,
+				count: canonical.count,
+			});
+
+		const catalogo = [
+			conEtiquetas('ambas', [colaborativaTagMock, surrealismoTagMock]),
+			conEtiquetas('solo-colaborativa', [colaborativaTagMock]),
+			conEtiquetas('solo-surrealismo', [surrealismoTagMock]),
+		];
+
+		const renderCatalogo = () => renderPage(new StubCatalogCollectionApi(catalogo));
+
+		it('should count each facet over the catalogue', async () => {
+			await renderCatalogo();
+
+			expect(
+				within(screen.getByTestId('filters')).getByLabelText(`${colaborativaTagMock.title} (2)`),
+			).toBeInTheDocument();
+			expect(
+				within(screen.getByTestId('filters')).getByLabelText(`${surrealismoTagMock.title} (2)`),
+			).toBeInTheDocument();
+		});
+
+		it('should narrow the listing to the collections carrying the chosen tag', async () => {
+			await renderCatalogo();
+
+			await userEvent.click(screen.getByLabelText(`${colaborativaTagMock.title} (2)`));
+
+			expect(within(screen.getByTestId('collections')).getAllByRole('link')).toHaveLength(2);
+			expect(screen.getByRole('heading', { level: 1, name: '2 Colecciones' })).toBeInTheDocument();
+		});
+
+		it('should drop the facets that no longer apply and recount the rest', async () => {
+			await renderCatalogo();
+
+			await userEvent.click(screen.getByLabelText(`${colaborativaTagMock.title} (2)`));
+
+			expect(screen.getByLabelText(`${surrealismoTagMock.title} (1)`)).toBeInTheDocument();
+		});
+
+		it('should offer a chip that removes the filter it names', async () => {
+			await renderCatalogo();
+			await userEvent.click(screen.getByLabelText(`${colaborativaTagMock.title} (2)`));
+
+			await userEvent.click(screen.getByRole('button', { name: `Quitar el filtro ${colaborativaTagMock.title}` }));
+
+			expect(screen.getByRole('heading', { level: 1, name: '3 Colecciones' })).toBeInTheDocument();
+		});
+
+		it('should collapse the category group without dropping the filters in effect', async () => {
+			await renderCatalogo();
+			await userEvent.click(screen.getByLabelText(`${colaborativaTagMock.title} (2)`));
+
+			await userEvent.click(screen.getByRole('button', { name: /Categoría/ }));
+
+			expect(screen.getByRole('button', { name: /Categoría/ })).toHaveAttribute('aria-expanded', 'false');
+			expect(screen.queryByLabelText(`${colaborativaTagMock.title} (2)`)).not.toBeInTheDocument();
+			expect(screen.getByRole('heading', { level: 1, name: '2 Colecciones' })).toBeInTheDocument();
+			expect(screen.getByTestId('active-filters')).toBeInTheDocument();
+		});
+
+		it('should clear every filter at once', async () => {
+			await renderCatalogo();
+			await userEvent.click(screen.getByLabelText(`${colaborativaTagMock.title} (2)`));
+
+			await userEvent.click(screen.getByRole('button', { name: 'Limpiar filtros' }));
+
+			expect(screen.getByRole('heading', { level: 1, name: '3 Colecciones' })).toBeInTheDocument();
+			expect(screen.queryByTestId('active-filters')).not.toBeInTheDocument();
+		});
+
+		// Toda faceta ofrecida tiene al menos una colección detrás: por eso la página no tiene estado de
+		// «ninguna coincide» — sería inalcanzable.
+		it('should never let a combination of offered facets empty the listing', async () => {
+			await renderCatalogo();
+			await userEvent.click(screen.getByLabelText(`${colaborativaTagMock.title} (2)`));
+
+			await userEvent.click(screen.getByLabelText(`${surrealismoTagMock.title} (1)`));
+
+			expect(within(screen.getByTestId('collections')).getAllByRole('link')).toHaveLength(1);
+			expect(screen.getByRole('heading', { level: 1, name: '1 Colección' })).toBeInTheDocument();
+		});
 	});
 
 	describe('código de respuesta', () => {

--- a/src/app/pages/collections/collections.page.stories.ts
+++ b/src/app/pages/collections/collections.page.stories.ts
@@ -2,15 +2,49 @@ import { applicationConfig, type Meta, type StoryObj } from '@storybook/angular-
 import { provideRouter } from '@angular/router';
 import { NEVER, of, throwError, type Observable } from 'rxjs';
 
-import type { Collection, CollectionTeaser } from '@models/collection.model';
+import { createCollectionTeaser, type Collection, type CollectionTeaser } from '@models/collection.model';
+import type { Tag } from '@models/tag.model';
 import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
+import {
+	absurdoTagMock,
+	colaborativaTagMock,
+	cuentoTagMock,
+	surrealismoTagMock,
+	teatroTagMock,
+	tragediaTagMock,
+} from '@mocks/onoff-tags.mock';
 
 import { provideCollectionApiMock } from '../../providers/collection.mock';
 import type { CollectionApi } from '../../providers/collection.provider';
 import CollectionsPage from './collections.page';
 
+// Las dos colecciones del corpus llevan la misma etiqueta, así que con ellas el panel ofrece una sola
+// faceta y no hay nada que filtrar. Las entradas derivadas reparten las etiquetas a propósito para que
+// se vean conteos distintos, facetas que desaparecen al elegir y combinaciones que conviven.
+const [canonical] = onoffCollectionTeasersMock;
+const derived = (title: string, slug: string, tags: readonly Tag[]): CollectionTeaser =>
+	createCollectionTeaser({
+		_id: `${canonical._id}-${slug}`,
+		slug,
+		title,
+		description: canonical.description,
+		imagery: canonical.imagery,
+		tags,
+		config: canonical.config,
+		mediaSources: canonical.mediaSources,
+		count: canonical.count,
+	});
+
 const catalogues = {
 	corpus: onoffCollectionTeasersMock,
+	extended: [
+		...onoffCollectionTeasersMock,
+		derived('Ámbar y ceniza', 'ambar-y-ceniza', [colaborativaTagMock, surrealismoTagMock]),
+		derived('Bitácora de la espera', 'bitacora-de-la-espera', [cuentoTagMock, tragediaTagMock]),
+		derived('Ñandubay', 'nandubay', [colaborativaTagMock, cuentoTagMock]),
+		derived('Teatro de sombras', 'teatro-de-sombras', [teatroTagMock]),
+		derived('Zoológico de bolsillo', 'zoologico-de-bolsillo', [surrealismoTagMock, absurdoTagMock]),
+	],
 	empty: [] as readonly CollectionTeaser[],
 } as const;
 
@@ -56,7 +90,7 @@ const meta: Meta<CollectionsPageArgs> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>El catálogo de colecciones, <strong>CollectionsPage</strong>, montado sobre el corpus de Onoff. Como el resto de las entradas bajo <strong>Páginas</strong>, no cataloga un componente sino el ensamblado completo: el encabezado con el conteo y la lista de tarjetas que llevan al detalle.</p><p>El único control elige el escenario del catálogo, que es lo único que mueve la página desde afuera: no recibe parámetros de ruta.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-collectionteasercard--docs" target="_top"><strong>CollectionTeaserCard</strong></a>, la misma tarjeta que enlaza a <a href="./?path=/docs/páginas-collectionpage--docs" target="_top"><strong>CollectionPage</strong></a>, y de su esqueleto.</p><p>El orden no es el que entrega el backend: se resuelve en la página con colación en español, porque la base compara por punto de código y mandaría al final del catálogo todo título que empiece con acento o eñe.</p><p>El encabezado fijo de la aplicación no se monta en el catálogo, así que el margen superior de la página se ve como espacio en blanco.</p></div>`,
+				component: `<div><p>El catálogo de colecciones, <strong>CollectionsPage</strong>, montado sobre el corpus de Onoff. Como el resto de las entradas bajo <strong>Páginas</strong>, no cataloga un componente sino el ensamblado completo: la columna de filtros, el encabezado con el conteo y la lista de tarjetas que llevan al detalle.</p><p>El único control elige el escenario del catálogo, que es lo único que mueve la página desde afuera: no recibe parámetros de ruta. Los filtros son estado propio y se manejan desde la columna izquierda.</p><p>Las facetas se cuentan sobre lo que está a la vista, así que al elegir una etiqueta las demás ajustan su número y las que no conviven con ella desaparecen. De ahí se sigue que no hay forma de vaciar el listado eligiendo filtros: toda faceta ofrecida tiene al menos una colección detrás.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-collectionteasercard--docs" target="_top"><strong>CollectionTeaserCard</strong></a>, la misma tarjeta que enlaza a <a href="./?path=/docs/páginas-collectionpage--docs" target="_top"><strong>CollectionPage</strong></a>, y de su esqueleto, más <a href="./?path=/docs/componentes-v3-divider--docs" target="_top"><strong>Divider</strong></a> entre las dos columnas.</p><p>El orden no es el que entrega el backend: se resuelve en la página con colación en español, porque la base compara por punto de código y mandaría al final del catálogo todo título que empiece con acento o eñe. El escenario <strong>extended</strong> es el que lo hace visible.</p><p>El encabezado fijo de la aplicación no se monta en el catálogo, así que el margen superior de la página se ve como espacio en blanco.</p></div>`,
 			},
 		},
 	},
@@ -64,8 +98,8 @@ const meta: Meta<CollectionsPageArgs> = {
 		scenario: {
 			name: 'Catálogo',
 			control: { type: 'inline-radio' },
-			options: ['corpus', 'loading', 'empty', 'failure'],
-			table: { type: { summary: "'corpus' | 'loading' | 'empty' | 'failure'" } },
+			options: ['corpus', 'extended', 'loading', 'empty', 'failure'],
+			table: { type: { summary: "'corpus' | 'extended' | 'loading' | 'empty' | 'failure'" } },
 		},
 	},
 };
@@ -74,11 +108,11 @@ export default meta;
 type Story = StoryObj<CollectionsPageArgs>;
 
 export const Playground: Story = {
-	args: { scenario: 'corpus' },
+	args: { scenario: 'extended' },
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>El catálogo con el control vivo. Cambiá <strong>Catálogo</strong> para recorrer los cuatro estados, y en particular para alternar entre <strong>corpus</strong> y <strong>loading</strong>: la lista real y la de esqueletos ocupan el mismo lugar, así que la alineación entre las dos se puede evaluar de un vistazo.</p>`,
+				story: `<p>El catálogo con el control vivo. Cambiá <strong>Catálogo</strong> para recorrer los cinco estados, y en particular para alternar entre <strong>extended</strong> y <strong>loading</strong>: la lista real y la de esqueletos ocupan el mismo lugar, así que la alineación entre las dos se puede evaluar de un vistazo.</p>`,
 			},
 		},
 	},
@@ -89,7 +123,18 @@ export const CatalogoDelCorpus: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Las colecciones del corpus, tal como las sirve el backend.</p><p><strong>Usos:</strong> mirar la tarjeta con datos reales.</p>`,
+				story: `<p>Las dos colecciones del corpus, tal como las sirve el backend.</p><p><strong>Usos:</strong> mirar la tarjeta con datos reales, sin entradas derivadas.</p>`,
+			},
+		},
+	},
+};
+
+export const CatalogoExtendido: Story = {
+	args: { scenario: 'extended' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El corpus más cinco entradas derivadas, con las etiquetas repartidas para que el panel de filtros se pueda ejercitar entero. Es la única entrada donde eso es posible: las colecciones del corpus llevan todas la misma etiqueta, así que con ellas hay una sola faceta y nada que elegir.</p><p>Qué mirar acá:</p><ul><li>Facetas con <strong>conteos distintos</strong>, que es lo que revela cuántas colecciones lleva cada etiqueta.</li><li>Al elegir una, las que <strong>no conviven</strong> con ella desaparecen y las que sí ajustan su número a lo que queda.</li><li>Elegir dos que conviven deja el cruce; como toda faceta ofrecida tiene al menos una colección detrás, <strong>no hay forma de vaciar el listado</strong>.</li><li>El encabezado sigue al resultado, porque es el conteo de lo que se está mostrando.</li></ul><p>También es donde se evalúa el orden: <strong>Ámbar y ceniza</strong> y <strong>Ñandubay</strong> aparecen donde corresponde alfabéticamente y no al final, que es donde los pondría una comparación por punto de código.</p>`,
 			},
 		},
 	},
@@ -100,7 +145,7 @@ export const CatalogoCargando: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>El catálogo mientras carga: la lista de esqueletos, en el mismo lugar y con la misma geometría que la lista real. Alternar con <strong>corpus</strong> desde el control de <strong>Playground</strong> es lo que permite verificar que una no salte respecto de la otra.</p><p>En la aplicación servida este estado no llega al HTML: el recurso bloquea el render del servidor. Se ve al navegar dentro de la aplicación.</p>`,
+				story: `<p>El catálogo mientras carga: la lista de esqueletos, en el mismo lugar y con la misma geometría que la lista real. Alternar con <strong>extended</strong> desde el control de <strong>Playground</strong> es lo que permite verificar que una no salte respecto de la otra.</p><p>En la aplicación servida este estado no llega al HTML: el recurso bloquea el render del servidor. Se ve al navegar dentro de la aplicación.</p>`,
 			},
 		},
 	},

--- a/src/app/pages/collections/collections.page.ts
+++ b/src/app/pages/collections/collections.page.ts
@@ -1,9 +1,6 @@
-import { Component, computed, effect, forwardRef, inject, RESPONSE_INIT } from '@angular/core';
+import { Component, computed, effect, forwardRef, inject, RESPONSE_INIT, signal } from '@angular/core';
 
 import { ssrBlockingRxResource } from '@app-utils/ssr-resource';
-
-import { CollectionTeaserCard } from '@components/collection-teaser-card/collection-teaser-card';
-import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
 
 import { CollectionApi } from '../../providers/collection.provider';
 
@@ -11,43 +8,62 @@ import { COLLECTIONS_HOST, type CollectionsHost } from './collections-host';
 import { CollectionsMetaTagsDirective } from './collections-meta-tags.directive';
 import { CollectionsStructuredDataDirective } from './collections-structured-data.directive';
 
+import { CollectionFiltersComponent } from '@components/collection-filters/collection-filters.component';
+import { CollectionTeaserCard } from '@components/collection-teaser-card/collection-teaser-card';
+import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
+import { DividerComponent } from '@components/divider/divider.component';
+
 @Component({
 	selector: 'cuentoneta-collections',
 	template: `
 		<!-- TODO(#2348): el despeje del encabezado fijo pasa al shell; hoy cada página lo repite. -->
-		<main class="mx-auto mt-header-height flex w-full max-w-310 flex-col gap-12 px-4 pt-8 pb-16">
-			<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">
-				{{ collections().length }} {{ collections().length === 1 ? 'Colección' : 'Colecciones' }}
-			</h1>
+		<main class="mx-auto mt-header-height flex w-full max-w-310 items-stretch gap-8 px-4 pt-8 pb-16">
+			<cuentoneta-collection-filters
+				(cleared)="clearFilters()"
+				(toggled)="toggleTag($event.slug)"
+				[collections]="visibleCollections()"
+				[selected]="selectedSlugs()"
+				class="hidden w-50 shrink-0 lg:flex"
+				data-testid="filters"
+			/>
 
-			@if (loading()) {
-				<section class="flex flex-col gap-8" aria-busy="true">
-					@for (placeholder of [1, 2, 3, 4]; track placeholder) {
-						<cuentoneta-collection-teaser-card-skeleton class="w-full" />
-					}
-				</section>
-			} @else if (failed()) {
-				<p class="font-inter text-base text-neutral-700" data-testid="catalog-error">
-					No pudimos cargar las colecciones. Probá de nuevo en un rato.
-				</p>
-			} @else if (collections().length > 0) {
-				<section class="flex flex-col gap-8" data-testid="collections">
-					@for (collection of collections(); track collection.slug) {
-						<cuentoneta-collection-teaser-card [collection]="collection" class="w-full" />
-					}
-				</section>
-			} @else {
-				<p class="font-inter text-base text-neutral-700" data-testid="catalog-empty">
-					Todavía no hay colecciones publicadas.
-				</p>
-			}
+			<cuentoneta-divider class="hidden lg:block" orientation="vertical" />
+
+			<div class="flex min-w-0 flex-1 flex-col gap-12 lg:pl-5">
+				<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">
+					{{ visibleCollections().length }} {{ visibleCollections().length === 1 ? 'Colección' : 'Colecciones' }}
+				</h1>
+
+				@if (loading()) {
+					<section class="flex flex-col gap-8" aria-busy="true">
+						@for (placeholder of [1, 2, 3, 4]; track placeholder) {
+							<cuentoneta-collection-teaser-card-skeleton class="w-full" />
+						}
+					</section>
+				} @else if (failed()) {
+					<p class="font-inter text-base text-neutral-700" data-testid="catalog-error">
+						No pudimos cargar las colecciones. Probá de nuevo en un rato.
+					</p>
+				} @else if (visibleCollections().length > 0) {
+					<section class="flex flex-col gap-8" data-testid="collections">
+						@for (collection of visibleCollections(); track collection.slug) {
+							<cuentoneta-collection-teaser-card [collection]="collection" class="w-full" />
+						}
+					</section>
+				} @else {
+					<p class="font-inter text-base text-neutral-700" data-testid="catalog-empty">
+						Todavía no hay colecciones publicadas.
+					</p>
+				}
+			</div>
 		</main>
 	`,
 	providers: [{ provide: COLLECTIONS_HOST, useExisting: forwardRef(() => CollectionsPage) }],
 	hostDirectives: [CollectionsMetaTagsDirective, CollectionsStructuredDataDirective],
-	imports: [CollectionTeaserCard, CollectionTeaserCardSkeletonComponent],
+	imports: [CollectionFiltersComponent, CollectionTeaserCard, CollectionTeaserCardSkeletonComponent, DividerComponent],
 })
 export default class CollectionsPage implements CollectionsHost {
+	// Providers
 	private readonly collectionApi = inject(CollectionApi);
 	private readonly responseInit = inject(RESPONSE_INIT, { optional: true });
 
@@ -69,6 +85,18 @@ export default class CollectionsPage implements CollectionsHost {
 
 	protected readonly loading = computed(() => this.catalogResource.isLoading());
 
+	protected readonly selectedSlugs = signal<readonly string[]>([]);
+
+	protected readonly visibleCollections = computed(() => {
+		const selected = this.selectedSlugs();
+		if (selected.length === 0) {
+			return this.collections();
+		}
+		return this.collections().filter((collection) =>
+			selected.every((slug) => collection.tags.some((tag) => tag.slug === slug)),
+		);
+	});
+
 	// Un fallo transitorio no puede salir 200: el borde lo cachearía como si fuera la página. No hay
 	// rama 404 — un catálogo no deja de existir.
 	private readonly respondErrorStatusEffect = effect(() => {
@@ -77,4 +105,14 @@ export default class CollectionsPage implements CollectionsHost {
 		}
 		this.responseInit.status = 503;
 	});
+
+	protected toggleTag(slug: string): void {
+		this.selectedSlugs.update((selected) =>
+			selected.includes(slug) ? selected.filter((candidate) => candidate !== slug) : [...selected, slug],
+		);
+	}
+
+	protected clearFilters(): void {
+		this.selectedSlugs.set([]);
+	}
 }


### PR DESCRIPTION
Última rebanada de #2288. Con esta mergeada, el issue queda cubierto y se puede cerrar.

## Qué entra

`CollectionFilters`, la columna izquierda del catálogo, y su cableado en la página.

## Cómo se reparte la responsabilidad

El panel **cuenta**; la página **decide**. El panel recibe las colecciones a la vista y la selección vigente, y lo único que emite es qué etiqueta se tocó. Que la selección entre como dato en vez de vivir adentro no es ceremonia: es lo que garantiza que el panel no pueda discrepar de lo que la página está mostrando.

Lo único que resuelve por su cuenta es si el grupo está plegado, que es estado visual sin consecuencias fuera del panel.

## La propiedad que sostiene el diseño

Las facetas se cuentan sobre **lo visible**, no sobre el catálogo entero. Elegir una etiqueta ajusta el número de las demás y descarta las que no conviven con ella. De ahí se sigue algo que conviene no romper al tocar esto: **ninguna combinación de facetas ofrecidas puede vaciar el listado**, porque toda faceta ofrecida tiene al menos una colección detrás. Por eso la página no tiene un estado de «ninguna coincide» — sería inalcanzable, y agregarlo sería agregar código muerto. Hay un caso de test que lo fija explícitamente.

El término «faceta» es vocabulario foráneo, y quedó documentado como patrón del modelo de dominio en `docs/DOMAIN_MODEL.md`.

## Alcance

El filtrado resuelve **en memoria** sobre el catálogo ya cargado. Engancharlo a la base es trabajo aparte, con su propio issue en 2.12.0.

Las stories de la página suman el escenario `extended`: las colecciones del corpus llevan todas la misma etiqueta, así que con ellas el panel ofrece una sola faceta y no hay nada que elegir. Eso también tiene issue propio —#2333, en 2.11.1— para ampliar el corpus y borrar esas entradas derivadas.

## Verificación

`pnpm test` completo en verde (199 archivos, 2412 casos), `storybook:build` en verde, `tsc --noEmit` y `lint` limpios. El comportamiento del panel se verificó además en el Storybook construido, midiendo las facetas en el navegador: elegir `Colaborativa` deja el listado en 4 y funde tres facetas; sumar `Surrealismo` deja el cruce en 1.

Parte de #2288.
