### PR TITLE
[#2105] - Agregar badge de Appgentina

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ La Cuentoneta también es parte de [For Good First Issue](https://forgoodfirstis
 
 La comunidad [Tertulia Literaria](https://discord.gg/tertulia-literaria-795704695485235231), enfocada a compartir conocimiento, lecturas y en general la grata convivencia, colabora activamente con la selección de historias, la generación de iniciativas y la confección de storylists en La Cuentoneta.
 
+<a href="https://appgentina.com.ar/producto/la-cuentoneta?ref=badge" title="La Cuentoneta | Appgentina">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://appgentina.com.ar/embed-svg/la-cuentoneta/dark">
+    <source media="(prefers-color-scheme: light)" srcset="https://appgentina.com.ar/embed-svg/la-cuentoneta">
+    <img alt="La Cuentoneta | Appgentina" src="https://appgentina.com.ar/embed-svg/la-cuentoneta" width="229" height="54">
+  </picture>
+</a>
+
+La Cuentoneta también se encuentra listada en [Appgentina](https://appgentina.com.ar/), una plataforma dedicada a difundir los productos digitales hechos en Argentina, permitiendo a la comunidad descubrir, compartir y apoyar el talento local.
+
 ---
 
 ## Accesibilidad


### PR DESCRIPTION
## Descripción

Agrega el badge de Appgentina provisto en el issue a la sección `Comunidad` de `README.md`, con sus dos variantes alternativas para light y dark mode servidas vía `<picture>` con `prefers-color-scheme`, el mismo patrón que ya usan los badges de FrontendCafé y For Good First Issue en esa sección. Incluye además un párrafo que menciona a La Cuentoneta como uno de los proyectos listados en la plataforma, siguiendo el formato de las menciones existentes de FrontendCafé, Tertulia Literaria y Good First Issue.

Closes #2105.

## Plan de pruebas

- [x] Los tres recursos provistos por el issue responden 200 (`image/svg+xml` / `text/html`), son variantes realmente distintas (light: fondo blanco + trazo `#50AEE4` · dark: fondo transparente + trazo `#9dd9fc`) y su tamaño intrínseco (`viewBox="0 0 229 54"`) coincide con los atributos `width`/`height` del `<img>` — sin distorsión ni layout shift.
- [x] Render autoritativo de GitHub: el HTML que GitHub genera para el README en esta rama (API `repos/…/readme?ref=feat/2105-agregar-badge-de-appgentina`) preserva el bloque completo — ancla con `href`/`title`, `<picture>` con ambos `<source>` proxeados por Camo hacia las URLs canónicas exactas y `<img>` fallback con `alt`/`width`/`height`.
- [x] Verificación visual del HTML renderizado por GitHub bajo ambos esquemas de color, con selección de fuente confirmada por esquema (`img.currentSrc`) y render exacto de 229×54:

  ![Badge Appgentina en esquema light](https://x0.at/lnJA.png)

  ![Badge Appgentina en esquema dark](https://x0.at/0Wrp.png)

- [x] El destino `https://appgentina.com.ar/producto/la-cuentoneta?ref=badge` responde 200 sin redirección y preserva el parámetro de atribución `?ref=badge`.
- [x] Tier local de gates en verde (`typecheck`, `lint`, `stylelint`, `check:agents`, `test` — dos timeouts ambientales de la suite completa bajo carga concurrente re-verificados en aislamiento: 54/54) y los once checks de CI del PR en verde sobre el commit final.
