### PR TITLE
[#2266] - Groundwork: ACL de teaser de colección y errores tipados de contenido

### DIFF
--- a/src/api/modules/collection/collection-teaser.acl.spec.ts
+++ b/src/api/modules/collection/collection-teaser.acl.spec.ts
@@ -1,0 +1,73 @@
+import type { CollectionsQueryResult } from '@sanity-types';
+import {
+	onoffRawCollectionTeasersWithFeaturedImage,
+	onoffRawCollectionTeasersWithoutFeaturedImage,
+} from '@mocks/onoff-raw-collections.mock';
+import { mapSanityCollectionTeaser } from './collection-teaser.acl';
+import { MalformedCollectionError } from './collection.errors';
+
+// Se piden por capacidad y no por nombre: el caso necesita "una con portada editorial", no una
+// colección puntual del canon.
+type RawCollectionTeaser = CollectionsQueryResult[number];
+const [withFeaturedImage] = onoffRawCollectionTeasersWithFeaturedImage;
+const [withoutFeaturedImage] = onoffRawCollectionTeasersWithoutFeaturedImage;
+
+describe('mapSanityCollectionTeaser imagery', () => {
+	it('uses the editorial cover when the collection declares one', () => {
+		const teaser = mapSanityCollectionTeaser(withFeaturedImage);
+
+		expect(teaser.imagery.kind).toBe('representative');
+	});
+
+	it('falls back to the fan of the first three work covers', () => {
+		const teaser = mapSanityCollectionTeaser(withoutFeaturedImage);
+
+		expect(teaser.imagery).toEqual({
+			kind: 'sample',
+			images: expect.arrayContaining([expect.any(String)]),
+		});
+		expect(teaser.imagery.kind === 'sample' && teaser.imagery.images).toHaveLength(3);
+	});
+
+	// Rellenar el abanico dejaría una imagen rota en la interfaz, así que el dato incompleto tumba el
+	// mapeo en la frontera.
+	it('rejects a collection whose fan cannot be completed', () => {
+		const shortFan: RawCollectionTeaser = {
+			...withoutFeaturedImage,
+			literaryWorkCoverImages: withoutFeaturedImage.literaryWorkCoverImages.slice(0, 2),
+		};
+
+		expect(() => mapSanityCollectionTeaser(shortFan)).toThrow(MalformedCollectionError);
+	});
+});
+
+describe('mapSanityCollectionTeaser guards', () => {
+	it('rejects a collection without prose', () => {
+		const descriptionless: RawCollectionTeaser = { ...withFeaturedImage, description: '' };
+
+		expect(() => mapSanityCollectionTeaser(descriptionless)).toThrow();
+	});
+
+	// Es la invariante "al menos una obra" traducida a lo único que el teaser transporta.
+	it('rejects a collection with no works', () => {
+		const empty: RawCollectionTeaser = { ...withFeaturedImage, count: 0 };
+
+		expect(() => mapSanityCollectionTeaser(empty)).toThrow();
+	});
+});
+
+describe('mapSanityCollectionTeaser prose', () => {
+	// El teaser se pinta dentro de una tarjeta que ya es un enlace, así que su prosa va sin enlaces
+	// propios: anidarlos produce marcado inválido.
+	it('strips links from the description', () => {
+		const linked: RawCollectionTeaser = {
+			...withFeaturedImage,
+			description: 'Una colección con [un enlace propio](https://www.cuentoneta.ar/about) en la prosa.',
+		};
+
+		const teaser = mapSanityCollectionTeaser(linked);
+
+		expect(teaser.description).not.toContain('<a');
+		expect(teaser.description).toContain('un enlace propio');
+	});
+});

--- a/src/api/modules/collection/collection-teaser.acl.ts
+++ b/src/api/modules/collection/collection-teaser.acl.ts
@@ -1,0 +1,72 @@
+import type { CollectionBySlugQueryResult, CollectionsQueryResult } from '@sanity-types';
+import { createCollectionTeaser, type CollectionImagery, type CollectionTeaser } from '@models/collection.model';
+import { createMarkdown, type Markdown } from '@models/markdown.model';
+import type { SanitizedHtml } from '@models/sanitized-html.model';
+import { markdownToLinklessSanitizedHtml } from '@utils/markdown-pipeline.utils';
+import { mapTags, urlFor } from '../../_utils/functions';
+import { mapMediaSources } from '../../_utils/media-sources.functions';
+import { MalformedCollectionError } from './collection.errors';
+
+// El ensamblado del teaser de colección es propiedad de este módulo y no del repository que hoy lo
+// produce, ni una primitiva genérica de `_utils/`: monta un agregado y hace cumplir sus invariantes.
+// `resolveCollectionImagery` codifica una de ellas —sin portada editorial hacen falta exactamente
+// tres portadas de muestra—, y una segunda definición haría que la misma colección se construyera por
+// un camino y fallara por el otro.
+//
+// El origen es una unión de proyecciones, no una sola: cuando un segundo repository dereferencia
+// colecciones con su propia proyección, entra acá. El seguro contra la deriva es el tipo — si una
+// diverge, la unión deja de aceptar el mapeo y el typecheck lo denuncia.
+type SanityCollectionTeaserSource = CollectionsQueryResult[number];
+type SanityFeaturedImage = NonNullable<CollectionBySlugQueryResult>['featuredImage'];
+
+export function mapSanityCollectionTeaser(raw: SanityCollectionTeaserSource): CollectionTeaser {
+	return createCollectionTeaser({
+		...mapSharedCollectionFields(raw, markdownToLinklessSanitizedHtml),
+		imagery: resolveCollectionImagery(
+			raw.slug,
+			raw.featuredImage,
+			raw.literaryWorkCoverImages.map((cover) => (cover ? urlFor(cover) : '')),
+		),
+		// Cero cuando la colección no tiene obras, que es el caso que la factory rechaza.
+		count: raw.count,
+	});
+}
+
+// Lo que las dos vistas de colección mapean igual. La descripción va sin default: el vacío tiene que
+// lanzar y quedar envuelto, no colarse como una colección sin prosa.
+//
+// Cada vista elige su pipeline: el teaser sin enlaces, la vista completa con ellos. Ahí la prosa no
+// se pinta dentro de nada, así que el enlace es legítimo.
+export function mapSharedCollectionFields(
+	raw: NonNullable<CollectionBySlugQueryResult> | SanityCollectionTeaserSource,
+	toSanitizedHtml: (markdown: Markdown) => SanitizedHtml,
+) {
+	return {
+		_id: raw._id,
+		slug: raw.slug,
+		title: raw.title,
+		description: toSanitizedHtml(createMarkdown(raw.description)),
+		tags: mapTags(raw.tags),
+		config: { showAuthors: raw.config.showAuthors },
+		mediaSources: mapMediaSources(raw.mediaSources),
+	};
+}
+
+// Las dos vistas le pasan las portadas de las **mismas tres** obras, para que una colección no pueda
+// construirse por un camino y fallar por el otro. Un abanico incompleto lanza en vez de rellenarse:
+// una portada vacía llega a la interfaz como una imagen rota.
+export function resolveCollectionImagery(
+	slug: string,
+	featuredImage: SanityFeaturedImage,
+	coverUrls: string[],
+): CollectionImagery {
+	const image = featuredImage ? urlFor(featuredImage) : '';
+	if (image !== '') {
+		return { kind: 'representative', image };
+	}
+	const [first, second, third] = coverUrls.filter((url) => url !== '');
+	if (first === undefined || second === undefined || third === undefined) {
+		throw new MalformedCollectionError(slug);
+	}
+	return { kind: 'sample', images: [first, second, third] };
+}

--- a/src/api/modules/collection/collection.repository.sanity.ts
+++ b/src/api/modules/collection/collection.repository.sanity.ts
@@ -1,24 +1,22 @@
 import type { SanityClient } from '@sanity/client';
-import type { CollectionBySlugQueryResult, CollectionsQueryResult } from '@sanity-types';
-import {
-	createCollection,
-	createCollectionTeaser,
-	type Collection,
-	type CollectionImagery,
-	type CollectionTeaser,
-} from '@models/collection.model';
+import type { CollectionBySlugQueryResult } from '@sanity-types';
+import { createCollection, type Collection, type CollectionTeaser } from '@models/collection.model';
 import { createLiteraryWorkExcerpt, type LiteraryWorkExcerpt } from '@models/literary-work-excerpt.model';
 import type { LiteraryWorkTeaser } from '@models/literary-work.model';
-import { createMarkdown, type Markdown } from '@models/markdown.model';
+import { createMarkdown } from '@models/markdown.model';
 import { createReadingTime, type ReadingTime } from '@models/reading-time.model';
 import { createSectionTitle } from '@models/section-title.model';
 import { createSlug } from '@models/slug.model';
-import type { SanitizedHtml } from '@models/sanitized-html.model';
-import { markdownToLinklessSanitizedHtml, markdownToSanitizedHtml } from '@utils/markdown-pipeline.utils';
+import { markdownToSanitizedHtml } from '@utils/markdown-pipeline.utils';
 import { mapAuthorTeaser, mapTags, urlFor } from '../../_utils/functions';
-import { mapMediaSources, mapMediaTeasers } from '../../_utils/media-sources.functions';
+import { mapMediaTeasers } from '../../_utils/media-sources.functions';
 import { client as sanityClient } from '../../_helpers/sanity-connector';
 import { collectionBySlugQuery, collectionsQuery } from '../../_queries/collection.query';
+import {
+	mapSanityCollectionTeaser,
+	mapSharedCollectionFields,
+	resolveCollectionImagery,
+} from './collection-teaser.acl';
 import { MalformedCollectionError } from './collection.errors';
 import type { CollectionRepository } from './collection.repository';
 
@@ -27,8 +25,6 @@ import type { CollectionRepository } from './collection.repository';
 type SanityCollection = NonNullable<CollectionBySlugQueryResult>;
 type SanityCollectionWork = SanityCollection['literaryWorks'][number];
 type SanityExcerpt = SanityCollectionWork['excerpt'][number];
-type SanityCollectionTeaser = CollectionsQueryResult[number];
-type SanityFeaturedImage = SanityCollection['featuredImage'];
 
 export class SanityCollectionRepository implements CollectionRepository {
 	constructor(private readonly client: SanityClient = sanityClient) {}
@@ -43,7 +39,7 @@ export class SanityCollectionRepository implements CollectionRepository {
 
 	public async fetchAll(): Promise<CollectionTeaser[]> {
 		const raw = await this.client.fetch(collectionsQuery);
-		return raw.map((teaser) => this.guard(teaser.slug, () => this.mapCollectionTeaser(teaser)));
+		return raw.map((teaser) => this.guard(teaser.slug, () => mapSanityCollectionTeaser(teaser)));
 	}
 
 	// Una colección mal curada tumba la llamada entera en vez de filtrarse: un listado que esconde
@@ -67,61 +63,14 @@ export class SanityCollectionRepository implements CollectionRepository {
 		const sampleCoverCount = 3;
 		const literaryWorks = raw.literaryWorks.map((work) => this.mapLiteraryWorkTeaser(work));
 		return createCollection({
-			...this.mapShared(raw, markdownToSanitizedHtml),
-			imagery: this.resolveImagery(
+			...mapSharedCollectionFields(raw, markdownToSanitizedHtml),
+			imagery: resolveCollectionImagery(
 				raw.slug,
 				raw.featuredImage,
 				literaryWorks.slice(0, sampleCoverCount).map((work) => work.coverImage),
 			),
 			literaryWorks,
 		});
-	}
-
-	// Cada vista elige su pipeline: el teaser sin enlaces, la vista completa con ellos. Ahí la prosa no
-	// se pinta dentro de nada, así que el enlace es legítimo.
-	private mapCollectionTeaser(raw: SanityCollectionTeaser): CollectionTeaser {
-		return createCollectionTeaser({
-			...this.mapShared(raw, markdownToLinklessSanitizedHtml),
-			imagery: this.resolveImagery(
-				raw.slug,
-				raw.featuredImage,
-				raw.literaryWorkCoverImages.map((cover) => (cover ? urlFor(cover) : '')),
-			),
-			// Cero cuando la colección no tiene obras, que es el caso que la factory rechaza.
-			count: raw.count,
-		});
-	}
-
-	// Lo que las dos vistas mapean igual. La descripción va sin default: el vacío tiene que lanzar y
-	// quedar envuelto, no colarse como una colección sin prosa.
-	private mapShared(
-		raw: SanityCollection | SanityCollectionTeaser,
-		toSanitizedHtml: (markdown: Markdown) => SanitizedHtml,
-	) {
-		return {
-			_id: raw._id,
-			slug: raw.slug,
-			title: raw.title,
-			description: toSanitizedHtml(createMarkdown(raw.description)),
-			tags: mapTags(raw.tags),
-			config: { showAuthors: raw.config.showAuthors },
-			mediaSources: mapMediaSources(raw.mediaSources),
-		};
-	}
-
-	// Las dos vistas le pasan las portadas de las **mismas tres** obras, para que una colección no pueda
-	// construirse por un camino y fallar por el otro. Un abanico incompleto lanza en vez de rellenarse:
-	// una portada vacía llega a la interfaz como una imagen rota.
-	private resolveImagery(slug: string, featuredImage: SanityFeaturedImage, coverUrls: string[]): CollectionImagery {
-		const image = featuredImage ? urlFor(featuredImage) : '';
-		if (image !== '') {
-			return { kind: 'representative', image };
-		}
-		const [first, second, third] = coverUrls.filter((url) => url !== '');
-		if (first === undefined || second === undefined || third === undefined) {
-			throw new MalformedCollectionError(slug);
-		}
-		return { kind: 'sample', images: [first, second, third] };
 	}
 
 	private mapLiteraryWorkTeaser(raw: SanityCollectionWork): LiteraryWorkTeaser {

--- a/src/api/modules/content/content.errors.ts
+++ b/src/api/modules/content/content.errors.ts
@@ -1,0 +1,23 @@
+export class LandingPageNotFoundError extends Error {
+	constructor(slug: string) {
+		super(`Landing page with slug "${slug}" not found`);
+		this.name = 'LandingPageNotFoundError';
+	}
+}
+
+// Se distingue de "la semana no existe" porque son dos problemas distintos: acá la landing está en el
+// content lake pero su contenido curado no permite construir el dominio, así que merece un status
+// propio en vez de confundirse con un 404.
+export class MalformedLandingPageError extends Error {
+	constructor(slug: string, options?: { cause?: unknown }) {
+		super(`Landing page with slug "${slug}" is malformed`, options);
+		this.name = 'MalformedLandingPageError';
+	}
+}
+
+export class RotatingContentNotFoundError extends Error {
+	constructor() {
+		super('Rotating content not found');
+		this.name = 'RotatingContentNotFoundError';
+	}
+}

--- a/src/mocks/onoff-raw-collections.mock.ts
+++ b/src/mocks/onoff-raw-collections.mock.ts
@@ -25,6 +25,13 @@ export const onoffRawCollectionsWithoutFeaturedImage: RawCollection[] = onoffRaw
 	(collection) => collection.featuredImage === null,
 );
 
+export const onoffRawCollectionTeasersWithFeaturedImage: CollectionsQueryResult = onoffRawCollectionTeasersMock.filter(
+	(teaser) => teaser.featuredImage !== null,
+);
+
+export const onoffRawCollectionTeasersWithoutFeaturedImage: CollectionsQueryResult =
+	onoffRawCollectionTeasersMock.filter((teaser) => teaser.featuredImage === null);
+
 // Las obras embebidas que declaran multimedia, que son las que ejercitan el mapeo de la vista de
 // teaser. Su proyección solo trae el tag, así que el shape difiere del de las obras de nivel documento.
 export const onoffRawCollectionWorksWithMediaSources: RawCollection['literaryWorks'] = onoffRawCollectionsMock


### PR DESCRIPTION
**Slice 1 de 6** de #2266. Cadena apilada; éste es el único que ramifica de `develop`.

Prepara el terreno para que la página de inicio pueda servir el dominio nuevo, **sin cambiar todavía ningún contrato ni ningún comportamiento**. Los dos cambios son independientes entre sí y de lo que viene después.

## Qué trae

**El ensamblado del teaser de colección sale del repository a su propio módulo** (`collection/collection-teaser.acl.ts`). Es un refactor puro: `SanityCollectionRepository` delega y sigue produciendo exactamente lo mismo.

El motivo no es evitar repetir código. `resolveCollectionImagery` codifica una invariante del agregado —sin portada editorial hacen falta exactamente tres portadas de muestra—, y cuando un segundo repository dereferencie colecciones, una segunda definición haría que la misma colección se construyera por un camino y fallara por el otro. El origen se tipa como unión de proyecciones justamente para que, si una diverge, deje de compilar.

**El módulo de contenido estrena errores tipados** (`content.errors.ts`). Todavía no los usa nadie: los consume el slice que reescribe el controller. "La semana no existe" y "existe pero no se puede construir" son dos problemas distintos y merecen status distintos; hoy el controller no atrapa nada y los dos salen como un 500 sin manejar.

## Qué se sacó de este slice

Traía además una operación `fetchIdsBySlugs` en el puerto de obras, con su query, para que el cron pudiera resolver slugs a identificadores. **Se retiró**: devolver pares `(_id, slug)` no es una vista de obra sino una consulta al servicio de otro módulo, y obligaba al caso de uso a cruzar dos repositories para escribir en uno.

La resolución pasó a vivir dentro de la escritura que la necesita, en el método `updateMostReadLiteraryWorks(slugs)` del repository de contenido (slice 5). El puerto de obras vuelve a hablar solo de obras.

## Plan de pruebas

- `typecheck`, `test`, `lint`, `stylelint` y `build` en verde.
- Spec nuevo del ACL de teaser de colección: las dos ramas de `imagery`, el abanico incompleto que lanza, la colección sin obras y la prosa sin enlaces.

Parte de #2266.
