### PR TITLE
[#1841] - Alinear el modelo Collection con el rename Story → LiteraryWork

### DIFF
--- a/.claude/references/clean-architecture.md
+++ b/.claude/references/clean-architecture.md
@@ -133,6 +133,7 @@ El **archivo** sigue siendo `<dominio>.mock.ts` y la **factory** `provide<X>ApiM
 | API de autores          | `AuthorApi`                      | `HttpAuthorApi`         | `StubAuthorApi`             |
 | API de storylists       | `StorylistApi`                   | `HttpStorylistApi`      | `StubStorylistApi`          |
 | API de obras literarias | `LiteraryWorkApi`\*              | `HttpLiteraryWorkApi`\* | `StubLiteraryWorkApi`\*     |
+| API de colecciones      | `CollectionApi`                  | `HttpCollectionApi`     | `StubCollectionApi`         |
 | Service (impl. única)   | `LayoutService` (token homónimo) | `WindowLayoutService`   | `ControllableLayoutService` |
 
 > Los dobles de API son **`Stub*`** (devuelven canned, ignoran la entrada); el de `LayoutService` es un **`Fake*` de entorno**, calificado `Controllable*` porque el viewport lo fija el test (`simulateViewport()`), no `window` como en el real (`WindowLayoutService`). No es `InMemory*`: no sustituye almacenamiento, sustituye el navegador. La diferencia no es de capa sino de qué sustituye el doble — ver la taxonomía de arriba.

--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -450,17 +450,20 @@ La idea clave: un mismo `Story` se modela distinto según el contexto. En **Cat�
 
 Cada contexto **posee las definiciones** de sus términos, co-localizadas con sus interfaces. Una misma palabra puede tener un matiz distinto por contexto, y esa divergencia es esperada. Términos clave (de `docs/DOMAIN_MODEL.md`):
 
-| Término            | Definición                                                                           | Contexto              |
-| ------------------ | ------------------------------------------------------------------------------------ | --------------------- |
-| **Historia**       | Obra literaria curada y publicada                                                    | Catálogo de Contenido |
-| **Obra literaria** | Obra narrativa con secciones/capítulos, entidad paralela a Historia (`LiteraryWork`) | Catálogo de Contenido |
-| **Slug**           | Identificador amigable, único e inmutable basado en el título                        | Todos                 |
-| **Epígrafe**       | Cita literaria que precede al texto principal                                        | Catálogo de Contenido |
-| **Teaser**         | Vista reducida de una entidad para listados y navegación                             | Todos                 |
-| **Colección**      | Agrupación temática u editorial de obras (`Collection`; `Storylist`, en baja)        | Curación              |
-| **Recurso**        | Enlace externo a información complementaria (`Resource`)                             | Catálogo de Contenido |
-| **Etiqueta**       | Tag de taxonomía (`Tag`) referenciable desde `Story`, `Author` y `Storylist`         | Todos                 |
-| **Curaduría**      | Proceso de seleccionar, ordenar y presentar historias                                | Curación              |
+| Término            | Definición                                                                                       | Contexto              |
+| ------------------ | ------------------------------------------------------------------------------------------------ | --------------------- |
+| **Historia**       | Obra literaria curada y publicada                                                                | Catálogo de Contenido |
+| **Obra literaria** | Obra narrativa con secciones/capítulos, entidad paralela a Historia (`LiteraryWork`)             | Catálogo de Contenido |
+| **Slug**           | Identificador amigable, único e inmutable basado en el título                                    | Todos                 |
+| **Epígrafe**       | Cita literaria que precede al texto principal                                                    | Catálogo de Contenido |
+| **Teaser**         | Vista reducida de una entidad para listados y navegación                                         | Todos                 |
+| **Colección**      | Agrupación temática u editorial de obras (`Collection`; `Storylist`, en baja)                    | Curación              |
+| **Recurso**        | Enlace externo a información complementaria (`Resource`)                                         | Catálogo de Contenido |
+| **Etiqueta**       | Tag de taxonomía (`Tag`) referenciable desde `Story`, `Author` y `Storylist`                     | Todos                 |
+| **Curaduría**      | Proceso de seleccionar, ordenar y presentar historias                                            | Curación              |
+| **Faceta**         | Etiqueta con su conteo dentro del resultado visible y su estado de selección (`CollectionFacet`) | Curación              |
+
+**Faceta** es vocabulario **foráneo** al negocio: viene de la clasificación facetada de la biblioteconomía y del `faceting` de los motores de búsqueda, y nombra la etiqueta contada **sobre el resultado visible**, no sobre el catálogo entero. Es un modelo de lectura derivado, no un agregado: no se persiste, ninguna query lo produce y hoy se calcula en el frontend. Su semántica —el conteo sigue a lo que está a la vista, la faceta vacía no se ofrece, combinar dos es conjunción— está en [`docs/DOMAIN_MODEL.md`](../../docs/DOMAIN_MODEL.md), y conviene leerla antes de tocar el filtrado: de ahí se sigue que elegir filtros no pueda vaciar un listado.
 
 **Convención para contextos nuevos:** al introducir un bounded context, definí su vocabulario junto a sus interfaces y aclará, por cada término, a qué términos existentes mapea o de cuáles diverge deliberadamente.
 

--- a/.claude/references/sanity-acl.md
+++ b/.claude/references/sanity-acl.md
@@ -42,9 +42,9 @@ queda contenido en el mapper; el dominio y el frontend no se enteran.
 >
 > El módulo `literary-work` está completo de punta a punta (repository → service → controller), con
 > el contrato en [`docs/LITERARY_WORK_DESIGN.md`](../../docs/LITERARY_WORK_DESIGN.md) §6.
-> `collection` está a mitad de camino: tiene su repository, y el service y el controller son trabajo
-> posterior. Los ejemplos de código de abajo se conservan sobre `story`, que sigue vigente para ese
-> patrón.
+> `collection` también, con la misma forma: la ACL vive dentro de su repository, y el service y el
+> controller quedan del lado del dominio. Los ejemplos de código de abajo se conservan sobre `story`,
+> que sigue vigente para ese patrón.
 >
 > **Qué sí se comparte desde `_utils/`.** La divergencia no es aislarse: los repositories que la
 > adoptaron siguen usando las primitivas genéricas de traducción (`mapTags`, `mapAuthorTeaser`,

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -783,10 +783,31 @@ El **Lenguaje Ubicuo** es el lenguaje estructurado alrededor del modelo de domin
 | **Recurso**              | Enlace externo a información complementaria                                                                                            | Catálogo de Contenido |
 | **Campaña de Contenido** | Promoción temporal de contenido con variantes responsivas                                                                              | Página de Inicio      |
 | **Curaduría**            | Proceso de seleccionar, ordenar y presentar historias                                                                                  | Curación              |
+| **Faceta**               | Etiqueta con su conteo dentro del resultado visible y su estado de selección (`CollectionFacet`)                                       | Curación              |
 
 ---
 
 ## Patrones y Estrategias
+
+### Patrón: Faceta (Faceted Navigation)
+
+**Descripción:** una **faceta** es una etiqueta acompañada de cuántas entidades del resultado **visible** la llevan, más si está elegida como filtro. No es la etiqueta: `Tag` es un documento del CMS que existe con independencia de que algo lo use, mientras que una faceta solo existe contra un conjunto de resultados concreto y su número cambia cada vez que ese conjunto cambia.
+
+**Origen del término:** viene de la clasificación facetada de la biblioteconomía (S. R. Ranganathan, década de 1930), que clasifica un objeto por varios ejes independientes en lugar de por un único árbol jerárquico. Recuperación de información lo adoptó, y de ahí pasó a los motores de búsqueda —Solr y Elasticsearch llaman _faceting_ a la agregación que cuenta documentos por valor de campo— y a las interfaces de catálogo, donde _faceted navigation_ nombra la columna de filtros con su conteo al lado. Es vocabulario **foráneo al dominio de La Cuentoneta**: se adopta porque nombra con precisión una figura que ya existía sin nombre, no porque el negocio hablara así.
+
+**Semántica que hay que preservar:**
+
+- El conteo se calcula sobre lo que está a la vista, **no** sobre el catálogo entero: al elegir una etiqueta, las demás ajustan su número a lo que queda.
+- Una faceta que llegaría a cero no se ofrece. De ahí se sigue una garantía que conviene no romper: elegir filtros **nunca puede vaciar el listado**, porque toda faceta ofrecida tiene al menos una entidad detrás.
+- Combinar dos facetas es conjunción, no disyunción: el resultado son las entidades que llevan **todas** las etiquetas elegidas.
+- La selección no es estado de la faceta sino del listado: quien filtra decide, y la faceta se limita a reflejar esa decisión. Así el panel nunca puede discrepar de lo que se está mostrando.
+
+**Dónde vive:** es un **modelo de lectura derivado**, no un agregado ni un objeto de valor del contenido. No se persiste en Sanity, ninguna query GROQ la produce y no viaja por el API: hoy se calcula en el frontend sobre las entidades ya cargadas. Si el filtrado pasara a resolverse contra la base, lo que cambia es dónde se cuenta —la agregación la haría la query—, no el concepto ni su semántica.
+
+**Qué no es:**
+
+- No es una etiqueta con un contador pegado: fuera de un resultado concreto, una faceta no significa nada.
+- No es una taxonomía nueva. Las facetas de hoy salen de las etiquetas existentes; otro eje de clasificación (autor, año, extensión) daría facetas distintas sobre el mismo patrón.
 
 ### Patrón: Clave de Negocio (Business Key)
 

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -70,7 +70,7 @@ POST /api/story/most-read          # Obtener historias más leídas
 **Agregados Raíz:**
 
 - `Storylist` - Colecciones de historias
-- `Collection` - Colecciones de obras literarias (entidad paralela a `Storylist`, no la reemplaza todavía). El modelo de dominio ya existe (`createCollection` y `createCollectionTeaser`, con invariantes hechas cumplir en código, y su propio corpus de mocks), y el repository de Sanity también, con su ACL adentro: la colección por slug, que transporta sus obras, y el listado, que devuelve teasers. El service, el controller y el traspaso del contenido real desde el Studio siguen siendo trabajo posterior, y `Storylist` sigue vigente hasta que se complete
+- `Collection` - Colecciones de obras literarias, **en reemplazo de `Storylist`**. El módulo está completo de punta a punta: modelo de dominio con invariantes hechas cumplir en código (`createCollection`, `createCollectionTeaser`) y su propio corpus de mocks, repository de Sanity con la ACL adentro, service, controller y rutas montadas — la colección por slug, que transporta sus obras, y el catálogo, que devuelve teasers. El contenido ya migró desde el Studio y `/collection` es la ruta que se indexa. `Storylist` sobrevive solo hasta que se den de baja su document type y las redirecciones permanentes de sus URLs, cada uno con su propio issue
 
 **Responsabilidades:**
 
@@ -82,6 +82,8 @@ POST /api/story/most-read          # Obtener historias más leídas
 **Interfaces de API:**
 
 ```
+GET /api/collection                # Catálogo de colecciones, en vista de teaser
+GET /api/collection/:slug          # Colección completa, con sus obras literarias
 GET /api/storylist/:slug           # Obtener colección completa
 GET /api/storylist/:slug/teaser    # Obtener resumen de colección
 ```
@@ -400,7 +402,7 @@ Las historias se referencian directamente en el array `stories`. Cada entrada es
 
 **Raíz de Agregado:** `Collection`
 
-> `Collection` es una **entidad paralela e independiente** a `Storylist`: agrupa `LiteraryWork` en vez de `Story`. Nace **en paralelo**, no la reemplaza — `Storylist` sigue vigente y sirviendo la página actual hasta su baja, que es un trabajo aparte. Es la **segunda** raíz de agregado con **invariantes hechas cumplir en código** (factory `createCollection` + el value object `Slug`, en `src/models/collection.model.ts`), después de `LiteraryWork`: `Storylist` y `Author` siguen teniendo las suyas descritas más abajo, pero no exigidas por un constructor. Esa es la dirección del proyecto, no una excepción puntual — cada entidad nueva del catálogo suma sus invariantes al código en vez de solo documentarlas.
+> `Collection` **reemplaza** a `Storylist`: agrupa `LiteraryWork` en vez de `Story`. Nació como entidad paralela e independiente, y hoy el reemplazo está consumado en lo que se sirve — el contenido migró y `/collection` es la ruta indexada—; `Storylist` sobrevive solo hasta la baja de su document type y las redirecciones de sus URLs, cada una un trabajo aparte. Es la **segunda** raíz de agregado con **invariantes hechas cumplir en código** (factory `createCollection` + el value object `Slug`, en `src/models/collection.model.ts`), después de `LiteraryWork`: `Storylist` y `Author` siguen teniendo las suyas descritas más abajo, pero no exigidas por un constructor. Esa es la dirección del proyecto, no una excepción puntual — cada entidad nueva del catálogo suma sus invariantes al código en vez de solo documentarlas.
 
 ```typescript
 interface Collection {
@@ -452,6 +454,20 @@ Creación de colección → Adición de obras literarias → Publicación de col
 
 **Relación con LiteraryWork:**
 Las obras se referencian directamente en el array `literaryWorks`. Cada entrada es una proyección de tipo `LiteraryWorkTeaser`, igual que `Storylist.stories` proyecta `Story` a `StoryTeaserWithAuthor`. La proyección GROQ anidada de `mediaSources` en esas entradas trae solo el tag (`{ _type }`), que el ACL mapea con `mapMediaTeasers` a `MediaTeaser[]`; el `mediaSources` de nivel documento de `Collection` sigue siendo la vista completa, mapeada con `mapMediaSources`.
+
+**Puntos de contacto con `LiteraryWork`:**
+
+`Collection` no define su propia noción de obra: la toma entera de `LiteraryWork`. Estas son las costuras por las que se tocan, y son las que hay que revisar de conjunto ante cualquier cambio en el vocabulario de la obra.
+
+| Capa                      | Dónde                                                        | Qué toca                                                                                                                   |
+| ------------------------- | ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| **Modelo**                | `src/models/collection.model.ts`                             | `literaryWorks: readonly LiteraryWorkTeaser[]` en la vista completa; `Array<never>` en la de teaser                        |
+| **DTO de transporte**     | `src/models/collection.dto.ts`                               | Reutiliza el schema del teaser de obra en vez de declarar uno propio                                                       |
+| **Query GROQ**            | `src/api/_queries/collection.query.ts`                       | Proyección anidada `literaryWorks[]->`, con `mediaSources` reducido a su tag                                               |
+| **ACL**                   | `src/api/modules/collection/collection.repository.sanity.ts` | Ensambla el teaser de obra con las primitivas compartidas (`createSlug`, `createReadingTime`, `createLiteraryWorkExcerpt`) |
+| **Provider del frontend** | `src/app/providers/collection.provider.ts`                   | `toLiteraryWorkTeaser`, ACL simétrico al del backend sobre el mismo DTO                                                    |
+| **Tipos del kernel**      | `@models/*`                                                  | `Slug`, `Tag`, `Media`/`MediaTeaser`, `SanitizedHtml`, `ReadingTime` — compartidos, no duplicados                          |
+| **Schema del Studio**     | `cms/schemas/collection.ts`                                  | El campo `literaryWorks` referencia documentos `literaryWork`                                                              |
 
 **Tres diferencias con `Storylist`** (más allá de agrupar `LiteraryWork` en vez de `Story`):
 
@@ -769,21 +785,21 @@ El **Lenguaje Ubicuo** es el lenguaje estructurado alrededor del modelo de domin
 
 ### Términos Clave
 
-| Término                  | Definición                                                                                                                             | Contexto              |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| **Historia**             | Obra literaria curada y publicada en la plataforma                                                                                     | Catálogo de Contenido |
-| **Obra literaria**       | Obra con secciones/capítulos (`LiteraryWork`), paralela a Historia                                                                     | Catálogo de Contenido |
-| **Sección / Capítulo**   | Unidad de contenido de una obra literaria: epígrafes + cuerpo Markdown saneado                                                         | Catálogo de Contenido |
-| **Anónimo**              | Author real del catálogo (slug `anonimo`) que representa la obra sin autoría atribuida (policy `isAnonymous`)                          | Catálogo de Contenido |
-| **Slug**                 | Identificador amigable, único e inmutable basado en el título                                                                          | Todos                 |
-| **Epígrafe**             | Cita literaria que precede al texto principal                                                                                          | Catálogo de Contenido |
-| **Teaser**               | Vista reducida de una entidad para listados y navegación                                                                               | Todos                 |
-| **Colección**            | Agrupación temática u editorial de historias (`Storylist`) o de obras literarias (`Collection`, en paralelo — no la reemplaza todavía) | Curación              |
-| **Colaborador**          | Persona que contribuye al proyecto en algún rol                                                                                        | Administración        |
-| **Recurso**              | Enlace externo a información complementaria                                                                                            | Catálogo de Contenido |
-| **Campaña de Contenido** | Promoción temporal de contenido con variantes responsivas                                                                              | Página de Inicio      |
-| **Curaduría**            | Proceso de seleccionar, ordenar y presentar historias                                                                                  | Curación              |
-| **Faceta**               | Etiqueta con su conteo dentro del resultado visible y su estado de selección (`CollectionFacet`)                                       | Curación              |
+| Término                  | Definición                                                                                                      | Contexto              |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- | --------------------- |
+| **Historia**             | Obra literaria curada y publicada en la plataforma                                                              | Catálogo de Contenido |
+| **Obra literaria**       | Obra con secciones/capítulos (`LiteraryWork`), paralela a Historia                                              | Catálogo de Contenido |
+| **Sección / Capítulo**   | Unidad de contenido de una obra literaria: epígrafes + cuerpo Markdown saneado                                  | Catálogo de Contenido |
+| **Anónimo**              | Author real del catálogo (slug `anonimo`) que representa la obra sin autoría atribuida (policy `isAnonymous`)   | Catálogo de Contenido |
+| **Slug**                 | Identificador amigable, único e inmutable basado en el título                                                   | Todos                 |
+| **Epígrafe**             | Cita literaria que precede al texto principal                                                                   | Catálogo de Contenido |
+| **Teaser**               | Vista reducida de una entidad para listados y navegación                                                        | Todos                 |
+| **Colección**            | Agrupación temática u editorial de obras literarias (`Collection`); `Storylist` es la forma anterior, en retiro | Curación              |
+| **Colaborador**          | Persona que contribuye al proyecto en algún rol                                                                 | Administración        |
+| **Recurso**              | Enlace externo a información complementaria                                                                     | Catálogo de Contenido |
+| **Campaña de Contenido** | Promoción temporal de contenido con variantes responsivas                                                       | Página de Inicio      |
+| **Curaduría**            | Proceso de seleccionar, ordenar y presentar historias                                                           | Curación              |
+| **Faceta**               | Etiqueta con su conteo dentro del resultado visible y su estado de selección (`CollectionFacet`)                | Curación              |
 
 ---
 


### PR DESCRIPTION
## Qué pedía el issue, y qué encontró la verificación

El issue pedía dejar preparada la infraestructura de `Collection` para el rename de `Story` a `LiteraryWork`, y su propia nota advertía que llegaría tarde si se tomaba con el código ya escrito. Eso fue lo que pasó: se verificó el estado real antes de planificar nada.

**La nomenclatura ya está alineada, en las cuatro capas.** El barrido de residuo de vocabulario `Story`/`storylist` sobre el módulo —modelo, DTO, query, repository, service, controller, provider del frontend y schema del Studio— devuelve **cero ocurrencias**:

- Modelo: `Collection.literaryWorks: readonly LiteraryWorkTeaser[]`
- Query GROQ: `'literaryWorks': coalesce(literaryWorks[]->{…`
- Schema del Studio: el campo `literaryWorks` referencia documentos `literaryWork`
- ACL: el repository tipa `LiteraryWorkTeaser`

Así que no hay nada que corregir en código, y este PR no toca ninguno. Lo que faltaba era el **registro**.

## Qué entra

**El inventario de puntos de contacto**, como tabla junto al agregado en `docs/DOMAIN_MODEL.md`: qué capa toca a `LiteraryWork` y por dónde —modelo, DTO de transporte, query, ACL, provider del frontend, tipos del kernel y schema del Studio—. Es la entrega que el issue pedía y que hasta ahora solo existía repartida entre el código y la prosa. Enuncia qué toca qué, sin repetir las definiciones que ya están arriba en el mismo documento.

**Tres afirmaciones que dejaron de ser ciertas:**

1. `Collection` descrita como «entidad paralela — no la reemplaza todavía». El contenido ya migró, `/collection` es la ruta que se indexa y el catálogo de `/storylist` fue retirado. El reemplazo está consumado en lo que se sirve; lo que resta es la baja del document type y las redirecciones, cada una con su issue.
2. «El service, el controller y el traspaso del contenido siguen siendo trabajo posterior». El módulo está completo de punta a punta y sus rutas están montadas.
3. La misma nota, en la referencia del ACL: `collection` ya no está «a mitad de camino».

**Dos huecos:** faltaban `GET /api/collection` y `GET /api/collection/:slug` en la lista de endpoints del contexto de Curación, y faltaba `CollectionApi` en la tabla de API providers del frontend — que es, literalmente, el punto de contacto «providers» que el issue pedía documentar.

## Un commit que no es de este issue

El primer commit es un **cherry-pick**: documenta «faceta» como término de dominio y quedó varado en la rama de #2309, que sigue sin mergear. El filtrado por facetas llegó a `develop` en cinco rebanadas y **ninguna se llevó esa definición**, así que la funcionalidad está en producción y el término que la explica no estaba documentado en ningún lado. Se trae acá porque toca exactamente los mismos dos archivos que este PR: mantenerlo aparte garantizaba un conflicto.

## Dos premisas del issue que quedaron desactualizadas

Se registran acá porque afectan la coordinación del retiro, no este diff:

- El body dice que el id `collection` se libera con la baja de los schemas viejos. **Ya está registrado en el Studio**; `storylist` y `collection` son documentos distintos que coexisten sin colisión. Lo que depende de aquel issue es la baja de `story`/`storylist`, no la liberación de `collection`.
- La tarea de trasladar los stable slugs al corpus de Onoff **ya se resolvió** en su propio issue, cerrado.

## Fuera de alcance, deliberadamente

El sitemap no emite una entrada por colección, solo la raíz `/collection`. No se aborda acá: ya está en el alcance explícito del issue de redirecciones y canónicas.

## Plan de pruebas

- `pnpm check:agents` en verde — valida el frontmatter, las anclas a `CLAUDE.md`, las rutas citadas por las referencias tocadas y que ninguna nombre un issue fuera de la allowlist de gobernanza.
- Sin tests nuevos: el diff no toca código ejecutable. Es la exención por naturaleza del cambio, no por tamaño.
- Verificado que las tres afirmaciones corregidas no sobreviven en otro lugar del documento.

Closes #1841.

Parte de #1472.
