### PR TITLE
[#1571] - Agrega la sección de autores destacados al catálogo

### DIFF
--- a/src/app/components/author-card-teaser/author-card-teaser.component.stories.ts
+++ b/src/app/components/author-card-teaser/author-card-teaser.component.stories.ts
@@ -33,7 +33,7 @@ const meta: Meta<AuthorCardTeaserComponent> = {
 		tags: {
 			control: { type: 'object' },
 			description: 'Tags asociados al autor',
-			table: { type: { summary: 'Tag[]' }, defaultValue: { summary: '[]' } },
+			table: { type: { summary: 'readonly Tag[]' }, defaultValue: { summary: '[]' } },
 		},
 		storyCount: {
 			control: { type: 'number' },

--- a/src/app/components/author-card-teaser/author-card-teaser.component.stories.ts
+++ b/src/app/components/author-card-teaser/author-card-teaser.component.stories.ts
@@ -53,7 +53,7 @@ export const Default: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Teaser completo del autor: avatar, fila de tags, nombre con bandera de nacionalidad y cantidad de historias. Toda la tarjeta es clickeable y navega al perfil del autor.</p><p><strong>Usos:</strong> Author List (listado de autores).</p>`,
+				story: `<p>Teaser completo del autor: avatar, fila de tags, nombre con bandera de nacionalidad y cantidad de historias. Toda la tarjeta es clickeable y navega al perfil del autor.</p><p><strong>Usos:</strong> la sección <a href="./?path=/docs/componentes-v3-highlightedauthors--docs" target="_top"><strong>HighlightedAuthors</strong></a> de la página de inicio, y el listado de autores.</p>`,
 			},
 		},
 	},

--- a/src/app/components/author-card-teaser/author-card-teaser.component.ts
+++ b/src/app/components/author-card-teaser/author-card-teaser.component.ts
@@ -73,6 +73,6 @@ export class AuthorCardTeaserComponent {
 
 	// Inputs
 	public readonly author = input.required<AuthorTeaser>();
-	public readonly tags = input<Tag[]>([]);
+	public readonly tags = input<readonly Tag[]>([]);
 	public readonly storyCount = input<number>();
 }

--- a/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
@@ -1,0 +1,179 @@
+// Librería de pruebas
+import { render, screen } from '@testing-library/angular';
+import { DeferBlockState } from '@angular/core/testing';
+import { provideRouter, RouterLink } from '@angular/router';
+
+// Componentes
+import { HighlightedAuthorsComponent } from './highlighted-authors.component';
+import { ButtonComponent } from '@components/button/button.component';
+import { AuthorCardTeaserComponent } from '@components/author-card-teaser/author-card-teaser.component';
+import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-teaser/author-card-teaser-skeleton.component';
+
+// Mocks
+import { onoffHighlightedAuthorsOfLength, onoffUntaggedHighlightedAuthor } from '@mocks/onoff-highlighted-authors.mock';
+
+describe('HighlightedAuthorsComponent', () => {
+	const defaultProviders = [provideRouter([])];
+	// `componentImports` reemplaza los imports del componente bajo prueba, no los suma: sin `RouterLink` ni
+	// el botón, el enlace del encabezado se renderiza como un `<a>` sin `href` y deja de tener rol de link.
+	const defaultImports = [
+		HighlightedAuthorsComponent,
+		RouterLink,
+		ButtonComponent,
+		AuthorCardTeaserComponent,
+		AuthorCardTeaserSkeletonComponent,
+	];
+
+	describe('Renderizado del componente', () => {
+		it('should display the section title', async () => {
+			await render(HighlightedAuthorsComponent, {
+				inputs: { authors: [] },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			expect(screen.getByRole('heading', { name: 'Autores/as destacados/as', level: 2 })).toBeInTheDocument();
+		});
+
+		it('should describe the section as a curated selection', async () => {
+			await render(HighlightedAuthorsComponent, {
+				inputs: { authors: [] },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			expect(screen.getByText('Una selección curada de autores y autoras imprescindibles')).toBeInTheDocument();
+		});
+
+		// El enlace se afirma con la lista vacía a propósito: es el caso en que el contenido curado todavía
+		// no llegó, y es donde un enlace condicionado al dato desaparecería sin que nada más lo note.
+		it('should link to the authors index even with nothing highlighted', async () => {
+			await render(HighlightedAuthorsComponent, {
+				inputs: { authors: [] },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			expect(screen.getByRole('link', { name: 'Ver todo' })).toHaveAttribute('href', '/authors');
+		});
+	});
+
+	describe('Comportamiento del bloque defer', () => {
+		it('should render one skeleton per grid slot while loading', async () => {
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				inputs: { authors: onoffHighlightedAuthorsOfLength(6) },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			const [deferBlockFixture] = await fixture.getDeferBlocks();
+			await deferBlockFixture.render(DeferBlockState.Loading);
+
+			expect(screen.getAllByRole('article')).toHaveLength(6);
+		});
+
+		it('should render one card per highlighted author when data is available', async () => {
+			const highlighted = onoffHighlightedAuthorsOfLength(6);
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				inputs: { authors: highlighted },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			const [deferBlockFixture] = await fixture.getDeferBlocks();
+			await deferBlockFixture.render(DeferBlockState.Complete);
+
+			expect(screen.getAllByRole('article')).toHaveLength(6);
+			highlighted.forEach(({ author }) => {
+				expect(screen.getByText(author.name)).toBeInTheDocument();
+			});
+		});
+
+		// Cada entrada tiene su propia identidad, así que contar enlaces no alcanza: se afirma que cada uno
+		// apunta al perfil que le corresponde y no seis veces al mismo.
+		it('should link every card to its own author profile', async () => {
+			const highlighted = onoffHighlightedAuthorsOfLength(3);
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				inputs: { authors: highlighted },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			const [deferBlockFixture] = await fixture.getDeferBlocks();
+			await deferBlockFixture.render(DeferBlockState.Complete);
+
+			highlighted.forEach(({ author }) => {
+				expect(screen.getByRole('link', { name: author.name })).toHaveAttribute('href', `/author/${author.slug}`);
+			});
+		});
+
+		it('should carry the story count of each highlighted author', async () => {
+			const [highlighted] = onoffHighlightedAuthorsOfLength(1);
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				inputs: { authors: [highlighted] },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			const [deferBlockFixture] = await fixture.getDeferBlocks();
+			await deferBlockFixture.render(DeferBlockState.Complete);
+
+			expect(screen.getByText(`${highlighted.storyCount} historias`)).toBeInTheDocument();
+		});
+
+		it('should transition from loading to complete state', async () => {
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				inputs: { authors: onoffHighlightedAuthorsOfLength(6) },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			const [deferBlockFixture] = await fixture.getDeferBlocks();
+
+			await deferBlockFixture.render(DeferBlockState.Loading);
+			expect(screen.queryAllByRole('link', { name: /François/ })).toHaveLength(0);
+
+			await deferBlockFixture.render(DeferBlockState.Complete);
+			expect(screen.getAllByRole('link', { name: /François/ })).toHaveLength(6);
+		});
+	});
+
+	// Los tags de autor se derivan de los editoriales de las obras, y esa reconciliación todavía no corre:
+	// la grilla sin etiquetas es el estado con el que la sección sale, no un borde.
+	describe('Autor sin etiquetas', () => {
+		it('should render the card without a tag list', async () => {
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				inputs: { authors: [onoffUntaggedHighlightedAuthor] },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			const [deferBlockFixture] = await fixture.getDeferBlocks();
+			await deferBlockFixture.render(DeferBlockState.Complete);
+
+			expect(screen.getByText(onoffUntaggedHighlightedAuthor.author.name)).toBeInTheDocument();
+			expect(screen.queryByTestId('tags')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Inputs del componente', () => {
+		it('should default to an empty list', async () => {
+			const { fixture } = await render(HighlightedAuthorsComponent, {
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			expect(fixture.componentInstance.authors()).toEqual([]);
+		});
+
+		it('should render neither cards nor skeletons when there is nothing highlighted', async () => {
+			await render(HighlightedAuthorsComponent, {
+				inputs: { authors: [] },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+
+			expect(screen.queryAllByRole('article')).toHaveLength(0);
+		});
+	});
+});

--- a/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
@@ -1,21 +1,19 @@
-// Librería de pruebas
 import { render, screen } from '@testing-library/angular';
 import { DeferBlockState } from '@angular/core/testing';
 import { provideRouter, RouterLink } from '@angular/router';
 
-// Componentes
 import { HighlightedAuthorsComponent } from './highlighted-authors.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { AuthorCardTeaserComponent } from '@components/author-card-teaser/author-card-teaser.component';
 import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-teaser/author-card-teaser-skeleton.component';
 
-// Mocks
 import { onoffHighlightedAuthorsOfLength, onoffUntaggedHighlightedAuthor } from '@mocks/onoff-highlighted-authors.mock';
 
 describe('HighlightedAuthorsComponent', () => {
 	const defaultProviders = [provideRouter([])];
-	// `componentImports` reemplaza los imports del componente bajo prueba, no los suma: sin `RouterLink` ni
-	// el botón, el enlace del encabezado se renderiza como un `<a>` sin `href` y deja de tener rol de link.
+	// `componentImports` reemplaza los imports del componente bajo prueba, no los suma. Sin `RouterLink` el
+	// enlace del encabezado se renderiza como un `<a>` sin `href` y deja de tener rol de link; el botón va
+	// por consistencia con lo que el componente declara, aunque solo aporte clases.
 	const defaultImports = [
 		HighlightedAuthorsComponent,
 		RouterLink,
@@ -54,14 +52,17 @@ describe('HighlightedAuthorsComponent', () => {
 				componentImports: defaultImports,
 			});
 
-			expect(screen.getByRole('link', { name: 'Ver todo' })).toHaveAttribute('href', '/authors');
+			expect(screen.getByRole('link', { name: 'Ver todos los autores' })).toHaveAttribute('href', '/authors');
 		});
 	});
 
 	describe('Comportamiento del bloque defer', () => {
-		it('should render one skeleton per grid slot while loading', async () => {
+		// Se afirma sobre el marcador de esqueleto y con una cantidad distinta de seis: la tarjeta real y el
+		// esqueleto son ambos `<article>`, así que contar artículos con la grilla llena se cumpliría igual
+		// aunque la rama de carga dibujara una cantidad fija o el bloque hubiera resuelto.
+		it('should render exactly one skeleton per highlighted author while loading', async () => {
 			const { fixture } = await render(HighlightedAuthorsComponent, {
-				inputs: { authors: onoffHighlightedAuthorsOfLength(6) },
+				inputs: { authors: onoffHighlightedAuthorsOfLength(3) },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
@@ -69,7 +70,7 @@ describe('HighlightedAuthorsComponent', () => {
 			const [deferBlockFixture] = await fixture.getDeferBlocks();
 			await deferBlockFixture.render(DeferBlockState.Loading);
 
-			expect(screen.getAllByRole('article')).toHaveLength(6);
+			expect(screen.getAllByTestId('skeleton')).toHaveLength(3);
 		});
 
 		it('should render one card per highlighted author when data is available', async () => {
@@ -122,19 +123,23 @@ describe('HighlightedAuthorsComponent', () => {
 		});
 
 		it('should transition from loading to complete state', async () => {
+			const highlighted = onoffHighlightedAuthorsOfLength(6);
 			const { fixture } = await render(HighlightedAuthorsComponent, {
-				inputs: { authors: onoffHighlightedAuthorsOfLength(6) },
+				inputs: { authors: highlighted },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
 
 			const [deferBlockFixture] = await fixture.getDeferBlocks();
+			const [{ author }] = highlighted;
 
 			await deferBlockFixture.render(DeferBlockState.Loading);
-			expect(screen.queryAllByRole('link', { name: /François/ })).toHaveLength(0);
+			expect(screen.getAllByTestId('skeleton')).toHaveLength(6);
+			expect(screen.queryByRole('link', { name: author.name })).not.toBeInTheDocument();
 
 			await deferBlockFixture.render(DeferBlockState.Complete);
-			expect(screen.getAllByRole('link', { name: /François/ })).toHaveLength(6);
+			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
+			expect(screen.getByRole('link', { name: author.name })).toBeInTheDocument();
 		});
 	});
 
@@ -156,17 +161,18 @@ describe('HighlightedAuthorsComponent', () => {
 		});
 	});
 
-	describe('Inputs del componente', () => {
-		it('should default to an empty list', async () => {
-			const { fixture } = await render(HighlightedAuthorsComponent, {
+	describe('Sin destacados', () => {
+		it('should render neither cards nor skeletons when the input is omitted', async () => {
+			await render(HighlightedAuthorsComponent, {
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
 
-			expect(fixture.componentInstance.authors()).toEqual([]);
+			expect(screen.queryAllByRole('article')).toHaveLength(0);
+			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
 		});
 
-		it('should render neither cards nor skeletons when there is nothing highlighted', async () => {
+		it('should render neither cards nor skeletons when the week has nothing highlighted', async () => {
 			await render(HighlightedAuthorsComponent, {
 				inputs: { authors: [] },
 				providers: defaultProviders,
@@ -174,6 +180,7 @@ describe('HighlightedAuthorsComponent', () => {
 			});
 
 			expect(screen.queryAllByRole('article')).toHaveLength(0);
+			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
 		});
 	});
 });

--- a/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
@@ -57,10 +57,11 @@ describe('HighlightedAuthorsComponent', () => {
 	});
 
 	describe('Comportamiento del bloque defer', () => {
-		// Se afirma sobre el marcador de esqueleto y con una cantidad distinta de seis: la tarjeta real y el
+		// Se afirma sobre el marcador de esqueleto, y con menos destacados que el tope: la tarjeta real y el
 		// esqueleto son ambos `<article>`, así que contar artículos con la grilla llena se cumpliría igual
-		// aunque la rama de carga dibujara una cantidad fija o el bloque hubiera resuelto.
-		it('should render exactly one skeleton per highlighted author while loading', async () => {
+		// aunque el bloque hubiera resuelto. La cantidad no sigue al input a propósito — la grilla en carga
+		// dibuja la sección llena aunque todavía no haya llegado ningún destacado.
+		it('should fill the grid with skeletons while loading, regardless of how many arrived', async () => {
 			const { fixture } = await render(HighlightedAuthorsComponent, {
 				inputs: { authors: onoffHighlightedAuthorsOfLength(3) },
 				providers: defaultProviders,
@@ -70,7 +71,7 @@ describe('HighlightedAuthorsComponent', () => {
 			const [deferBlockFixture] = await fixture.getDeferBlocks();
 			await deferBlockFixture.render(DeferBlockState.Loading);
 
-			expect(screen.getAllByTestId('skeleton')).toHaveLength(3);
+			expect(screen.getAllByTestId('skeleton')).toHaveLength(6);
 		});
 
 		it('should render one card per highlighted author when data is available', async () => {

--- a/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
@@ -6,7 +6,8 @@ import { onoffHighlightedAuthorsOfLength, onoffUntaggedHighlightedAuthor } from 
 
 // Un solo dataset compartido por todas las stories: los mismos destacados en cada estado hacen que el
 // switch del catálogo compare siempre lo mismo.
-const highlightedAuthors = onoffHighlightedAuthorsOfLength(6);
+const SKELETON_COUNT = 6;
+const highlightedAuthors = onoffHighlightedAuthorsOfLength(SKELETON_COUNT);
 
 // La grilla sin etiquetas, que es el estado con el que la sección sale a producción.
 const untaggedAuthors = highlightedAuthors.map((highlighted) => ({
@@ -77,24 +78,28 @@ export const SinEtiquetas: Story = {
 };
 
 // La rama de carga replica el shell de la sección (encabezado + grilla internos): es lo que se ve
-// mientras corre el @defer, y replicarlo completo mantiene 1:1 el alto contra el estado real.
+// mientras corre el @defer. Los esqueletos son una cantidad fija, igual que en el componente: la grilla
+// en carga dibuja la sección llena aunque todavia no haya llegado ningun destacado.
 // Bindings explícitos (no argsToTemplate) porque loading no es un input del componente, y
 // argsToTemplate generaría [loading]="loading" contra un destino inexistente.
-export const Estados: StoryObj<HighlightedAuthorsComponent & { loading: boolean }> = {
-	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
+export const Estados: StoryObj<HighlightedAuthorsComponent & { loading: boolean; skeletonCount: number }> = {
+	argTypes: {
+		loading: { control: 'boolean', name: 'Cargando' },
+		skeletonCount: { table: { disable: true } },
+	},
 	render: (args) => ({
 		props: args,
 		template: `
 			@if (loading) {
 				<div class="flex flex-col gap-8">
-					<div class="flex items-start justify-between gap-4">
+					<div class="flex items-center justify-between gap-4">
 						<div class="flex flex-col content-between gap-1">
 							<h2 class="font-inter text-2xl font-bold">Autores/as destacados/as</h2>
 							<div class="font-inter text-sm text-neutral-600">Una selección curada de autores y autoras imprescindibles</div>
 						</div>
 					</div>
 					<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-						@for (_ of authors; track $index) {
+						@for (_ of [].constructor(skeletonCount); track $index) {
 							<cuentoneta-author-card-teaser-skeleton class="w-full" data-testid="skeleton" />
 						}
 					</section>
@@ -106,13 +111,14 @@ export const Estados: StoryObj<HighlightedAuthorsComponent & { loading: boolean 
 	}),
 	args: {
 		loading: true,
+		skeletonCount: SKELETON_COUNT,
 		authors: highlightedAuthors,
 	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					'Activá/desactivá "Cargando" para alternar entre el estado real y el estado de carga de la sección: encabezado fijo más un esqueleto por slot de la grilla —iterando los mismos datos, la paridad con la rama real vale por construcción—. El enlace "Ver todo" no se replica: la rama de carga no navega.<br><br><strong>Usos:</strong> la sección de autores destacados de la página de inicio, mientras resuelve el contenido de la semana.',
+					'Activá/desactivá "Cargando" para alternar entre el estado real y el estado de carga de la sección: encabezado fijo más la grilla llena de esqueletos. La cantidad es fija y no sigue a lo recibido, porque el esqueleto tiene que dibujar la sección completa aunque todavía no haya llegado ningún destacado. El enlace "Ver todo" no se replica: la rama de carga no navega.<br><br><strong>Usos:</strong> la sección de autores destacados de la página de inicio, mientras resuelve el contenido de la semana.',
 			},
 		},
 	},

--- a/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
@@ -70,7 +70,7 @@ export const SinEtiquetas: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>La grilla sin etiquetas de autor. <strong>No es un borde: es el estado con el que la sección sale a producción</strong>, porque las etiquetas del autor se derivan de las editoriales de sus obras y esa reconciliación todavía no corre.</p><p>Es la story contra la que hay que dar el diseño por bueno: sin la fila de etiquetas, la tarjeta pierde alto y la grilla se compacta.</p>`,
+				story: `<p>La grilla sin etiquetas de autor. <strong>No es un borde: es el estado con el que la sección sale a producción</strong>, porque las etiquetas del autor se derivan de las editoriales de sus obras y esa reconciliación todavía no corre.</p><p>Es la story contra la que hay que dar el diseño por bueno: sin la fila de etiquetas, la tarjeta pierde alto y la grilla se compacta.</p><p><strong>Usos:</strong> la sección de autores destacados de la página de inicio, en su estado de salida.</p>`,
 			},
 		},
 	},
@@ -95,7 +95,7 @@ export const Estados: StoryObj<HighlightedAuthorsComponent & { loading: boolean 
 					</div>
 					<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
 						@for (_ of authors; track $index) {
-							<cuentoneta-author-card-teaser-skeleton class="w-full" />
+							<cuentoneta-author-card-teaser-skeleton class="w-full" data-testid="skeleton" />
 						}
 					</section>
 				</div>
@@ -112,7 +112,7 @@ export const Estados: StoryObj<HighlightedAuthorsComponent & { loading: boolean 
 		docs: {
 			description: {
 				story:
-					'Activá/desactivá "Cargando" para alternar entre el estado real y el estado de carga de la sección: encabezado fijo más un esqueleto por slot de la grilla —iterando los mismos datos, la paridad con la rama real vale por construcción—. El enlace "Ver todo" no se replica: la rama de carga no navega.',
+					'Activá/desactivá "Cargando" para alternar entre el estado real y el estado de carga de la sección: encabezado fijo más un esqueleto por slot de la grilla —iterando los mismos datos, la paridad con la rama real vale por construcción—. El enlace "Ver todo" no se replica: la rama de carga no navega.<br><br><strong>Usos:</strong> la sección de autores destacados de la página de inicio, mientras resuelve el contenido de la semana.',
 			},
 		},
 	},
@@ -130,7 +130,7 @@ export const Vacia: Story = {
 		docs: {
 			description: {
 				story:
-					'Sin destacados el @defer no dispara: queda el encabezado de sección con su enlace al índice de autores, sin tarjetas ni skeletons. Es el valor default del input authors, y el enlace sigue siendo navegable.',
+					'Sin destacados el @defer no dispara: queda el encabezado de sección con su enlace al índice de autores, sin tarjetas ni skeletons. Es el valor default del input authors, y el enlace sigue siendo navegable.<br><br><strong>Usos:</strong> la sección de autores destacados de la página de inicio, en una semana sin curaduría cargada.',
 			},
 		},
 	},

--- a/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
@@ -1,0 +1,137 @@
+import { argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
+
+import { HighlightedAuthorsComponent } from './highlighted-authors.component';
+import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-teaser/author-card-teaser-skeleton.component';
+import { onoffHighlightedAuthorsOfLength, onoffUntaggedHighlightedAuthor } from '@mocks/onoff-highlighted-authors.mock';
+
+// Un solo dataset compartido por todas las stories: los mismos destacados en cada estado hacen que el
+// switch del catálogo compare siempre lo mismo.
+const highlightedAuthors = onoffHighlightedAuthorsOfLength(6);
+
+// La grilla sin etiquetas, que es el estado con el que la sección sale a producción.
+const untaggedAuthors = highlightedAuthors.map((highlighted) => ({
+	...highlighted,
+	tags: onoffUntaggedHighlightedAuthor.tags,
+}));
+
+const meta: Meta<HighlightedAuthorsComponent> = {
+	component: HighlightedAuthorsComponent,
+	title: 'Componentes V3/HighlightedAuthors',
+	decorators: [
+		moduleMetadata({
+			imports: [AuthorCardTeaserSkeletonComponent],
+		}),
+	],
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>El <strong>HighlightedAuthors</strong> es la sección de autores destacados de la página de inicio en el Design System v3: encabezado "Autores/as destacados/as" con subtítulo y enlace al índice de autores, más una grilla responsiva de una columna en mobile, dos desde <code>sm</code> y tres desde <code>lg</code>, con una vista previa por autor resuelta por <a href="./?path=/docs/componentes-v3-authorcardteaser--docs" target="_top"><strong>AuthorCardTeaser</strong></a>.</p><p>Está tipado contra <strong>HighlightedAuthor</strong>, la proyección de curación semanal del contenido de la página de inicio, que compone el teaser del autor con las etiquetas de la tirada y su cantidad de obras. La curaduría y el tope de seis los decide el backend: el componente presenta lo que recibe, sin recortar ni ordenar. Mientras difiere la carga dibuja los skeletons de <strong>AuthorCardTeaserSkeleton</strong> dentro de su bloque <code>@defer</code>, y sin destacados queda solo el encabezado.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		authors: {
+			control: { type: 'object' },
+			description: 'Autores destacados de la semana; vacío deja solo el encabezado',
+			table: { type: { summary: 'readonly HighlightedAuthor[]' }, defaultValue: { summary: '[]' } },
+		},
+	},
+};
+export default meta;
+type Story = StoryObj<HighlightedAuthorsComponent>;
+
+export const Primary: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-highlighted-authors ${argsToTemplate(args)} />`,
+	}),
+	args: {
+		authors: highlightedAuthors,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Seis destacados derivados del canon de Onoff mediante el selector del agregador de mocks; la grilla arma dos filas de tres desde viewport <code>lg</code>.</p><p>Los seis salen del mismo autor canónico, así que comparten retrato, nacionalidad y cantidad de obras: la grilla se ve más pareja de lo que se verá con contenido real, y no ejercita nombres de largo dispar ni banderas distintas. Se corrige al ampliar el corpus con autores propios.</p><p><strong>Usos:</strong> la sección de autores destacados de la página de inicio.</p>`,
+			},
+		},
+	},
+};
+
+export const SinEtiquetas: Story = {
+	name: 'Sin etiquetas',
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-highlighted-authors ${argsToTemplate(args)} />`,
+	}),
+	args: {
+		authors: untaggedAuthors,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>La grilla sin etiquetas de autor. <strong>No es un borde: es el estado con el que la sección sale a producción</strong>, porque las etiquetas del autor se derivan de las editoriales de sus obras y esa reconciliación todavía no corre.</p><p>Es la story contra la que hay que dar el diseño por bueno: sin la fila de etiquetas, la tarjeta pierde alto y la grilla se compacta.</p>`,
+			},
+		},
+	},
+};
+
+// La rama de carga replica el shell de la sección (encabezado + grilla internos): es lo que se ve
+// mientras corre el @defer, y replicarlo completo mantiene 1:1 el alto contra el estado real.
+// Bindings explícitos (no argsToTemplate) porque loading no es un input del componente, y
+// argsToTemplate generaría [loading]="loading" contra un destino inexistente.
+export const Estados: StoryObj<HighlightedAuthorsComponent & { loading: boolean }> = {
+	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
+	render: (args) => ({
+		props: args,
+		template: `
+			@if (loading) {
+				<div class="flex flex-col gap-8">
+					<div class="flex items-start justify-between gap-4">
+						<div class="flex flex-col content-between gap-1">
+							<h2 class="font-inter text-2xl font-bold">Autores/as destacados/as</h2>
+							<div class="font-inter text-sm text-neutral-600">Una selección curada de autores y autoras imprescindibles</div>
+						</div>
+					</div>
+					<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+						@for (_ of authors; track $index) {
+							<cuentoneta-author-card-teaser-skeleton class="w-full" />
+						}
+					</section>
+				</div>
+			} @else {
+				<cuentoneta-highlighted-authors [authors]="authors" />
+			}
+		`,
+	}),
+	args: {
+		loading: true,
+		authors: highlightedAuthors,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Activá/desactivá "Cargando" para alternar entre el estado real y el estado de carga de la sección: encabezado fijo más un esqueleto por slot de la grilla —iterando los mismos datos, la paridad con la rama real vale por construcción—. El enlace "Ver todo" no se replica: la rama de carga no navega.',
+			},
+		},
+	},
+};
+
+export const Vacia: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-highlighted-authors ${argsToTemplate(args)} />`,
+	}),
+	args: {
+		authors: [],
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Sin destacados el @defer no dispara: queda el encabezado de sección con su enlace al índice de autores, sin tarjetas ni skeletons. Es el valor default del input authors, y el enlace sigue siendo navegable.',
+			},
+		},
+	},
+};

--- a/src/app/components/highlighted-authors/highlighted-authors.component.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.ts
@@ -23,8 +23,6 @@ import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-tease
 				<h2 class="font-inter text-2xl font-bold">Autores/as destacados/as</h2>
 				<div class="font-inter text-sm text-neutral-600">Una selección curada de autores y autoras imprescindibles</div>
 			</div>
-			<!-- El nombre visible no dice adónde lleva fuera de su contexto visual, y va a competir con el
-			     de cualquier sección hermana que sume el suyo. -->
 			<a
 				[routerLink]="['/', appRoutes.Authors]"
 				cuentoneta-button
@@ -48,9 +46,6 @@ import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-tease
 					/>
 				}
 			} @loading (minimum 500ms) {
-				<!-- Cantidad fija y no la de lo recibido: el esqueleto tiene que dibujar la grilla completa
-				     aunque todavía no haya llegado ningún destacado, que es cuando se lo necesita. Iterar el
-				     input lo ataría a que el disparador siga siendo "hay al menos uno". -->
 				@for (_ of [].constructor(SKELETON_COUNT); track $index) {
 					<cuentoneta-author-card-teaser-skeleton class="w-full" data-testid="skeleton" />
 				}

--- a/src/app/components/highlighted-authors/highlighted-authors.component.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.ts
@@ -18,18 +18,20 @@ import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-tease
 	selector: 'cuentoneta-highlighted-authors',
 	imports: [RouterLink, ButtonComponent, AuthorCardTeaserComponent, AuthorCardTeaserSkeletonComponent],
 	template: `
-		<div class="flex items-start justify-between gap-4">
+		<div class="flex items-center justify-between gap-4">
 			<div class="flex flex-col content-between gap-1">
 				<h2 class="font-inter text-2xl font-bold">Autores/as destacados/as</h2>
 				<div class="font-inter text-sm text-neutral-600">Una selección curada de autores y autoras imprescindibles</div>
 			</div>
+			<!-- El nombre visible no dice adónde lleva fuera de su contexto visual, y va a competir con el
+			     de cualquier sección hermana que sume el suyo. -->
 			<a
 				[routerLink]="['/', appRoutes.Authors]"
 				cuentoneta-button
 				variant="outline"
 				size="sm"
 				class="shrink-0"
-				data-testid="see-all"
+				aria-label="Ver todos los autores"
 			>
 				Ver todo
 			</a>
@@ -46,8 +48,10 @@ import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-tease
 					/>
 				}
 			} @loading (minimum 500ms) {
-				@for (_ of [].constructor(SKELETON_COUNT); track $index) {
-					<cuentoneta-author-card-teaser-skeleton class="w-full" />
+				<!-- Un esqueleto por destacado recibido, y no una cantidad fija: es lo que hace que el alto de
+				     la grilla en carga coincida con el real por construcción, sin fijarlo desde afuera. -->
+				@for (_ of authors(); track $index) {
+					<cuentoneta-author-card-teaser-skeleton class="w-full" data-testid="skeleton" />
 				}
 			}
 		</section>
@@ -57,7 +61,6 @@ import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-tease
 	},
 })
 export class HighlightedAuthorsComponent {
-	protected readonly SKELETON_COUNT = 6;
 	protected readonly appRoutes = AppRoutes;
 
 	public readonly authors = input<readonly HighlightedAuthor[]>([]);

--- a/src/app/components/highlighted-authors/highlighted-authors.component.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.ts
@@ -1,0 +1,64 @@
+import { Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import type { HighlightedAuthor } from '@models/landing-page-content.model';
+import { AppRoutes } from '../../app.routes';
+import { ButtonComponent } from '@components/button/button.component';
+import { AuthorCardTeaserComponent } from '@components/author-card-teaser/author-card-teaser.component';
+import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-teaser/author-card-teaser-skeleton.component';
+
+/**
+ * Sección de autores destacados de la página de inicio, según el Design System v3: cabecera con enlace al
+ * índice de autores y una grilla de vistas previas de autor.
+ *
+ * La curaduría es semanal y la decide la edición, así que el componente solo presenta lo que recibe: no
+ * recorta ni ordena. El tope de seis lo aplica el backend.
+ */
+@Component({
+	selector: 'cuentoneta-highlighted-authors',
+	imports: [RouterLink, ButtonComponent, AuthorCardTeaserComponent, AuthorCardTeaserSkeletonComponent],
+	template: `
+		<div class="flex items-start justify-between gap-4">
+			<div class="flex flex-col content-between gap-1">
+				<h2 class="font-inter text-2xl font-bold">Autores/as destacados/as</h2>
+				<div class="font-inter text-sm text-neutral-600">Una selección curada de autores y autoras imprescindibles</div>
+			</div>
+			<a
+				[routerLink]="['/', appRoutes.Authors]"
+				cuentoneta-button
+				variant="outline"
+				size="sm"
+				class="shrink-0"
+				data-testid="see-all"
+			>
+				Ver todo
+			</a>
+		</div>
+
+		<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+			@defer (when authors().length > 0) {
+				@for (highlighted of authors(); track highlighted.author._id) {
+					<cuentoneta-author-card-teaser
+						[author]="highlighted.author"
+						[tags]="highlighted.tags"
+						[storyCount]="highlighted.storyCount"
+						class="w-full"
+					/>
+				}
+			} @loading (minimum 500ms) {
+				@for (_ of [].constructor(SKELETON_COUNT); track $index) {
+					<cuentoneta-author-card-teaser-skeleton class="w-full" />
+				}
+			}
+		</section>
+	`,
+	host: {
+		class: 'flex flex-col gap-8',
+	},
+})
+export class HighlightedAuthorsComponent {
+	protected readonly SKELETON_COUNT = 6;
+	protected readonly appRoutes = AppRoutes;
+
+	public readonly authors = input<readonly HighlightedAuthor[]>([]);
+}

--- a/src/app/components/highlighted-authors/highlighted-authors.component.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.ts
@@ -48,9 +48,10 @@ import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-tease
 					/>
 				}
 			} @loading (minimum 500ms) {
-				<!-- Un esqueleto por destacado recibido, y no una cantidad fija: es lo que hace que el alto de
-				     la grilla en carga coincida con el real por construcción, sin fijarlo desde afuera. -->
-				@for (_ of authors(); track $index) {
+				<!-- Cantidad fija y no la de lo recibido: el esqueleto tiene que dibujar la grilla completa
+				     aunque todavía no haya llegado ningún destacado, que es cuando se lo necesita. Iterar el
+				     input lo ataría a que el disparador siga siendo "hay al menos uno". -->
+				@for (_ of [].constructor(SKELETON_COUNT); track $index) {
 					<cuentoneta-author-card-teaser-skeleton class="w-full" data-testid="skeleton" />
 				}
 			}
@@ -61,6 +62,8 @@ import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-tease
 	},
 })
 export class HighlightedAuthorsComponent {
+	// El mismo tope que el backend aplica a la curaduría: la grilla en carga dibuja la sección llena.
+	protected readonly SKELETON_COUNT = 6;
 	protected readonly appRoutes = AppRoutes;
 
 	public readonly authors = input<readonly HighlightedAuthor[]>([]);

--- a/src/mocks/onoff-highlighted-authors.acl-alignment.spec.ts
+++ b/src/mocks/onoff-highlighted-authors.acl-alignment.spec.ts
@@ -1,0 +1,19 @@
+import { mapHighlightedAuthors } from '../api/_utils/functions';
+import { onoffHighlightedAuthorsMock } from './onoff-highlighted-authors.mock';
+import { onoffRawHighlightedAuthorsMock } from './onoff-raw-landing-page.mock';
+
+/* eslint-disable no-restricted-syntax -- vi.mock: el builder de imágenes de Sanity no tiene punto de inyección */
+vi.mock('@sanity/image-url', async () => {
+	const { stubImageUrlBuilderModule } = await import('@testing/sanity-image-url.stub');
+	return stubImageUrlBuilderModule();
+});
+/* eslint-enable no-restricted-syntax */
+
+// Cierra la cadena entera del corpus de destacados: el documento alimenta la query, la query genera el raw
+// y el raw pasa por el ACL. Sin este cruce, el corpus de dominio —que es lo que consumen la story y el
+// spec del componente— podría afirmar una forma que la API no devuelve.
+describe('el corpus de dominio de HighlightedAuthor coincide con el mapeo del ACL', () => {
+	it('maps the raw highlighted authors into their domain mock', () => {
+		expect(mapHighlightedAuthors(onoffRawHighlightedAuthorsMock)).toStrictEqual(onoffHighlightedAuthorsMock);
+	});
+});

--- a/src/mocks/onoff-highlighted-authors.mock.ts
+++ b/src/mocks/onoff-highlighted-authors.mock.ts
@@ -1,0 +1,38 @@
+import type { HighlightedAuthor } from '@models/landing-page-content.model';
+import { embeddedAuthorTeaserMock } from './author.mock';
+import { cuentoTagMock, dramaPsicologicoTagMock } from './onoff-tags.mock';
+import { onoffRawHighlightedAuthorsMock } from './onoff-raw-landing-page.mock';
+
+// El autor viaja como teaser con su lista de etiquetas vacía —es lo que devuelve el mapper de teaser en
+// toda vista— y las del destacado van en el wrapper. El conteo sale del crudo generado, así que sigue al
+// corpus si cambia la cantidad de obras que lo referencian.
+const [canonicalRaw] = onoffRawHighlightedAuthorsMock;
+
+export const onoffHighlightedAuthorsMock: HighlightedAuthor[] = [
+	{
+		author: embeddedAuthorTeaserMock,
+		tags: [cuentoTagMock, dramaPsicologicoTagMock],
+		storyCount: canonicalRaw.storyCount,
+	},
+];
+
+// Los tags de autor se derivan de los editoriales de las obras, y esa reconciliación todavía no corre:
+// una grilla sin etiquetas no es un borde sino el estado con el que la sección sale a producción.
+export const onoffUntaggedHighlightedAuthor: HighlightedAuthor = { ...onoffHighlightedAuthorsMock[0], tags: [] };
+
+// El corpus modela un solo autor, así que poblar la grilla exige derivar variantes. Se varía la
+// identidad y no solo la cantidad para que un spec pueda afirmar **cuáles** entradas se renderizaron:
+// con seis copias idénticas, contar tarjetas no distingue una grilla correcta de una que repite la misma.
+export function onoffHighlightedAuthorsOfLength(count: number): HighlightedAuthor[] {
+	const [base] = onoffHighlightedAuthorsMock;
+
+	return Array.from({ length: count }, (_, index) => ({
+		...base,
+		author: {
+			...base.author,
+			_id: `${base.author._id}-${index + 1}`,
+			slug: `${base.author.slug}-${index + 1}`,
+			name: `${base.author.name} ${index + 1}`,
+		},
+	}));
+}


### PR DESCRIPTION
## Qué hace

Primero de los dos PRs de #1571. Suma al catálogo la sección **HighlightedAuthors**: cabecera con enlace al índice de autores y grilla responsiva de vistas previas de autor, según el diseño de Figma.

**Todavía no lo consume nadie:** el cableado en la página de inicio va en el PR 2. Acá el componente queda catalogado y cubierto.

## Tres correcciones al alcance que declaraba el issue

Verificadas contra el código, no supuestas:

| El issue decía | Lo que hay |
| --- | --- |
| Montar `AuthorTeaserV3` | Se llama **`AuthorCardTeaser`** y ya expone `[author] [tags] [storyCount]`. No hubo que crear ni rediseñar la tarjeta — este PR es su primer consumidor de producción |
| Ocultar "Ver todo" con `@if` hasta que exista `/authors` | **La ruta existe y su página es funcional.** El enlace se renderiza siempre, y hay un caso que lo afirma con la lista vacía |
| Un componente de skeleton propio | Sobra. Los tres decks del repositorio resuelven la carga dentro de su propio `@loading` repitiendo el skeleton de la tarjeta; un componente aparte duplicaría cabecera y grilla solo para sostener la paridad de alto |

## Por qué el input de la tarjeta se amplía

Las etiquetas llegan desde el dominio como `readonly Tag[]` y el input de la tarjeta las pedía mutables, así que con `strictTemplates` el binding no compilaba.

Se amplió el input a `readonly Tag[]` en vez de castear en el borde: es **ampliación de contrato** —quien ya le pasa un arreglo mutable sigue compilando— y deja la restricción donde es cierta. Castear habría escondido que la tarjeta no necesita mutar lo que recibe.

## El estado con el que esto sale

Las etiquetas del autor se derivan de las editoriales de sus obras, y esa reconciliación **todavía no corre**: en producción la carga está prácticamente vacía. Por eso hay una story **Sin etiquetas** y un caso de spec dedicados — no cubren un borde, cubren el estado real de salida. Es la story contra la que conviene dar el diseño por bueno, porque sin la fila de etiquetas la tarjeta pierde alto y la grilla se compacta.

## El corpus

`onoffHighlightedAuthorsMock` se deriva del canon, nunca se escribe a mano, y un **cruce contra el ACL** (`onoff-highlighted-authors.acl-alignment.spec.ts`) afirma que el mapeo real produce exactamente ese mock. Sin ese cruce, el corpus de dominio —que es lo que consumen story y spec— podría prometer una forma que la API no devuelve.

El corpus modela un solo autor, así que el selector que puebla la grilla varía **identidad** (`_id`, `slug`, `name`) y no solo cantidad: con seis copias idénticas, contar tarjetas no distinguiría una grilla correcta de una que repite la misma entrada.

## Plan de pruebas

- **Los once gates de CI, verdes.**
- **Spec del componente (11 casos):** cabecera y subtítulo; el enlace al índice de autores **con la lista vacía** —que es la regresión del criterio "no genera link muerto"—; una tarjeta por destacado; cada enlace apuntando al perfil que le corresponde y no seis veces al mismo; el conteo de obras; la transición carga → contenido; la tarjeta sin etiquetas; y la ausencia de tarjetas y esqueletos sin destacados.
- **Cruce contra el ACL**, que ata el corpus de dominio al mapeo real: si el mapeo cambia de forma, el corpus deja de compilar contra él.
- **Storybook compilado en local**, además del gate, con las cuatro stories revisadas en canvas.

### Lo que la grilla en carga reserva

Dibuja la sección **llena**, así que reserva el alto de una semana completa y no el de lo que efectivamente llegue. Una semana con menos destacados encoge al resolver; si ese salto se vuelve perceptible, corresponde fijar el alto por breakpoint como hacen las secciones hermanas de la página de inicio.

### Un caso que pasaba por el motivo equivocado

El caso del estado de carga contaba elementos `article`, y **la tarjeta real y el esqueleto son los dos un `article`**: con la grilla llena, la aserción se cumplía igual si el bloque hubiera resuelto. Pasa a contar el marcador de esqueleto, y con una cantidad distinta de la del tope, así que ahora sí distingue las dos ramas.

La cantidad de esqueletos es **fija**, y no la de lo recibido. Se probó lo segundo y se descartó: ata la rama de carga a que el disparador siga siendo "hay al menos uno", y ante cualquier otro el esqueleto queda vacío justo cuando se lo necesita —antes de que llegue el primer destacado—. El caso lo afirma con **menos destacados que el tope**, que es donde las dos formas dan distinto.

Parte de #1571.

Parte de #1568.
