### PR TITLE
[#2266] - El módulo de contenido migra al patrón de puerto y adaptador

### DIFF
--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -9,7 +9,7 @@ import {
 	mapTags,
 	urlFor,
 } from './functions';
-import { elOdioRawTeaser } from '@mocks/onoff-raw-stories.mock';
+import { onoffRawTeasersMock } from '@mocks/onoff-raw-stories.mock';
 import { rawOnoffAuthor, rawOnoffAuthorTeaser } from '@mocks/onoff-raw-author.mock';
 import { onoffRawContentCampaignsMock } from '@mocks/onoff-raw-landing-page.mock';
 import { onoffRawTagsMock } from '@mocks/onoff-raw-tags.mock';
@@ -86,9 +86,14 @@ describe('mapAuthorTeaser (ACL)', () => {
 });
 
 // El input crudo no incluye `tags`: el mapper es la única fuente del campo vacío (consistente con `mapAuthorTeaser`).
+//
+// El teaser sale de la colección del canon y no de un export por obra: el caso necesita "un teaser
+// crudo cualquiera", no uno puntual, y pedirlo por nombre lo ataría a la obra que exista hoy.
 describe('mapStoryTeaser (ACL)', () => {
+	const [rawTeaser] = onoffRawTeasersMock;
+
 	it('sets tags to [] from the mapper, not from the raw spread', () => {
-		const result = mapStoryTeaser([elOdioRawTeaser]);
+		const result = mapStoryTeaser([rawTeaser]);
 
 		expect(result[0].tags).toEqual([]);
 	});

--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -4,24 +4,14 @@ import {
 	mapAuthorTeaser,
 	mapBlockContentToTextParagraphs,
 	mapContentCampaigns,
-	mapHighlightedAuthors,
-	mapLandingPageContent,
 	mapResources,
-	mapStoryNavigationTeaserWithAuthor,
 	mapStoryTeaser,
 	mapTags,
 	urlFor,
 } from './functions';
-import { elOdioRawTeaser, onoffRawNavTeasersMock } from '@mocks/onoff-raw-stories.mock';
+import { elOdioRawTeaser } from '@mocks/onoff-raw-stories.mock';
 import { rawOnoffAuthor, rawOnoffAuthorTeaser } from '@mocks/onoff-raw-author.mock';
-import {
-	onoffRawContentCampaignsMock,
-	onoffRawHighlightedAuthorsMock,
-	onoffRawLandingPageMock,
-	overflowingRawHighlightedAuthors,
-	untaggedRawHighlightedAuthor,
-} from '@mocks/onoff-raw-landing-page.mock';
-import type { RotatingContent } from '@models/landing-page-content.model';
+import { onoffRawContentCampaignsMock } from '@mocks/onoff-raw-landing-page.mock';
 import { onoffRawTagsMock } from '@mocks/onoff-raw-tags.mock';
 import { withoutUrl } from '@testing/resource-without-url';
 import { viewportElementSizes } from '@models/content-campaign.model';
@@ -99,14 +89,6 @@ describe('mapAuthorTeaser (ACL)', () => {
 describe('mapStoryTeaser (ACL)', () => {
 	it('sets tags to [] from the mapper, not from the raw spread', () => {
 		const result = mapStoryTeaser([elOdioRawTeaser]);
-
-		expect(result[0].tags).toEqual([]);
-	});
-});
-
-describe('mapStoryNavigationTeaserWithAuthor (ACL)', () => {
-	it('sets tags to [] from the mapper, not from the raw spread', () => {
-		const result = mapStoryNavigationTeaserWithAuthor([onoffRawNavTeasersMock[0]]);
 
 		expect(result[0].tags).toEqual([]);
 	});
@@ -206,94 +188,6 @@ describe('mapContentCampaigns (ACL)', () => {
 		} as unknown as (typeof onoffRawContentCampaignsMock)[number];
 
 		expect(() => mapContentCampaigns([withoutXs])).toThrow('Campaign content not found');
-	});
-});
-
-describe('mapLandingPageContent (ACL)', () => {
-	// El repository invoca al mapper con el spread de dos queries, y la rotación va segunda: aporta lo
-	// que la landing no proyecta y, al hacerlo, también pisa su `_id`. El caso reproduce ese orden con
-	// una identidad propia para que la aserción distinga cuál de las dos sobrevive.
-	const rotatingContent: RotatingContent = { _id: 'rotating-content-onoff', name: 'Rotación de Onoff', mostRead: [] };
-	const raw = { ...onoffRawLandingPageMock, ...rotatingContent };
-
-	it('exposes exactly the domain contract, dropping the raw slug and name', () => {
-		const result = mapLandingPageContent(raw);
-
-		expect(Object.keys(result).sort()).toEqual([
-			'_id',
-			'campaigns',
-			'cards',
-			'config',
-			'highlightedAuthors',
-			'latestReads',
-			'mostRead',
-		]);
-	});
-
-	it('takes its identity from the rotating content that overrides the landing page', () => {
-		const result = mapLandingPageContent(raw);
-
-		expect(result._id).toBe(rotatingContent._id);
-		expect(result._id).not.toBe(onoffRawLandingPageMock._id);
-	});
-
-	it('preserves the config the query returned', () => {
-		expect(mapLandingPageContent(raw).config).toEqual(onoffRawLandingPageMock.config);
-	});
-
-	it('maps every campaign the query returned, in order', () => {
-		const expectedSlugs = onoffRawLandingPageMock.campaigns.map(({ slug }) => slug);
-
-		expect(expectedSlugs.length).toBeGreaterThan(0);
-		expect(mapLandingPageContent(raw).campaigns.map(({ slug }) => slug)).toEqual(expectedSlugs);
-	});
-
-	it('maps every highlighted author the query returned, in order', () => {
-		const expectedIds = onoffRawLandingPageMock.highlightedAuthors.map(({ author }) => author._id);
-
-		expect(expectedIds.length).toBeGreaterThan(0);
-		expect(mapLandingPageContent(raw).highlightedAuthors.map(({ author }) => author._id)).toEqual(expectedIds);
-	});
-});
-
-describe('mapHighlightedAuthors (ACL)', () => {
-	const [canonical] = onoffRawHighlightedAuthorsMock;
-
-	it('maps every tag the author carries, in order', () => {
-		const expected = canonical.tags.map(({ slug }) => slug);
-
-		expect(expected.length).toBeGreaterThan(0);
-		expect(mapHighlightedAuthors([canonical])[0].tags.map(({ slug }) => slug)).toEqual(expected);
-	});
-
-	it('keeps the first six entries when the document carries more', () => {
-		const result = mapHighlightedAuthors(overflowingRawHighlightedAuthors);
-
-		expect(overflowingRawHighlightedAuthors.length).toBeGreaterThan(6);
-		expect(result.map(({ author }) => author._id)).toEqual(
-			overflowingRawHighlightedAuthors.slice(0, 6).map(({ author }) => author._id),
-		);
-	});
-
-	it('produces an empty tag list for an author with no tags', () => {
-		expect(mapHighlightedAuthors([untaggedRawHighlightedAuthor])[0].tags).toEqual([]);
-	});
-
-	it('carries the count the query computed', () => {
-		expect(mapHighlightedAuthors([canonical])[0].storyCount).toBe(canonical.storyCount);
-	});
-
-	// El teaser entrega su lista de etiquetas vacía en toda vista del repositorio, así que las del
-	// destacado viajan en el wrapper aunque salgan del mismo autor.
-	it('maps the author as a teaser, whose own tag list stays empty', () => {
-		const [result] = mapHighlightedAuthors([canonical]);
-
-		expect(result.author).toEqual(mapAuthorTeaser(canonical.author));
-		expect(result.author.tags).toEqual([]);
-	});
-
-	it('returns an empty array when the document has no highlighted authors', () => {
-		expect(mapHighlightedAuthors([])).toEqual([]);
 	});
 });
 

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -3,7 +3,6 @@ import { client } from '../_helpers/sanity-connector';
 
 // Funciones
 import { mapMediaSources } from './media-sources.functions';
-import { mapImagery } from './storylist-imagery.functions';
 
 // Tipos de Sanity
 
@@ -13,10 +12,8 @@ import { createImageUrlBuilder, SanityImageSource } from '@sanity/image-url';
 // Modelos
 import { Author, AuthorProfile, AuthorTeaser } from '@models/author.model';
 import { ContentCampaign, viewportElementSizes } from '@models/content-campaign.model';
-import type { HighlightedAuthor, LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
-import { StorylistTeaser } from '@models/storylist.model';
 import { Resource } from '@models/resource.model';
-import { Story, StoryNavigationTeaserWithAuthor, StoryTeaser, StoryTeaserWithAuthor } from '@models/story.model';
+import { Story, StoryTeaser, StoryTeaserWithAuthor } from '@models/story.model';
 import { Tag } from '@models/tag.model';
 import { TextBlockContent } from '@models/block-content.model';
 import { createMarkdown } from '@models/markdown.model';
@@ -30,7 +27,6 @@ import {
 	CollectionBySlugQueryResult,
 	LandingPageContentQueryResult,
 	LiteraryWorkBySlugQueryResult,
-	RotatingContentQueryResult,
 	StoriesByAuthorSlugQueryResult,
 	StoriesBySlugsQueryResult,
 	StoryBySlugQueryResult,
@@ -194,22 +190,6 @@ export function mapTags(tags: TagsSubQuery): Tag[] {
 	}));
 }
 
-function mapStorylistTeasers(result: StorylistTeasersQueryResult): StorylistTeaser[] {
-	return result.map((item) => {
-		const { featuredImage, storyCoverImages, mediaSources, ...rest } = item;
-		return {
-			...rest,
-			config: { ...item.config, showAuthors: item.config?.showAuthors ?? false },
-			description: mapBlockContentToTextParagraphs(item.description),
-			tags: mapTags(item.tags),
-			stories: [],
-			tabs: [],
-			media: mapMediaSources(mediaSources),
-			imagery: mapImagery({ featuredImage, storyCoverImages }),
-		};
-	});
-}
-
 // TODO: Agregar soporte a futuro para mapear imágenes dentro del cuerpo de una story
 export function mapBlockContentToTextParagraphs(content: BlockContent): TextBlockContent[] {
 	return content.filter((element) => element._type === 'block') as TextBlockContent[];
@@ -262,58 +242,7 @@ export function mapStoryTeaser(result: StoryTeasersQueryResult): StoryTeaser[] {
 	return stories;
 }
 
-type MostReadStoriesSubQuery = NonNullable<RotatingContentQueryResult>['mostRead'];
-export function mapStoryNavigationTeaserWithAuthor(
-	result: NonNullable<MostReadStoriesSubQuery>,
-): StoryNavigationTeaserWithAuthor[] {
-	const stories = [];
-
-	for (const item of result) {
-		const { mediaSources, resources, coverImage, ...properties } = item;
-
-		stories.push({
-			...properties,
-			author: mapAuthorTeaser(item.author),
-			coverImage: urlFor(coverImage),
-			media: mapMediaSources(mediaSources),
-			resources: mapResources(resources),
-			paragraphs: [],
-			tags: [],
-		});
-	}
-
-	return stories;
-}
-
-export function mapLandingPageContent(
-	result: NonNullable<LandingPageContentQueryResult> & RotatingContent,
-): LandingPageContent {
-	return {
-		_id: result._id,
-		config: result.config,
-		cards: mapStorylistTeasers(result.cards),
-		campaigns: mapContentCampaigns(result.campaigns),
-		mostRead: result.mostRead,
-		latestReads: mapStoryNavigationTeaserWithAuthor(result.latestReads),
-		highlightedAuthors: mapHighlightedAuthors(result.highlightedAuthors),
-	};
-}
-
 type HighlightedAuthorsSubQuery = NonNullable<LandingPageContentQueryResult>['highlightedAuthors'];
-export function mapHighlightedAuthors(highlightedAuthors: HighlightedAuthorsSubQuery): HighlightedAuthor[] {
-	// El Studio limita la carga a seis entradas, pero esa regla gobierna la edición y no lo ya guardado:
-	// una migración o un backfill pueden dejar más. El recorte acá es una salvaguarda, no la regla.
-	const limit = 6;
-
-	return highlightedAuthors.slice(0, limit).map((entry) => ({
-		author: mapAuthorTeaser(entry.author),
-		// El teaser entrega su lista vacía en toda vista del repositorio, así que las etiquetas del
-		// destacado se mapean acá aunque salgan del mismo autor.
-		tags: mapTags(entry.tags),
-		storyCount: entry.storyCount,
-	}));
-}
-
 type ContentCampaignsSubQuery = NonNullable<LandingPageContentQueryResult>['campaigns'];
 export function mapContentCampaigns(campaigns: ContentCampaignsSubQuery): ContentCampaign[] {
 	return campaigns.map((campaign) => {

--- a/src/api/modules/content/content.controller.spec.ts
+++ b/src/api/modules/content/content.controller.spec.ts
@@ -1,0 +1,78 @@
+import { Hono } from 'hono';
+import { setSystemTime, useFakeTimers, useRealTimers } from '@test-utils';
+import { buildWeekSlug } from '@utils/week-slug.utils';
+import type { LandingPageContent } from '@models/landing-page-content.model';
+import { createContentController } from './content.controller';
+import { MalformedLandingPageError } from './content.errors';
+import { InMemoryContentRepository } from './content.repository.mock';
+import type { ContentRepository } from './content.repository';
+
+const CURRENT_DATE = new Date(2025, 10, 14);
+const CURRENT_SLUG = buildWeekSlug(CURRENT_DATE);
+
+function appWith(repository: ContentRepository): Hono {
+	const app = new Hono();
+	app.route('/content', createContentController(repository));
+	return app;
+}
+
+const curatedLandingPage: LandingPageContent = {
+	_id: `landing-page-${CURRENT_SLUG}`,
+	config: CURRENT_SLUG,
+	cards: [],
+	campaigns: [],
+	mostRead: [],
+	latestReads: [],
+	highlightedAuthors: [],
+};
+
+beforeEach(() => {
+	useFakeTimers();
+	setSystemTime(CURRENT_DATE);
+});
+
+afterEach(() => useRealTimers());
+
+describe('contentController', () => {
+	it('serves the landing page of the current week', async () => {
+		const app = appWith(
+			new InMemoryContentRepository({ landingPages: [{ slug: CURRENT_SLUG, content: curatedLandingPage }] }),
+		);
+
+		const response = await app.request('/content/landing-page');
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({ config: CURRENT_SLUG });
+	});
+
+	it('answers 404 when the week has not been curated', async () => {
+		const response = await appWith(new InMemoryContentRepository()).request('/content/landing-page');
+
+		expect(response.status).toBe(404);
+	});
+});
+
+describe('contentController with malformed data', () => {
+	// La landing existe: lo que falla es su curaduría, no el pedido.
+	class FailingContentRepository extends InMemoryContentRepository {
+		public override async fetchLandingPageContent(): Promise<never> {
+			throw new MalformedLandingPageError(CURRENT_SLUG);
+		}
+	}
+
+	const failing = appWith(new FailingContentRepository());
+
+	it('answers 500 with a stable code', async () => {
+		const response = await failing.request('/content/landing-page');
+
+		expect(response.status).toBe(500);
+		await expect(response.json()).resolves.toEqual({ error: 'landing_page_malformed' });
+	});
+
+	// El mensaje del error nombra el documento culpable, que es información de la redacción.
+	it('keeps the offending slug out of the response', async () => {
+		const response = await failing.request('/content/landing-page');
+
+		await expect(response.text()).resolves.not.toContain(CURRENT_SLUG);
+	});
+});

--- a/src/api/modules/content/content.controller.spec.ts
+++ b/src/api/modules/content/content.controller.spec.ts
@@ -7,7 +7,10 @@ import { MalformedLandingPageError } from './content.errors';
 import { InMemoryContentRepository } from './content.repository.mock';
 import type { ContentRepository } from './content.repository';
 
-const CURRENT_DATE = new Date(2025, 10, 14);
+// La semana sale de la fecha real y no de una literal: a estos casos no les importa cuál es, sino que
+// la que el service pide sea la que está curada. El reloj se congela igual en ese instante, para que un
+// caso que corra justo en el cruce de semana no cambie de respuesta a mitad de camino.
+const CURRENT_DATE = new Date();
 const CURRENT_SLUG = buildWeekSlug(CURRENT_DATE);
 
 function appWith(repository: ContentRepository): Hono {

--- a/src/api/modules/content/content.controller.ts
+++ b/src/api/modules/content/content.controller.ts
@@ -6,10 +6,7 @@ import { LandingPageNotFoundError, MalformedLandingPageError } from './content.e
 import type { ContentRepository } from './content.repository';
 import { addNextWeeksLandingPageContent, getLandingPageContent } from './content.service';
 
-// El error de curaduría responde con un código y no con su mensaje: ese mensaje nombra el documento
-// culpable, que es información de la redacción y no del cliente. Por eso mismo se loguea antes de
-// traducirlo: la causa —qué dato, qué invariante— muere acá si nadie la registra, y sin ella el 500 no
-// dice qué hay que corregir en el Studio.
+/** Traduce los errores del módulo al status que le corresponde a cada uno. */
 async function respond<T>(c: Context, produce: () => Promise<T>) {
 	try {
 		return c.json(await produce());
@@ -18,10 +15,14 @@ async function respond<T>(c: Context, produce: () => Promise<T>) {
 			return c.json({ error: error.message }, 404);
 		}
 		if (error instanceof MalformedLandingPageError) {
+			// Se loguea antes de traducir porque la respuesta no lleva la causa: sin este registro, qué dato
+			// y qué invariante lo produjeron mueren acá y el 500 no dice qué corregir en el Studio.
 			console.error('content.controller: la página de inicio no se pudo construir', {
 				message: error.message,
 				cause: error.cause,
 			});
+			// Responde un código y no el mensaje: ese mensaje nombra el documento culpable, que es
+			// información de la redacción y no del cliente.
 			return c.json({ error: 'landing_page_malformed' }, 500);
 		}
 		throw error;

--- a/src/api/modules/content/content.controller.ts
+++ b/src/api/modules/content/content.controller.ts
@@ -1,29 +1,49 @@
-// Hono: Imports y configuración
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 
-// Esquemas de zod
 import { addWeeksSchema } from './content.schema';
-
-// Funciones de service
+import { LandingPageNotFoundError, MalformedLandingPageError } from './content.errors';
+import type { ContentRepository } from './content.repository';
 import { addNextWeeksLandingPageContent, getLandingPageContent } from './content.service';
 
-const contentController = new Hono();
+// El error de curaduría responde con un código y no con su mensaje: ese mensaje nombra el documento
+// culpable, que es información de la redacción y no del cliente. Por eso mismo se loguea antes de
+// traducirlo: la causa —qué dato, qué invariante— muere acá si nadie la registra, y sin ella el 500 no
+// dice qué hay que corregir en el Studio.
+async function respond<T>(c: Context, produce: () => Promise<T>) {
+	try {
+		return c.json(await produce());
+	} catch (error) {
+		if (error instanceof LandingPageNotFoundError) {
+			return c.json({ error: error.message }, 404);
+		}
+		if (error instanceof MalformedLandingPageError) {
+			console.error('content.controller: la página de inicio no se pudo construir', {
+				message: error.message,
+				cause: error.cause,
+			});
+			return c.json({ error: 'landing_page_malformed' }, 500);
+		}
+		throw error;
+	}
+}
 
-contentController.get('/landing-page', async (c) => {
-	const result = await getLandingPageContent();
-	return c.json(result);
-});
+export function createContentController(repository?: ContentRepository) {
+	const controller = new Hono();
 
-/**
- * Endpoint encargado de agregar instancias de documentos landingPage para las próximas semanas, a fin de generar automáticamente
- * los documentos que luego son modificados manualmente para actualizar el contenido de la landing page desde Sanity Studio
- */
+	controller.get('/landing-page', async (c) => respond(c, () => getLandingPageContent(repository)));
 
-contentController.get('/add-next-weeks-landing-page-content', zValidator('query', addWeeksSchema), async (c) => {
-	const { weeksInTheFuture } = c.req.valid('query');
-	const result = await addNextWeeksLandingPageContent(weeksInTheFuture);
-	return c.json(result);
-});
+	/**
+	 * Endpoint encargado de agregar instancias de documentos landingPage para las próximas semanas, a fin de generar automáticamente
+	 * los documentos que luego son modificados manualmente para actualizar el contenido de la landing page desde Sanity Studio
+	 */
+	controller.get('/add-next-weeks-landing-page-content', zValidator('query', addWeeksSchema), async (c) => {
+		const { weeksInTheFuture } = c.req.valid('query');
+		return respond(c, () => addNextWeeksLandingPageContent(weeksInTheFuture, repository));
+	});
 
+	return controller;
+}
+
+const contentController = createContentController();
 export default contentController;

--- a/src/api/modules/content/content.errors.ts
+++ b/src/api/modules/content/content.errors.ts
@@ -21,3 +21,12 @@ export class RotatingContentNotFoundError extends Error {
 		this.name = 'RotatingContentNotFoundError';
 	}
 }
+
+// El contenido rotativo es otro documento, así que su curaduría rota merece su propio error: envuelto
+// en el de la landing, el mensaje diría que está mal la semana cuando la semana está bien.
+export class MalformedRotatingContentError extends Error {
+	constructor(options?: { cause?: unknown }) {
+		super('Rotating content is malformed', options);
+		this.name = 'MalformedRotatingContentError';
+	}
+}

--- a/src/api/modules/content/content.errors.ts
+++ b/src/api/modules/content/content.errors.ts
@@ -1,3 +1,4 @@
+/** La semana pedida no está cargada en el content lake. */
 export class LandingPageNotFoundError extends Error {
 	constructor(slug: string) {
 		super(`Landing page with slug "${slug}" not found`);
@@ -5,9 +6,12 @@ export class LandingPageNotFoundError extends Error {
 	}
 }
 
-// Se distingue de "la semana no existe" porque son dos problemas distintos: acá la landing está en el
-// content lake pero su contenido curado no permite construir el dominio, así que merece un status
-// propio en vez de confundirse con un 404.
+/**
+ * La semana existe, pero su contenido curado no permite construir el dominio.
+ *
+ * Es un problema distinto del anterior y por eso merece un status propio: uno se corrige cargando la
+ * semana y el otro corrigiendo lo que ya se cargó.
+ */
 export class MalformedLandingPageError extends Error {
 	constructor(slug: string, options?: { cause?: unknown }) {
 		super(`Landing page with slug "${slug}" is malformed`, options);
@@ -15,6 +19,7 @@ export class MalformedLandingPageError extends Error {
 	}
 }
 
+/** El documento de contenido rotativo no está instalado. */
 export class RotatingContentNotFoundError extends Error {
 	constructor() {
 		super('Rotating content not found');
@@ -22,8 +27,12 @@ export class RotatingContentNotFoundError extends Error {
 	}
 }
 
-// El contenido rotativo es otro documento, así que su curaduría rota merece su propio error: envuelto
-// en el de la landing, el mensaje diría que está mal la semana cuando la semana está bien.
+/**
+ * El contenido rotativo existe, pero su contenido curado no permite construir el dominio.
+ *
+ * Lleva error propio y no el de la landing porque es otro documento: envuelto en aquél, el mensaje
+ * culparía a una semana que está bien.
+ */
 export class MalformedRotatingContentError extends Error {
 	constructor(options?: { cause?: unknown }) {
 		super('Rotating content is malformed', options);

--- a/src/api/modules/content/content.repository.mock.ts
+++ b/src/api/modules/content/content.repository.mock.ts
@@ -1,0 +1,93 @@
+import type { LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
+import type { StoryNavigationTeaserWithAuthor } from '@models/story.model';
+import { RotatingContentNotFoundError } from './content.errors';
+import type {
+	ContentRepository,
+	KeyedReference,
+	LandingPageCreatePayload,
+	LandingPageReferences,
+	LandingPageSummary,
+} from './content.repository';
+
+// La semana es la clave de búsqueda y no vive dentro del dominio —la landing no transporta su slug—,
+// así que el almacenamiento la lleva al lado.
+export interface StoredLandingPage {
+	readonly slug: string;
+	readonly content: LandingPageContent;
+}
+
+interface InMemoryContentOptions {
+	readonly landingPages?: readonly StoredLandingPage[];
+	readonly rotatingContent?: RotatingContent | null;
+	readonly latestReferences?: LandingPageReferences | null;
+	// El catálogo contra el que se resuelven las referencias que se escriben. Sustituye al content lake:
+	// sin él, el doble solo podría reapuntar el slot a lo que ya estaba en el slot.
+	readonly stories?: readonly StoryNavigationTeaserWithAuthor[];
+}
+
+// Fake de almacenamiento: sustituye el content lake por listas en memoria, con la misma semántica de
+// búsqueda. Las escrituras se acumulan y quedan observables, para que un spec de service pueda afirmar
+// sobre lo escrito en vez de sobre la llamada.
+export class InMemoryContentRepository implements ContentRepository {
+	private readonly landingPages: readonly StoredLandingPage[];
+	private readonly latestReferences: LandingPageReferences | null;
+	private readonly stories: readonly StoryNavigationTeaserWithAuthor[];
+	private rotatingContent: RotatingContent | null;
+
+	public readonly createdLandingPages: LandingPageCreatePayload[] = [];
+
+	constructor(options: InMemoryContentOptions = {}) {
+		this.landingPages = options.landingPages ?? [];
+		this.rotatingContent = options.rotatingContent ?? null;
+		this.latestReferences = options.latestReferences ?? null;
+		this.stories = options.stories ?? [];
+	}
+
+	public async fetchLandingPageContent(slug: string): Promise<LandingPageContent | null> {
+		return this.landingPages.find((landingPage) => landingPage.slug === slug)?.content ?? null;
+	}
+
+	public async fetchRotatingContent(): Promise<RotatingContent | null> {
+		return this.rotatingContent;
+	}
+
+	public async fetchLandingPagesList(slugs: string[]): Promise<readonly LandingPageSummary[]> {
+		return this.landingPages
+			.filter((landingPage) => slugs.includes(landingPage.slug))
+			.map(({ slug, content }) => ({ _id: content._id, slug, config: content.config }));
+	}
+
+	public async fetchLatestLandingPageReferences(): Promise<LandingPageReferences | null> {
+		return this.latestReferences;
+	}
+
+	public async createLandingPages(landingPageObjects: LandingPageCreatePayload[]): Promise<unknown[]> {
+		this.createdLandingPages.push(...landingPageObjects);
+		return landingPageObjects;
+	}
+
+	// Muta la lista en vez de registrar la llamada: lo que el caso de uso promete es que la próxima
+	// lectura vea lo escrito, y eso es lo que el spec tiene que poder afirmar. Una referencia a algo que
+	// el almacenamiento no conoce no vuelve, igual que una referencia colgada no resuelve en el content
+	// lake.
+	//
+	// Sin el singleton **lanza**, igual que el adaptador real: `patch()` sobre un documento inexistente
+	// falla en el content lake, y un doble que retornara en silencio dejaría pasar en verde a un cron que
+	// en producción se cae.
+	public async updateMostReadStories(references: readonly KeyedReference[]): Promise<void> {
+		if (!this.rotatingContent) {
+			throw new RotatingContentNotFoundError();
+		}
+		const known = new Map(
+			[
+				...this.stories,
+				...this.rotatingContent.mostRead,
+				...this.landingPages.flatMap(({ content }) => [...content.mostRead, ...content.latestReads]),
+			].map((story) => [story._id, story] as const),
+		);
+		this.rotatingContent = {
+			...this.rotatingContent,
+			mostRead: references.flatMap((reference) => known.get(reference._ref) ?? []),
+		};
+	}
+}

--- a/src/api/modules/content/content.repository.sanity.spec.ts
+++ b/src/api/modules/content/content.repository.sanity.spec.ts
@@ -1,0 +1,215 @@
+import type { SanityClient } from '@sanity/client';
+import { fn } from '@test-utils';
+import {
+	onoffRawHighlightedAuthorsMock,
+	onoffRawLandingPageMock,
+	overflowingRawHighlightedAuthors,
+	untaggedRawHighlightedAuthor,
+} from '@mocks/onoff-raw-landing-page.mock';
+import { onoffRawNavTeasersMock } from '@mocks/onoff-raw-stories.mock';
+import { mapAuthorTeaser } from '../../_utils/functions';
+import { landingPageContentQuery, rotatingContentQuery } from '../../_queries/content.query';
+import { SanityContentRepository } from './content.repository.sanity';
+
+const LANDING_SLUG = onoffRawLandingPageMock.slug;
+
+// El corpus no modela un documento de contenido rotativo, así que la rotación se arma acá con los
+// teasers de navegación del canon: son la misma proyección que la landing usa para sus últimas
+// novedades.
+const rawRotatingContent = {
+	_id: 'rotatingContent',
+	name: 'Lo más leído',
+	mostRead: onoffRawNavTeasersMock.slice(0, 2),
+};
+
+// El repository consulta dos queries en la misma llamada, así que el doble del client despacha por la
+// query recibida en vez de devolver un canned único: con un solo valor, el contenido rotativo llegaría
+// con la forma de la landing y ninguna aserción sobre el resultado lo notaría.
+function repoWith(landingPage: unknown, rotatingContent: unknown = rawRotatingContent) {
+	const fetch = fn((query: unknown) => Promise.resolve(query === rotatingContentQuery ? rotatingContent : landingPage));
+	const repository = new SanityContentRepository({ fetch } as unknown as SanityClient);
+	return { repository, fetch };
+}
+
+function repoReturning(landingPage: unknown, rotatingContent?: unknown): SanityContentRepository {
+	return repoWith(landingPage, rotatingContent).repository;
+}
+
+describe('SanityContentRepository query selection', () => {
+	it('asks for the landing page query, passing the week slug as a parameter', async () => {
+		const { repository, fetch } = repoWith(onoffRawLandingPageMock);
+
+		await repository.fetchLandingPageContent(LANDING_SLUG);
+
+		expect(fetch).toHaveBeenCalledWith(landingPageContentQuery, { slug: LANDING_SLUG });
+	});
+
+	it('asks for the rotating content query as well, which the landing page does not project', async () => {
+		const { repository, fetch } = repoWith(onoffRawLandingPageMock);
+
+		await repository.fetchLandingPageContent(LANDING_SLUG);
+
+		expect(fetch).toHaveBeenCalledWith(rotatingContentQuery);
+	});
+});
+
+describe('SanityContentRepository.fetchLandingPageContent', () => {
+	it('exposes exactly the domain contract, dropping the raw slug', async () => {
+		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
+
+		expect(Object.keys(result ?? {}).sort()).toEqual([
+			'_id',
+			'campaigns',
+			'cards',
+			'config',
+			'highlightedAuthors',
+			'latestReads',
+			'mostRead',
+		]);
+	});
+
+	it('keeps the identity of the landing page, not of the rotating content', async () => {
+		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
+
+		expect(result?._id).toBe(onoffRawLandingPageMock._id);
+		expect(result?._id).not.toBe(rawRotatingContent._id);
+	});
+
+	it('preserves the config the query returned', async () => {
+		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
+
+		expect(result?.config).toBe(onoffRawLandingPageMock.config);
+	});
+
+	it('maps every campaign the query returned, in order', async () => {
+		const expected = onoffRawLandingPageMock.campaigns.map(({ slug }) => slug);
+
+		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
+
+		expect(expected.length).toBeGreaterThan(0);
+		expect(result?.campaigns.map(({ slug }) => slug)).toEqual(expected);
+	});
+
+	// Los dos slots salen de documentos distintos: cruzarlos es el defecto que ninguna aserción sobre un
+	// solo slot detectaría.
+	it('feeds the most read slot from the rotating content, not from the landing page', async () => {
+		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
+
+		expect(result?.mostRead.map(({ slug }) => slug)).toEqual(rawRotatingContent.mostRead.map(({ slug }) => slug));
+	});
+
+	// La rotación es un documento aparte y puede faltar sin que la landing deje de servirse: lo que se
+	// vacía es el slot, no la página.
+	it('serves an empty most read slot when the rotating content is missing', async () => {
+		const result = await repoReturning(onoffRawLandingPageMock, null).fetchLandingPageContent(LANDING_SLUG);
+
+		expect(result?.mostRead).toEqual([]);
+	});
+
+	it('returns null when the week has no landing page', async () => {
+		expect(await repoReturning(null).fetchLandingPageContent(LANDING_SLUG)).toBeNull();
+	});
+
+	// El mapeo del teaser de navegación es la única fuente de la lista vacía de etiquetas: el crudo no la
+	// trae.
+	it('sets tags to [] from the mapper, not from the raw spread', async () => {
+		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
+
+		result?.latestReads.forEach((story) => expect(story.tags).toEqual([]));
+	});
+});
+
+describe('SanityContentRepository highlighted authors', () => {
+	const [canonical] = onoffRawHighlightedAuthorsMock;
+
+	async function highlightedAuthorsOf(highlightedAuthors: typeof onoffRawHighlightedAuthorsMock) {
+		const result = await repoReturning({ ...onoffRawLandingPageMock, highlightedAuthors }).fetchLandingPageContent(
+			LANDING_SLUG,
+		);
+		return result?.highlightedAuthors ?? [];
+	}
+
+	it('maps every tag the author carries, in order', async () => {
+		const expected = canonical.tags.map(({ slug }) => slug);
+
+		expect(expected.length).toBeGreaterThan(0);
+		expect((await highlightedAuthorsOf([canonical]))[0].tags.map(({ slug }) => slug)).toEqual(expected);
+	});
+
+	it('keeps the first six entries when the document carries more', async () => {
+		const result = await highlightedAuthorsOf(overflowingRawHighlightedAuthors);
+
+		expect(overflowingRawHighlightedAuthors.length).toBeGreaterThan(6);
+		expect(result.map(({ author }) => author._id)).toEqual(
+			overflowingRawHighlightedAuthors.slice(0, 6).map(({ author }) => author._id),
+		);
+	});
+
+	it('produces an empty tag list for an author with no tags', async () => {
+		expect((await highlightedAuthorsOf([untaggedRawHighlightedAuthor]))[0].tags).toEqual([]);
+	});
+
+	it('carries the count the query computed', async () => {
+		expect((await highlightedAuthorsOf([canonical]))[0].storyCount).toBe(canonical.storyCount);
+	});
+
+	// El teaser entrega su lista de etiquetas vacía en toda vista del repositorio, así que las del
+	// destacado viajan en el wrapper aunque salgan del mismo autor.
+	it('maps the author as a teaser, whose own tag list stays empty', async () => {
+		const [result] = await highlightedAuthorsOf([canonical]);
+
+		expect(result.author).toEqual(mapAuthorTeaser(canonical.author));
+		expect(result.author.tags).toEqual([]);
+	});
+
+	it('returns an empty array when the document has no highlighted authors', async () => {
+		expect(await highlightedAuthorsOf([])).toEqual([]);
+	});
+});
+
+describe('SanityContentRepository.fetchLatestLandingPageReferences', () => {
+	const raw = {
+		_id: 'landing-page-1974-24',
+		_type: 'landingPage',
+		slug: '1974-24',
+		config: '1974-24',
+		campaigns: [{ _key: 'campaign-1', _type: 'reference', _ref: 'campaign-1' }],
+		cards: [{ _key: 'card-1', _type: 'reference', _ref: 'card-1' }],
+		latestReads: [],
+		highlightedAuthors: [],
+	};
+
+	// La semana nueva es un documento nuevo: si la identidad de la base viajara, el clon la pisaría.
+	it('drops the identity of the week it clones', async () => {
+		const references = await repoReturning(raw).fetchLatestLandingPageReferences('1974-24');
+
+		expect(references).not.toHaveProperty('_id');
+		expect(references).not.toHaveProperty('slug');
+		expect(references).not.toHaveProperty('config');
+	});
+
+	it('carries every reference list the clone needs', async () => {
+		const references = await repoReturning(raw).fetchLatestLandingPageReferences('1974-24');
+
+		expect(references?.campaigns).toEqual(raw.campaigns);
+		expect(references?.cards).toEqual(raw.cards);
+	});
+
+	it('returns null when there is no earlier week to clone', async () => {
+		expect(await repoReturning(null).fetchLatestLandingPageReferences('1974-24')).toBeNull();
+	});
+});
+
+describe('SanityContentRepository.updateMostReadStories', () => {
+	it('patches the rotating content singleton with the given references', async () => {
+		const commit = fn(() => Promise.resolve(undefined));
+		const patch = fn(() => ({ commit }));
+		const repository = new SanityContentRepository({ patch } as unknown as SanityClient);
+		const references = [{ _key: 'story-1', _type: 'reference' as const, _ref: 'story-1' }];
+
+		await repository.updateMostReadStories(references);
+
+		expect(patch).toHaveBeenCalledWith('rotatingContent', { set: { mostRead: references } });
+		expect(commit).toHaveBeenCalled();
+	});
+});

--- a/src/api/modules/content/content.repository.sanity.spec.ts
+++ b/src/api/modules/content/content.repository.sanity.spec.ts
@@ -1,5 +1,6 @@
 import type { SanityClient } from '@sanity/client';
 import { fn } from '@test-utils';
+import { stubSanityClient } from '@testing/sanity-client.stub';
 import {
 	onoffRawHighlightedAuthorsMock,
 	onoffRawLandingPageMock,
@@ -22,13 +23,9 @@ const rawRotatingContent = {
 	mostRead: onoffRawNavTeasersMock.slice(0, 2),
 };
 
-// El repository consulta dos queries en la misma llamada, así que el doble del client despacha por la
-// query recibida en vez de devolver un canned único: con un solo valor, el contenido rotativo llegaría
-// con la forma de la landing y ninguna aserción sobre el resultado lo notaría.
 function repoWith(landingPage: unknown, rotatingContent: unknown = rawRotatingContent) {
-	const fetch = fn((query: unknown) => Promise.resolve(query === rotatingContentQuery ? rotatingContent : landingPage));
-	const repository = new SanityContentRepository({ fetch } as unknown as SanityClient);
-	return { repository, fetch };
+	const { client, fetch } = stubSanityClient([[rotatingContentQuery, rotatingContent]], landingPage);
+	return { repository: new SanityContentRepository(client), fetch };
 }
 
 function repoReturning(landingPage: unknown, rotatingContent?: unknown): SanityContentRepository {
@@ -136,12 +133,13 @@ describe('SanityContentRepository highlighted authors', () => {
 		expect((await highlightedAuthorsOf([canonical]))[0].tags.map(({ slug }) => slug)).toEqual(expected);
 	});
 
-	it('keeps the first six entries when the document carries more', async () => {
+	// El adaptador no recorta: cuántos destacados se muestran lo decide la pantalla, y cuántos se pueden
+	// cargar lo hace cumplir el Studio sobre un campo que nació con esa regla.
+	it('maps every entry the document carries, without capping the list', async () => {
 		const result = await highlightedAuthorsOf(overflowingRawHighlightedAuthors);
 
-		expect(overflowingRawHighlightedAuthors.length).toBeGreaterThan(6);
 		expect(result.map(({ author }) => author._id)).toEqual(
-			overflowingRawHighlightedAuthors.slice(0, 6).map(({ author }) => author._id),
+			overflowingRawHighlightedAuthors.map(({ author }) => author._id),
 		);
 	});
 

--- a/src/api/modules/content/content.repository.sanity.ts
+++ b/src/api/modules/content/content.repository.sanity.ts
@@ -43,9 +43,10 @@ const ROTATING_CONTENT_ID = 'rotatingContent';
 export class SanityContentRepository implements ContentRepository {
 	constructor(private readonly client: SanityClient = sanityClient) {}
 
-	// La landing se arma con dos documentos: el de la semana y el rotativo, que aporta lo más leído y es
-	// independiente de ella.
+	/** Entrega el contenido curado de una semana, con su bloque de lo más leído ya resuelto. */
 	public async fetchLandingPageContent(slug: string): Promise<LandingPageContent | null> {
+		// Son dos documentos independientes, así que se piden en paralelo: el rotativo no depende de qué
+		// semana se esté sirviendo.
 		const [raw, rotating] = await Promise.all([
 			this.client.fetch(landingPageContentQuery, { slug }),
 			this.fetchRotatingContent(),
@@ -54,18 +55,19 @@ export class SanityContentRepository implements ContentRepository {
 			return null;
 		}
 		if (!rotating) {
-			// La landing se sigue sirviendo con el slot vacío, pero la degradación tiene que dejar rastro:
-			// sin esto, el bloque de lo más leído desaparece de la home con un 200 y nadie se entera.
+			// Se degrada a slot vacío en vez de fallar, pero deja rastro: sin esto, el bloque de lo más
+			// leído desaparece de la home con un 200 y nadie se entera.
 			console.warn('SanityContentRepository: el contenido rotativo no existe; la home queda sin lo más leído');
 		}
 		return this.guard(slug, () => this.mapLandingPageContent(raw, rotating?.mostRead ?? []));
 	}
 
-	// Su ausencia no es una curaduría incompleta sino una instalación incompleta, y el llamador decide
-	// qué hacer con eso: la landing se sigue sirviendo con el slot vacío.
+	/** Entrega la rotación de lo más leído, o `null` si el documento no está instalado. */
 	public async fetchRotatingContent(): Promise<RotatingContent | null> {
 		const raw = await this.client.fetch(rotatingContentQuery);
 		if (!raw) {
+			// Su ausencia no es una curaduría incompleta sino una instalación incompleta, así que qué hacer
+			// con ella la decide el llamador y no este adaptador.
 			return null;
 		}
 		try {
@@ -75,18 +77,20 @@ export class SanityContentRepository implements ContentRepository {
 		}
 	}
 
+	/** Dice cuáles de las semanas pedidas ya están cargadas. */
 	public async fetchLandingPagesList(slugs: string[]): Promise<readonly LandingPageSummary[]> {
 		const raw = await this.client.fetch(landingPageListQuery, { slugs });
 		return raw.map(({ _id, slug, config }) => ({ _id, slug, config }));
 	}
 
-	// El `_id` se descarta acá y no en el service: la semana nueva es un documento nuevo, y arrastrarlo
-	// haría que el clon pisara al original.
+	/** Entrega las referencias de la última semana curada, que son la base de las semanas que se generen. */
 	public async fetchLatestLandingPageReferences(currentSlug: string): Promise<LandingPageReferences | null> {
 		const raw = await this.client.fetch(latestLandingPageReferencesQuery, { currentSlug });
 		if (!raw) {
 			return null;
 		}
+		// El `_id` no se copia: quien clone esto crea un documento nuevo, y arrastrarlo haría que el clon
+		// pisara al original.
 		return {
 			_type: raw._type,
 			campaigns: raw.campaigns,
@@ -104,9 +108,7 @@ export class SanityContentRepository implements ContentRepository {
 		await this.client.patch(ROTATING_CONTENT_ID, { set: { mostRead: [...references] } }).commit();
 	}
 
-	// Una landing mal curada tumba la llamada entera en vez de servirse a medias: un dato roto en la
-	// página de inicio es un bug que hay que ver, no esconder. El slug va en el error porque, sobre una
-	// landing por semana, saber que "alguna" está mal no alcanza para arreglarlo.
+	/** Traduce cualquier fallo de construcción del dominio a un error que nombra la semana culpable. */
 	private guard<T>(slug: string, map: () => T): T {
 		try {
 			return map();
@@ -114,6 +116,10 @@ export class SanityContentRepository implements ContentRepository {
 			if (error instanceof MalformedLandingPageError) {
 				throw error;
 			}
+			// Envolver y no filtrar: una landing mal curada tumba la llamada entera en vez de servirse a
+			// medias, porque un dato roto en la página de inicio es un bug que hay que ver, no esconder. El
+			// slug viaja en el error porque, sobre una landing por semana, saber que "alguna" está mal no
+			// alcanza para arreglarlo.
 			throw new MalformedLandingPageError(slug, { cause: error });
 		}
 	}
@@ -149,8 +155,12 @@ export class SanityContentRepository implements ContentRepository {
 		});
 	}
 
-	// La misma vista la proyectan la landing y el contenido rotativo: el mapeo se tipa contra la unión
-	// para que ninguna de las dos pueda divergir sin que el typecheck lo denuncie.
+	/**
+	 * Traduce la vista de navegación que comparten los dos slots de destacados.
+	 *
+	 * El tipo de entrada es la unión de las dos proyecciones que la producen —la de la landing y la del
+	 * contenido rotativo— para que ninguna pueda divergir sin que el typecheck lo denuncie.
+	 */
 	private mapNavigationTeasers(
 		result: SanityLandingPage['latestReads'] | SanityRotatingContent['mostRead'],
 	): StoryNavigationTeaserWithAuthor[] {
@@ -168,14 +178,11 @@ export class SanityContentRepository implements ContentRepository {
 		});
 	}
 
+	/** Traduce los autores que la semana destaca, con las etiquetas y el conteo que solo esta pantalla usa. */
 	private mapHighlightedAuthors(raw: SanityLandingPage['highlightedAuthors']): HighlightedAuthor[] {
-		// El Studio limita la carga a seis entradas, pero esa regla gobierna la edición y no lo ya guardado:
-		// una migración o un backfill pueden dejar más. El recorte acá es una salvaguarda, no la regla.
-		const limit = 6;
-
-		return raw.slice(0, limit).map((entry) => ({
+		return raw.map((entry) => ({
 			author: mapAuthorTeaser(entry.author),
-			// El teaser entrega su lista vacía en toda vista del repositorio, así que las etiquetas del
+			// El teaser entrega su lista de etiquetas vacía en toda vista del repositorio, así que las del
 			// destacado se mapean acá aunque salgan del mismo autor.
 			tags: mapTags(entry.tags),
 			storyCount: entry.storyCount,

--- a/src/api/modules/content/content.repository.sanity.ts
+++ b/src/api/modules/content/content.repository.sanity.ts
@@ -1,0 +1,184 @@
+import type { SanityClient } from '@sanity/client';
+import type {
+	LandingPageContentQueryResult,
+	RotatingContentQueryResult,
+	StorylistTeasersQueryResult,
+} from '@sanity-types';
+import type { HighlightedAuthor, LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
+import type { StorylistTeaser } from '@models/storylist.model';
+import type { StoryNavigationTeaserWithAuthor } from '@models/story.model';
+import {
+	mapAuthorTeaser,
+	mapBlockContentToTextParagraphs,
+	mapContentCampaigns,
+	mapResources,
+	mapTags,
+	urlFor,
+} from '../../_utils/functions';
+import { mapMediaSources } from '../../_utils/media-sources.functions';
+import { mapImagery } from '../../_utils/storylist-imagery.functions';
+import { client as sanityClient } from '../../_helpers/sanity-connector';
+import {
+	landingPageContentQuery,
+	landingPageListQuery,
+	latestLandingPageReferencesQuery,
+	rotatingContentQuery,
+} from '../../_queries/content.query';
+import { MalformedLandingPageError, MalformedRotatingContentError } from './content.errors';
+import type {
+	ContentRepository,
+	KeyedReference,
+	LandingPageCreatePayload,
+	LandingPageReferences,
+	LandingPageSummary,
+} from './content.repository';
+
+type SanityLandingPage = NonNullable<LandingPageContentQueryResult>;
+type SanityRotatingContent = NonNullable<RotatingContentQueryResult>;
+
+// El documento rotativo es único por diseño, y tanto la query que lo lee como el patch que lo escribe
+// lo fijan por este `_id`.
+const ROTATING_CONTENT_ID = 'rotatingContent';
+
+export class SanityContentRepository implements ContentRepository {
+	constructor(private readonly client: SanityClient = sanityClient) {}
+
+	// La landing se arma con dos documentos: el de la semana y el rotativo, que aporta lo más leído y es
+	// independiente de ella.
+	public async fetchLandingPageContent(slug: string): Promise<LandingPageContent | null> {
+		const [raw, rotating] = await Promise.all([
+			this.client.fetch(landingPageContentQuery, { slug }),
+			this.fetchRotatingContent(),
+		]);
+		if (!raw) {
+			return null;
+		}
+		if (!rotating) {
+			// La landing se sigue sirviendo con el slot vacío, pero la degradación tiene que dejar rastro:
+			// sin esto, el bloque de lo más leído desaparece de la home con un 200 y nadie se entera.
+			console.warn('SanityContentRepository: el contenido rotativo no existe; la home queda sin lo más leído');
+		}
+		return this.guard(slug, () => this.mapLandingPageContent(raw, rotating?.mostRead ?? []));
+	}
+
+	// Su ausencia no es una curaduría incompleta sino una instalación incompleta, y el llamador decide
+	// qué hacer con eso: la landing se sigue sirviendo con el slot vacío.
+	public async fetchRotatingContent(): Promise<RotatingContent | null> {
+		const raw = await this.client.fetch(rotatingContentQuery);
+		if (!raw) {
+			return null;
+		}
+		try {
+			return { _id: raw._id, name: raw.name, mostRead: this.mapNavigationTeasers(raw.mostRead) };
+		} catch (error) {
+			throw new MalformedRotatingContentError({ cause: error });
+		}
+	}
+
+	public async fetchLandingPagesList(slugs: string[]): Promise<readonly LandingPageSummary[]> {
+		const raw = await this.client.fetch(landingPageListQuery, { slugs });
+		return raw.map(({ _id, slug, config }) => ({ _id, slug, config }));
+	}
+
+	// El `_id` se descarta acá y no en el service: la semana nueva es un documento nuevo, y arrastrarlo
+	// haría que el clon pisara al original.
+	public async fetchLatestLandingPageReferences(currentSlug: string): Promise<LandingPageReferences | null> {
+		const raw = await this.client.fetch(latestLandingPageReferencesQuery, { currentSlug });
+		if (!raw) {
+			return null;
+		}
+		return {
+			_type: raw._type,
+			campaigns: raw.campaigns,
+			cards: raw.cards,
+			latestReads: raw.latestReads,
+			highlightedAuthors: raw.highlightedAuthors,
+		};
+	}
+
+	public async createLandingPages(landingPageObjects: LandingPageCreatePayload[]): Promise<unknown[]> {
+		return Promise.all(landingPageObjects.map((object) => this.client.create(object)));
+	}
+
+	public async updateMostReadStories(references: readonly KeyedReference[]): Promise<void> {
+		await this.client.patch(ROTATING_CONTENT_ID, { set: { mostRead: [...references] } }).commit();
+	}
+
+	// Una landing mal curada tumba la llamada entera en vez de servirse a medias: un dato roto en la
+	// página de inicio es un bug que hay que ver, no esconder. El slug va en el error porque, sobre una
+	// landing por semana, saber que "alguna" está mal no alcanza para arreglarlo.
+	private guard<T>(slug: string, map: () => T): T {
+		try {
+			return map();
+		} catch (error) {
+			if (error instanceof MalformedLandingPageError) {
+				throw error;
+			}
+			throw new MalformedLandingPageError(slug, { cause: error });
+		}
+	}
+
+	private mapLandingPageContent(
+		raw: SanityLandingPage,
+		mostRead: StoryNavigationTeaserWithAuthor[],
+	): LandingPageContent {
+		return {
+			_id: raw._id,
+			config: raw.config,
+			cards: this.mapStorylistTeasers(raw.cards),
+			campaigns: mapContentCampaigns(raw.campaigns),
+			mostRead,
+			latestReads: this.mapNavigationTeasers(raw.latestReads),
+			highlightedAuthors: this.mapHighlightedAuthors(raw.highlightedAuthors),
+		};
+	}
+
+	private mapStorylistTeasers(result: StorylistTeasersQueryResult): StorylistTeaser[] {
+		return result.map((item) => {
+			const { featuredImage, storyCoverImages, mediaSources, ...rest } = item;
+			return {
+				...rest,
+				config: { ...item.config, showAuthors: item.config?.showAuthors ?? false },
+				description: mapBlockContentToTextParagraphs(item.description),
+				tags: mapTags(item.tags),
+				stories: [],
+				tabs: [],
+				media: mapMediaSources(mediaSources),
+				imagery: mapImagery({ featuredImage, storyCoverImages }),
+			};
+		});
+	}
+
+	// La misma vista la proyectan la landing y el contenido rotativo: el mapeo se tipa contra la unión
+	// para que ninguna de las dos pueda divergir sin que el typecheck lo denuncie.
+	private mapNavigationTeasers(
+		result: SanityLandingPage['latestReads'] | SanityRotatingContent['mostRead'],
+	): StoryNavigationTeaserWithAuthor[] {
+		return result.map((item) => {
+			const { mediaSources, resources, coverImage, ...properties } = item;
+			return {
+				...properties,
+				author: mapAuthorTeaser(item.author),
+				coverImage: urlFor(coverImage),
+				media: mapMediaSources(mediaSources),
+				resources: mapResources(resources),
+				paragraphs: [],
+				tags: [],
+			};
+		});
+	}
+
+	private mapHighlightedAuthors(raw: SanityLandingPage['highlightedAuthors']): HighlightedAuthor[] {
+		// El Studio limita la carga a seis entradas, pero esa regla gobierna la edición y no lo ya guardado:
+		// una migración o un backfill pueden dejar más. El recorte acá es una salvaguarda, no la regla.
+		const limit = 6;
+
+		return raw.slice(0, limit).map((entry) => ({
+			author: mapAuthorTeaser(entry.author),
+			// El teaser entrega su lista vacía en toda vista del repositorio, así que las etiquetas del
+			// destacado se mapean acá aunque salgan del mismo autor.
+			tags: mapTags(entry.tags),
+			storyCount: entry.storyCount,
+		}));
+	}
+}

--- a/src/api/modules/content/content.repository.ts
+++ b/src/api/modules/content/content.repository.ts
@@ -1,84 +1,37 @@
-// Sanity
-import { client } from '../../_helpers/sanity-connector';
+import type { LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
 
-// Queries
-import {
-	landingPageContentQuery,
-	landingPageListQuery,
-	latestLandingPageReferencesQuery,
-	rotatingContentQuery,
-} from '@queries/content.query';
-import {
-	LandingPageContentQueryResult,
-	LandingPageListQueryResult,
-	LatestLandingPageReferencesQueryResult,
-} from '@sanity-types';
-import { mapLandingPageContent, mapStoryNavigationTeaserWithAuthor } from '../../_utils/functions';
-import { LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
+export type KeyedReference = { _key: string; _type: 'reference'; _ref: string };
 
-export async function fetchLandingPageContent(slug: string): Promise<LandingPageContentQueryResult> {
-	return client.fetch(landingPageContentQuery, { slug });
+// Lo que el generador de semanas necesita saber de una landing ya cargada: su identidad y qué semana
+// configura. No es dominio —no transporta contenido curado— pero tampoco es el shape de Sanity: el
+// puerto lo declara por su cuenta para que el service no dependa de los tipos del typegen.
+export interface LandingPageSummary {
+	readonly _id: string;
+	readonly slug: string;
+	readonly config: string;
 }
 
-export async function fetchLatestLandingPageReferences(
-	currentSlug: string,
-): Promise<LatestLandingPageReferencesQueryResult> {
-	return client.fetch(latestLandingPageReferencesQuery, { currentSlug });
+// La carga de una semana futura se arma copiando las referencias de la última semana curada, sin
+// resolverlas: el generador no lee contenido, lo reapunta. Por eso habla de referencias crudas y no de
+// dominio — pero la forma la declara el puerto, no la query.
+export interface LandingPageReferences {
+	readonly _type: string;
+	readonly campaigns: readonly KeyedReference[];
+	readonly cards: readonly KeyedReference[];
+	readonly latestReads: readonly KeyedReference[];
+	readonly highlightedAuthors: readonly KeyedReference[];
 }
 
-export async function fetchLandingPagesList(slugs: string[]): Promise<LandingPageListQueryResult> {
-	return client.fetch(landingPageListQuery, { slugs });
-}
-
-export async function fetchRotatingContent(): Promise<RotatingContent> {
-	const result = await client.fetch(rotatingContentQuery);
-	if (!result) {
-		throw new Error('Rotating content not found');
-	}
-
-	return { ...result, mostRead: mapStoryNavigationTeaserWithAuthor(result.mostRead) };
-}
-
-type KeyedReference = { _key: string; _type: 'reference'; _ref: string };
-
-type LandingPageCreatePayload = {
-	_type: string;
+export type LandingPageCreatePayload = LandingPageReferences & {
 	config: string;
 	slug: { _type: string; current: string };
-	campaigns: KeyedReference[];
-	cards: KeyedReference[];
-	latestReads: KeyedReference[];
-	highlightedAuthors: KeyedReference[];
 };
 
-export async function createLandingPages(landingPageObjects: LandingPageCreatePayload[]) {
-	return Promise.all(landingPageObjects.map((object) => client.create(object)));
-}
-
-// TODO: Rever estructura luego de migrar funciones de mapeo
-export async function fetchAndMapLandingPageContent(slug: string): Promise<LandingPageContent> {
-	const landingPageResult = await fetchLandingPageContent(slug);
-	const rotatingContentResult = await fetchRotatingContent();
-
-	if (!landingPageResult || !rotatingContentResult) {
-		throw new Error('Landing page content not found');
-	}
-
-	return {
-		...mapLandingPageContent({ ...landingPageResult, ...rotatingContentResult }),
-	};
-}
-
-/**
- * Updates the mostRead stories in the rotating content document
- */
-export async function updateRotatingContentMostRead(
-	stories: Array<{ _key: string; _type: string; _ref: string }>,
-): Promise<void> {
-	const rotatingContent = await fetchRotatingContent();
-	if (!rotatingContent) {
-		throw new Error('Rotating content not found');
-	}
-
-	await client.patch(rotatingContent._id, { set: { mostRead: stories } }).commit();
+export interface ContentRepository {
+	fetchLandingPageContent(slug: string): Promise<LandingPageContent | null>;
+	fetchRotatingContent(): Promise<RotatingContent | null>;
+	fetchLandingPagesList(slugs: string[]): Promise<readonly LandingPageSummary[]>;
+	fetchLatestLandingPageReferences(currentSlug: string): Promise<LandingPageReferences | null>;
+	createLandingPages(landingPageObjects: LandingPageCreatePayload[]): Promise<unknown[]>;
+	updateMostReadStories(references: readonly KeyedReference[]): Promise<void>;
 }

--- a/src/api/modules/content/content.repository.ts
+++ b/src/api/modules/content/content.repository.ts
@@ -11,9 +11,12 @@ export interface LandingPageSummary {
 	readonly config: string;
 }
 
-// La carga de una semana futura se arma copiando las referencias de la última semana curada, sin
-// resolverlas: el generador no lee contenido, lo reapunta. Por eso habla de referencias crudas y no de
-// dominio — pero la forma la declara el puerto, no la query.
+/**
+ * El contenido de una landing expresado como referencias sin resolver.
+ *
+ * Habla de referencias y no de dominio porque su consumidor las reapunta en vez de leerlas; la forma la
+ * declara el puerto y no la query, para que el service no dependa de los tipos del typegen.
+ */
 export interface LandingPageReferences {
 	readonly _type: string;
 	readonly campaigns: readonly KeyedReference[];

--- a/src/api/modules/content/content.service.spec.ts
+++ b/src/api/modules/content/content.service.spec.ts
@@ -1,261 +1,196 @@
 import { addWeeks } from 'date-fns';
 import { buildWeekSlug } from '@utils/week-slug.utils';
-import {
-	clearAllMocks,
-	runOnlyPendingTimers,
-	setSystemTime,
-	useFakeTimers,
-	useRealTimers,
-	type Mock,
-} from '@test-utils';
-import * as contentRepository from './content.repository';
-import * as contentService from './content.service';
-import { LandingPageContentQueryResult } from '@sanity-types';
+import { clearAllMocks, runOnlyPendingTimers, setSystemTime, useFakeTimers, useRealTimers } from '@test-utils';
+import type { LandingPageContent } from '@models/landing-page-content.model';
+import { LandingPageNotFoundError, RotatingContentNotFoundError } from './content.errors';
+import type { LandingPageReferences } from './content.repository';
+import { InMemoryContentRepository, type StoredLandingPage } from './content.repository.mock';
+import { addNextWeeksLandingPageContent, getLandingPageContent, getRotatingContent } from './content.service';
 
-/* eslint-disable no-restricted-syntax -- vi.mock/vi.fn: mock de módulo del repository; se migra a inyección de dependencias en #1503 */
-vi.mock('./content.repository', () => ({
-	fetchLandingPagesList: vi.fn(),
-	fetchLandingPageContent: vi.fn(),
-	createLandingPages: vi.fn(),
-	fetchLatestLandingPageReferences: vi.fn(),
-	fetchRotatingContent: vi.fn(),
-}));
-/* eslint-enable no-restricted-syntax */
+// La base a clonar son las referencias de la última semana curada, sin resolver: el generador no lee
+// contenido, lo reapunta. No lleva identidad — descartarla es responsabilidad del adaptador, que es
+// donde el spec del repository la afirma.
+const latestReferences: LandingPageReferences = {
+	_type: 'landingPage',
+	campaigns: [{ _key: 'campaign-1', _type: 'reference', _ref: 'campaign-1' }],
+	cards: [{ _key: 'card-1', _type: 'reference', _ref: 'card-1' }],
+	latestReads: [{ _key: 'story-1', _type: 'reference', _ref: 'story-1' }],
+	highlightedAuthors: [{ _key: 'highlighted-1', _type: 'reference', _ref: 'author-1' }],
+};
 
-describe('ContentService', () => {
-	beforeEach(() => {
-		clearAllMocks();
-		useFakeTimers();
+function emptyLandingPageContent(config: string): LandingPageContent {
+	return {
+		_id: `landing-page-${config}`,
+		config,
+		cards: [],
+		campaigns: [],
+		mostRead: [],
+		latestReads: [],
+		highlightedAuthors: [],
+	};
+}
+
+function storedWeeks(slugs: readonly string[]): StoredLandingPage[] {
+	return slugs.map((slug) => ({ slug, content: emptyLandingPageContent(slug) }));
+}
+
+beforeEach(() => {
+	clearAllMocks();
+	useFakeTimers();
+});
+
+afterEach(() => {
+	runOnlyPendingTimers();
+	useRealTimers();
+});
+
+describe('getLandingPageContent', () => {
+	const currentDate = new Date(2025, 10, 14);
+	const currentSlug = buildWeekSlug(currentDate);
+
+	beforeEach(() => setSystemTime(currentDate));
+
+	it('serves the landing page of the current ISO week', async () => {
+		const repository = new InMemoryContentRepository({ landingPages: storedWeeks([currentSlug]) });
+
+		expect((await getLandingPageContent(repository)).config).toBe(currentSlug);
 	});
 
-	afterEach(() => {
-		runOnlyPendingTimers();
-		useRealTimers();
+	// La semana sin curar es un 404 y no un 500: el documento todavía no existe, no está roto.
+	it('throws LandingPageNotFoundError when the week has not been curated', async () => {
+		await expect(getLandingPageContent(new InMemoryContentRepository())).rejects.toThrow(LandingPageNotFoundError);
+	});
+});
+
+describe('getRotatingContent', () => {
+	it('serves the stored rotating content', async () => {
+		const rotatingContent = { _id: 'rotatingContent', name: 'Rotación', mostRead: [] };
+		const repository = new InMemoryContentRepository({ rotatingContent });
+
+		expect(await getRotatingContent(repository)).toEqual(rotatingContent);
 	});
 
-	describe('addNextWeeksLandingPageContent', () => {
-		const currentDate = new Date(2025, 10, 14);
-		const currentSlug = buildWeekSlug(currentDate);
+	it('throws RotatingContentNotFoundError when the singleton is not installed', async () => {
+		await expect(getRotatingContent(new InMemoryContentRepository())).rejects.toThrow(RotatingContentNotFoundError);
+	});
+});
 
-		const mockLandingPage = {
-			_id: 'landing-page-current',
-			campaigns: [{ _id: 'campaign-1' }, { _id: 'campaign-2' }],
-			cards: [{ _id: 'card-1' }],
-			latestReads: [{ _id: 'story-1' }, { _id: 'story-2' }],
-			highlightedAuthors: [{ _key: 'highlighted-1', _type: 'reference', _ref: 'author-1' }],
-		};
+describe('addNextWeeksLandingPageContent', () => {
+	const currentDate = new Date(2025, 10, 14);
+	const currentSlug = buildWeekSlug(currentDate);
 
-		beforeEach(() => {
-			setSystemTime(currentDate);
+	beforeEach(() => setSystemTime(currentDate));
+
+	function repositoryWith(existingSlugs: readonly string[] = []) {
+		return new InMemoryContentRepository({ landingPages: storedWeeks(existingSlugs), latestReferences });
+	}
+
+	function weekAhead(weeks: number): string {
+		return buildWeekSlug(addWeeks(currentDate, weeks));
+	}
+
+	it('creates one landing page per missing week', async () => {
+		const repository = repositoryWith();
+
+		const result = await addNextWeeksLandingPageContent(4, repository);
+
+		expect(result).toHaveLength(4);
+		expect(repository.createdLandingPages.map(({ config }) => config)).toEqual([1, 2, 3, 4].map(weekAhead));
+	});
+
+	it('labels the week with its ISO week-year, not the calendar year, across the Dec/Jan boundary', async () => {
+		// 2025-12-29 (lunes) es la semana ISO 01 de 2026: se etiqueta 2026, no 2025, preservando el orden
+		// lexicográfico = cronológico en el cruce dic/ene.
+		setSystemTime(new Date(2025, 11, 29));
+		const repository = repositoryWith();
+
+		await addNextWeeksLandingPageContent(4, repository);
+
+		expect(repository.createdLandingPages[0].config).toBe('2026-02');
+	});
+
+	it('uses ISO-8601 week numbering (Monday-start), not the locale default', async () => {
+		// 2026-07-05 es domingo: en ISO (lunes = día 1) pertenece a la semana 27; el default locale de
+		// date-fns (domingo = día 1) lo pondría en la 28.
+		setSystemTime(new Date(2026, 6, 5));
+		const repository = repositoryWith();
+
+		await addNextWeeksLandingPageContent(4, repository);
+
+		expect(repository.createdLandingPages[0].config).toBe('2026-28');
+	});
+
+	it('generates contiguous ISO weeks with no gap when the cron runs on a Sunday', async () => {
+		// Bajo ISO el domingo es el último día de su semana, así que la home pide esa misma semana ese
+		// domingo y la siguiente de lunes a sábado: las dos tienen que quedar cubiertas.
+		setSystemTime(new Date(2026, 5, 28)); // domingo, semana ISO 2026-26
+		const repository = repositoryWith();
+
+		await addNextWeeksLandingPageContent(4, repository);
+
+		expect(repository.createdLandingPages.map(({ config }) => config)).toEqual([
+			'2026-27',
+			'2026-28',
+			'2026-29',
+			'2026-30',
+		]);
+		expect(repository.createdLandingPages.map(({ config }) => config)).toContain(buildWeekSlug(new Date(2026, 5, 29)));
+	});
+
+	it('clones the base verbatim', async () => {
+		const repository = repositoryWith();
+
+		await addNextWeeksLandingPageContent(2, repository);
+
+		repository.createdLandingPages.forEach((created) => {
+			expect(created.campaigns).toEqual(latestReferences.campaigns);
+			expect(created.cards).toEqual(latestReferences.cards);
+			expect(created.latestReads).toEqual(latestReferences.latestReads);
 		});
+	});
 
-		it('should create missing weeks landing pages when they do not exist', async () => {
-			const weeksInTheFuture = 4;
+	// El clonado enumera los campos que copia, así que un campo nuevo que quede afuera no rompe nada: el
+	// slot se vaciaría solo cada semana, sin emitir ningún error.
+	it('carries the highlighted authors over to every cloned week', async () => {
+		const repository = repositoryWith();
 
-			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
-			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(mockLandingPage);
-			(contentRepository.createLandingPages as Mock).mockResolvedValue([
-				{ _id: 'created-1' },
-				{ _id: 'created-2' },
-				{ _id: 'created-3' },
-				{ _id: 'created-4' },
-			]);
+		await addNextWeeksLandingPageContent(3, repository);
 
-			const result = await contentService.addNextWeeksLandingPageContent(weeksInTheFuture);
-
-			expect(result).toHaveLength(4);
-			expect(contentRepository.fetchLandingPagesList).toHaveBeenCalledWith(
-				expect.arrayContaining([
-					expect.stringMatching(/^2025-\d{2}$/),
-					expect.stringMatching(/^2025-\d{2}$/),
-					expect.stringMatching(/^2025-\d{2}$/),
-					expect.stringMatching(/^2025-\d{2}$/),
-				]),
-			);
-			// Regresión: la base a clonar debe pedirse acotada a la semana actual. Pedirla sin argumentos
-			// termina clonando el último stub futuro autogenerado en vez de la última semana válida.
-			expect(contentRepository.fetchLatestLandingPageReferences).toHaveBeenCalledWith(currentSlug);
+		expect(repository.createdLandingPages).toHaveLength(3);
+		repository.createdLandingPages.forEach((created) => {
+			expect(created.highlightedAuthors).toEqual(latestReferences.highlightedAuthors);
 		});
+	});
 
-		it('should label the week with its ISO week-year, not the calendar year, across the Dec/Jan boundary', async () => {
-			// 2025-12-29 (lunes) es la semana ISO 01 de 2026: getISOWeekYear la etiqueta 2026, no 2025,
-			// preservando el orden lexicográfico = cronológico en el cruce dic/ene.
-			setSystemTime(new Date(2025, 11, 29));
+	it('names each cloned week by its own slug', async () => {
+		const repository = repositoryWith();
 
-			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
-			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(mockLandingPage);
-			(contentRepository.createLandingPages as Mock).mockResolvedValue([]);
+		await addNextWeeksLandingPageContent(2, repository);
 
-			await contentService.addNextWeeksLandingPageContent(4);
+		expect(repository.createdLandingPages.map(({ slug }) => slug.current)).toEqual([1, 2].map(weekAhead));
+	});
 
-			expect(contentRepository.fetchLatestLandingPageReferences).toHaveBeenCalledWith('2026-01');
-		});
+	it('creates nothing when every week already exists', async () => {
+		const repository = repositoryWith([1, 2, 3, 4].map(weekAhead));
 
-		it('should use ISO-8601 week numbering (Monday-start), not the locale default — decision pinned in #1751', async () => {
-			// 2026-07-05 es domingo: en ISO (lunes = día 1) pertenece a la semana 27; el default locale
-			// de date-fns (domingo = día 1) lo pondría en la 28. Fija ISO para que un refactor no lo revierta.
-			setSystemTime(new Date(2026, 6, 5));
+		expect(await addNextWeeksLandingPageContent(4, repository)).toEqual([]);
+		expect(repository.createdLandingPages).toEqual([]);
+	});
 
-			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
-			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(mockLandingPage);
-			(contentRepository.createLandingPages as Mock).mockResolvedValue([]);
+	it('creates only the missing weeks when some already exist', async () => {
+		const repository = repositoryWith([1, 2].map(weekAhead));
 
-			await contentService.addNextWeeksLandingPageContent(4);
+		const result = await addNextWeeksLandingPageContent(4, repository);
 
-			expect(contentRepository.fetchLatestLandingPageReferences).toHaveBeenCalledWith('2026-27');
-		});
+		expect(result).toHaveLength(2);
+		expect(repository.createdLandingPages.map(({ config }) => config)).toEqual([3, 4].map(weekAhead));
+	});
 
-		it('generates contiguous ISO weeks with no gap when the cron runs on a Sunday', async () => {
-			// El cron corre en domingo. Bajo ISO el domingo es el último día de su
-			// semana, así que la home la pide ese domingo y pide la SIGUIENTE de lunes a sábado. Este test
-			// fija que ambas quedan cubiertas: la base se pide para la semana del domingo (2026-26) y se
-			// generan las 4 siguientes contiguas (2026-27..2026-30), incluida la que la home leerá el lunes.
-			setSystemTime(new Date(2026, 5, 28)); // domingo, semana ISO 2026-26
-			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
-			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(mockLandingPage);
-			(contentRepository.createLandingPages as Mock).mockResolvedValue([]);
+	it('throws when there is no base week to clone', async () => {
+		const repository = new InMemoryContentRepository({ latestReferences: null });
 
-			await contentService.addNextWeeksLandingPageContent(4);
-
-			expect(contentRepository.fetchLatestLandingPageReferences).toHaveBeenCalledWith('2026-26');
-			expect(contentRepository.fetchLandingPagesList).toHaveBeenCalledWith([
-				'2026-27',
-				'2026-28',
-				'2026-29',
-				'2026-30',
-			]);
-			// La semana que la home leerá de lunes a sábado (lunes 29/jun → 2026-27) está entre las generadas.
-			const generatedSlugs = (contentRepository.fetchLandingPagesList as Mock).mock.calls[0][0];
-			expect(generatedSlugs).toContain(buildWeekSlug(new Date(2026, 5, 29)));
-		});
-
-		it('should clone the base returned by the repository verbatim, without leaking its _id', async () => {
-			const weeksInTheFuture = 2;
-
-			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
-			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(mockLandingPage);
-			(contentRepository.createLandingPages as Mock).mockResolvedValue([{ _id: 'created-1' }, { _id: 'created-2' }]);
-
-			await contentService.addNextWeeksLandingPageContent(weeksInTheFuture);
-
-			// El filtrado de "última semana no futura" vive en la query GROQ (config <= $currentSlug); el
-			// service solo pasa la semana actual y clona la base tal cual la recibe, sin selección propia.
-			expect(contentRepository.fetchLatestLandingPageReferences).toHaveBeenCalledWith(currentSlug);
-
-			const createdObjects = (contentRepository.createLandingPages as Mock).mock.calls[0][0] as Array<
-				Record<string, unknown>
-			>;
-			createdObjects.forEach((obj) => {
-				expect(obj.campaigns).toEqual(mockLandingPage.campaigns);
-				expect(obj.cards).toEqual(mockLandingPage.cards);
-				expect(obj.latestReads).toEqual(mockLandingPage.latestReads);
-				expect(obj).not.toHaveProperty('_id');
-			});
-		});
-
-		// El clonado enumera los campos que copia, así que un campo nuevo que quede afuera no rompe nada:
-		// los destacados se vaciarían solos cada semana, sin emitir ningún error.
-		it('should carry the highlighted authors over to every cloned week', async () => {
-			const weeksInTheFuture = 3;
-
-			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
-			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(mockLandingPage);
-			(contentRepository.createLandingPages as Mock).mockResolvedValue([]);
-
-			await contentService.addNextWeeksLandingPageContent(weeksInTheFuture);
-
-			const createdObjects = (contentRepository.createLandingPages as Mock).mock.calls[0][0] as Array<
-				Record<string, unknown>
-			>;
-
-			expect(createdObjects).toHaveLength(weeksInTheFuture);
-			createdObjects.forEach((obj) => {
-				expect(obj.highlightedAuthors).toEqual(mockLandingPage.highlightedAuthors);
-			});
-		});
-
-		it('should return an empty array when all weeks already exist', async () => {
-			const weeksInTheFuture = 4;
-			const futureWeeks = Array.from({ length: weeksInTheFuture }, (_, index) => ({
-				_id: `landing-page-${index}`,
-				config: buildWeekSlug(addWeeks(currentDate, index + 1)),
-			}));
-
-			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue(futureWeeks);
-
-			const result = await contentService.addNextWeeksLandingPageContent(weeksInTheFuture);
-
-			expect(result).toEqual([]);
-			expect(contentRepository.createLandingPages).not.toHaveBeenCalled();
-		});
-
-		it('should throw an error when current landing page is not found', async () => {
-			const weeksInTheFuture = 4;
-
-			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
-			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(null);
-
-			await expect(contentService.addNextWeeksLandingPageContent(weeksInTheFuture)).rejects.toThrow(
-				`Latest landing page for the '${currentSlug}' slug content not found`,
-			);
-		});
-
-		it('should throw an error when landing page list query fails', async () => {
-			const weeksInTheFuture = 4;
-
-			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue(null);
-
-			await expect(contentService.addNextWeeksLandingPageContent(weeksInTheFuture)).rejects.toThrow(
-				'Could not retrieve the landing page configs',
-			);
-		});
-
-		it('should create only missing weeks when some already exist', async () => {
-			const weeksInTheFuture = 4;
-			const existingWeek = Array.from({ length: 2 }, (_, index) => ({
-				_id: `landing-page-${index}`,
-				config: buildWeekSlug(addWeeks(currentDate, index + 1)),
-			}));
-
-			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue(existingWeek);
-			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(mockLandingPage);
-			(contentRepository.createLandingPages as Mock).mockResolvedValue([{ _id: 'created-3' }, { _id: 'created-4' }]);
-
-			const result = await contentService.addNextWeeksLandingPageContent(weeksInTheFuture);
-
-			expect(result).toHaveLength(2);
-			expect(contentRepository.createLandingPages).toHaveBeenCalled();
-
-			const callArgs = (contentRepository.createLandingPages as Mock).mock.calls[0][0];
-			expect(callArgs).toHaveLength(2);
-			callArgs.forEach((obj: LandingPageContentQueryResult) => {
-				expect(obj).toHaveProperty('config');
-				expect(obj).toHaveProperty('slug');
-				expect(obj).toHaveProperty('campaigns');
-				expect(obj).toHaveProperty('cards');
-				expect(obj).toHaveProperty('latestReads');
-				expect(obj).toHaveProperty('highlightedAuthors');
-			});
-		});
-
-		it('should call createLandingPages with Promise.all for parallel execution', async () => {
-			const weeksInTheFuture = 3;
-
-			(contentRepository.fetchLandingPagesList as Mock).mockResolvedValue([]);
-			(contentRepository.fetchLatestLandingPageReferences as Mock).mockResolvedValue(mockLandingPage);
-			(contentRepository.createLandingPages as Mock).mockResolvedValue([
-				{ _id: 'created-1' },
-				{ _id: 'created-2' },
-				{ _id: 'created-3' },
-			]);
-
-			await contentService.addNextWeeksLandingPageContent(weeksInTheFuture);
-
-			// Verify that createLandingPages was called (which internally uses Promise.all)
-			expect(contentRepository.createLandingPages).toHaveBeenCalled();
-			const passedObjects = (contentRepository.createLandingPages as Mock).mock.calls[0][0];
-			expect(Array.isArray(passedObjects)).toBe(true);
-			expect(passedObjects.length).toBe(weeksInTheFuture);
-		});
+		await expect(addNextWeeksLandingPageContent(4, repository)).rejects.toThrow(
+			`Latest landing page for the '${currentSlug}' slug content not found`,
+		);
 	});
 });

--- a/src/api/modules/content/content.service.ts
+++ b/src/api/modules/content/content.service.ts
@@ -1,35 +1,44 @@
-// Repository
-import {
-	createLandingPages,
-	fetchAndMapLandingPageContent,
-	fetchLandingPagesList,
-	fetchLatestLandingPageReferences,
-	fetchRotatingContent,
-} from './content.repository';
-
-// Modelos
-import { LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
-
-// Utils
+import type { LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
 import { addWeeks } from 'date-fns';
 import slugify from 'slugify';
 import { buildWeekSlug } from '@utils/week-slug.utils';
+import { LandingPageNotFoundError, RotatingContentNotFoundError } from './content.errors';
+import type { ContentRepository, LandingPageCreatePayload } from './content.repository';
+import { SanityContentRepository } from './content.repository.sanity';
 
-export async function getLandingPageContent(): Promise<LandingPageContent> {
-	return fetchAndMapLandingPageContent(buildWeekSlug(new Date()));
+// El repository es stateless, así que instanciarlo por llamada (default) no comparte estado.
+
+export async function getLandingPageContent(
+	repository: ContentRepository = new SanityContentRepository(),
+): Promise<LandingPageContent> {
+	const slug = buildWeekSlug(new Date());
+	const landingPageContent = await repository.fetchLandingPageContent(slug);
+	if (!landingPageContent) {
+		throw new LandingPageNotFoundError(slug);
+	}
+	return landingPageContent;
 }
 
-export async function getRotatingContent(): Promise<RotatingContent> {
-	return await fetchRotatingContent();
+export async function getRotatingContent(
+	repository: ContentRepository = new SanityContentRepository(),
+): Promise<RotatingContent> {
+	const rotatingContent = await repository.fetchRotatingContent();
+	if (!rotatingContent) {
+		throw new RotatingContentNotFoundError();
+	}
+	return rotatingContent;
 }
 
-export async function addNextWeeksLandingPageContent(weeksInTheFuture: number = 4) {
+export async function addNextWeeksLandingPageContent(
+	weeksInTheFuture: number = 4,
+	repository: ContentRepository = new SanityContentRepository(),
+) {
 	const currentDate = new Date();
 	const currentLandingPageSlug = buildWeekSlug(currentDate);
 
 	const slugs = Array.from({ length: weeksInTheFuture }, (_, index) => buildWeekSlug(addWeeks(currentDate, index + 1)));
 
-	const existingLandingPagesList = await fetchLandingPagesList(slugs);
+	const existingLandingPagesList = await repository.fetchLandingPagesList(slugs);
 
 	if (!existingLandingPagesList) {
 		throw new Error(`Could not retrieve the landing page configs for the [${slugs.join(', ')}] slugs not found.`);
@@ -41,7 +50,7 @@ export async function addNextWeeksLandingPageContent(weeksInTheFuture: number = 
 		return [];
 	}
 
-	const latestLandingPageConfig = await fetchLatestLandingPageReferences(currentLandingPageSlug);
+	const latestLandingPageConfig = await repository.fetchLatestLandingPageReferences(currentLandingPageSlug);
 
 	if (!latestLandingPageConfig) {
 		throw new Error(`Latest landing page for the '${currentLandingPageSlug}' slug content not found`);
@@ -49,18 +58,14 @@ export async function addNextWeeksLandingPageContent(weeksInTheFuture: number = 
 
 	const notLoadedWeeks = slugs.filter((t) => !existingLandingPagesList.find((r) => r.config === t));
 
-	const landingPageObjects = notLoadedWeeks.map((weekYear) => {
-		const config = { ...latestLandingPageConfig };
-		delete (config as { _id?: string })._id;
-		return {
-			...config,
-			config: weekYear,
-			slug: {
-				_type: 'slug',
-				current: slugify(weekYear),
-			},
-		};
-	});
+	const landingPageObjects: LandingPageCreatePayload[] = notLoadedWeeks.map((weekYear) => ({
+		...latestLandingPageConfig,
+		config: weekYear,
+		slug: {
+			_type: 'slug',
+			current: slugify(weekYear),
+		},
+	}));
 
-	return await createLandingPages(landingPageObjects);
+	return await repository.createLandingPages(landingPageObjects);
 }

--- a/src/api/modules/content/content.service.ts
+++ b/src/api/modules/content/content.service.ts
@@ -6,8 +6,6 @@ import { LandingPageNotFoundError, RotatingContentNotFoundError } from './conten
 import type { ContentRepository, LandingPageCreatePayload } from './content.repository';
 import { SanityContentRepository } from './content.repository.sanity';
 
-// El repository es stateless, así que instanciarlo por llamada (default) no comparte estado.
-
 export async function getLandingPageContent(
 	repository: ContentRepository = new SanityContentRepository(),
 ): Promise<LandingPageContent> {

--- a/src/api/modules/story/story.service.ts
+++ b/src/api/modules/story/story.service.ts
@@ -23,7 +23,8 @@ import { getLandingPageContent, getRotatingContent } from '../content/content.se
 import { fetchClarityData } from '../../_helpers/clarity-connector';
 
 // Repository
-import { updateRotatingContentMostRead } from '../content/content.repository';
+import type { ContentRepository } from '../content/content.repository';
+import { SanityContentRepository } from '../content/content.repository.sanity';
 
 // Funciones de mapeo
 import { mapMediaSources } from '../../_utils/media-sources.functions';
@@ -66,7 +67,9 @@ export async function getMostReadStoryNavigationTeasers(
 	return result.mostRead.slice(offset, offset + limit);
 }
 
-export async function updateMostReadStories(): Promise<RotatingContent> {
+export async function updateMostReadStories(
+	contentRepository: ContentRepository = new SanityContentRepository(),
+): Promise<RotatingContent> {
 	const popularPagesMetrics = (await fetchClarityData()).find((metric) => metric.metricName === 'PopularPages');
 	if (!popularPagesMetrics) {
 		throw new Error('Could not fetch metrics.');
@@ -80,10 +83,10 @@ export async function updateMostReadStories(): Promise<RotatingContent> {
 	const stories = await getStoriesBySlug(mostReadStoriesSlugs);
 
 	// Actualiza landing page referencias a las historias marcadas como "más leídas" actuales
-	const mostReadStories = stories.map((s) => ({ _key: s._id, _type: 'story', _ref: s._id }));
-	await updateRotatingContentMostRead(mostReadStories);
+	const mostReadStories = stories.map((s) => ({ _key: s._id, _type: 'reference' as const, _ref: s._id }));
+	await contentRepository.updateMostReadStories(mostReadStories);
 
-	return await getRotatingContent();
+	return await getRotatingContent(contentRepository);
 }
 
 export async function getStories(limit: number = 100, offset: number = 0): Promise<StoryTeaserWithAuthor[]> {

--- a/src/mocks/onoff-highlighted-authors.acl-alignment.spec.ts
+++ b/src/mocks/onoff-highlighted-authors.acl-alignment.spec.ts
@@ -1,6 +1,9 @@
-import { mapHighlightedAuthors } from '../api/_utils/functions';
+import type { SanityClient } from '@sanity/client';
+import { fn } from '@test-utils';
+import { SanityContentRepository } from '../api/modules/content/content.repository.sanity';
+import { rotatingContentQuery } from '../api/_queries/content.query';
 import { onoffHighlightedAuthorsMock } from './onoff-highlighted-authors.mock';
-import { onoffRawHighlightedAuthorsMock } from './onoff-raw-landing-page.mock';
+import { onoffRawLandingPageMock } from './onoff-raw-landing-page.mock';
 
 /* eslint-disable no-restricted-syntax -- vi.mock: el builder de imágenes de Sanity no tiene punto de inyección */
 vi.mock('@sanity/image-url', async () => {
@@ -9,11 +12,28 @@ vi.mock('@sanity/image-url', async () => {
 });
 /* eslint-enable no-restricted-syntax */
 
+// El mapeo de los destacados es privado del repository de la página de inicio, así que el cruce entra
+// por su superficie pública en vez de por el mapper: es la misma cadena, ejercitada por donde el
+// consumidor real la recorre. El contenido rotativo no participa de este cruce, así que se responde
+// vacío.
+function repository(): SanityContentRepository {
+	const fetch = fn((query: unknown) =>
+		Promise.resolve(
+			query === rotatingContentQuery
+				? { _id: 'rotatingContent', name: 'Lo más leído', mostRead: [] }
+				: onoffRawLandingPageMock,
+		),
+	);
+	return new SanityContentRepository({ fetch } as unknown as SanityClient);
+}
+
 // Cierra la cadena entera del corpus de destacados: el documento alimenta la query, la query genera el raw
 // y el raw pasa por el ACL. Sin este cruce, el corpus de dominio —que es lo que consumen la story y el
 // spec del componente— podría afirmar una forma que la API no devuelve.
 describe('el corpus de dominio de HighlightedAuthor coincide con el mapeo del ACL', () => {
-	it('maps the raw highlighted authors into their domain mock', () => {
-		expect(mapHighlightedAuthors(onoffRawHighlightedAuthorsMock)).toStrictEqual(onoffHighlightedAuthorsMock);
+	it('maps the raw highlighted authors into their domain mock', async () => {
+		const landingPage = await repository().fetchLandingPageContent(onoffRawLandingPageMock.slug);
+
+		expect(landingPage?.highlightedAuthors).toStrictEqual(onoffHighlightedAuthorsMock);
 	});
 });

--- a/src/mocks/onoff-highlighted-authors.acl-alignment.spec.ts
+++ b/src/mocks/onoff-highlighted-authors.acl-alignment.spec.ts
@@ -1,5 +1,4 @@
-import type { SanityClient } from '@sanity/client';
-import { fn } from '@test-utils';
+import { stubSanityClient } from '@testing/sanity-client.stub';
 import { SanityContentRepository } from '../api/modules/content/content.repository.sanity';
 import { rotatingContentQuery } from '../api/_queries/content.query';
 import { onoffHighlightedAuthorsMock } from './onoff-highlighted-authors.mock';
@@ -12,19 +11,16 @@ vi.mock('@sanity/image-url', async () => {
 });
 /* eslint-enable no-restricted-syntax */
 
-// El mapeo de los destacados es privado del repository de la página de inicio, así que el cruce entra
-// por su superficie pública en vez de por el mapper: es la misma cadena, ejercitada por donde el
-// consumidor real la recorre. El contenido rotativo no participa de este cruce, así que se responde
-// vacío.
+// El mapeo de los destacados es privado del repository, así que el cruce entra por su superficie
+// pública: es la misma cadena, ejercitada por donde la recorre el consumidor real.
 function repository(): SanityContentRepository {
-	const fetch = fn((query: unknown) =>
-		Promise.resolve(
-			query === rotatingContentQuery
-				? { _id: 'rotatingContent', name: 'Lo más leído', mostRead: [] }
-				: onoffRawLandingPageMock,
-		),
+	// El contenido rotativo no participa de este cruce, pero la lectura lo pide igual, así que se
+	// responde vacío en vez de dejarlo sin respuesta.
+	const { client } = stubSanityClient(
+		[[rotatingContentQuery, { _id: 'rotatingContent', name: 'Lo más leído', mostRead: [] }]],
+		onoffRawLandingPageMock,
 	);
-	return new SanityContentRepository({ fetch } as unknown as SanityClient);
+	return new SanityContentRepository(client);
 }
 
 // Cierra la cadena entera del corpus de destacados: el documento alimenta la query, la query genera el raw

--- a/src/testing/sanity-client.stub.ts
+++ b/src/testing/sanity-client.stub.ts
@@ -1,0 +1,26 @@
+import type { SanityClient } from '@sanity/client';
+import { fn } from '@test-utils';
+
+/**
+ * Cliente de Sanity que responde según la query que se le pide.
+ *
+ * Es el seam para ejercitar un **repository real** contra crudo del corpus: lo que se prueba es su ACL,
+ * así que sustituir el repository entero por su doble en memoria no serviría — ése guarda dominio ya
+ * construido y no traduce nada.
+ *
+ * Responde por query y no con un valor único porque un repository que consulta más de una en la misma
+ * llamada, respondido con un canned, recibiría el crudo de una con la forma de la otra sin que ninguna
+ * aserción sobre el resultado lo note.
+ *
+ * Devuelve también el spy para poder observar con qué query y con qué parámetros se lo llamó.
+ */
+export function stubSanityClient(
+	responses: ReadonlyArray<readonly [query: string, response: unknown]>,
+	fallback?: unknown,
+) {
+	const byQuery = new Map(responses);
+	const fetch = fn((query: unknown) =>
+		Promise.resolve(byQuery.has(query as string) ? byQuery.get(query as string) : fallback),
+	);
+	return { client: { fetch } as unknown as SanityClient, fetch };
+}


### PR DESCRIPTION
**Slice 2 de 6** de #2266. Apilado sobre #2380 — **mergear ése primero**.

`content` era el último módulo de contenido con la traducción crudo→dominio en `_utils/functions.ts` y sus lecturas como funciones sueltas. Pasa a la forma que ya adoptaron `collection` y `literary-work`.

**El contrato de dominio no cambia.** La landing entrega exactamente lo mismo que antes: `cards` sigue siendo `StorylistTeaser[]` y los destacados siguen siendo `StoryNavigationTeaserWithAuthor[]`. Lo que cambia es quién los produce y por dónde se lo puede sustituir. El cambio de contrato viene en el slice siguiente, y llega a un módulo cuya estructura ya se revisó por separado.

## Qué trae

**Puerto + adaptador + doble en memoria.** La ACL de la landing sale de `_utils/functions.ts` y entra al adaptador como métodos privados, sin cambiarle la forma a nada.

**El puerto declara sus propias formas de lectura.** Dos lecturas estaban tipadas contra los `*QueryResult` del typegen y el service las consumía: es la fuga de shape externo que el ACL existe para impedir. Ahora el puerto declara la identidad de una semana cargada y el juego de referencias que el generador clona, y el adaptador traduce. De paso, descartar la identidad de la semana que se clona vuelve a ser responsabilidad del adaptador, que es donde se puede afirmar — antes el service borraba un `_id` de un objeto que el puerto ni siquiera declaraba.

**El controller adopta el guard del módulo de colecciones.** La semana sin curar responde 404; la landing mal curada, 500 con un código estable que no filtra el documento culpable.

**El spec del service deja de mockear el módulo del repository** y recibe el doble en memoria por parámetro, que es el patrón al que apunta [`testing.md`](.claude/references/testing.md). El `eslint-disable` de module mocking desaparece de ese archivo.

## Dos comportamientos que antes no se observaban

La **ausencia del contenido rotativo** se sigue degradando a slot vacío —es un documento independiente de la semana— pero ahora avisa: sin eso, el bloque de lo más leído desaparece de la página con un 200 y nadie se entera.

El **error de curaduría** se loguea con su causa antes de traducirse. El 500 responde un código sin mensaje para no filtrar qué documento está mal, y con eso la causa moría ahí: nadie sabía qué corregir en el Studio.

## Plan de pruebas

- `typecheck`, `test` (2494 casos), `lint`, `stylelint` y `build` en verde.
- Specs nuevos: el del adaptador —que recoge la cobertura que salía de `functions.spec.ts` y suma el cruce de los dos documentos, la rotación ausente y la identidad descartada al clonar— y el del controller, con sus tres caminos.

Parte de #2266.
