### PR TITLE
[#1571] - Monta los autores destacados en la página de inicio

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -26,11 +26,6 @@
 		<cuentoneta-most-read-stories-card-deck [stories]="mostRead()" class="flex flex-col gap-8" />
 	</section>
 
-	<!--
-        Sin altura fijada, a diferencia de las secciones de arriba: la grilla en carga dibuja la sección
-        llena, así que reserva el alto de una semana completa. Una semana con menos destacados encoge al
-        resolver; si ese salto se vuelve perceptible, corresponde fijar el alto por breakpoint.
-    -->
 	<section class="mb-8">
 		<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" />
 	</section>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -27,8 +27,9 @@
 	</section>
 
 	<!--
-        Sin altura fijada, a diferencia de las secciones de arriba: la rama de carga de la sección dibuja
-        un esqueleto por slot en la misma grilla que la rama real, así que el alto ya queda reservado.
+        Sin altura fijada, a diferencia de las secciones de arriba: la grilla en carga dibuja la sección
+        llena, así que reserva el alto de una semana completa. Una semana con menos destacados encoge al
+        resolver; si ese salto se vuelve perceptible, corresponde fijar el alto por breakpoint.
     -->
 	<section class="mb-8">
 		<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" />

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -26,6 +26,14 @@
 		<cuentoneta-most-read-stories-card-deck [stories]="mostRead()" class="flex flex-col gap-8" />
 	</section>
 
+	<!--
+        Sin altura fijada, a diferencia de las secciones de arriba: la rama de carga de la sección dibuja
+        un esqueleto por slot en la misma grilla que la rama real, así que el alto ya queda reservado.
+    -->
+	<section class="mb-8">
+		<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" />
+	</section>
+
 	<section class="mb-8">
 		<cuentoneta-storylist-teasers-deck [teasers]="collections()" class="flex flex-col gap-8" />
 	</section>

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -8,8 +8,7 @@ import { Component, input } from '@angular/core';
 import { Storylist } from '@models/storylist.model';
 import { map, type Observable } from 'rxjs';
 import type { ContentApi } from '../../providers/content.provider';
-import type { LandingPageContent } from '@models/landing-page-content.model';
-import type { HighlightedAuthor } from '@models/landing-page-content.model';
+import type { HighlightedAuthor, LandingPageContent } from '@models/landing-page-content.model';
 import { onoffHighlightedAuthorsOfLength } from '@mocks/onoff-highlighted-authors.mock';
 
 describe.skip('HomeComponent', () => {
@@ -73,7 +72,7 @@ describe('HomeComponent — autores destacados', () => {
 	it('should link to the authors index from the home', async () => {
 		await renderHome(onoffHighlightedAuthorsOfLength(6));
 
-		expect(screen.getByRole('link', { name: 'Ver todo' })).toHaveAttribute('href', '/authors');
+		expect(screen.getByRole('link', { name: 'Ver todos los autores' })).toHaveAttribute('href', '/authors');
 	});
 
 	it('should render the section even when the week has no highlighted authors', async () => {

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,11 +1,16 @@
 import HomeComponent from './home.component';
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 import { CommonModule, NgForOf, NgIf, NgOptimizedImage } from '@angular/common';
 import { provideRouter } from '@angular/router';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { provideContentApiMock } from '../../providers/content.mock';
+import { provideContentApiMock, StubContentApi } from '../../providers/content.mock';
 import { Component, input } from '@angular/core';
 import { Storylist } from '@models/storylist.model';
+import { map, type Observable } from 'rxjs';
+import type { ContentApi } from '../../providers/content.provider';
+import type { LandingPageContent } from '@models/landing-page-content.model';
+import type { HighlightedAuthor } from '@models/landing-page-content.model';
+import { onoffHighlightedAuthorsOfLength } from '@mocks/onoff-highlighted-authors.mock';
 
 describe.skip('HomeComponent', () => {
 	const setup = async () => {
@@ -38,3 +43,42 @@ class MockStorylistCardDeckComponent {
 	public readonly storylist = input<Storylist>();
 	public readonly isLoading = input<boolean>(false);
 }
+
+// El doble canned del provider entrega la landing vacía; acá solo se le pone contenido a los destacados,
+// que es lo único que esta sección deriva.
+class StubHighlightedAuthorsContentApi implements ContentApi {
+	constructor(private readonly highlightedAuthors: readonly HighlightedAuthor[]) {}
+
+	public getLandingPageContent(): Observable<LandingPageContent> {
+		return new StubContentApi()
+			.getLandingPageContent()
+			.pipe(map((content) => ({ ...content, highlightedAuthors: this.highlightedAuthors })));
+	}
+}
+
+describe('HomeComponent — autores destacados', () => {
+	const renderHome = (highlightedAuthors: readonly HighlightedAuthor[]) =>
+		render(HomeComponent, {
+			providers: [provideRouter([]), provideContentApiMock(new StubHighlightedAuthorsContentApi(highlightedAuthors))],
+		});
+
+	it('should render the highlighted authors section header', async () => {
+		await renderHome(onoffHighlightedAuthorsOfLength(6));
+
+		expect(screen.getByRole('heading', { name: 'Autores/as destacados/as', level: 2 })).toBeInTheDocument();
+	});
+
+	// La cabecera y su enlace quedan fuera del bloque diferido, así que se renderizan en el HTML servido:
+	// es lo que hace que la home enlace al índice de autores sin depender de que el cliente hidrate.
+	it('should link to the authors index from the home', async () => {
+		await renderHome(onoffHighlightedAuthorsOfLength(6));
+
+		expect(screen.getByRole('link', { name: 'Ver todo' })).toHaveAttribute('href', '/authors');
+	});
+
+	it('should render the section even when the week has no highlighted authors', async () => {
+		await renderHome([]);
+
+		expect(screen.getByRole('heading', { name: 'Autores/as destacados/as', level: 2 })).toBeInTheDocument();
+	});
+});

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -17,6 +17,7 @@ import { MostReadStoriesCardDeckComponent } from '@components/most-read-stories-
 import { LatestStoriesCardDeck } from '@components/latest-stories-card-deck/latest-stories-card-deck';
 import { CarouselSkeletonComponent } from '@components/carousel/carousel-skeleton.component';
 import { StorylistTeasersDeck } from '@components/storylist-teasers-deck/storylist-teasers-deck';
+import { HighlightedAuthorsComponent } from '@components/highlighted-authors/highlighted-authors.component';
 
 @Component({
 	selector: 'cuentoneta-home',
@@ -27,6 +28,7 @@ import { StorylistTeasersDeck } from '@components/storylist-teasers-deck/storyli
 		LatestStoriesCardDeck,
 		CarouselSkeletonComponent,
 		StorylistTeasersDeck,
+		HighlightedAuthorsComponent,
 	],
 	hostDirectives: [HomeMetaTagsDirective, HomeStructuredDataDirective],
 })
@@ -46,4 +48,7 @@ export default class HomeComponent {
 	protected readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
 	protected readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
 	protected readonly latestReads = computed(() => this.landingPageContent()?.latestReads.slice(0, 6) || []);
+	// Sin recorte propio: el tope de destacados lo aplica el ACL, y duplicarlo acá dejaría dos que pueden
+	// divergir sin que nada lo note.
+	protected readonly highlightedAuthors = computed(() => this.landingPageContent()?.highlightedAuthors ?? []);
 }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -48,7 +48,5 @@ export default class HomeComponent {
 	protected readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
 	protected readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
 	protected readonly latestReads = computed(() => this.landingPageContent()?.latestReads.slice(0, 6) || []);
-	// Sin recorte propio: el tope de destacados lo aplica el ACL, y duplicarlo acá dejaría dos que pueden
-	// divergir sin que nada lo note.
 	protected readonly highlightedAuthors = computed(() => this.landingPageContent()?.highlightedAuthors ?? []);
 }


### PR DESCRIPTION
## Qué hace

Segundo de los dos PRs de #1571, apilado sobre #2371. Monta la sección de autores destacados en la página de inicio.

Deliberadamente acotado a **tres archivos** de `src/app/pages/home/`: #2267 y #2184 trabajan sobre la misma página, y cuanto menos superficie toque este PR, menos rebase les cuesta.

## Dónde va la sección

Entre el deck de más leídas y el de colecciones:

> carrusel → últimas novedades → más leídas → **autores destacados** → colecciones → Sobre La Cuentoneta

## Dos cosas que la sección hace distinto a sus hermanas, a propósito

**No recorta.** El resto de los derivados de la página aplica `.slice(0, 6)`; este no. El tope de destacados ya lo aplica el mapeo del backend, y repetirlo acá dejaría dos topes que pueden divergir sin que nada lo note.

**No fija alto.** Las secciones de arriba fijan altura para evitar el rebote vertical de la carga inicial — el propio template lo explica. Acá la grilla en carga dibuja la sección **llena**, así que reserva el alto de una semana completa: una semana con menos destacados encoge al resolver. Se deja sin fijar y con el motivo escrito al lado, para que quien vea el salto sepa dónde corregirlo.

## La cobertura

Tres casos nuevos, en un `describe` propio:

- La cabecera de la sección se renderiza.
- El enlace "Ver todo" apunta a `/authors` **desde la home**. Cabecera y enlace quedan fuera del bloque diferido, así que viajan en el HTML servido: la home enlaza al índice de autores sin depender de que el cliente hidrate.
- La sección se renderiza igual cuando la semana no trae destacados.

El doble del provider se construye sobre el canned existente y solo le pone contenido a los destacados, que es lo único que esta página deriva acá.

### Un bloque muerto que este PR no toca

`home.component.spec.ts` arrastra un `describe.skip` que monta un componente que ya no existe en la aplicación, y cuyo único caso afirma sobre una promesa sin `await`. **No cubre nada.** Se deja intacto a propósito: su limpieza no tiene relación con este issue y va en un PR propio.

## Sobre el HTML servido

Vale dejarlo dicho porque es fácil suponer lo contrario: la cabecera y su enlace **sí** viajan en el HTML servido —quedan fuera del bloque diferido—, así que la página de inicio gana un enlace real al índice de autores, que hoy no tenía. Las seis tarjetas, en cambio, se resuelven del lado del cliente, igual que las de los tres decks hermanos.

No se corrige acá a propósito: es deuda compartida con esos tres decks, la suite de indexado ya la trackea con un caso deshabilitado que espera a que **todos** dejen de diferir, y la alternativa correcta —server-renderizar difiriendo la hidratación— pide habilitar hidratación incremental para toda la aplicación. El camino de rastreo igual no se pierde: desde el índice de autores cada perfil ya es alcanzable, así que lo que queda del lado del cliente son los atajos, no el acceso.

## Plan de pruebas

- **Los once gates de CI, verdes**, incluido `e2e`, que corre sobre `/` y por lo tanto sobre el DOM que este PR cambia.
- **Tres casos nuevos** en un `describe` propio: la cabecera de la sección; el enlace a `/authors` **desde la home**; y que la sección se renderice igual cuando la semana no trae destacados.
- **Suite completa**: 2463 tests en verde.
### Lo que falta verificar a ojo

**No revisé la sección en el navegador.** Conviene mirar los tres breakpoints (1, 2 y 3 columnas) antes de mergear, prestando atención al salto entre la grilla en carga —siempre llena— y la real, que puede traer menos destacados. Si el rebote se nota, corresponde fijar el alto por breakpoint como hacen las secciones hermanas.

Closes #1571

Parte de #1568.
