### PR TITLE
[#1080] - Tests de ReadPage: e2e (Playwright) + unitarios

### DIFF
--- a/cms/migrations/add-a-la-deriva-audio-narration/README.md
+++ b/cms/migrations/add-a-la-deriva-audio-narration/README.md
@@ -1,0 +1,41 @@
+# `add-a-la-deriva-audio-narration`
+
+Agrega a la obra **"A la deriva"** su narración en audio —el episodio real del podcast _Armario de Cuentos_ en Spotify— como segundo recurso multimedia.
+
+## Por qué
+
+Ninguna obra de ningún dataset tenía dos formatos multimedia de tipos distintos: el selector de formatos de la página de lectura nunca tuvo datos reales que lo ejerciten. Los tests de extremo a extremo afirman el cambio de formato sobre esta obra, y su guarda de curaduría sale roja —a propósito, nombrando qué falta— en todo dataset donde esta migración no haya corrido.
+
+El recurso es **contenido editorial genuino** (una narración real del cuento correcto), así que vale igual para `production`: no es un fixture que haya que limpiar después.
+
+## Semántica
+
+- **Idempotente por URL, no por clave:** el dataset ya curado a mano lleva el mismo episodio, y un recurso cargado desde el Studio tendría clave propia; la identidad real del episodio es su URL, y duplicarlo mostraría dos veces la misma narración en el selector.
+- **Recorre también los borradores:** publicar uno creado antes de la corrida reemplaza al documento publicado por su contenido, y dejarlo afuera perdería el recurso en esa publicación.
+- Sólo toca la obra `a-la-deriva`; el filtro se revalida sobre el documento.
+
+## Comandos
+
+Desde `cms/`. El destino va siempre explícito: `--project` y `--dataset` son **inseparables**. El identificador de proyecto se resuelve del entorno, nunca se escribe literal.
+
+```bash
+# Dry-run (es el comportamiento por defecto)
+pnpm exec sanity migration run add-a-la-deriva-audio-narration \
+  --project "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')" \
+  --dataset <destino>
+
+# Aplicar. `--no-confirm` hace falta cuando no hay TTY.
+pnpm exec sanity migration run add-a-la-deriva-audio-narration \
+  --project "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')" \
+  --dataset <destino> --no-dry-run --no-confirm
+```
+
+Destinos pendientes: **`staging`** (destraba el gate `e2e` de CI) y **`production`** (editorial). En `development` ya está curado a mano y la corrida es un no-op, que también sirve de verificación de la idempotencia.
+
+## Verificación posterior
+
+```groq
+count(array::unique(*[_type == 'literaryWork' && slug.current == 'a-la-deriva'][0].mediaSources[]._type))
+```
+
+Debe dar **2 o más**. Es la misma propiedad —tipos distintos, no cantidad— que exige la guarda de los e2e.

--- a/cms/migrations/add-a-la-deriva-audio-narration/index.spec.ts
+++ b/cms/migrations/add-a-la-deriva-audio-narration/index.spec.ts
@@ -1,0 +1,76 @@
+import { evaluate, parse } from 'groq-js';
+import { describe, expect, it } from 'vitest';
+
+import migration, { AUDIO_NARRATION } from './index';
+
+const migrateDocument = (doc: Record<string, unknown>) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never) as { path: string[]; op: { type: string; items?: unknown[] } }[];
+};
+
+const youTubeVideo = { _key: 'yt1', _type: 'youTubeVideo', videoId: 'ymKePA9X7eQ' };
+
+const aLaDeriva = (overrides: Record<string, unknown> = {}) => ({
+	_id: 'lw-a-la-deriva',
+	_type: 'literaryWork',
+	slug: { current: 'a-la-deriva' },
+	mediaSources: [youTubeVideo],
+	...overrides,
+});
+
+describe('migración de la narración en audio de A la deriva', () => {
+	// El filtro se ejecuta con el mismo motor que GROQ y no se compara como texto: una aserción textual
+	// pasa igual con un filtro roto mientras el literal coincida.
+	describe('el filtro decide qué entra', () => {
+		const matching = async (...docs: Record<string, unknown>[]) => {
+			const result = await evaluate(parse(`*[${migration.filter}]._id`), { dataset: docs });
+			return (await result.get()) as string[];
+		};
+
+		it('admite la obra y también su borrador', async () => {
+			const docs = [aLaDeriva(), aLaDeriva({ _id: 'drafts.lw-a-la-deriva' })];
+
+			expect(await matching(...docs)).toEqual(['lw-a-la-deriva', 'drafts.lw-a-la-deriva']);
+		});
+
+		it('deja fuera cualquier otra obra', async () => {
+			expect(await matching({ _id: 'otra', _type: 'literaryWork', slug: { current: 'el-fin' } })).toEqual([]);
+		});
+	});
+
+	it('agrega la narración al final de los recursos existentes', () => {
+		const patches = migrateDocument(aLaDeriva());
+
+		expect(patches.map(({ path, op }) => [path[0], op.type])).toEqual([
+			['mediaSources', 'setIfMissing'],
+			['mediaSources', 'insert'],
+		]);
+		expect(patches[1].op.items).toEqual([AUDIO_NARRATION]);
+	});
+
+	it('crea el array cuando la obra no declara ningún recurso', () => {
+		const patches = migrateDocument(aLaDeriva({ mediaSources: undefined }));
+
+		expect(patches).toHaveLength(2);
+	});
+
+	// La identidad del recurso es su URL, no su clave: el dataset curado a mano lleva el mismo episodio
+	// bajo la misma clave, pero uno cargado desde el Studio tendría clave propia y sigue siendo el mismo
+	// contenido — duplicarlo mostraría dos veces la misma narración en el selector.
+	it('no duplica el episodio aunque esté bajo otra clave', () => {
+		const alreadyCurated = aLaDeriva({
+			mediaSources: [
+				youTubeVideo,
+				{ _key: 'clave-del-studio', _type: 'spotifyPodcastEpisode', url: AUDIO_NARRATION.url },
+			],
+		});
+
+		expect(migrateDocument(alreadyCurated)).toEqual([]);
+	});
+
+	// El guard revalida sobre el documento porque el filtro es una optimización del runner, no la garantía.
+	it('ignora una obra que no es la del recurso', () => {
+		expect(migrateDocument({ _id: 'otra', slug: { current: 'el-fin' }, mediaSources: [] })).toEqual([]);
+	});
+});

--- a/cms/migrations/add-a-la-deriva-audio-narration/index.ts
+++ b/cms/migrations/add-a-la-deriva-audio-narration/index.ts
@@ -1,0 +1,57 @@
+import { append, at, defineMigration, setIfMissing } from 'sanity/migrate';
+
+/**
+ * La narración real del cuento por el podcast Armario de Cuentos. Es contenido editorial genuino —no un
+ * fixture inventado—, así que el mismo recurso vale para los tres datasets; además le da a la obra el
+ * segundo formato de tipo distinto que los tests de extremo a extremo necesitan para afirmar el cambio
+ * de formato, una propiedad que hasta esta curación ningún documento de ningún dataset cumplía.
+ */
+export const AUDIO_NARRATION = Object.freeze({
+	_key: 'e2efixture0801',
+	_type: 'spotifyPodcastEpisode',
+	title: 'Narración del cuento en formato audio',
+	description: 'Narración del cuento tomada del podcast *Armario de Cuentos*, disponible en Spotify.',
+	url: 'https://open.spotify.com/episode/6VhnNw8hKIh0mQNskcFLAz',
+});
+
+const TARGET_SLUG = 'a-la-deriva';
+
+interface MediaSource {
+	_key: string;
+	_type: string;
+	url?: string;
+}
+
+interface LiteraryWorkDocument {
+	_id: string;
+	slug?: { current?: string };
+	mediaSources?: MediaSource[];
+}
+
+/**
+ * Agrega la narración en audio de "A la deriva" a sus recursos multimedia.
+ *
+ * Es idempotente **por URL**, no por clave: el dataset ya curado a mano lleva el mismo episodio y no debe
+ * duplicarse, y la URL es la identidad real del recurso — una clave distinta con el mismo episodio sigue
+ * siendo el mismo contenido dos veces.
+ *
+ * Recorre también los borradores: publicar uno creado antes de la corrida reemplaza al documento
+ * publicado por su contenido, y dejarlo afuera perdería el recurso en esa publicación.
+ */
+export default defineMigration({
+	title: 'Agregar la narración en audio de A la deriva a sus recursos multimedia',
+	documentTypes: ['literaryWork'],
+	filter: `slug.current == "${TARGET_SLUG}"`,
+	migrate: {
+		document(doc: LiteraryWorkDocument) {
+			// El filtro es una optimización del runner, no la garantía: se revalida sobre el documento.
+			if (doc.slug?.current !== TARGET_SLUG) {
+				return [];
+			}
+			if ((doc.mediaSources ?? []).some((media) => media.url === AUDIO_NARRATION.url)) {
+				return [];
+			}
+			return [at('mediaSources', setIfMissing([])), at('mediaSources', append([AUDIO_NARRATION]))];
+		},
+	},
+});

--- a/e2e/_utils/read-fixtures.ts
+++ b/e2e/_utils/read-fixtures.ts
@@ -1,39 +1,39 @@
 /**
- * Fixture de la obra estable para los e2e de la página de lectura.
+ * Fixtures de obras para los e2e de la página de lectura.
  *
- * La identidad sale de `STABLE_SLUGS.literaryWork`; todo lo demás se resuelve en runtime contra el API,
- * para que las aserciones se deriven de lo que el dataset efectivamente sirve y no de prosa clavada en el
- * spec. Las propiedades de curaduría que la obra necesita cumplir (formatos multimedia, otra obra del
- * autor) las afirman guardas propias del spec: acá sólo se trae el dato.
+ * La identidad sale de los slugs estables de `seo-fixtures`; todo lo demás se resuelve en runtime contra
+ * el API, para que las aserciones se deriven de lo que el dataset efectivamente sirve y no de prosa
+ * clavada en el spec. Las propiedades de curaduría que cada obra necesita cumplir (formatos multimedia,
+ * otra obra del autor) las afirman guardas propias del spec: acá sólo se trae el dato.
  */
 import type { APIRequestContext } from '@playwright/test';
 
 import { literaryWorkDtoSchema, type LiteraryWorkDto } from '@models/literary-work.dto';
 
-import { STABLE_SLUGS } from './seo-fixtures';
-
-const STABLE_LITERARY_WORK_ROUTE = `/api/literary-work/${STABLE_SLUGS.literaryWork}`;
-
 /**
- * La obra estable tal como la entrega el API, o `undefined` si el dataset no la tiene.
+ * Una obra tal como la entrega el API, o `undefined` si el dataset no la tiene.
  *
  * Sólo el 404 se traduce a `undefined` —es el estado que la guarda del spec reporta como fixture
  * ausente—; cualquier otro fallo lanza, porque un API caído no es una obra ausente y confundirlos
  * haría que la guarda diagnostique curaduría donde hay infraestructura.
  */
-export async function fetchStableLiteraryWork(request: APIRequestContext): Promise<LiteraryWorkDto | undefined> {
-	const response = await request.get(STABLE_LITERARY_WORK_ROUTE);
+export async function fetchLiteraryWork(
+	request: APIRequestContext,
+	slug: string,
+): Promise<LiteraryWorkDto | undefined> {
+	const route = `/api/literary-work/${slug}`;
+	const response = await request.get(route);
 	if (response.status() === 404) {
 		return undefined;
 	}
 	if (response.status() !== 200) {
-		throw new Error(`"${STABLE_LITERARY_WORK_ROUTE}" respondió ${response.status()}: el API no está sirviendo obras`);
+		throw new Error(`"${route}" respondió ${response.status()}: el API no está sirviendo obras`);
 	}
 
 	// Un cambio de contrato llega como error de contrato, no como una aserción comparando contra undefined.
 	const parsed = literaryWorkDtoSchema.safeParse(await response.json());
 	if (!parsed.success) {
-		throw new Error(`"${STABLE_LITERARY_WORK_ROUTE}" no cumple el contrato de la obra: ${parsed.error.message}`);
+		throw new Error(`"${route}" no cumple el contrato de la obra: ${parsed.error.message}`);
 	}
 	return parsed.data;
 }

--- a/e2e/_utils/read-fixtures.ts
+++ b/e2e/_utils/read-fixtures.ts
@@ -1,0 +1,39 @@
+/**
+ * Fixture de la obra estable para los e2e de la página de lectura.
+ *
+ * La identidad sale de `STABLE_SLUGS.literaryWork`; todo lo demás se resuelve en runtime contra el API,
+ * para que las aserciones se deriven de lo que el dataset efectivamente sirve y no de prosa clavada en el
+ * spec. Las propiedades de curaduría que la obra necesita cumplir (formatos multimedia, otra obra del
+ * autor) las afirman guardas propias del spec: acá sólo se trae el dato.
+ */
+import type { APIRequestContext } from '@playwright/test';
+
+import { literaryWorkDtoSchema, type LiteraryWorkDto } from '@models/literary-work.dto';
+
+import { STABLE_SLUGS } from './seo-fixtures';
+
+const STABLE_LITERARY_WORK_ROUTE = `/api/literary-work/${STABLE_SLUGS.literaryWork}`;
+
+/**
+ * La obra estable tal como la entrega el API, o `undefined` si el dataset no la tiene.
+ *
+ * Sólo el 404 se traduce a `undefined` —es el estado que la guarda del spec reporta como fixture
+ * ausente—; cualquier otro fallo lanza, porque un API caído no es una obra ausente y confundirlos
+ * haría que la guarda diagnostique curaduría donde hay infraestructura.
+ */
+export async function fetchStableLiteraryWork(request: APIRequestContext): Promise<LiteraryWorkDto | undefined> {
+	const response = await request.get(STABLE_LITERARY_WORK_ROUTE);
+	if (response.status() === 404) {
+		return undefined;
+	}
+	if (response.status() !== 200) {
+		throw new Error(`"${STABLE_LITERARY_WORK_ROUTE}" respondió ${response.status()}: el API no está sirviendo obras`);
+	}
+
+	// Un cambio de contrato llega como error de contrato, no como una aserción comparando contra undefined.
+	const parsed = literaryWorkDtoSchema.safeParse(await response.json());
+	if (!parsed.success) {
+		throw new Error(`"${STABLE_LITERARY_WORK_ROUTE}" no cumple el contrato de la obra: ${parsed.error.message}`);
+	}
+	return parsed.data;
+}

--- a/e2e/_utils/seo-fixtures.ts
+++ b/e2e/_utils/seo-fixtures.ts
@@ -6,6 +6,10 @@ export const STABLE_SLUGS = Object.freeze({
 	// Cada slug de acá tiene que existir en los dos datasets que sirven a los e2e (development en local,
 	// staging en CI): el que exista solo en uno deja sus casos salteados justo donde tenían que correr.
 	literaryWork: 'el-fin',
+	// La obra estable con curaduría multimedia: al menos dos recursos, para que el cambio de formato
+	// tenga qué elegir, y de un autor con más de una obra, para que las sugerencias del pie no salgan
+	// vacías. `el-fin` no puede cubrir ninguna de las dos cosas.
+	literaryWorkWithMedia: 'a-la-deriva',
 	// El mismo de storylist a propósito: las dos rutas sirven la misma colección hasta que una redirija
 	// a la otra, y compartir el slug deja esa comparación al alcance.
 	collection: 'verano-2022',

--- a/e2e/read.spec.ts
+++ b/e2e/read.spec.ts
@@ -49,7 +49,10 @@ async function openWork(page: Page, route: string): Promise<void> {
 
 test('read — el hero presenta la obra que el API dice que es', async ({ page }) => {
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
-	test.skip(status !== 200 || !work, `"${ROUTE}" no responde 200 en el dataset`);
+	test.skip(status !== 200, `"${ROUTE}" no responde 200 en el dataset`);
+	// Separado del anterior: un motivo compuesto reporta siempre el primero, y el diagnóstico se pierde.
+	// eslint-disable-next-line playwright/no-skipped-test -- ídem
+	test.skip(!work, `el API no sirve "${STABLE_SLUGS.literaryWork}"`);
 
 	await openWork(page, ROUTE);
 
@@ -78,14 +81,20 @@ test('read — una obra inexistente ofrece la vuelta al inicio', async ({ page }
 	await expect(page).toHaveURL(/\/home$/);
 });
 
+// El caso del cambio de formato afirma por el tipo del widget montado, así que dos recursos del mismo
+// tipo pasarían un conteo y lo matarían igual: la propiedad que la curaduría debe sostener es de tipos
+// distintos, y este derivador es el que consumen la guarda y los skips dependientes.
+const distinctMediaTypes = (dto: LiteraryWorkDto | undefined): number =>
+	new Set((dto?.mediaSources ?? []).map(({ type }) => type)).size;
+
 // Guarda de curaduría, como caso propio: el cambio de formato sólo se puede afirmar si la obra curada
-// ofrece más de uno, y ninguna otra puede buscarse porque el módulo no expone un listado. Si esto sale
-// rojo, la acción es cargar un segundo recurso multimedia a esa obra en development y staging.
+// ofrece formatos distintos, y ninguna otra puede buscarse porque el módulo no expone un listado. Si
+// esto sale rojo, la acción es curar esa obra en development y staging.
 test('read — la obra con multimedia ofrece más de un formato', () => {
 	expect(mediaWork, `el API no sirve "${STABLE_SLUGS.literaryWorkWithMedia}"`).toBeDefined();
 	expect(
-		mediaWork?.mediaSources.length ?? 0,
-		`"${STABLE_SLUGS.literaryWorkWithMedia}" necesita al menos dos recursos multimedia en el dataset: sin ellos, el cambio de formato no se verifica en ningún lado`,
+		distinctMediaTypes(mediaWork),
+		`"${STABLE_SLUGS.literaryWorkWithMedia}" necesita al menos dos recursos multimedia de tipos distintos en el dataset: sin ellos, el cambio de formato no se verifica en ningún lado`,
 	).toBeGreaterThan(1);
 });
 
@@ -100,7 +109,7 @@ test('read — el bloque multimedia ofrece una opción por recurso', async ({ pa
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta su guarda; repetirla acá sería el mismo fallo dos veces
 	test.skip(!mediaWork, `"${MEDIA_ROUTE}" no está en el dataset`);
 	// eslint-disable-next-line playwright/no-skipped-test -- ídem: la curaduría faltante la reporta su propia guarda
-	test.skip((mediaWork?.mediaSources.length ?? 0) < 2, 'la obra curada no ofrece formatos para elegir');
+	test.skip(distinctMediaTypes(mediaWork) < 2, 'la obra curada no ofrece formatos distintos para elegir');
 
 	await openWork(page, MEDIA_ROUTE);
 	const block = await settleMediaBlock(page);
@@ -116,7 +125,7 @@ test('read — cambiar de formato monta el widget del formato elegido', async ({
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta su guarda; repetirla acá sería el mismo fallo dos veces
 	test.skip(!mediaWork, `"${MEDIA_ROUTE}" no está en el dataset`);
 	// eslint-disable-next-line playwright/no-skipped-test -- ídem: la curaduría faltante la reporta su propia guarda
-	test.skip((mediaWork?.mediaSources.length ?? 0) < 2, 'la obra curada no ofrece formatos para elegir');
+	test.skip(distinctMediaTypes(mediaWork) < 2, 'la obra curada no ofrece formatos distintos para elegir');
 
 	await openWork(page, MEDIA_ROUTE);
 	const block = await settleMediaBlock(page);
@@ -124,7 +133,8 @@ test('read — cambiar de formato monta el widget del formato elegido', async ({
 
 	// Se afirma por el componente de widget montado, no por el contenido del proveedor: YouTube y
 	// Spotify en CI son flaky, y qué widget se monta es exactamente lo que el selector decide. El tag
-	// del elemento delata el formato sin esperar ninguna carga externa.
+	// del elemento delata el formato sin esperar ninguna carga externa. La lista enumera los widgets del
+	// catálogo (`media-widget-registry.ts`): uno nuevo se suma acá para que el caso lo alcance.
 	const widgets = block.locator(
 		'cuentoneta-youtube-video-widget, cuentoneta-spotify-audio-widget, cuentoneta-audio-recording-widget, cuentoneta-space-recording-widget',
 	);
@@ -142,11 +152,15 @@ test('read — cambiar de formato monta el widget del formato elegido', async ({
 	await expect(widgets).toHaveCount(1);
 });
 
-/** Scrollea hasta el pie y espera las sugerencias, que difieren por viewport. */
-async function settleSuggestions(page: Page, headingPattern: RegExp) {
+/**
+ * Scrollea hasta el pie y espera las sugerencias, que difieren por viewport.
+ *
+ * El heading va como string y no como patrón: interpolar un nombre de autor o un título de colección en
+ * una expresión regular reinterpreta su puntuación como sintaxis, y el nombre lo decide la curaduría.
+ */
+async function settleSuggestions(page: Page, heading: string) {
 	await page.locator('cuentoneta-reading-suggestions').scrollIntoViewIfNeeded();
-	const heading = page.getByRole('heading', { name: headingPattern });
-	await expect(heading).toBeVisible();
+	await expect(page.getByRole('heading', { name: heading })).toBeVisible();
 }
 
 // Ancla en la obra curada y no en la estable: el autor de `el-fin` tiene una sola obra publicada, así
@@ -156,15 +170,17 @@ test('read — sin contexto, el pie sugiere más obras del autor', async ({ page
 	test.skip(!mediaWork, `"${MEDIA_ROUTE}" no está en el dataset`);
 
 	await openWork(page, MEDIA_ROUTE);
-	await settleSuggestions(page, new RegExp(`Más obras de ${mediaWork?.authors[0]?.name}`));
+	await settleSuggestions(page, `Más obras de ${mediaWork?.authors[0]?.name}`);
 
 	// Los enlaces de lectura se acotan por prefijo: el bloque ofrece además el acceso a la página del
 	// autor ("ver más"), que es parte del diseño y se afirma aparte.
 	const readingLinks = page.locator('cuentoneta-reading-suggestions').locator('a[href^="/read/"]');
 
-	// Control positivo: sin él, una lista vacía dejaría la exclusión de abajo cumpliéndose en vacío. Si
-	// esto falla, la curaduría pendiente es que el autor de la obra curada tenga otra obra publicada.
-	await expect(readingLinks.first()).toBeVisible();
+	// Control positivo: sin él, una lista vacía dejaría la exclusión de abajo cumpliéndose en vacío.
+	await expect(
+		readingLinks.first(),
+		'no hay sugerencias: la curaduría pendiente es que el autor de la obra curada tenga otra obra publicada',
+	).toBeVisible();
 
 	const destinations = await readingLinks.evaluateAll((links) => links.map((link) => link.getAttribute('href') ?? ''));
 	expect(
@@ -188,8 +204,6 @@ test('read — sin contexto, el pie sugiere más obras del autor', async ({ page
 // y la página los CONSUME. Entrar directo con la URL armada probaría la mitad de consumo, que el spec
 // unitario ya cubre.
 test('read — llegar desde una colección cambia la fuente de las sugerencias', async ({ page }) => {
-	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
-	test.skip(status !== 200 || !work, `"${ROUTE}" no responde 200 en el dataset`);
 	// eslint-disable-next-line playwright/no-skipped-test -- el catálogo sin la colección estable ya lo reportan los e2e de colección
 	test.skip(!stableCollection, `el catálogo no trae "${STABLE_SLUGS.collection}"`);
 
@@ -200,5 +214,5 @@ test('read — llegar desde una colección cambia la fuente de las sugerencias',
 	await page.getByTestId('literary-works').locator('a[href^="/read/"]').first().click();
 
 	await expect(page).toHaveURL(/navigation=collection/);
-	await settleSuggestions(page, new RegExp(`Más obras de ${stableCollection?.title}`));
+	await settleSuggestions(page, `Más obras de ${stableCollection?.title}`);
 });

--- a/e2e/read.spec.ts
+++ b/e2e/read.spec.ts
@@ -60,7 +60,7 @@ test('read — el hero presenta la obra que el API dice que es', async ({ page }
 	const author = work?.authors[0];
 	const authorLink = page.getByRole('link', { name: author?.name ?? '' }).first();
 	await expect(authorLink).toBeVisible();
-	expect(await authorLink.getAttribute('href')).toBe(`/author/${author?.slug}`);
+	await expect(authorLink).toHaveAttribute('href', `/author/${author?.slug}`);
 
 	await expect(page.getByText(`${work?.totalReadingTime} minutos de lectura`)).toBeVisible();
 });

--- a/e2e/read.spec.ts
+++ b/e2e/read.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Flujo de la página de lectura hidratada: el hero, el bloque multimedia y las sugerencias del pie.
+ *
+ * `e2e/seo/read.spec.ts` mira esta misma ruta, pero mira el HTML que ve el crawler. Acá se ejercita lo
+ * que sólo existe después de hidratar y en un navegador real: los bloques diferidos (`on idle` /
+ * `on viewport`), la interacción de cambio de formato y la navegación entre páginas con sus query params.
+ *
+ * Las aserciones se derivan del DTO que entrega el API (`_utils/read-fixtures.ts`), no de prosa clavada:
+ * el spec afirma que la página muestra la obra que el API dice que es.
+ */
+import { expect, test, type Page } from '@playwright/test';
+
+import type { LiteraryWorkDto } from '@models/literary-work.dto';
+
+import { fetchLiteraryWork } from './_utils/read-fixtures';
+import { DESKTOP_VIEWPORT, fetchCollectionCatalog, type CollectionCatalogEntry } from './_utils/collection-fixtures';
+import { STABLE_SLUGS } from './_utils/seo-fixtures';
+
+const ROUTE = `/read/${STABLE_SLUGS.literaryWork}`;
+const MEDIA_ROUTE = `/read/${STABLE_SLUGS.literaryWorkWithMedia}`;
+
+let status = 0;
+let work: LiteraryWorkDto | undefined;
+// Los casos de multimedia y de sugerencias anclan en la obra curada para eso: `el-fin` no declara
+// recursos y su autor tiene una sola obra, así que ninguno de los dos frentes se puede afirmar sobre él.
+let mediaWork: LiteraryWorkDto | undefined;
+let stableCollection: CollectionCatalogEntry | undefined;
+
+test.beforeAll(async ({ request }) => {
+	status = (await request.get(ROUTE)).status();
+	work = await fetchLiteraryWork(request, STABLE_SLUGS.literaryWork);
+	mediaWork = await fetchLiteraryWork(request, STABLE_SLUGS.literaryWorkWithMedia);
+	stableCollection = (await fetchCollectionCatalog(request)).find((entry) => entry.slug === STABLE_SLUGS.collection);
+});
+
+// Guardas como casos propios, no como `skip` silencioso: los e2e de esta ruta tienen historia de
+// saltearse en verde cuando el dataset no acompaña, y un caso salteado en CI es cobertura que no existe.
+test('read — la obra estable existe en el dataset y cumple el contrato', () => {
+	expect(status, `"${ROUTE}" no responde 200: nada de esta suite verifica la página real`).toBe(200);
+	expect(work, `el API no sirve "${STABLE_SLUGS.literaryWork}": no habría con qué comparar`).toBeDefined();
+});
+
+/** Abre una obra con su contenido ya resuelto: el recurso bloquea el SSR, así que el h1 llega con el documento. */
+async function openWork(page: Page, route: string): Promise<void> {
+	await page.setViewportSize(DESKTOP_VIEWPORT);
+	await page.goto(route);
+	await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+}
+
+test('read — el hero presenta la obra que el API dice que es', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(status !== 200 || !work, `"${ROUTE}" no responde 200 en el dataset`);
+
+	await openWork(page, ROUTE);
+
+	await expect(page.getByRole('heading', { level: 1 })).toHaveText(work?.title ?? '');
+
+	// El enlace del autor se busca por su nombre accesible: es lo que un lector de pantalla anuncia, y
+	// derivarlo del DTO descarta que la página muestre un autor que no es el de la obra.
+	const author = work?.authors[0];
+	const authorLink = page.getByRole('link', { name: author?.name ?? '' }).first();
+	await expect(authorLink).toBeVisible();
+	expect(await authorLink.getAttribute('href')).toBe(`/author/${author?.slug}`);
+
+	await expect(page.getByText(`${work?.totalReadingTime} minutos de lectura`)).toBeVisible();
+});
+
+// El 404 del SSR ya lo afirma la suite de indexado; acá se cubre lo que sólo el navegador ve: que el
+// estado no encontrado ofrece una salida navegable y que la salida efectivamente navega.
+test('read — una obra inexistente ofrece la vuelta al inicio', async ({ page }) => {
+	await page.setViewportSize(DESKTOP_VIEWPORT);
+	await page.goto('/read/obra-inexistente-e2e');
+
+	await expect(page.getByText('No encontramos esta obra')).toBeVisible();
+
+	await page.getByRole('link', { name: 'Volver al inicio' }).click();
+	// La raíz redirige a /home, así que es la URL en la que el lector efectivamente aterriza.
+	await expect(page).toHaveURL(/\/home$/);
+});
+
+// Guarda de curaduría, como caso propio: el cambio de formato sólo se puede afirmar si la obra curada
+// ofrece más de uno, y ninguna otra puede buscarse porque el módulo no expone un listado. Si esto sale
+// rojo, la acción es cargar un segundo recurso multimedia a esa obra en development y staging.
+test('read — la obra con multimedia ofrece más de un formato', () => {
+	expect(mediaWork, `el API no sirve "${STABLE_SLUGS.literaryWorkWithMedia}"`).toBeDefined();
+	expect(
+		mediaWork?.mediaSources.length ?? 0,
+		`"${STABLE_SLUGS.literaryWorkWithMedia}" necesita al menos dos recursos multimedia en el dataset: sin ellos, el cambio de formato no se verifica en ningún lado`,
+	).toBeGreaterThan(1);
+});
+
+/** Espera el bloque multimedia, que difiere en idle y no viaja en el HTML del servidor. */
+async function settleMediaBlock(page: Page) {
+	const block = page.getByRole('region', { name: /diferentes formatos/i });
+	await expect(block.getByRole('group', { name: 'Formatos disponibles' })).toBeVisible();
+	return block;
+}
+
+test('read — el bloque multimedia ofrece una opción por recurso', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta su guarda; repetirla acá sería el mismo fallo dos veces
+	test.skip(!mediaWork, `"${MEDIA_ROUTE}" no está en el dataset`);
+	// eslint-disable-next-line playwright/no-skipped-test -- ídem: la curaduría faltante la reporta su propia guarda
+	test.skip((mediaWork?.mediaSources.length ?? 0) < 2, 'la obra curada no ofrece formatos para elegir');
+
+	await openWork(page, MEDIA_ROUTE);
+	const block = await settleMediaBlock(page);
+
+	// Una opción por recurso, contra el DTO: un grupo vacío o incompleto delataría un catálogo de widgets
+	// que descarta formatos en silencio.
+	await expect(block.getByRole('group', { name: 'Formatos disponibles' }).getByRole('button')).toHaveCount(
+		mediaWork?.mediaSources.length ?? 0,
+	);
+});
+
+test('read — cambiar de formato monta el widget del formato elegido', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta su guarda; repetirla acá sería el mismo fallo dos veces
+	test.skip(!mediaWork, `"${MEDIA_ROUTE}" no está en el dataset`);
+	// eslint-disable-next-line playwright/no-skipped-test -- ídem: la curaduría faltante la reporta su propia guarda
+	test.skip((mediaWork?.mediaSources.length ?? 0) < 2, 'la obra curada no ofrece formatos para elegir');
+
+	await openWork(page, MEDIA_ROUTE);
+	const block = await settleMediaBlock(page);
+	const options = block.getByRole('group', { name: 'Formatos disponibles' }).getByRole('button');
+
+	// Se afirma por el componente de widget montado, no por el contenido del proveedor: YouTube y
+	// Spotify en CI son flaky, y qué widget se monta es exactamente lo que el selector decide. El tag
+	// del elemento delata el formato sin esperar ninguna carga externa.
+	const widgets = block.locator(
+		'cuentoneta-youtube-video-widget, cuentoneta-spotify-audio-widget, cuentoneta-audio-recording-widget, cuentoneta-space-recording-widget',
+	);
+	const mountedWidget = () => widgets.first().evaluate((element) => element.tagName.toLowerCase());
+
+	// Control positivo: hay exactamente un widget montado antes de elegir.
+	await expect(widgets).toHaveCount(1);
+	const widgetBefore = await mountedWidget();
+
+	await options.nth(1).click();
+
+	await expect
+		.poll(mountedWidget, { message: 'el widget no cambió tras elegir el segundo formato' })
+		.not.toBe(widgetBefore);
+	await expect(widgets).toHaveCount(1);
+});
+
+/** Scrollea hasta el pie y espera las sugerencias, que difieren por viewport. */
+async function settleSuggestions(page: Page, headingPattern: RegExp) {
+	await page.locator('cuentoneta-reading-suggestions').scrollIntoViewIfNeeded();
+	const heading = page.getByRole('heading', { name: headingPattern });
+	await expect(heading).toBeVisible();
+}
+
+// Ancla en la obra curada y no en la estable: el autor de `el-fin` tiene una sola obra publicada, así
+// que sus sugerencias por autor salen vacías y el caso no afirmaría nada.
+test('read — sin contexto, el pie sugiere más obras del autor', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta su guarda; repetirla acá sería el mismo fallo dos veces
+	test.skip(!mediaWork, `"${MEDIA_ROUTE}" no está en el dataset`);
+
+	await openWork(page, MEDIA_ROUTE);
+	await settleSuggestions(page, new RegExp(`Más obras de ${mediaWork?.authors[0]?.name}`));
+
+	// Los enlaces de lectura se acotan por prefijo: el bloque ofrece además el acceso a la página del
+	// autor ("ver más"), que es parte del diseño y se afirma aparte.
+	const readingLinks = page.locator('cuentoneta-reading-suggestions').locator('a[href^="/read/"]');
+
+	// Control positivo: sin él, una lista vacía dejaría la exclusión de abajo cumpliéndose en vacío. Si
+	// esto falla, la curaduría pendiente es que el autor de la obra curada tenga otra obra publicada.
+	await expect(readingLinks.first()).toBeVisible();
+
+	const destinations = await readingLinks.evaluateAll((links) => links.map((link) => link.getAttribute('href') ?? ''));
+	expect(
+		destinations.some((href) => href.startsWith(MEDIA_ROUTE)),
+		'la obra que se está leyendo se sugiere a sí misma',
+	).toBe(false);
+
+	// Las sugerencias arrastran el contexto de autor: navegar entre ellas no lo pierde.
+	expect(
+		destinations.every((href) => href.includes('navigation=author')),
+		`sugerencias sin contexto: ${destinations}`,
+	).toBe(true);
+
+	const authorAccess = page
+		.locator('cuentoneta-reading-suggestions')
+		.locator(`a[href^="/author/${mediaWork?.authors[0]?.slug}"]`);
+	await expect(authorAccess.first()).toBeVisible();
+});
+
+// El único cableado que ningún unitario ve: la tarjeta de la colección EMITE los query params de contexto
+// y la página los CONSUME. Entrar directo con la URL armada probaría la mitad de consumo, que el spec
+// unitario ya cubre.
+test('read — llegar desde una colección cambia la fuente de las sugerencias', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(status !== 200 || !work, `"${ROUTE}" no responde 200 en el dataset`);
+	// eslint-disable-next-line playwright/no-skipped-test -- el catálogo sin la colección estable ya lo reportan los e2e de colección
+	test.skip(!stableCollection, `el catálogo no trae "${STABLE_SLUGS.collection}"`);
+
+	await page.setViewportSize(DESKTOP_VIEWPORT);
+	await page.goto(`/collection/${STABLE_SLUGS.collection}`);
+	await expect(page.locator('main h1')).toBeVisible();
+
+	await page.getByTestId('literary-works').locator('a[href^="/read/"]').first().click();
+
+	await expect(page).toHaveURL(/navigation=collection/);
+	await settleSuggestions(page, new RegExp(`Más obras de ${stableCollection?.title}`));
+});

--- a/src/app/pages/collection/collection.page.html
+++ b/src/app/pages/collection/collection.page.html
@@ -18,6 +18,10 @@
 				[showMultimedia]="true"
 				[excerptLines]="excerptLines()"
 				[tagLabel]="collection.tags[0]?.title"
+				[navigationParams]="{
+					navigation: 'collection',
+					navigationSlug: collection.slug,
+				}"
 			/>
 			}
 		</div>

--- a/src/app/pages/collection/collection.page.spec.ts
+++ b/src/app/pages/collection/collection.page.spec.ts
@@ -73,6 +73,19 @@ describe('CollectionPage', () => {
 			);
 		});
 
+		// Sin los query params, la página de lectura no sabe desde dónde se llegó y cae a sugerir por
+		// autor: el contexto de colección sólo existe si la tarjeta lo emite.
+		it('should link each work carrying the collection as navigation context', async () => {
+			await renderPage(showingAuthors);
+
+			const [firstWork] = showingAuthors.literaryWorks;
+			const link = screen.getByRole('link', { name: firstWork.title });
+
+			expect(link.getAttribute('href')).toBe(
+				`/read/${firstWork.slug}?navigation=collection&navigationSlug=${showingAuthors.slug}`,
+			);
+		});
+
 		it('should render the information panel of the collection', async () => {
 			await renderPage(showingAuthors);
 

--- a/src/app/pages/read/read.page.html
+++ b/src/app/pages/read/read.page.html
@@ -64,5 +64,5 @@
 	El esqueleto se pinta con `@if`/`@else` planos y nunca dentro de un `@defer`: el recurso bloquea el
 	render del servidor, así que al serializar la obra ya está y el crawler recibe el cuerpo real.
 -->
-<cuentoneta-read-page-skeleton />
+<cuentoneta-read-page-skeleton data-testid="read-page-skeleton" />
 }

--- a/src/app/pages/read/read.page.spec.ts
+++ b/src/app/pages/read/read.page.spec.ts
@@ -6,7 +6,7 @@ import { renderDeferBlocks } from '@testing/defer-blocks';
 // 3rd party modules
 import { render, screen, within } from '@testing-library/angular';
 import { restoreAllMocks, spyOn } from '@test-utils';
-import { throwError, type Observable } from 'rxjs';
+import { Subject, throwError, type Observable } from 'rxjs';
 
 // Models
 import { createLiteraryWork, type LiteraryWork } from '@models/literary-work.model';
@@ -40,6 +40,20 @@ class StubFailingLiteraryWorkApi implements LiteraryWorkApi {
 
 	public getBySlug(): Observable<LiteraryWork> {
 		return throwError(() => new HttpErrorResponse({ status: this.status, statusText: 'error' }));
+	}
+}
+
+// Sustituye el timing del entorno, no el dato: el test decide cuándo llega la obra, que es lo único que
+// permite observar el estado intermedio. Los stubs emiten sincrónico y el skeleton nunca alcanza a verse.
+class ControllableLiteraryWorkApi implements LiteraryWorkApi {
+	private readonly work = new Subject<LiteraryWork>();
+
+	public getBySlug(): Observable<LiteraryWork> {
+		return this.work.asObservable();
+	}
+
+	public emit(literaryWork: LiteraryWork): void {
+		this.work.next(literaryWork);
 	}
 }
 
@@ -139,6 +153,25 @@ describe('ReadPage', () => {
 	};
 
 	afterEach(() => restoreAllMocks());
+
+	// Afirma la promesa del comentario de la plantilla —el esqueleto se pinta con `@if`/`@else` planos—
+	// que hasta acá ningún test sostenía: quitarlo no rompía nada.
+	describe('estado de carga', () => {
+		it('muestra el esqueleto de página hasta que la obra llega, y el contenido después', async () => {
+			const api = new ControllableLiteraryWorkApi();
+			await setup(representativeLiteraryWork, { api });
+
+			// Control positivo doble: el esqueleto está y el contenido todavía no. Sin la segunda mitad, un
+			// esqueleto que conviviera con el contenido pasaría igual.
+			expect(screen.getByTestId('read-page-skeleton')).toBeTruthy();
+			expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
+
+			api.emit(representativeLiteraryWork);
+
+			expect(await screen.findByRole('heading', { level: 1, name: representativeLiteraryWork.title })).toBeTruthy();
+			expect(screen.queryByTestId('read-page-skeleton')).toBeNull();
+		});
+	});
 
 	// Test de aceptación del criterio principal de LiteraryWork: una obra de una sola sección ofrece al lector
 	// las mismas affordances que la página Story (story.component.html) — título como encabezado


### PR DESCRIPTION
## Qué hace

Suma la cobertura de `ReadPage` que el issue pide, en sus dos capas, traducida del enunciado original —anterior al rename Story→LiteraryWork— a la implementación V3 vigente:

- **`e2e/read.spec.ts`** (Playwright): el hero derivado del DTO del API, la salida navegable del estado no encontrado, el bloque multimedia con cambio de formato, y las sugerencias del pie por los dos contextos — incluido el flujo real colección→lectura.
- **`read.page.spec.ts`** (Vitest + ATL): el único hueco que quedaba en la suite existente — el estado de carga. Un doble `ControllableLiteraryWorkApi` retiene la emisión para observar el estado intermedio: skeleton antes, contenido después. La matriz de variantes restante ya estaba cubierta por los specs que dejaron los issues que ensamblaron la página.

El e2e cubre sólo lo que exige navegador real: bloques diferidos (`on idle` / `on viewport`) que no viajan en el HTML del servidor, interacción de cambio de formato, y navegación entre páginas con query params. Las invariantes de indexado siguen en su suite propia.

## Defecto que la cobertura destapó

**Llegar a una obra desde una colección perdía el contexto de navegación.** La tarjeta de obra acepta `navigationParams` y la página de lectura los consume, pero `CollectionPage` nunca se los pasaba: el pie sugería por autor en vez de por colección. Los decks de la home sí los emiten; ésta era la única entrada que no. Es un cableado entre páginas que ningún unitario puede ver, porque cada mitad funciona sola. Corregido acá, con su caso unitario en `collection.page.spec.ts` y el flujo completo afirmado por el e2e.

## Estrategia de fixtures

Dos obras estables, porque una no alcanza:

| Slug | Cubre | Por qué |
| --- | --- | --- |
| `el-fin` (existente) | Hero, contrato del API | El estable histórico de la suite |
| `a-la-deriva` (nuevo, `literaryWorkWithMedia`) | Multimedia, sugerencias | `el-fin` no declara recursos y su autor tiene una sola obra publicada: ni el cambio de formato ni las sugerencias por autor se pueden afirmar sobre él |

La identidad sale del slug estable; las propiedades de curaduría (formatos de **tipos distintos**, otra obra del autor) las afirman **guardas como casos propios** que en un dataset incompleto salen rojos nombrando qué falta — el modo de falla histórico de los e2e de `/read` era exactamente el skip silencioso.

## Curación de datasets, por migración

Ninguna obra de ningún dataset —producción incluida— tenía dos formatos multimedia de tipos distintos: el selector de formatos nunca había tenido datos reales que lo ejerciten. La curación viaja como migración versionada (`cms/migrations/add-a-la-deriva-audio-narration/`, con spec y README): agrega a "A la deriva" su narración en audio real —el episodio del podcast *Armario de Cuentos* en Spotify—, que es contenido editorial genuino y no un fixture a limpiar. Idempotente por URL, recorre también los borradores.

**Ya aplicada y verificada en los tres datasets** (`development` la tenía curada a mano y la corrida generó 0 mutaciones, que es la idempotencia probada contra el dato real; `staging` y `production` quedaron con 2 tipos de recurso).

## Plan de pruebas

- Los 12 casos nuevos del e2e verdes en Chromium y Firefox contra un build de producción local y el dataset `development`, con **0 salteados** — verificado explícitamente, porque un caso salteado en CI es cobertura que no existe.
- Suite de Vitest completa verde, incluidos el caso nuevo de estado de carga (46 en `read.page.spec.ts`) y el de query params (12 en `collection.page.spec.ts`); 245 del Studio con los 6 de la migración.
- Tier local de gates: `typecheck`, `lint` (sólo el warning preexistente ajeno), `stylelint`, `test`, `check-agents` verdes.
- Migración corrida y verificada por dataset con su consulta de tipos distintos (≥2 en los tres).
- La review local corrió completa: 0 críticos, 2 advertencias y 3 sugerencias, los 5 corregidos.

Closes #1080.

Parte de #1471.
