### PR TITLE
[#1570] - Traduce los autores destacados al modelo de dominio

### DIFF
--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -541,6 +541,13 @@ interface LandingPageContent {
 	campaigns: ContentCampaign[]; // Campañas de marketing
 	mostRead: StoryNavigationTeaserWithAuthor[]; // Top 10 historias más leídas
 	latestReads: StoryNavigationTeaserWithAuthor[]; // Últimas historias publicadas
+	highlightedAuthors: readonly HighlightedAuthor[]; // Hasta 6 autores destacados de la semana
+}
+
+interface HighlightedAuthor {
+	author: AuthorTeaser;
+	tags: readonly Tag[]; // Etiquetas de la semana primero, después las del autor, sin repetir
+	storyCount: number; // Obras del autor, contadas sobre los dos tipos de documento
 }
 ```
 
@@ -548,6 +555,10 @@ interface LandingPageContent {
 
 - Agregar contenido de múltiples contextos para presentación en página inicio
 - Mantener datos de lectura y estadísticas
+
+`HighlightedAuthor` es una proyección de curación de este contexto, no una vista del agregado `Author`: sus etiquetas son las de la tirada y su conteo es un dato que solo esta pantalla paga. Por eso ninguno de los dos vive en `AuthorTeaser`, que entrega su propia lista de etiquetas vacía.
+
+El tope de seis rige la edición en el Studio y no lo ya persistido, así que el mapeo lo vuelve a aplicar como salvaguarda.
 
 > **Nota:** Para comprender la implementación práctica de este agregado, incluyendo la generación automática de configuraciones y actualización de contenido, consulta la documentación sobre [Estrategias de Actualización de Contenido](./CONTENT_UPDATE_STRATEGIES.md).
 

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -15,6 +15,7 @@ import {
 import { elOdioRawTeaser, onoffRawNavTeasersMock } from '@mocks/onoff-raw-stories.mock';
 import { rawOnoffAuthor, rawOnoffAuthorTeaser } from '@mocks/onoff-raw-author.mock';
 import {
+	divergentDuplicateRawHighlightedAuthor,
 	onoffRawContentCampaignsMock,
 	onoffRawHighlightedAuthorsMock,
 	onoffRawLandingPageMock,
@@ -280,6 +281,20 @@ describe('mapHighlightedAuthors (ACL)', () => {
 		const slugs = mapHighlightedAuthors([canonical])[0].tags.map(({ slug }) => slug);
 
 		expect(slugs).toEqual([...new Set(slugs)]);
+	});
+
+	// El descarte tiene que quedarse con la etiqueta de la semana, no con la del autor: es la que da
+	// contexto a la tirada, y el epic contempla que las dos difieran en algo más que el slug.
+	it('keeps the tag of the week, not the derived one, when both carry the same slug', () => {
+		const entry = divergentDuplicateRawHighlightedAuthor;
+		const [weekly] = entry.additionalTags;
+		const derived = entry.author.tags.find((tag) => tag.slug === weekly.slug);
+
+		expect(derived?.title).not.toBe(weekly.title);
+
+		const survivor = mapHighlightedAuthors([entry])[0].tags.find((tag) => tag.slug === weekly.slug);
+
+		expect(survivor?.title).toBe(weekly.title);
 	});
 
 	it('keeps the first six entries when the document carries more', () => {

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -4,6 +4,7 @@ import {
 	mapAuthorTeaser,
 	mapBlockContentToTextParagraphs,
 	mapContentCampaigns,
+	mapHighlightedAuthors,
 	mapLandingPageContent,
 	mapResources,
 	mapStoryNavigationTeaserWithAuthor,
@@ -13,7 +14,13 @@ import {
 } from './functions';
 import { elOdioRawTeaser, onoffRawNavTeasersMock } from '@mocks/onoff-raw-stories.mock';
 import { rawOnoffAuthor, rawOnoffAuthorTeaser } from '@mocks/onoff-raw-author.mock';
-import { onoffRawContentCampaignsMock, onoffRawLandingPageMock } from '@mocks/onoff-raw-landing-page.mock';
+import {
+	onoffRawContentCampaignsMock,
+	onoffRawHighlightedAuthorsMock,
+	onoffRawLandingPageMock,
+	overflowingRawHighlightedAuthors,
+	untaggedRawHighlightedAuthor,
+} from '@mocks/onoff-raw-landing-page.mock';
 import type { RotatingContent } from '@models/landing-page-content.model';
 import { onoffRawTagsMock } from '@mocks/onoff-raw-tags.mock';
 import { withoutUrl } from '@testing/resource-without-url';
@@ -212,7 +219,15 @@ describe('mapLandingPageContent (ACL)', () => {
 	it('exposes exactly the domain contract, dropping the raw slug and name', () => {
 		const result = mapLandingPageContent(raw);
 
-		expect(Object.keys(result).sort()).toEqual(['_id', 'campaigns', 'cards', 'config', 'latestReads', 'mostRead']);
+		expect(Object.keys(result).sort()).toEqual([
+			'_id',
+			'campaigns',
+			'cards',
+			'config',
+			'highlightedAuthors',
+			'latestReads',
+			'mostRead',
+		]);
 	});
 
 	it('takes its identity from the rotating content that overrides the landing page', () => {
@@ -231,6 +246,70 @@ describe('mapLandingPageContent (ACL)', () => {
 
 		expect(expectedSlugs.length).toBeGreaterThan(0);
 		expect(mapLandingPageContent(raw).campaigns.map(({ slug }) => slug)).toEqual(expectedSlugs);
+	});
+
+	it('maps every highlighted author the query returned, in order', () => {
+		const expectedIds = onoffRawLandingPageMock.highlightedAuthors.map(({ author }) => author._id);
+
+		expect(expectedIds.length).toBeGreaterThan(0);
+		expect(mapLandingPageContent(raw).highlightedAuthors.map(({ author }) => author._id)).toEqual(expectedIds);
+	});
+});
+
+describe('mapHighlightedAuthors (ACL)', () => {
+	const [canonical] = onoffRawHighlightedAuthorsMock;
+
+	it('leads with the tags of the week and follows with the ones the author already carries', () => {
+		const [result] = mapHighlightedAuthors([canonical]);
+
+		const weekly = canonical.additionalTags.map(({ slug }) => slug);
+		const derived = canonical.author.tags.map(({ slug }) => slug).filter((slug) => !weekly.includes(slug));
+
+		expect(weekly.length).toBeGreaterThan(0);
+		expect(derived.length).toBeGreaterThan(0);
+		expect(result.tags.map(({ slug }) => slug)).toEqual([...weekly, ...derived]);
+	});
+
+	it('lists a tag present in both sources only once', () => {
+		const shared = canonical.additionalTags.filter(({ slug }) =>
+			canonical.author.tags.some((tag) => tag.slug === slug),
+		);
+
+		expect(shared.length).toBeGreaterThan(0);
+
+		const slugs = mapHighlightedAuthors([canonical])[0].tags.map(({ slug }) => slug);
+
+		expect(slugs).toEqual([...new Set(slugs)]);
+	});
+
+	it('keeps the first six entries when the document carries more', () => {
+		const result = mapHighlightedAuthors(overflowingRawHighlightedAuthors);
+
+		expect(overflowingRawHighlightedAuthors.length).toBeGreaterThan(6);
+		expect(result.map(({ author }) => author._id)).toEqual(
+			overflowingRawHighlightedAuthors.slice(0, 6).map(({ author }) => author._id),
+		);
+	});
+
+	it('produces an empty tag list for an author with no tags of either kind', () => {
+		expect(mapHighlightedAuthors([untaggedRawHighlightedAuthor])[0].tags).toEqual([]);
+	});
+
+	it('carries the count the query computed', () => {
+		expect(mapHighlightedAuthors([canonical])[0].storyCount).toBe(canonical.storyCount);
+	});
+
+	// Los tags del destacado son los de la tirada, no los del autor: el teaser los entrega vacíos en
+	// toda vista, y este mapper es el que decide cuáles se muestran.
+	it('maps the author as a teaser, whose own tag list stays empty', () => {
+		const [result] = mapHighlightedAuthors([canonical]);
+
+		expect(result.author).toEqual(mapAuthorTeaser(canonical.author));
+		expect(result.author.tags).toEqual([]);
+	});
+
+	it('returns an empty array when the document has no highlighted authors', () => {
+		expect(mapHighlightedAuthors([])).toEqual([]);
 	});
 });
 

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -13,7 +13,7 @@ import { createImageUrlBuilder, SanityImageSource } from '@sanity/image-url';
 // Modelos
 import { Author, AuthorProfile, AuthorTeaser } from '@models/author.model';
 import { ContentCampaign, viewportElementSizes } from '@models/content-campaign.model';
-import { LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
+import { HighlightedAuthor, LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
 import { StorylistTeaser } from '@models/storylist.model';
 import { Resource } from '@models/resource.model';
 import { Story, StoryNavigationTeaserWithAuthor, StoryTeaser, StoryTeaserWithAuthor } from '@models/story.model';
@@ -85,8 +85,13 @@ type AuthorTeaserForStoriesSubQuery = NonNullable<StorylistQueryResult>['stories
 type AuthorTeaserForListSubQuery = UnwrapArray<AuthorsQueryResult>;
 type AuthorTeaserForCollectionSubQuery =
 	NonNullable<CollectionBySlugQueryResult>['literaryWorks'][number]['authors'][number];
+type AuthorTeaserForHighlightSubQuery = HighlightedAuthorsSubQuery[number]['author'];
 export function mapAuthorTeaser(
-	rawAuthorData: AuthorTeaserForStoriesSubQuery | AuthorTeaserForListSubQuery | AuthorTeaserForCollectionSubQuery,
+	rawAuthorData:
+		| AuthorTeaserForStoriesSubQuery
+		| AuthorTeaserForListSubQuery
+		| AuthorTeaserForCollectionSubQuery
+		| AuthorTeaserForHighlightSubQuery,
 ): AuthorTeaser {
 	return {
 		_id: rawAuthorData._id,
@@ -289,7 +294,26 @@ export function mapLandingPageContent(
 		campaigns: mapContentCampaigns(result.campaigns),
 		mostRead: result.mostRead,
 		latestReads: mapStoryNavigationTeaserWithAuthor(result.latestReads),
+		highlightedAuthors: mapHighlightedAuthors(result.highlightedAuthors),
 	};
+}
+
+// El Studio limita la carga a seis entradas, pero esa regla gobierna la edición y no lo ya guardado:
+// una migración o un backfill pueden dejar más. El recorte acá es una salvaguarda, no la regla.
+const HIGHLIGHTED_AUTHORS_LIMIT = 6;
+
+type HighlightedAuthorsSubQuery = NonNullable<LandingPageContentQueryResult>['highlightedAuthors'];
+export function mapHighlightedAuthors(highlightedAuthors: HighlightedAuthorsSubQuery): HighlightedAuthor[] {
+	return highlightedAuthors.slice(0, HIGHLIGHTED_AUTHORS_LIMIT).map((entry) => ({
+		author: mapAuthorTeaser(entry.author),
+		tags: dedupeTagsBySlug([...mapTags(entry.additionalTags), ...mapTags(entry.author.tags)]),
+		storyCount: entry.storyCount,
+	}));
+}
+
+// Las puntuales de la semana encabezan la lista, así que ante una repetida gana la primera aparición.
+function dedupeTagsBySlug(tags: Tag[]): Tag[] {
+	return [...new Map(tags.map((tag) => [tag.slug, tag])).values()];
 }
 
 type ContentCampaignsSubQuery = NonNullable<LandingPageContentQueryResult>['campaigns'];

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -13,7 +13,7 @@ import { createImageUrlBuilder, SanityImageSource } from '@sanity/image-url';
 // Modelos
 import { Author, AuthorProfile, AuthorTeaser } from '@models/author.model';
 import { ContentCampaign, viewportElementSizes } from '@models/content-campaign.model';
-import { HighlightedAuthor, LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
+import type { HighlightedAuthor, LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
 import { StorylistTeaser } from '@models/storylist.model';
 import { Resource } from '@models/resource.model';
 import { Story, StoryNavigationTeaserWithAuthor, StoryTeaser, StoryTeaserWithAuthor } from '@models/story.model';
@@ -184,7 +184,9 @@ type TagsSubQuery =
 	| NonNullable<StorylistTeasersQueryResult>[0]['tags']
 	| NonNullable<LiteraryWorkBySlugQueryResult>['tags']
 	| NonNullable<CollectionBySlugQueryResult>['tags']
-	| NonNullable<CollectionBySlugQueryResult>['literaryWorks'][number]['tags'];
+	| NonNullable<CollectionBySlugQueryResult>['literaryWorks'][number]['tags']
+	| HighlightedAuthorsSubQuery[number]['additionalTags']
+	| HighlightedAuthorsSubQuery[number]['author']['tags'];
 export function mapTags(tags: TagsSubQuery): Tag[] {
 	return tags.map((tag) => ({
 		title: tag.title,
@@ -298,13 +300,13 @@ export function mapLandingPageContent(
 	};
 }
 
-// El Studio limita la carga a seis entradas, pero esa regla gobierna la edición y no lo ya guardado:
-// una migración o un backfill pueden dejar más. El recorte acá es una salvaguarda, no la regla.
-const HIGHLIGHTED_AUTHORS_LIMIT = 6;
-
 type HighlightedAuthorsSubQuery = NonNullable<LandingPageContentQueryResult>['highlightedAuthors'];
 export function mapHighlightedAuthors(highlightedAuthors: HighlightedAuthorsSubQuery): HighlightedAuthor[] {
-	return highlightedAuthors.slice(0, HIGHLIGHTED_AUTHORS_LIMIT).map((entry) => ({
+	// El Studio limita la carga a seis entradas, pero esa regla gobierna la edición y no lo ya guardado:
+	// una migración o un backfill pueden dejar más. El recorte acá es una salvaguarda, no la regla.
+	const limit = 6;
+
+	return highlightedAuthors.slice(0, limit).map((entry) => ({
 		author: mapAuthorTeaser(entry.author),
 		tags: dedupeTagsBySlug([...mapTags(entry.additionalTags), ...mapTags(entry.author.tags)]),
 		storyCount: entry.storyCount,
@@ -312,8 +314,18 @@ export function mapHighlightedAuthors(highlightedAuthors: HighlightedAuthorsSubQ
 }
 
 // Las puntuales de la semana encabezan la lista, así que ante una repetida gana la primera aparición.
+// Reconstruir con un `Map` no serviría: conservaría esa posición pero con el valor de la última, que
+// es la derivada.
 function dedupeTagsBySlug(tags: Tag[]): Tag[] {
-	return [...new Map(tags.map((tag) => [tag.slug, tag])).values()];
+	const seen = new Set<string>();
+
+	return tags.filter((tag) => {
+		if (seen.has(tag.slug)) {
+			return false;
+		}
+		seen.add(tag.slug);
+		return true;
+	});
 }
 
 type ContentCampaignsSubQuery = NonNullable<LandingPageContentQueryResult>['campaigns'];

--- a/src/app/providers/content.mock.ts
+++ b/src/app/providers/content.mock.ts
@@ -15,6 +15,7 @@ export class StubContentApi implements ContentApi {
 			campaigns: [],
 			mostRead: [],
 			latestReads: [],
+			highlightedAuthors: [],
 		};
 		return of(landingPageContent);
 	}

--- a/src/mocks/onoff-raw-landing-page.mock.ts
+++ b/src/mocks/onoff-raw-landing-page.mock.ts
@@ -21,6 +21,21 @@ export const overflowingRawHighlightedAuthors: RawHighlightedAuthor[] = Array.fr
 	return { ...canonical, author: { ...canonical.author, _id: `${canonical.author._id}-${index}` } };
 });
 
+// El canon repite un slug entre las dos fuentes, pero con el mismo contenido, así que no distingue
+// cuál de las dos sobrevive al descarte. Acá la derivada difiere en el título para que sí lo haga.
+export const divergentDuplicateRawHighlightedAuthor: RawHighlightedAuthor = (() => {
+	const canonical = onoffRawHighlightedAuthorsMock[0];
+	const [shared] = canonical.additionalTags;
+
+	return {
+		...canonical,
+		author: {
+			...canonical.author,
+			tags: canonical.author.tags.map((tag) => (tag.slug === shared.slug ? { ...tag, title: 'Título derivado' } : tag)),
+		},
+	};
+})();
+
 export const untaggedRawHighlightedAuthor: RawHighlightedAuthor = {
 	...onoffRawHighlightedAuthorsMock[0],
 	additionalTags: [],

--- a/src/mocks/onoff-raw-landing-page.mock.ts
+++ b/src/mocks/onoff-raw-landing-page.mock.ts
@@ -6,3 +6,23 @@ export const onoffRawLandingPageMock: NonNullable<LandingPageContentQueryResult>
 // La campaña no tiene agregador propio porque no tiene query propia: es sub-proyección de la de landing, y
 // separarlas dejaría un módulo cuyo valor sale entero de este.
 export const onoffRawContentCampaignsMock = onoffRawLandingPageMock.campaigns;
+
+type RawHighlightedAuthors = NonNullable<LandingPageContentQueryResult>['highlightedAuthors'];
+type RawHighlightedAuthor = RawHighlightedAuthors[number];
+
+export const onoffRawHighlightedAuthorsMock: RawHighlightedAuthors = onoffRawLandingPageMock.highlightedAuthors;
+
+// Escenarios de borde, construidos por spread sobre el canon para que cambien con él.
+
+// El corpus tiene un solo autor, así que las entradas se distinguen por identidad para que el recorte
+// pueda afirmarse sobre cuáles sobreviven y no solo sobre cuántas.
+export const overflowingRawHighlightedAuthors: RawHighlightedAuthor[] = Array.from({ length: 7 }, (_, index) => {
+	const canonical = onoffRawHighlightedAuthorsMock[0];
+	return { ...canonical, author: { ...canonical.author, _id: `${canonical.author._id}-${index}` } };
+});
+
+export const untaggedRawHighlightedAuthor: RawHighlightedAuthor = {
+	...onoffRawHighlightedAuthorsMock[0],
+	additionalTags: [],
+	author: { ...onoffRawHighlightedAuthorsMock[0].author, tags: [] },
+};

--- a/src/models/landing-page-content.model.ts
+++ b/src/models/landing-page-content.model.ts
@@ -1,6 +1,16 @@
 import { StorylistTeaser } from '@models/storylist.model';
 import { ContentCampaign } from '@models/content-campaign.model';
 import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
+import type { AuthorTeaser } from '@models/author.model';
+import type { Tag } from '@models/tag.model';
+
+// Las etiquetas viven acá y no en el teaser porque son las de esta tirada: las puntuales de la semana
+// primero y después las que el autor ya tiene asignadas. El teaser las entrega vacías en toda vista.
+export interface HighlightedAuthor {
+	readonly author: AuthorTeaser;
+	readonly tags: readonly Tag[];
+	readonly storyCount: number;
+}
 
 export interface LandingPageContent {
 	_id: string;
@@ -9,6 +19,7 @@ export interface LandingPageContent {
 	campaigns: ContentCampaign[];
 	mostRead: StoryNavigationTeaserWithAuthor[];
 	latestReads: StoryNavigationTeaserWithAuthor[];
+	readonly highlightedAuthors: readonly HighlightedAuthor[];
 }
 
 export interface RotatingContent {


### PR DESCRIPTION
## Qué hace

Último de los tres PRs de #1570, apilado sobre #2361. Traduce los autores destacados al modelo de dominio y cierra el contrato: a partir de acá `GET /api/content/landing-page` los devuelve y el frontend puede consumirlos.

## Dónde vive cada dato, y por qué

```typescript
interface HighlightedAuthor {
	readonly author: AuthorTeaser;
	readonly tags: readonly Tag[];
	readonly storyCount: number;
}
```

Las etiquetas y el conteo **no** entran al teaser de autor, y no es un descuido:

- Las **etiquetas** son las de esta tirada —las puntuales de la semana más las del autor—, no una propiedad del autor. El teaser entrega su propia lista vacía en toda vista del repositorio, así que quien lea `highlightedAuthor.author.tags` la va a encontrar así; las que se muestran son las del wrapper. Hay un caso que lo afirma, para que quede dicho en código ejecutable y no solo en prosa.
- El **conteo** es una subconsulta por destacado. Ponerlo en el teaser obligaría a todo listado de autor a pagarlo sin usarlo.

Es la misma razón por la que el tipo vive junto a `LandingPageContent` y no en el modelo de autor: es una proyección de curación de esta pantalla, no una vista del agregado.

## El descarte de duplicados conserva la etiqueta de la semana

La primera versión reconstruía la lista con un `Map`, que conserva la **posición** de la primera aparición pero el **valor** de la última. Ante un slug repetido sobrevivía la etiqueta derivada del autor, ocupando el lugar de la puntual — lo contrario de lo que el diseño pide.

Hoy no se nota, porque las dos fuentes dereferencian el mismo documento de etiqueta y los valores coinciden. Dejaría de no notarse en cuanto una etiqueta de la semana difiera en algo más que el slug, que es lo que el epic contempla con el override de color.

El caso que lo exhibe hace divergir el título de la derivada, porque el canon por sí solo no puede distinguir cuál de las dos sobrevive.

## Las otras dos decisiones del mapeo

| Decisión | Por qué |
| --- | --- |
| Las puntuales encabezan la lista | Es el orden que pide el diseño: la etiqueta de la semana es la que da contexto a la tirada |
| El recorte a seis se vuelve a aplicar acá | El límite del Studio gobierna la edición, no lo ya persistido: no alcanza a un backfill ni a una migración |

El recorte va documentado como salvaguarda y no como regla de dominio, que es lo que efectivamente es.

## Los escenarios de borde salen del canon

Ninguno se escribió a mano: los tres se derivan por spread sobre la entrada canónica de la fixture generada, así que siguen al corpus si cambia. El escenario de desborde varía la identidad de cada entrada para que el recorte pueda afirmarse sobre **cuáles** sobreviven y no solo sobre cuántas.

## Plan de pruebas

- **Los once gates de CI, verdes.**
- **Specs del mapper**: orden de las etiquetas, descarte de la repetida, cuál de las dos sobrevive, recorte a seis, autor sin etiquetas de ninguna clase, el conteo tal cual y el autor mapeado como teaser con su lista vacía.
- **Verificado que el caso del descarte falla con la implementación anterior**, que es lo que lo vuelve un test de regresión y no una afirmación de lo que ya pasaba.
- **Caso en el mapper de la landing** que afirma que los destacados viajan al agregado, en orden.
- Aserciones **derivadas del fixture**, sin literales que caduquen.

## Orden de merge

Último de una pila de tres. Su base es #2361, que a su vez sale de #2359. Merge en ese orden.

Closes #1570

Parte de #1568.
