### PR TITLE
[#1841] - Suma collection a la superficie de pruebas manuales

### DIFF
--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -305,7 +305,9 @@ pnpm run dev
 Navega por la colección y ejecuta los endpoints que necesites probar. Todos los endpoints están organizados por recurso:
 
 - `/story` - Endpoints de cuentos
+- `/literary-work` - Endpoints de obras literarias
 - `/author` - Endpoints de autores
+- `/collection` - Endpoints de colecciones de obras literarias
 - `/storylist` - Endpoints de listas de cuentos
 - `/content` - Contenido de landing page
 - `/contributor` - Información de contribuyentes

--- a/docs/api/bruno/collection/get-collection-by-slug.bru
+++ b/docs/api/bruno/collection/get-collection-by-slug.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Get collection by slug
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{apiUrl}}{{baseApiPath}}/collection/:slug
+  body: none
+  auth: none
+}
+
+params:path {
+  slug: geometrias-del-desvelo
+}
+
+docs {
+  Colección completa por su slug, con sus obras literarias en vista de teaser. Slug inexistente
+  responde 404 con body { error }.
+
+  El `mediaSources` de las obras embebidas viaja acotado —solo tipo y título—, que es lo que la
+  tarjeta necesita para pintar el ícono de la plataforma; el `mediaSources` de nivel colección sí es
+  la vista completa.
+
+  `imagery` tiene dos formas según haya o no portada editorial propia: `representative` con una
+  imagen, o `sample` con exactamente tres portadas tomadas de sus obras. Las dos colecciones del
+  corpus de Onoff ejercitan una rama cada una (fuente: src/mocks/onoff-collections.mock.ts):
+  - geometrias-del-desvelo — portada editorial propia
+  - inventario-de-las-pasiones — abanico derivado de sus obras
+}

--- a/docs/api/bruno/collection/get-collections.bru
+++ b/docs/api/bruno/collection/get-collections.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Get all collections
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{apiUrl}}{{baseApiPath}}/collection
+  body: none
+  auth: none
+}
+
+docs {
+  Catálogo de colecciones, en vista de teaser: cada entrada trae su portada resuelta y el conteo de
+  obras, pero no las obras en sí (`literaryWorks` viaja vacío).
+
+  Una colección mal curada tumba la llamada entera en vez de filtrarse del listado: el ACL prefiere
+  fallar a servir un catálogo que esconde elementos en silencio. Responde 500 con body
+  { error: "collection_malformed" }. La respuesta no nombra a la colección culpable: el mensaje que
+  la identifica viaja en el error, del lado del servidor.
+
+  Un catálogo sin colecciones es un resultado legítimo y responde 200 con un arreglo vacío.
+}


### PR DESCRIPTION
Último hallazgo pendiente de la review de #1841, el único que quedó sin abordar en #2350 y #2358.

## El hueco

La colección de Bruno tiene una carpeta por recurso del API —`story`, `author`, `storylist`, `literary-work`, `content`, `contributor`, `og`, `utilities`— y **ninguna para `collection`**, que está montado en `src/api/routes.ts` desde hace varios PRs. La lista de recursos de `DEVELOPMENT_GUIDE.md` tampoco nombraba `collection` ni `literary-work`.

El efecto práctico: probar el catálogo a mano obligaba a escribir la request desde cero cada vez, justo en el módulo que más se movió últimamente.

## Qué entra

Dos requests, con la misma forma que las de `literary-work`:

- **`GET /api/collection`** — el catálogo en vista de teaser.
- **`GET /api/collection/:slug`** — la colección completa, con `geometrias-del-desvelo` como slug por defecto.

La documentación de cada una dice lo que un tester no puede deducir de la URL:

- El listado **no transporta obras** (`literaryWorks` viaja vacío) pero sí el conteo y la portada resuelta.
- Una colección mal curada **tumba la llamada entera** en vez de filtrarse del listado, con 500 y `{ error: "collection_malformed" }`. Es una decisión deliberada del ACL —un listado que esconde elementos es un bug de datos que nadie ve—, y sorprende si no se la conoce.
- Un catálogo vacío es un resultado legítimo: 200 con arreglo vacío.
- `imagery` tiene **dos formas** según haya o no portada editorial propia, y las dos colecciones del corpus ejercitan una cada una: `geometrias-del-desvelo` la representativa, `inventario-de-las-pasiones` el abanico derivado de sus obras.

## Verificación

Los códigos y los cuerpos de error se leyeron del controller, no de la memoria: el 404 con `{ error }` y el 500 con `{ error: "collection_malformed" }` están en su `respond`. Una afirmación intermedia —que el slug de la colección culpable quedaba en el log del servidor— **se descartó al no encontrar logging en el controller**, en vez de darla por buena.

Las requests no se ejecutaron contra un servidor: el diff es la colección de Bruno y la lista del guide, y levantar el API pedía credenciales de Sanity que esta sesión no tiene. Lo verificable sin eso —rutas, códigos, cuerpos y slugs del corpus— se verificó contra el código.

Sin tests: el diff no toca código ejecutable.

Sobre #1841, ya cerrado: es el último hallazgo de su review.
