### PR TITLE
[#1570] - Declara autores destacados en el documento de página de inicio

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -1942,346 +1942,6 @@
 		}
 	},
 	{
-		"type": "type",
-		"name": "nationality.reference",
-		"value": {
-			"type": "object",
-			"attributes": {
-				"_ref": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string"
-					}
-				},
-				"_type": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string",
-						"value": "reference"
-					}
-				},
-				"_weak": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "boolean"
-					},
-					"optional": true
-				}
-			},
-			"dereferencesTo": "nationality"
-		}
-	},
-	{
-		"name": "author",
-		"type": "document",
-		"attributes": {
-			"_id": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_type": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string",
-					"value": "author"
-				}
-			},
-			"_createdAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_updatedAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_rev": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"name": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": false
-			},
-			"slug": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "slug"
-				},
-				"optional": false
-			},
-			"image": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "object",
-					"attributes": {
-						"asset": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageAsset.reference"
-							},
-							"optional": true
-						},
-						"media": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "unknown"
-							},
-							"optional": true
-						},
-						"hotspot": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageHotspot"
-							},
-							"optional": true
-						},
-						"crop": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageCrop"
-							},
-							"optional": true
-						},
-						"_type": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "string",
-								"value": "image"
-							}
-						}
-					}
-				},
-				"optional": false
-			},
-			"nationality": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "nationality.reference"
-				},
-				"optional": false
-			},
-			"bornOn": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": true
-			},
-			"bornOnYear": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "computedNumber"
-				},
-				"optional": true
-			},
-			"diedOn": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": true
-			},
-			"diedOnYear": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "computedNumber"
-				},
-				"optional": true
-			},
-			"biography": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "markdown"
-				},
-				"optional": false
-			},
-			"resources": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "array",
-					"of": {
-						"type": "object",
-						"attributes": {
-							"title": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string"
-								},
-								"optional": false
-							},
-							"url": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string"
-								},
-								"optional": false
-							},
-							"resourceType": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "inline",
-									"name": "resourceType.reference"
-								},
-								"optional": false
-							},
-							"_type": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string",
-									"value": "resource"
-								}
-							}
-						},
-						"rest": {
-							"type": "object",
-							"attributes": {
-								"_key": {
-									"type": "objectAttribute",
-									"value": {
-										"type": "string"
-									}
-								}
-							}
-						}
-					}
-				},
-				"optional": true
-			},
-			"tags": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "array",
-					"of": {
-						"type": "object",
-						"attributes": {
-							"_key": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string"
-								}
-							}
-						},
-						"rest": {
-							"type": "inline",
-							"name": "tag.reference"
-						}
-					}
-				},
-				"optional": true
-			}
-		}
-	},
-	{
-		"name": "nationality",
-		"type": "document",
-		"attributes": {
-			"_id": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_type": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string",
-					"value": "nationality"
-				}
-			},
-			"_createdAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_updatedAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_rev": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"country": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": false
-			},
-			"flag": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "object",
-					"attributes": {
-						"asset": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageAsset.reference"
-							},
-							"optional": true
-						},
-						"media": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "unknown"
-							},
-							"optional": true
-						},
-						"hotspot": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageHotspot"
-							},
-							"optional": true
-						},
-						"crop": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageCrop"
-							},
-							"optional": true
-						},
-						"_type": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "string",
-								"value": "image"
-							}
-						}
-					}
-				},
-				"optional": false
-			}
-		}
-	},
-	{
 		"name": "collection",
 		"type": "document",
 		"attributes": {
@@ -3638,6 +3298,406 @@
 					}
 				},
 				"optional": true
+			},
+			"highlightedAuthors": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "array",
+					"of": {
+						"type": "object",
+						"attributes": {
+							"author": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "inline",
+									"name": "author.reference"
+								},
+								"optional": false
+							},
+							"additionalTags": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "array",
+									"of": {
+										"type": "object",
+										"attributes": {
+											"_key": {
+												"type": "objectAttribute",
+												"value": {
+													"type": "string"
+												}
+											}
+										},
+										"rest": {
+											"type": "inline",
+											"name": "tag.reference"
+										}
+									}
+								},
+								"optional": true
+							},
+							"_type": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string",
+									"value": "highlightedAuthor"
+								}
+							}
+						},
+						"rest": {
+							"type": "object",
+							"attributes": {
+								"_key": {
+									"type": "objectAttribute",
+									"value": {
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				},
+				"optional": true
+			}
+		}
+	},
+	{
+		"type": "type",
+		"name": "nationality.reference",
+		"value": {
+			"type": "object",
+			"attributes": {
+				"_ref": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string"
+					}
+				},
+				"_type": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string",
+						"value": "reference"
+					}
+				},
+				"_weak": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "boolean"
+					},
+					"optional": true
+				}
+			},
+			"dereferencesTo": "nationality"
+		}
+	},
+	{
+		"name": "author",
+		"type": "document",
+		"attributes": {
+			"_id": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_type": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string",
+					"value": "author"
+				}
+			},
+			"_createdAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_updatedAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_rev": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"name": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": false
+			},
+			"slug": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "slug"
+				},
+				"optional": false
+			},
+			"image": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "object",
+					"attributes": {
+						"asset": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageAsset.reference"
+							},
+							"optional": true
+						},
+						"media": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "unknown"
+							},
+							"optional": true
+						},
+						"hotspot": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageHotspot"
+							},
+							"optional": true
+						},
+						"crop": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageCrop"
+							},
+							"optional": true
+						},
+						"_type": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "string",
+								"value": "image"
+							}
+						}
+					}
+				},
+				"optional": false
+			},
+			"nationality": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "nationality.reference"
+				},
+				"optional": false
+			},
+			"bornOn": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"bornOnYear": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "computedNumber"
+				},
+				"optional": true
+			},
+			"diedOn": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"diedOnYear": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "computedNumber"
+				},
+				"optional": true
+			},
+			"biography": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "markdown"
+				},
+				"optional": false
+			},
+			"resources": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "array",
+					"of": {
+						"type": "object",
+						"attributes": {
+							"title": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								},
+								"optional": false
+							},
+							"url": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								},
+								"optional": false
+							},
+							"resourceType": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "inline",
+									"name": "resourceType.reference"
+								},
+								"optional": false
+							},
+							"_type": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string",
+									"value": "resource"
+								}
+							}
+						},
+						"rest": {
+							"type": "object",
+							"attributes": {
+								"_key": {
+									"type": "objectAttribute",
+									"value": {
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				},
+				"optional": true
+			},
+			"tags": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "array",
+					"of": {
+						"type": "object",
+						"attributes": {
+							"_key": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								}
+							}
+						},
+						"rest": {
+							"type": "inline",
+							"name": "tag.reference"
+						}
+					}
+				},
+				"optional": true
+			}
+		}
+	},
+	{
+		"name": "nationality",
+		"type": "document",
+		"attributes": {
+			"_id": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_type": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string",
+					"value": "nationality"
+				}
+			},
+			"_createdAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_updatedAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_rev": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"country": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": false
+			},
+			"flag": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "object",
+					"attributes": {
+						"asset": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageAsset.reference"
+							},
+							"optional": true
+						},
+						"media": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "unknown"
+							},
+							"optional": true
+						},
+						"hotspot": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageHotspot"
+							},
+							"optional": true
+						},
+						"crop": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageCrop"
+							},
+							"optional": true
+						},
+						"_type": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "string",
+								"value": "image"
+							}
+						}
+					}
+				},
+				"optional": false
 			}
 		}
 	},

--- a/cms/schemas/landingPage.ts
+++ b/cms/schemas/landingPage.ts
@@ -113,5 +113,38 @@ export default defineType({
 				}),
 			],
 		}),
+		defineField({
+			name: 'highlightedAuthors',
+			title: 'Autores destacados',
+			type: 'array',
+			validation: (Rule) => Rule.max(6),
+			of: [
+				defineArrayMember({
+					name: 'highlightedAuthor',
+					title: 'Autor destacado',
+					type: 'object',
+					fields: [
+						defineField({
+							name: 'author',
+							title: 'Autor',
+							type: 'reference',
+							to: [{ type: 'author' }],
+							validation: (Rule) => Rule.required(),
+						}),
+						defineField({
+							name: 'additionalTags',
+							title: 'Etiquetas de la semana',
+							description:
+								'Etiquetas puntuales de esta tirada (por ejemplo "Cumpleaños"). Se muestran antes de las que el autor ya tiene asignadas.',
+							type: 'array',
+							of: [defineArrayMember({ type: 'reference', to: [{ type: 'tag' }] })],
+						}),
+					],
+					preview: {
+						select: { title: 'author.name' },
+					},
+				}),
+			],
+		}),
 	],
 });

--- a/docs/CONTENT_UPDATE_STRATEGIES.md
+++ b/docs/CONTENT_UPDATE_STRATEGIES.md
@@ -122,11 +122,17 @@ Este proceso garantiza que:
   collections: Array<CollectionReference>,           // Colecciones con tarjetas (vigente)
   latestLiteraryWorks: Array<LiteraryWorkReference>, // Obras destacadas (vigente)
   cards: Array<StorylistReference>,                  // Tarjetas de contenido (en baja)
-  latestReads: Array<StoryReference>                 // Historias destacadas (en baja)
+  latestReads: Array<StoryReference>,                // Historias destacadas (en baja)
+  highlightedAuthors: Array<{                        // Hasta 6 autores destacados
+    author: AuthorReference,
+    additionalTags?: Array<TagReference>             // Etiquetas puntuales de esta semana
+  }>
 }
 ```
 
 > **Convivencia de campos.** `collections` y `latestLiteraryWorks` reemplazan a `cards` y `latestReads`, por el mismo motivo que en `rotatingContent`. Los cuatro coexisten hasta que se retiren los dos primeros.
+
+`highlightedAuthors` es el único campo que se edita como objetos y no como referencias planas, porque cada entrada lleva sus propias etiquetas de la semana además del autor. El tope de seis lo impone el Studio sobre la edición, así que no gobierna lo ya guardado.
 
 ### Nomenclatura de Slugs
 

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -339,64 +339,6 @@ export type BlockContent = Array<
 
 export type ComputedNumber = number;
 
-export type NationalityReference = {
-	_ref: string;
-	_type: 'reference';
-	_weak?: boolean;
-	[internalGroqTypeReferenceTo]?: 'nationality';
-};
-
-export type Author = {
-	_id: string;
-	_type: 'author';
-	_createdAt: string;
-	_updatedAt: string;
-	_rev: string;
-	name: string;
-	slug: Slug;
-	image: {
-		asset?: SanityImageAssetReference;
-		media?: unknown;
-		hotspot?: SanityImageHotspot;
-		crop?: SanityImageCrop;
-		_type: 'image';
-	};
-	nationality: NationalityReference;
-	bornOn?: string;
-	bornOnYear?: ComputedNumber;
-	diedOn?: string;
-	diedOnYear?: ComputedNumber;
-	biography: Markdown;
-	resources?: Array<{
-		title: string;
-		url: string;
-		resourceType: ResourceTypeReference;
-		_type: 'resource';
-		_key: string;
-	}>;
-	tags?: Array<
-		{
-			_key: string;
-		} & TagReference
-	>;
-};
-
-export type Nationality = {
-	_id: string;
-	_type: 'nationality';
-	_createdAt: string;
-	_updatedAt: string;
-	_rev: string;
-	country: string;
-	flag: {
-		asset?: SanityImageAssetReference;
-		media?: unknown;
-		hotspot?: SanityImageHotspot;
-		crop?: SanityImageCrop;
-		_type: 'image';
-	};
-};
-
 export type Collection = {
 	_id: string;
 	_type: 'collection';
@@ -634,6 +576,74 @@ export type LandingPage = {
 			_key: string;
 		} & LiteraryWorkReference
 	>;
+	highlightedAuthors?: Array<{
+		author: AuthorReference;
+		additionalTags?: Array<
+			{
+				_key: string;
+			} & TagReference
+		>;
+		_type: 'highlightedAuthor';
+		_key: string;
+	}>;
+};
+
+export type NationalityReference = {
+	_ref: string;
+	_type: 'reference';
+	_weak?: boolean;
+	[internalGroqTypeReferenceTo]?: 'nationality';
+};
+
+export type Author = {
+	_id: string;
+	_type: 'author';
+	_createdAt: string;
+	_updatedAt: string;
+	_rev: string;
+	name: string;
+	slug: Slug;
+	image: {
+		asset?: SanityImageAssetReference;
+		media?: unknown;
+		hotspot?: SanityImageHotspot;
+		crop?: SanityImageCrop;
+		_type: 'image';
+	};
+	nationality: NationalityReference;
+	bornOn?: string;
+	bornOnYear?: ComputedNumber;
+	diedOn?: string;
+	diedOnYear?: ComputedNumber;
+	biography: Markdown;
+	resources?: Array<{
+		title: string;
+		url: string;
+		resourceType: ResourceTypeReference;
+		_type: 'resource';
+		_key: string;
+	}>;
+	tags?: Array<
+		{
+			_key: string;
+		} & TagReference
+	>;
+};
+
+export type Nationality = {
+	_id: string;
+	_type: 'nationality';
+	_createdAt: string;
+	_updatedAt: string;
+	_rev: string;
+	country: string;
+	flag: {
+		asset?: SanityImageAssetReference;
+		media?: unknown;
+		hotspot?: SanityImageHotspot;
+		crop?: SanityImageCrop;
+		_type: 'image';
+	};
 };
 
 export type Resource = {
@@ -793,9 +803,6 @@ export type AllSanitySchemaTypes =
 	| Story
 	| BlockContent
 	| ComputedNumber
-	| NationalityReference
-	| Author
-	| Nationality
 	| Collection
 	| Storylist
 	| ContentCampaign
@@ -803,6 +810,9 @@ export type AllSanitySchemaTypes =
 	| StorylistReference
 	| CollectionReference
 	| LandingPage
+	| NationalityReference
+	| Author
+	| Nationality
 	| Resource
 	| ResourceType
 	| Contributor


### PR DESCRIPTION
## Qué hace

Primero de los tres PRs de #1570. Declara en el Studio el campo `highlightedAuthors` del documento de página de inicio y regenera el schema extraído y los tipos.

**No cambia ningún contrato ni ningún lector:** el campo nace vacío, se puebla editorialmente y nadie lo consulta todavía. La proyección GROQ y el corpus van en el PR 2; el contrato de dominio y la ACL, en el PR 3.

## La forma del campo

`highlightedAuthors` es el primer array de **objetos** del documento — los otros tres (`campaigns`, `cards`, `latestReads`) son de referencias planas. Cada entrada lleva:

| Campo | Tipo | Por qué |
| --- | --- | --- |
| `author` | referencia a `author`, requerida | El destacado no significa nada sin autor |
| `additionalTags` | array de referencias a `tag` | Etiquetas puntuales de esa tirada (por ejemplo "Cumpleaños"), que se suman a las que el autor ya tiene asignadas |

El array lleva `Rule.max(6)`, y el miembro un `preview` que selecciona `author.name` para que la lista del Studio no muestre seis entradas "Untitled".

## Por qué el tope de 6 no se replica como validación de dominio

`Rule.max(6)` gobierna la **edición**, no lo persistido: no alcanza a documentos ya guardados, a un backfill ni a una migración. Por eso no se agrega validación en el borde del API —el endpoint de la landing no recibe parámetros que validar— y el recorte defensivo vive en el mapper, que llega en el PR 3.

## Por qué el diff de los archivos generados es más grande que el campo

`cms/schema.json` y `src/sanity/types.ts` mueven de lugar bloques que este PR no toca. No es drift ajeno arrastrado: al declarar el campo, las referencias a autor y a etiqueta pasan a emitirse antes del documento de página de inicio, y eso corre a los tipos que venían después. Verificado tipo por tipo contra la versión anterior: de los 42 tipos del schema extraído, **el único que cambia de contenido es `landingPage`**; el resto son idénticos y solo cambian de posición.

Los dos archivos se regeneraron con `pnpm sanity:run-typegen-generator`, no se editaron a mano.

## Orden de merge

Primero de una pila de tres. Los siguientes tienen su base en éste:

1. **Este PR** — el campo en el Studio.
2. Proyección GROQ, clonado semanal y corpus.
3. Contrato de dominio, ACL y documentación.

La palabra de cierre de #1570 va en el tercero, que es el que completa el trabajo: ponerla acá cerraría el issue con dos tercios sin mergear.

## Plan de pruebas

- **Los once gates de CI, verdes.**
- **`pnpm sanity:typecheck`, `pnpm sanity:test` y `pnpm sanity:build`** en local: el campo no rompe el type-check del Studio ni su bundle.
- **Verificación del diff de los generados, tipo por tipo:** de los 42 tipos del schema extraído, el único que cambia de contenido es el del documento de página de inicio; los 41 restantes son idénticos y solo cambian de posición. Descarta que el regenerado arrastre drift ajeno.

Parte de #1570.

Parte de #1568.
