### PR TITLE
[#1570] - Quita las etiquetas puntuales del autor destacado

### DIFF
--- a/cms/schema.json
+++ b/cms/schema.json
@@ -1942,6 +1942,346 @@
 		}
 	},
 	{
+		"type": "type",
+		"name": "nationality.reference",
+		"value": {
+			"type": "object",
+			"attributes": {
+				"_ref": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string"
+					}
+				},
+				"_type": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "string",
+						"value": "reference"
+					}
+				},
+				"_weak": {
+					"type": "objectAttribute",
+					"value": {
+						"type": "boolean"
+					},
+					"optional": true
+				}
+			},
+			"dereferencesTo": "nationality"
+		}
+	},
+	{
+		"name": "author",
+		"type": "document",
+		"attributes": {
+			"_id": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_type": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string",
+					"value": "author"
+				}
+			},
+			"_createdAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_updatedAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_rev": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"name": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": false
+			},
+			"slug": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "slug"
+				},
+				"optional": false
+			},
+			"image": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "object",
+					"attributes": {
+						"asset": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageAsset.reference"
+							},
+							"optional": true
+						},
+						"media": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "unknown"
+							},
+							"optional": true
+						},
+						"hotspot": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageHotspot"
+							},
+							"optional": true
+						},
+						"crop": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageCrop"
+							},
+							"optional": true
+						},
+						"_type": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "string",
+								"value": "image"
+							}
+						}
+					}
+				},
+				"optional": false
+			},
+			"nationality": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "nationality.reference"
+				},
+				"optional": false
+			},
+			"bornOn": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"bornOnYear": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "computedNumber"
+				},
+				"optional": true
+			},
+			"diedOn": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"diedOnYear": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "computedNumber"
+				},
+				"optional": true
+			},
+			"biography": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "inline",
+					"name": "markdown"
+				},
+				"optional": false
+			},
+			"resources": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "array",
+					"of": {
+						"type": "object",
+						"attributes": {
+							"title": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								},
+								"optional": false
+							},
+							"url": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								},
+								"optional": false
+							},
+							"resourceType": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "inline",
+									"name": "resourceType.reference"
+								},
+								"optional": false
+							},
+							"_type": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string",
+									"value": "resource"
+								}
+							}
+						},
+						"rest": {
+							"type": "object",
+							"attributes": {
+								"_key": {
+									"type": "objectAttribute",
+									"value": {
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				},
+				"optional": true
+			},
+			"tags": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "array",
+					"of": {
+						"type": "object",
+						"attributes": {
+							"_key": {
+								"type": "objectAttribute",
+								"value": {
+									"type": "string"
+								}
+							}
+						},
+						"rest": {
+							"type": "inline",
+							"name": "tag.reference"
+						}
+					}
+				},
+				"optional": true
+			}
+		}
+	},
+	{
+		"name": "nationality",
+		"type": "document",
+		"attributes": {
+			"_id": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_type": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string",
+					"value": "nationality"
+				}
+			},
+			"_createdAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_updatedAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_rev": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"country": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": false
+			},
+			"flag": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "object",
+					"attributes": {
+						"asset": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageAsset.reference"
+							},
+							"optional": true
+						},
+						"media": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "unknown"
+							},
+							"optional": true
+						},
+						"hotspot": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageHotspot"
+							},
+							"optional": true
+						},
+						"crop": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "inline",
+								"name": "sanity.imageCrop"
+							},
+							"optional": true
+						},
+						"_type": {
+							"type": "objectAttribute",
+							"value": {
+								"type": "string",
+								"value": "image"
+							}
+						}
+					}
+				},
+				"optional": false
+			}
+		}
+	},
+	{
 		"name": "collection",
 		"type": "document",
 		"attributes": {
@@ -3306,293 +3646,6 @@
 					"of": {
 						"type": "object",
 						"attributes": {
-							"author": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "inline",
-									"name": "author.reference"
-								},
-								"optional": false
-							},
-							"additionalTags": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "array",
-									"of": {
-										"type": "object",
-										"attributes": {
-											"_key": {
-												"type": "objectAttribute",
-												"value": {
-													"type": "string"
-												}
-											}
-										},
-										"rest": {
-											"type": "inline",
-											"name": "tag.reference"
-										}
-									}
-								},
-								"optional": true
-							},
-							"_type": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string",
-									"value": "highlightedAuthor"
-								}
-							}
-						},
-						"rest": {
-							"type": "object",
-							"attributes": {
-								"_key": {
-									"type": "objectAttribute",
-									"value": {
-										"type": "string"
-									}
-								}
-							}
-						}
-					}
-				},
-				"optional": true
-			}
-		}
-	},
-	{
-		"type": "type",
-		"name": "nationality.reference",
-		"value": {
-			"type": "object",
-			"attributes": {
-				"_ref": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string"
-					}
-				},
-				"_type": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "string",
-						"value": "reference"
-					}
-				},
-				"_weak": {
-					"type": "objectAttribute",
-					"value": {
-						"type": "boolean"
-					},
-					"optional": true
-				}
-			},
-			"dereferencesTo": "nationality"
-		}
-	},
-	{
-		"name": "author",
-		"type": "document",
-		"attributes": {
-			"_id": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_type": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string",
-					"value": "author"
-				}
-			},
-			"_createdAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_updatedAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_rev": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"name": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": false
-			},
-			"slug": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "slug"
-				},
-				"optional": false
-			},
-			"image": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "object",
-					"attributes": {
-						"asset": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageAsset.reference"
-							},
-							"optional": true
-						},
-						"media": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "unknown"
-							},
-							"optional": true
-						},
-						"hotspot": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageHotspot"
-							},
-							"optional": true
-						},
-						"crop": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageCrop"
-							},
-							"optional": true
-						},
-						"_type": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "string",
-								"value": "image"
-							}
-						}
-					}
-				},
-				"optional": false
-			},
-			"nationality": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "nationality.reference"
-				},
-				"optional": false
-			},
-			"bornOn": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": true
-			},
-			"bornOnYear": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "computedNumber"
-				},
-				"optional": true
-			},
-			"diedOn": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": true
-			},
-			"diedOnYear": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "computedNumber"
-				},
-				"optional": true
-			},
-			"biography": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "inline",
-					"name": "markdown"
-				},
-				"optional": false
-			},
-			"resources": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "array",
-					"of": {
-						"type": "object",
-						"attributes": {
-							"title": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string"
-								},
-								"optional": false
-							},
-							"url": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string"
-								},
-								"optional": false
-							},
-							"resourceType": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "inline",
-									"name": "resourceType.reference"
-								},
-								"optional": false
-							},
-							"_type": {
-								"type": "objectAttribute",
-								"value": {
-									"type": "string",
-									"value": "resource"
-								}
-							}
-						},
-						"rest": {
-							"type": "object",
-							"attributes": {
-								"_key": {
-									"type": "objectAttribute",
-									"value": {
-										"type": "string"
-									}
-								}
-							}
-						}
-					}
-				},
-				"optional": true
-			},
-			"tags": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "array",
-					"of": {
-						"type": "object",
-						"attributes": {
 							"_key": {
 								"type": "objectAttribute",
 								"value": {
@@ -3602,102 +3655,11 @@
 						},
 						"rest": {
 							"type": "inline",
-							"name": "tag.reference"
+							"name": "author.reference"
 						}
 					}
 				},
 				"optional": true
-			}
-		}
-	},
-	{
-		"name": "nationality",
-		"type": "document",
-		"attributes": {
-			"_id": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_type": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string",
-					"value": "nationality"
-				}
-			},
-			"_createdAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_updatedAt": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"_rev": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				}
-			},
-			"country": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "string"
-				},
-				"optional": false
-			},
-			"flag": {
-				"type": "objectAttribute",
-				"value": {
-					"type": "object",
-					"attributes": {
-						"asset": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageAsset.reference"
-							},
-							"optional": true
-						},
-						"media": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "unknown"
-							},
-							"optional": true
-						},
-						"hotspot": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageHotspot"
-							},
-							"optional": true
-						},
-						"crop": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "inline",
-								"name": "sanity.imageCrop"
-							},
-							"optional": true
-						},
-						"_type": {
-							"type": "objectAttribute",
-							"value": {
-								"type": "string",
-								"value": "image"
-							}
-						}
-					}
-				},
-				"optional": false
 			}
 		}
 	},

--- a/cms/schemas/landingPage.ts
+++ b/cms/schemas/landingPage.ts
@@ -122,27 +122,8 @@ export default defineType({
 				defineArrayMember({
 					name: 'highlightedAuthor',
 					title: 'Autor destacado',
-					type: 'object',
-					fields: [
-						defineField({
-							name: 'author',
-							title: 'Autor',
-							type: 'reference',
-							to: [{ type: 'author' }],
-							validation: (Rule) => Rule.required(),
-						}),
-						defineField({
-							name: 'additionalTags',
-							title: 'Etiquetas de la semana',
-							description:
-								'Etiquetas puntuales de esta tirada (por ejemplo "Cumpleaños"). Se muestran antes de las que el autor ya tiene asignadas.',
-							type: 'array',
-							of: [defineArrayMember({ type: 'reference', to: [{ type: 'tag' }] })],
-						}),
-					],
-					preview: {
-						select: { title: 'author.name' },
-					},
+					type: 'reference',
+					to: [{ type: 'author' }],
 				}),
 			],
 		}),

--- a/docs/CONTENT_UPDATE_STRATEGIES.md
+++ b/docs/CONTENT_UPDATE_STRATEGIES.md
@@ -123,16 +123,13 @@ Este proceso garantiza que:
   latestLiteraryWorks: Array<LiteraryWorkReference>, // Obras destacadas (vigente)
   cards: Array<StorylistReference>,                  // Tarjetas de contenido (en baja)
   latestReads: Array<StoryReference>,                // Historias destacadas (en baja)
-  highlightedAuthors: Array<{                        // Hasta 6 autores destacados
-    author: AuthorReference,
-    additionalTags?: Array<TagReference>             // Etiquetas puntuales de esta semana
-  }>
+  highlightedAuthors: Array<AuthorReference>         // Hasta 6 autores destacados
 }
 ```
 
 > **Convivencia de campos.** `collections` y `latestLiteraryWorks` reemplazan a `cards` y `latestReads`, por el mismo motivo que en `rotatingContent`. Los cuatro coexisten hasta que se retiren los dos primeros.
 
-`highlightedAuthors` es el único campo que se edita como objetos y no como referencias planas, porque cada entrada lleva sus propias etiquetas de la semana además del autor. El tope de seis lo impone el Studio sobre la edición, así que no gobierna lo ya guardado.
+El tope de seis de `highlightedAuthors` lo impone el Studio sobre la edición, así que no gobierna lo ya guardado.
 
 Como los otros tres, viaja en la copia semanal: si quedara afuera, los destacados se vaciarían en cada rotación sin emitir ningún error.
 

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -546,7 +546,7 @@ interface LandingPageContent {
 
 interface HighlightedAuthor {
 	author: AuthorTeaser;
-	tags: readonly Tag[]; // Etiquetas de la semana primero, después las del autor, sin repetir
+	tags: readonly Tag[]; // Las etiquetas derivadas del autor
 	storyCount: number; // Obras del autor, contadas sobre los dos tipos de documento
 }
 ```
@@ -556,7 +556,7 @@ interface HighlightedAuthor {
 - Agregar contenido de múltiples contextos para presentación en página inicio
 - Mantener datos de lectura y estadísticas
 
-`HighlightedAuthor` es una proyección de curación de este contexto, no una vista del agregado `Author`: sus etiquetas son las de la tirada y su conteo es un dato que solo esta pantalla paga. Por eso ninguno de los dos vive en `AuthorTeaser`, que entrega su propia lista de etiquetas vacía.
+`HighlightedAuthor` es una proyección de curación de este contexto, no una vista del agregado `Author`: su conteo es un dato que solo esta pantalla paga, y sus etiquetas viajan en el wrapper porque `AuthorTeaser` entrega la suya vacía en toda vista del repositorio.
 
 El tope de seis rige la edición en el Studio y no lo ya persistido, así que el mapeo lo vuelve a aplicar como salvaguarda.
 

--- a/src/api/_queries/content.query.ts
+++ b/src/api/_queries/content.query.ts
@@ -110,8 +110,8 @@ export const landingPageContentQuery = defineQuery(`
             'resources': [],
         }
     },[]),
-    'highlightedAuthors': coalesce(highlightedAuthors[]{
-        'author': author->{
+    'highlightedAuthors': coalesce(highlightedAuthors[]->{
+        'author': {
             _id,
             'slug': slug.current,
             name,
@@ -121,14 +121,9 @@ export const landingPageContentQuery = defineQuery(`
             bornOnYear,
             diedOn,
             diedOnYear,
-            'resources': [],
-            'tags': coalesce(tags[]->{
-                title,
-                'slug': slug.current,
-                description
-            }, [])
+            'resources': []
         },
-        'additionalTags': coalesce(additionalTags[]->{
+        'tags': coalesce(tags[]->{
             title,
             'slug': slug.current,
             description
@@ -136,7 +131,7 @@ export const landingPageContentQuery = defineQuery(`
         'storyCount': count(array::unique(*[
             !(_id in path('drafts.**')) &&
             _type in ['story', 'literaryWork'] &&
-            references(^.author._ref)
+            references(^._id)
         ].slug.current))
     },[]),
 }`);

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -15,7 +15,6 @@ import {
 import { elOdioRawTeaser, onoffRawNavTeasersMock } from '@mocks/onoff-raw-stories.mock';
 import { rawOnoffAuthor, rawOnoffAuthorTeaser } from '@mocks/onoff-raw-author.mock';
 import {
-	divergentDuplicateRawHighlightedAuthor,
 	onoffRawContentCampaignsMock,
 	onoffRawHighlightedAuthorsMock,
 	onoffRawLandingPageMock,
@@ -260,41 +259,11 @@ describe('mapLandingPageContent (ACL)', () => {
 describe('mapHighlightedAuthors (ACL)', () => {
 	const [canonical] = onoffRawHighlightedAuthorsMock;
 
-	it('leads with the tags of the week and follows with the ones the author already carries', () => {
-		const [result] = mapHighlightedAuthors([canonical]);
+	it('maps every tag the author carries, in order', () => {
+		const expected = canonical.tags.map(({ slug }) => slug);
 
-		const weekly = canonical.additionalTags.map(({ slug }) => slug);
-		const derived = canonical.author.tags.map(({ slug }) => slug).filter((slug) => !weekly.includes(slug));
-
-		expect(weekly.length).toBeGreaterThan(0);
-		expect(derived.length).toBeGreaterThan(0);
-		expect(result.tags.map(({ slug }) => slug)).toEqual([...weekly, ...derived]);
-	});
-
-	it('lists a tag present in both sources only once', () => {
-		const shared = canonical.additionalTags.filter(({ slug }) =>
-			canonical.author.tags.some((tag) => tag.slug === slug),
-		);
-
-		expect(shared.length).toBeGreaterThan(0);
-
-		const slugs = mapHighlightedAuthors([canonical])[0].tags.map(({ slug }) => slug);
-
-		expect(slugs).toEqual([...new Set(slugs)]);
-	});
-
-	// El descarte tiene que quedarse con la etiqueta de la semana, no con la del autor: es la que da
-	// contexto a la tirada, y el epic contempla que las dos difieran en algo más que el slug.
-	it('keeps the tag of the week, not the derived one, when both carry the same slug', () => {
-		const entry = divergentDuplicateRawHighlightedAuthor;
-		const [weekly] = entry.additionalTags;
-		const derived = entry.author.tags.find((tag) => tag.slug === weekly.slug);
-
-		expect(derived?.title).not.toBe(weekly.title);
-
-		const survivor = mapHighlightedAuthors([entry])[0].tags.find((tag) => tag.slug === weekly.slug);
-
-		expect(survivor?.title).toBe(weekly.title);
+		expect(expected.length).toBeGreaterThan(0);
+		expect(mapHighlightedAuthors([canonical])[0].tags.map(({ slug }) => slug)).toEqual(expected);
 	});
 
 	it('keeps the first six entries when the document carries more', () => {
@@ -306,7 +275,7 @@ describe('mapHighlightedAuthors (ACL)', () => {
 		);
 	});
 
-	it('produces an empty tag list for an author with no tags of either kind', () => {
+	it('produces an empty tag list for an author with no tags', () => {
 		expect(mapHighlightedAuthors([untaggedRawHighlightedAuthor])[0].tags).toEqual([]);
 	});
 
@@ -314,8 +283,8 @@ describe('mapHighlightedAuthors (ACL)', () => {
 		expect(mapHighlightedAuthors([canonical])[0].storyCount).toBe(canonical.storyCount);
 	});
 
-	// Los tags del destacado son los de la tirada, no los del autor: el teaser los entrega vacíos en
-	// toda vista, y este mapper es el que decide cuáles se muestran.
+	// El teaser entrega su lista de etiquetas vacía en toda vista del repositorio, así que las del
+	// destacado viajan en el wrapper aunque salgan del mismo autor.
 	it('maps the author as a teaser, whose own tag list stays empty', () => {
 		const [result] = mapHighlightedAuthors([canonical]);
 

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -185,8 +185,7 @@ type TagsSubQuery =
 	| NonNullable<LiteraryWorkBySlugQueryResult>['tags']
 	| NonNullable<CollectionBySlugQueryResult>['tags']
 	| NonNullable<CollectionBySlugQueryResult>['literaryWorks'][number]['tags']
-	| HighlightedAuthorsSubQuery[number]['additionalTags']
-	| HighlightedAuthorsSubQuery[number]['author']['tags'];
+	| HighlightedAuthorsSubQuery[number]['tags'];
 export function mapTags(tags: TagsSubQuery): Tag[] {
 	return tags.map((tag) => ({
 		title: tag.title,
@@ -308,24 +307,11 @@ export function mapHighlightedAuthors(highlightedAuthors: HighlightedAuthorsSubQ
 
 	return highlightedAuthors.slice(0, limit).map((entry) => ({
 		author: mapAuthorTeaser(entry.author),
-		tags: dedupeTagsBySlug([...mapTags(entry.additionalTags), ...mapTags(entry.author.tags)]),
+		// El teaser entrega su lista vacía en toda vista del repositorio, así que las etiquetas del
+		// destacado se mapean acá aunque salgan del mismo autor.
+		tags: mapTags(entry.tags),
 		storyCount: entry.storyCount,
 	}));
-}
-
-// Las puntuales de la semana encabezan la lista, así que ante una repetida gana la primera aparición.
-// Reconstruir con un `Map` no serviría: conservaría esa posición pero con el valor de la última, que
-// es la derivada.
-function dedupeTagsBySlug(tags: Tag[]): Tag[] {
-	const seen = new Set<string>();
-
-	return tags.filter((tag) => {
-		if (seen.has(tag.slug)) {
-			return false;
-		}
-		seen.add(tag.slug);
-		return true;
-	});
 }
 
 type ContentCampaignsSubQuery = NonNullable<LandingPageContentQueryResult>['campaigns'];

--- a/src/api/modules/content/content.repository.ts
+++ b/src/api/modules/content/content.repository.ts
@@ -48,13 +48,7 @@ type LandingPageCreatePayload = {
 	campaigns: KeyedReference[];
 	cards: KeyedReference[];
 	latestReads: KeyedReference[];
-	highlightedAuthors: Array<{
-		_key: string;
-		_type: 'highlightedAuthor';
-		// La referencia al autor no lleva `_key`: es un campo del objeto, no un elemento de array.
-		author: { _type: 'reference'; _ref: string };
-		additionalTags?: KeyedReference[];
-	}>;
+	highlightedAuthors: KeyedReference[];
 };
 
 export async function createLandingPages(landingPageObjects: LandingPageCreatePayload[]) {

--- a/src/api/modules/content/content.service.spec.ts
+++ b/src/api/modules/content/content.service.spec.ts
@@ -42,14 +42,7 @@ describe('ContentService', () => {
 			campaigns: [{ _id: 'campaign-1' }, { _id: 'campaign-2' }],
 			cards: [{ _id: 'card-1' }],
 			latestReads: [{ _id: 'story-1' }, { _id: 'story-2' }],
-			highlightedAuthors: [
-				{
-					_key: 'highlighted-1',
-					_type: 'highlightedAuthor',
-					author: { _type: 'reference', _ref: 'author-1' },
-					additionalTags: [{ _key: 'tag-1', _type: 'reference', _ref: 'tag-1' }],
-				},
-			],
+			highlightedAuthors: [{ _key: 'highlighted-1', _type: 'reference', _ref: 'author-1' }],
 		};
 
 		beforeEach(() => {
@@ -160,8 +153,8 @@ describe('ContentService', () => {
 			});
 		});
 
-		// Los destacados son el único contenido de la landing que se edita como objetos y no como
-		// referencias planas; si la rotación los dejara afuera se vaciarían solos cada semana, sin error.
+		// El clonado enumera los campos que copia, así que un campo nuevo que quede afuera no rompe nada:
+		// los destacados se vaciarían solos cada semana, sin emitir ningún error.
 		it('should carry the highlighted authors over to every cloned week', async () => {
 			const weeksInTheFuture = 3;
 

--- a/src/mocks/onoff-raw-landing-page.mock.ts
+++ b/src/mocks/onoff-raw-landing-page.mock.ts
@@ -21,23 +21,7 @@ export const overflowingRawHighlightedAuthors: RawHighlightedAuthor[] = Array.fr
 	return { ...canonical, author: { ...canonical.author, _id: `${canonical.author._id}-${index}` } };
 });
 
-// El canon repite un slug entre las dos fuentes, pero con el mismo contenido, así que no distingue
-// cuál de las dos sobrevive al descarte. Acá la derivada difiere en el título para que sí lo haga.
-export const divergentDuplicateRawHighlightedAuthor: RawHighlightedAuthor = (() => {
-	const canonical = onoffRawHighlightedAuthorsMock[0];
-	const [shared] = canonical.additionalTags;
-
-	return {
-		...canonical,
-		author: {
-			...canonical.author,
-			tags: canonical.author.tags.map((tag) => (tag.slug === shared.slug ? { ...tag, title: 'Título derivado' } : tag)),
-		},
-	};
-})();
-
 export const untaggedRawHighlightedAuthor: RawHighlightedAuthor = {
 	...onoffRawHighlightedAuthorsMock[0],
-	additionalTags: [],
-	author: { ...onoffRawHighlightedAuthorsMock[0].author, tags: [] },
+	tags: [],
 };

--- a/src/mocks/onoff/landing-page/landing-page.raw.mock.ts
+++ b/src/mocks/onoff/landing-page/landing-page.raw.mock.ts
@@ -1,7 +1,7 @@
 // Este archivo lo escribe `pnpm corpus:generate` evaluando la query GROQ real sobre los documentos del
 // corpus. No se edita a mano: cualquier cambio se pierde en la próxima corrida.
 import type { LandingPageContentQueryResult } from '@sanity-types';
-import { cuentoRawTag, dramaPsicologicoRawTag, metaficcionRawTag } from '../../onoff-raw-tags.mock';
+import { cuentoRawTag, dramaPsicologicoRawTag } from '../../onoff-raw-tags.mock';
 
 export const onoffRawLandingPageMock: NonNullable<LandingPageContentQueryResult> = {
 	_id: 'onoff-landing-page-1974-24',
@@ -72,9 +72,8 @@ export const onoffRawLandingPageMock: NonNullable<LandingPageContentQueryResult>
 				diedOn: '1994-12-31',
 				diedOnYear: 1994,
 				resources: [],
-				tags: [cuentoRawTag, dramaPsicologicoRawTag],
 			},
-			additionalTags: [cuentoRawTag, metaficcionRawTag],
+			tags: [cuentoRawTag, dramaPsicologicoRawTag],
 			storyCount: 8,
 		},
 	],

--- a/src/mocks/onoff/landing-page/onoff.landing-page.document.ts
+++ b/src/mocks/onoff/landing-page/onoff.landing-page.document.ts
@@ -1,8 +1,6 @@
 import type { LandingPage } from '@sanity-types';
 import { documentReference, documentSystemFields, slugField } from '../document/sanity-document.factory';
-import { tagReference } from '../document/support-documents.projection';
 import { onoffAuthorDocument } from '../author/author.document.projection';
-import { cuentoRawTag, metaficcionRawTag } from '../../onoff-raw-tags.mock';
 import { coleccionCompletaContentCampaignDocument } from './coleccion-completa-onoff.content-campaign.document';
 import { palacioNueveFronterasContentCampaignDocument } from './el-palacio-de-las-nueve-fronteras.content-campaign.document';
 
@@ -13,7 +11,7 @@ const week = '1974-24';
 
 // Sin `cards` ni `latestReads` a propósito: referencian agregados que el corpus no modela como documentos,
 // y la guarda del generador aborta ante una referencia colgada. El porqué, en el README del corpus.
-// `highlightedAuthors` sí entra: tanto el autor como las etiquetas existen como documentos del dataset.
+// `highlightedAuthors` sí entra: el autor que referencia existe como documento del dataset.
 export const onoffLandingPageDocument: LandingPage = {
 	...documentSystemFields(`onoff-landing-page-${week}`),
 	_type: 'landingPage',
@@ -31,14 +29,5 @@ export const onoffLandingPageDocument: LandingPage = {
 			_ref: palacioNueveFronterasContentCampaignDocument._id,
 		},
 	],
-	highlightedAuthors: [
-		{
-			_key: 'francois-onoff',
-			_type: 'highlightedAuthor',
-			author: documentReference(onoffAuthorDocument._id),
-			// Una etiqueta que el autor ya tiene y otra que no: la primera fuerza el descarte del duplicado
-			// en la concatenación, la segunda comprueba que las puntuales encabecen la lista.
-			additionalTags: [tagReference(cuentoRawTag.slug), tagReference(metaficcionRawTag.slug)],
-		},
-	],
+	highlightedAuthors: [{ _key: 'francois-onoff', ...documentReference(onoffAuthorDocument._id) }],
 };

--- a/src/models/landing-page-content.model.ts
+++ b/src/models/landing-page-content.model.ts
@@ -4,8 +4,8 @@ import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 import type { AuthorTeaser } from '@models/author.model';
 import type { Tag } from '@models/tag.model';
 
-// Las etiquetas viven acá y no en el teaser porque son las de esta tirada: las puntuales de la semana
-// primero y después las que el autor ya tiene asignadas. El teaser las entrega vacías en toda vista.
+// Las etiquetas y el conteo viven acá y no en el teaser: el teaser entrega su lista de etiquetas vacía
+// en toda vista del repositorio, y el conteo lo paga solo esta pantalla.
 export interface HighlightedAuthor {
 	readonly author: AuthorTeaser;
 	readonly tags: readonly Tag[];

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -339,6 +339,64 @@ export type BlockContent = Array<
 
 export type ComputedNumber = number;
 
+export type NationalityReference = {
+	_ref: string;
+	_type: 'reference';
+	_weak?: boolean;
+	[internalGroqTypeReferenceTo]?: 'nationality';
+};
+
+export type Author = {
+	_id: string;
+	_type: 'author';
+	_createdAt: string;
+	_updatedAt: string;
+	_rev: string;
+	name: string;
+	slug: Slug;
+	image: {
+		asset?: SanityImageAssetReference;
+		media?: unknown;
+		hotspot?: SanityImageHotspot;
+		crop?: SanityImageCrop;
+		_type: 'image';
+	};
+	nationality: NationalityReference;
+	bornOn?: string;
+	bornOnYear?: ComputedNumber;
+	diedOn?: string;
+	diedOnYear?: ComputedNumber;
+	biography: Markdown;
+	resources?: Array<{
+		title: string;
+		url: string;
+		resourceType: ResourceTypeReference;
+		_type: 'resource';
+		_key: string;
+	}>;
+	tags?: Array<
+		{
+			_key: string;
+		} & TagReference
+	>;
+};
+
+export type Nationality = {
+	_id: string;
+	_type: 'nationality';
+	_createdAt: string;
+	_updatedAt: string;
+	_rev: string;
+	country: string;
+	flag: {
+		asset?: SanityImageAssetReference;
+		media?: unknown;
+		hotspot?: SanityImageHotspot;
+		crop?: SanityImageCrop;
+		_type: 'image';
+	};
+};
+
 export type Collection = {
 	_id: string;
 	_type: 'collection';
@@ -576,74 +634,11 @@ export type LandingPage = {
 			_key: string;
 		} & LiteraryWorkReference
 	>;
-	highlightedAuthors?: Array<{
-		author: AuthorReference;
-		additionalTags?: Array<
-			{
-				_key: string;
-			} & TagReference
-		>;
-		_type: 'highlightedAuthor';
-		_key: string;
-	}>;
-};
-
-export type NationalityReference = {
-	_ref: string;
-	_type: 'reference';
-	_weak?: boolean;
-	[internalGroqTypeReferenceTo]?: 'nationality';
-};
-
-export type Author = {
-	_id: string;
-	_type: 'author';
-	_createdAt: string;
-	_updatedAt: string;
-	_rev: string;
-	name: string;
-	slug: Slug;
-	image: {
-		asset?: SanityImageAssetReference;
-		media?: unknown;
-		hotspot?: SanityImageHotspot;
-		crop?: SanityImageCrop;
-		_type: 'image';
-	};
-	nationality: NationalityReference;
-	bornOn?: string;
-	bornOnYear?: ComputedNumber;
-	diedOn?: string;
-	diedOnYear?: ComputedNumber;
-	biography: Markdown;
-	resources?: Array<{
-		title: string;
-		url: string;
-		resourceType: ResourceTypeReference;
-		_type: 'resource';
-		_key: string;
-	}>;
-	tags?: Array<
+	highlightedAuthors?: Array<
 		{
 			_key: string;
-		} & TagReference
+		} & AuthorReference
 	>;
-};
-
-export type Nationality = {
-	_id: string;
-	_type: 'nationality';
-	_createdAt: string;
-	_updatedAt: string;
-	_rev: string;
-	country: string;
-	flag: {
-		asset?: SanityImageAssetReference;
-		media?: unknown;
-		hotspot?: SanityImageHotspot;
-		crop?: SanityImageCrop;
-		_type: 'image';
-	};
 };
 
 export type Resource = {
@@ -803,6 +798,9 @@ export type AllSanitySchemaTypes =
 	| Story
 	| BlockContent
 	| ComputedNumber
+	| NationalityReference
+	| Author
+	| Nationality
 	| Collection
 	| Storylist
 	| ContentCampaign
@@ -810,9 +808,6 @@ export type AllSanitySchemaTypes =
 	| StorylistReference
 	| CollectionReference
 	| LandingPage
-	| NationalityReference
-	| Author
-	| Nationality
 	| Resource
 	| ResourceType
 	| Contributor
@@ -1296,22 +1291,17 @@ export type LatestLandingPageReferencesQueryResult = {
 		  >
 		| Array<never>;
 	highlightedAuthors:
-		| Array<{
-				author: AuthorReference;
-				additionalTags?: Array<
-					{
-						_key: string;
-					} & TagReference
-				>;
-				_type: 'highlightedAuthor';
-				_key: string;
-		  }>
+		| Array<
+				{
+					_key: string;
+				} & AuthorReference
+		  >
 		| Array<never>;
 } | null;
 
 // Source: ../src/api/_queries/content.query.ts
 // Variable: landingPageContentQuery
-// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{    _id,    'slug': slug.current,    config,    'cards': coalesce(cards[]->{        _id,        title,        'slug': slug.current,        description,        featuredImage,        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'storyCoverImages': coalesce(stories[]->coverImage, []),        'count': coalesce(count(stories), 0),				config,				'tabs': [],	      'mediaSources': coalesce(mediaSources[], []),    },[]),    'campaigns': coalesce(campaigns[]->{        _id,        'title': coalesce(title, ''),        'slug': coalesce(slug.current, ''),        'url': coalesce(url, ''),        'contents': {            'xs': {                'image': contents.xs.image            },            'md': {                'image': contents.md.image            }        }    },[]),    'latestReads': coalesce(latestReads[]->{        _id,        'slug': slug.current,        title,        'badLanguage': coalesce(badLanguage, false),        'body': [],        'originalPublication': coalesce(originalPublication, ''),        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {             _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[]),    'highlightedAuthors': coalesce(highlightedAuthors[]{        'author': author->{            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear,            'resources': [],            'tags': coalesce(tags[]->{                title,                'slug': slug.current,                description            }, [])        },        'additionalTags': coalesce(additionalTags[]->{            title,            'slug': slug.current,            description        }, []),        'storyCount': count(array::unique(*[            !(_id in path('drafts.**')) &&            _type in ['story', 'literaryWork'] &&            references(^.author._ref)        ].slug.current))    },[]),}
+// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{    _id,    'slug': slug.current,    config,    'cards': coalesce(cards[]->{        _id,        title,        'slug': slug.current,        description,        featuredImage,        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'storyCoverImages': coalesce(stories[]->coverImage, []),        'count': coalesce(count(stories), 0),				config,				'tabs': [],	      'mediaSources': coalesce(mediaSources[], []),    },[]),    'campaigns': coalesce(campaigns[]->{        _id,        'title': coalesce(title, ''),        'slug': coalesce(slug.current, ''),        'url': coalesce(url, ''),        'contents': {            'xs': {                'image': contents.xs.image            },            'md': {                'image': contents.md.image            }        }    },[]),    'latestReads': coalesce(latestReads[]->{        _id,        'slug': slug.current,        title,        'badLanguage': coalesce(badLanguage, false),        'body': [],        'originalPublication': coalesce(originalPublication, ''),        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {             _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[]),    'highlightedAuthors': coalesce(highlightedAuthors[]->{        'author': {            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear,            'resources': []        },        'tags': coalesce(tags[]->{            title,            'slug': slug.current,            description        }, []),        'storyCount': count(array::unique(*[            !(_id in path('drafts.**')) &&            _type in ['story', 'literaryWork'] &&            references(^._id)        ].slug.current))    },[]),}
 export type LandingPageContentQueryResult = {
 	_id: string;
 	slug: string;
@@ -1550,15 +1540,8 @@ export type LandingPageContentQueryResult = {
 					diedOn: string | null;
 					diedOnYear: ComputedNumber | null;
 					resources: Array<never>;
-					tags:
-						| Array<{
-								title: string;
-								slug: string;
-								description: string;
-						  }>
-						| Array<never>;
 				};
-				additionalTags:
+				tags:
 					| Array<{
 							title: string;
 							slug: string;
@@ -2664,7 +2647,7 @@ declare module '@sanity/client' {
 		"\n*[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{\n    _id,\n    name,\n    'mostRead': coalesce(mostRead[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        'badLanguage': coalesce(badLanguage, false),\n        'body': [],\n        'originalPublication': coalesce(originalPublication, ''),\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[])\n}": RotatingContentQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current in $slugs]{\n\t\t_id,\n\t\t'slug': slug.current,\n\t\tconfig,\n}": LandingPageListQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{\n    _id,\n    _type,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[],[]),\n    'campaigns': coalesce(campaigns[],[]),\n    'latestReads': coalesce(latestReads,[]),\n    'highlightedAuthors': coalesce(highlightedAuthors,[]),\n} | order(config desc, _createdAt desc)[0]\n": LatestLandingPageReferencesQueryResult;
-		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{\n    _id,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[]->{\n        _id,\n        title,\n        'slug': slug.current,\n        description,\n        featuredImage,\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCoverImages': coalesce(stories[]->coverImage, []),\n        'count': coalesce(count(stories), 0),\n\t\t\t\tconfig,\n\t\t\t\t'tabs': [],\n\t      'mediaSources': coalesce(mediaSources[], []),\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'image': contents.xs.image\n            },\n            'md': {\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'latestReads': coalesce(latestReads[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        'badLanguage': coalesce(badLanguage, false),\n        'body': [],\n        'originalPublication': coalesce(originalPublication, ''),\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> { \n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[]),\n    'highlightedAuthors': coalesce(highlightedAuthors[]{\n        'author': author->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear,\n            'resources': [],\n            'tags': coalesce(tags[]->{\n                title,\n                'slug': slug.current,\n                description\n            }, [])\n        },\n        'additionalTags': coalesce(additionalTags[]->{\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCount': count(array::unique(*[\n            !(_id in path('drafts.**')) &&\n            _type in ['story', 'literaryWork'] &&\n            references(^.author._ref)\n        ].slug.current))\n    },[]),\n}": LandingPageContentQueryResult;
+		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{\n    _id,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[]->{\n        _id,\n        title,\n        'slug': slug.current,\n        description,\n        featuredImage,\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCoverImages': coalesce(stories[]->coverImage, []),\n        'count': coalesce(count(stories), 0),\n\t\t\t\tconfig,\n\t\t\t\t'tabs': [],\n\t      'mediaSources': coalesce(mediaSources[], []),\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'image': contents.xs.image\n            },\n            'md': {\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'latestReads': coalesce(latestReads[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        'badLanguage': coalesce(badLanguage, false),\n        'body': [],\n        'originalPublication': coalesce(originalPublication, ''),\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> { \n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[]),\n    'highlightedAuthors': coalesce(highlightedAuthors[]->{\n        'author': {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear,\n            'resources': []\n        },\n        'tags': coalesce(tags[]->{\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCount': count(array::unique(*[\n            !(_id in path('drafts.**')) &&\n            _type in ['story', 'literaryWork'] &&\n            references(^._id)\n        ].slug.current))\n    },[]),\n}": LandingPageContentQueryResult;
 		"\n*[_type == 'contributor' && !(_id in path('drafts.**'))]\n{\n\tname,\n\t'slug': slug.current,\n\tarea,\n\tlink {\n\t\thandle,\n\t\turl\n\t},\n\tnotes\n}|order(name asc)\n": AllContributorsQueryResult;
 		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            description\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                description\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'content': coalesce(content[]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }, [])\n}[0]": LiteraryWorkBySlugQueryResult;
 		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            description\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                description\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'section': content[$section...$sectionEnd]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }\n}[0]": LiteraryWorkSectionBySlugQueryResult;


### PR DESCRIPTION
## Qué hace

Cuarto PR de #1570, apilado sobre #2362. Saca del stack completo las **etiquetas puntuales por entrada** (`additionalTags`): schema del Studio, proyección GROQ, tipos generados, clonado semanal, ACL, modelo de dominio, corpus, specs y documentación.

Es funcionalidad que se abordará más adelante y que hoy no tiene consumidor: #1571, el único que va a leer este contrato, renderiza la lista de etiquetas plana y no distingue su origen.

## Qué se lleva puesto

Las etiquetas puntuales eran la razón de ser de casi toda la complejidad del mapeo:

| Antes | Ahora |
| --- | --- |
| Dos fuentes de etiquetas por destacado | Una: las derivadas del autor |
| Orden explícito entre ellas | No aplica |
| Descarte de duplicados por slug | No aplica |

Con una sola fuente, el mapeo pasa a ser un `mapTags` directo y el helper de descarte desaparece junto con los tres casos que lo cubrían.

## Por qué el array deja de ser de objetos

La entrada del destacado era un objeto **porque llevaba dato propio además de la referencia**. Sin las etiquetas no lleva ninguno, así que un objeto de un solo campo es una referencia con pasos de más: quien lo lea dentro de seis meses va a preguntarse por qué está envuelto, y la respuesta va a ser "por un campo que se quitó".

Colapsarlo lo deja estructuralmente idéntico a los otros cinco campos del documento, y de paso el Studio vuelve a rotular cada entrada con el nombre del autor por su cuenta, sin la vista previa que el objeto necesitaba.

**El costo, explícito:** si las etiquetas puntuales vuelven, reintroducirlas ya no es aditivo — hay que migrar las entradas de referencia a objeto. Hoy eso no cuesta nada porque ningún dataset tiene el campo poblado, y cuando vuelva será una migración de forma sobre los documentos de landing, del mismo tipo que la de #2316. Si preferís pagar hoy la ceremonia para no pagar mañana la migración, este commit se revierte solo. La vuelta quedó registrada en #2369, con esa migración en su alcance.

## Lo que no cambia

**El contrato de dominio.** `HighlightedAuthor` sigue entregando `author`, `tags` y `storyCount`, así que #1571 no se entera. Lo único que cambia es que `tags` pasa a tener una sola fuente.

Las etiquetas siguen viajando en el wrapper y no en el teaser: `AuthorTeaser` entrega su propia lista vacía en toda vista del repositorio, por convención, así que el destacado tiene que mapearlas por su cuenta aunque salgan del mismo autor.

## Sin migración

El schema todavía no se desplegó —los tres PRs de la pila siguen abiertos—, así que ningún dataset tiene `highlightedAuthors` poblado. No hay dato que convertir ni que dar de baja.

## Plan de pruebas

- **Los once gates de CI, verdes.**
- **Barrido por el campo y por el concepto**, no solo por el identificador: no queda ninguna mención residual en `src/`, `cms/` ni `docs/`.
- **Specs del mapper**, reducidos a lo que sigue existiendo: las etiquetas del autor mapeadas en orden, el recorte a seis, el autor sin etiquetas, el conteo tal cual y el autor como teaser con su lista vacía. Los tres casos de orden y descarte se van con la funcionalidad.
- **Spec de query** (`content.query.spec.ts`), sin cambios: sigue afirmando que el conteo no duplica la obra migrada. Es la garantía de que el cambio de forma de la proyección no tocó la corrección del conteo.
- **Corpus regenerado** con `pnpm corpus:generate`; el gate de frescura queda verde sin tocarlo.
- **`pnpm sanity:typecheck` y `pnpm sanity:test`** en local, verdes.

Parte de #1570.

Parte de #1568.
