### PR TITLE
[#2266] - La página de inicio suma colecciones y obras a su contrato

### DIFF
--- a/scripts/generate-raw-corpus/generate-raw-corpus.ts
+++ b/scripts/generate-raw-corpus/generate-raw-corpus.ts
@@ -128,6 +128,13 @@ function targetsFor(queries: Record<string, string>, landingPageSlug: string): T
 			query: queryNamed(queries, 'collectionsQuery'),
 		},
 		landingPageTarget(queries, landingPageSlug),
+		{
+			file: join('src/mocks/onoff/landing-page', 'rotating-content.raw.mock.ts'),
+			exportName: 'onoffRawRotatingContentMock',
+			typeImport: 'RotatingContentQueryResult',
+			typeAnnotation: 'NonNullable<RotatingContentQueryResult>',
+			query: queryNamed(queries, 'rotatingContentQuery'),
+		},
 	];
 }
 

--- a/src/api/_queries/content.query.ts
+++ b/src/api/_queries/content.query.ts
@@ -1,9 +1,42 @@
 import { defineQuery } from 'groq';
 
+// Los campos de obra y colección conviven con los de historia y storylist: el Studio ya declara los dos
+// juegos y la aplicación migra sus lectores de a uno. Los viejos se retiran cuando ninguno los lea.
+//
+// La vista de navegación de una obra —la que pintan las tarjetas de la página de inicio— va sin
+// extracto: ninguno de sus consumidores muestra cuerpo. Cada aparición repite el literal porque
+// `defineQuery` lo exige; lo que impide que se desincronicen es el mapeo del repository, tipado contra
+// la unión de todas ellas.
+
 export const rotatingContentQuery = defineQuery(`
 *[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{
     _id,
     name,
+    'mostReadLiteraryWorks': coalesce(mostReadLiteraryWorks[]->{
+        _id,
+        'slug': slug.current,
+        title,
+        coverImage,
+        totalReadingTime,
+        'sectionCount': count(content),
+        'tags': coalesce(tags[] -> {
+            title,
+            'slug': slug.current,
+            description
+        }, []),
+        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),
+        'authors': coalesce(authors[]->{
+            _id,
+            'slug': slug.current,
+            name,
+            image,
+            nationality->,
+            bornOn,
+            bornOnYear,
+            diedOn,
+            diedOnYear
+        }, [])
+    },[]),
     'mostRead': coalesce(mostRead[]->{
         _id,
         'slug': slug.current,
@@ -46,6 +79,8 @@ export const latestLandingPageReferencesQuery = defineQuery(`
     'cards': coalesce(cards[],[]),
     'campaigns': coalesce(campaigns[],[]),
     'latestReads': coalesce(latestReads,[]),
+    'collections': coalesce(collections,[]),
+    'latestLiteraryWorks': coalesce(latestLiteraryWorks,[]),
     'highlightedAuthors': coalesce(highlightedAuthors,[]),
 } | order(config desc, _createdAt desc)[0]
 `);
@@ -55,6 +90,52 @@ export const landingPageContentQuery = defineQuery(`
     _id,
     'slug': slug.current,
     config,
+    'collections': coalesce(collections[]->{
+        _id,
+        'slug': slug.current,
+        title,
+        description,
+        featuredImage,
+        'config': { 'showAuthors': coalesce(config.showAuthors, false) },
+        'tags': coalesce(tags[] -> {
+            title,
+            'slug': slug.current,
+            description
+        }, []),
+        'mediaSources': coalesce(mediaSources[]{
+            ...,
+            _type == 'spaceRecording' => {
+                'audioUrl': audioFile.asset->url
+            }
+        }, []),
+        'count': coalesce(count(literaryWorks), 0),
+        'literaryWorkCoverImages': coalesce(literaryWorks[0...3]->coverImage, [])
+    },[]),
+    'latestLiteraryWorks': coalesce(latestLiteraryWorks[]->{
+        _id,
+        'slug': slug.current,
+        title,
+        coverImage,
+        totalReadingTime,
+        'sectionCount': count(content),
+        'tags': coalesce(tags[] -> {
+            title,
+            'slug': slug.current,
+            description
+        }, []),
+        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),
+        'authors': coalesce(authors[]->{
+            _id,
+            'slug': slug.current,
+            name,
+            image,
+            nationality->,
+            bornOn,
+            bornOnYear,
+            diedOn,
+            diedOnYear
+        }, [])
+    },[]),
     'cards': coalesce(cards[]->{
         _id,
         title,

--- a/src/api/modules/collection/collection-teaser.acl.ts
+++ b/src/api/modules/collection/collection-teaser.acl.ts
@@ -1,4 +1,4 @@
-import type { CollectionBySlugQueryResult, CollectionsQueryResult } from '@sanity-types';
+import type { CollectionBySlugQueryResult, CollectionsQueryResult, LandingPageContentQueryResult } from '@sanity-types';
 import { createCollectionTeaser, type CollectionImagery, type CollectionTeaser } from '@models/collection.model';
 import { createMarkdown, type Markdown } from '@models/markdown.model';
 import type { SanitizedHtml } from '@models/sanitized-html.model';
@@ -13,10 +13,12 @@ import { MalformedCollectionError } from './collection.errors';
 // tres portadas de muestra—, y una segunda definición haría que la misma colección se construyera por
 // un camino y fallara por el otro.
 //
-// El origen es una unión de proyecciones, no una sola: cuando un segundo repository dereferencia
-// colecciones con su propia proyección, entra acá. El seguro contra la deriva es el tipo — si una
-// diverge, la unión deja de aceptar el mapeo y el typecheck lo denuncia.
-type SanityCollectionTeaserSource = CollectionsQueryResult[number];
+// El origen es una unión de proyecciones, no una sola: el catálogo de colecciones y la página de
+// inicio dereferencian colecciones cada una por su lado, y `defineQuery` exige literales, así que la
+// proyección se repite. El seguro contra la deriva es el tipo — si una diverge, la unión deja de
+// aceptar el mapeo y el typecheck lo denuncia.
+type SanityCollectionTeaserSource =
+	CollectionsQueryResult[number] | NonNullable<LandingPageContentQueryResult>['collections'][number];
 type SanityFeaturedImage = NonNullable<CollectionBySlugQueryResult>['featuredImage'];
 
 export function mapSanityCollectionTeaser(raw: SanityCollectionTeaserSource): CollectionTeaser {

--- a/src/api/modules/content/content.controller.spec.ts
+++ b/src/api/modules/content/content.controller.spec.ts
@@ -23,9 +23,12 @@ const curatedLandingPage: LandingPageContent = {
 	_id: `landing-page-${CURRENT_SLUG}`,
 	config: CURRENT_SLUG,
 	cards: [],
+	collections: [],
 	campaigns: [],
 	mostRead: [],
+	mostReadLiteraryWorks: [],
 	latestReads: [],
+	latestLiteraryWorks: [],
 	highlightedAuthors: [],
 };
 

--- a/src/api/modules/content/content.repository.sanity.spec.ts
+++ b/src/api/modules/content/content.repository.sanity.spec.ts
@@ -4,22 +4,23 @@ import { stubSanityClient } from '@testing/sanity-client.stub';
 import {
 	onoffRawHighlightedAuthorsMock,
 	onoffRawLandingPageMock,
+	onoffRawRotatingContentMock,
 	overflowingRawHighlightedAuthors,
 	untaggedRawHighlightedAuthor,
 } from '@mocks/onoff-raw-landing-page.mock';
 import { onoffRawNavTeasersMock } from '@mocks/onoff-raw-stories.mock';
 import { mapAuthorTeaser } from '../../_utils/functions';
 import { landingPageContentQuery, rotatingContentQuery } from '../../_queries/content.query';
+import { MalformedLandingPageError } from './content.errors';
 import { SanityContentRepository } from './content.repository.sanity';
 
 const LANDING_SLUG = onoffRawLandingPageMock.slug;
 
-// El corpus no modela un documento de contenido rotativo, así que la rotación se arma acá con los
-// teasers de navegación del canon: son la misma proyección que la landing usa para sus últimas
-// novedades.
+// El slot de obras sale del corpus; el de historias se arma acá con los teasers de navegación del
+// canon, porque el documento del corpus ya no declara el campo en baja y este spec necesita las dos
+// listas pobladas para poder distinguirlas.
 const rawRotatingContent = {
-	_id: 'rotatingContent',
-	name: 'Lo más leído',
+	...onoffRawRotatingContentMock,
 	mostRead: onoffRawNavTeasersMock.slice(0, 2),
 };
 
@@ -58,10 +59,13 @@ describe('SanityContentRepository.fetchLandingPageContent', () => {
 			'_id',
 			'campaigns',
 			'cards',
+			'collections',
 			'config',
 			'highlightedAuthors',
+			'latestLiteraryWorks',
 			'latestReads',
 			'mostRead',
+			'mostReadLiteraryWorks',
 		]);
 	});
 
@@ -113,6 +117,83 @@ describe('SanityContentRepository.fetchLandingPageContent', () => {
 		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
 
 		result?.latestReads.forEach((story) => expect(story.tags).toEqual([]));
+	});
+
+	it('maps every collection the query returned, in order', async () => {
+		const expected = onoffRawLandingPageMock.collections.map(({ slug }) => slug);
+
+		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
+
+		expect(expected.length).toBeGreaterThan(0);
+		expect(result?.collections.map(({ slug }) => slug)).toEqual(expected);
+	});
+
+	// La vista de navegación de obra no declara extracto, y el teaser sí: si alguna vez volviera a
+	// mapearse como teaser, el slot cargaría el cuerpo de cada obra destacada sin que nadie lo pinte.
+	it('serves the navigation view of each highlighted work, without an excerpt', async () => {
+		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
+
+		const [work] = result?.latestLiteraryWorks ?? [];
+		expect(work).not.toHaveProperty('excerpt');
+		expect(Object.keys(work).sort()).toEqual([
+			'_id',
+			'authors',
+			'coverImage',
+			'mediaSources',
+			'sectionCount',
+			'slug',
+			'tags',
+			'title',
+			'totalReadingTime',
+		]);
+	});
+
+	it('wraps a malformed collection instead of letting the factory error escape', async () => {
+		const [collection, ...rest] = onoffRawLandingPageMock.collections;
+		const broken = { ...onoffRawLandingPageMock, collections: [{ ...collection, description: '' }, ...rest] };
+
+		await expect(repoReturning(broken).fetchLandingPageContent(LANDING_SLUG)).rejects.toThrow(
+			MalformedLandingPageError,
+		);
+	});
+
+	// Sin el total no hay nada que mostrar en la tarjeta: es una obra que el backfill todavía no tocó.
+	it('rejects a highlighted work with no total reading time', async () => {
+		const [work, ...rest] = onoffRawLandingPageMock.latestLiteraryWorks;
+		const broken = {
+			...onoffRawLandingPageMock,
+			latestLiteraryWorks: [{ ...work, totalReadingTime: null }, ...rest],
+		};
+
+		await expect(repoReturning(broken).fetchLandingPageContent(LANDING_SLUG)).rejects.toThrow(
+			MalformedLandingPageError,
+		);
+	});
+
+	// La proyección devuelve la lista vacía tanto para la obra sin autores como para la que los perdió, y
+	// la tarjeta de la home muestra al primero sin preguntar: sin este rechazo, una obra mal curada tumba
+	// el render de la página entera en vez de fallar donde se puede corregir.
+	it('rejects a highlighted work with no authors', async () => {
+		const [work, ...rest] = onoffRawLandingPageMock.latestLiteraryWorks;
+		const broken = { ...onoffRawLandingPageMock, latestLiteraryWorks: [{ ...work, authors: [] }, ...rest] };
+
+		await expect(repoReturning(broken).fetchLandingPageContent(LANDING_SLUG)).rejects.toThrow(
+			MalformedLandingPageError,
+		);
+	});
+
+	// El guard existe para nombrar la semana culpable; el error de la obra viaja como causa.
+	it('names the week in the error and keeps the offending work as its cause', async () => {
+		const [work, ...rest] = onoffRawLandingPageMock.latestLiteraryWorks;
+		const broken = { ...onoffRawLandingPageMock, latestLiteraryWorks: [{ ...work, authors: [] }, ...rest] };
+
+		const error = await repoReturning(broken)
+			.fetchLandingPageContent(LANDING_SLUG)
+			.then(() => undefined)
+			.catch((caught: MalformedLandingPageError) => caught);
+
+		expect(error?.message).toContain(LANDING_SLUG);
+		expect((error?.cause as Error).message).toContain(work.slug);
 	});
 });
 

--- a/src/api/modules/content/content.repository.sanity.ts
+++ b/src/api/modules/content/content.repository.sanity.ts
@@ -8,6 +8,11 @@ import type { HighlightedAuthor, LandingPageContent, RotatingContent } from '@mo
 import type { StorylistTeaser } from '@models/storylist.model';
 import type { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 import {
+	createLiteraryWorkNavigationTeaser,
+	type LiteraryWorkNavigationTeaserWithAuthors,
+} from '@models/literary-work.model';
+import { createReadingTime } from '@models/reading-time.model';
+import {
 	mapAuthorTeaser,
 	mapBlockContentToTextParagraphs,
 	mapContentCampaigns,
@@ -15,8 +20,9 @@ import {
 	mapTags,
 	urlFor,
 } from '../../_utils/functions';
-import { mapMediaSources } from '../../_utils/media-sources.functions';
+import { mapMediaSources, mapMediaTeasers } from '../../_utils/media-sources.functions';
 import { mapImagery } from '../../_utils/storylist-imagery.functions';
+import { mapSanityCollectionTeaser } from '../collection/collection-teaser.acl';
 import { client as sanityClient } from '../../_helpers/sanity-connector';
 import {
 	landingPageContentQuery,
@@ -59,7 +65,7 @@ export class SanityContentRepository implements ContentRepository {
 			// leído desaparece de la home con un 200 y nadie se entera.
 			console.warn('SanityContentRepository: el contenido rotativo no existe; la home queda sin lo más leído');
 		}
-		return this.guard(slug, () => this.mapLandingPageContent(raw, rotating?.mostRead ?? []));
+		return this.guard(slug, () => this.mapLandingPageContent(raw, rotating));
 	}
 
 	/** Entrega la rotación de lo más leído, o `null` si el documento no está instalado. */
@@ -71,7 +77,12 @@ export class SanityContentRepository implements ContentRepository {
 			return null;
 		}
 		try {
-			return { _id: raw._id, name: raw.name, mostRead: this.mapNavigationTeasers(raw.mostRead) };
+			return {
+				_id: raw._id,
+				name: raw.name,
+				mostRead: this.mapNavigationTeasers(raw.mostRead),
+				mostReadLiteraryWorks: raw.mostReadLiteraryWorks.map((work) => this.mapLiteraryWorkNavigationTeaser(work)),
+			};
 		} catch (error) {
 			throw new MalformedRotatingContentError({ cause: error });
 		}
@@ -96,6 +107,8 @@ export class SanityContentRepository implements ContentRepository {
 			campaigns: raw.campaigns,
 			cards: raw.cards,
 			latestReads: raw.latestReads,
+			collections: raw.collections,
+			latestLiteraryWorks: raw.latestLiteraryWorks,
 			highlightedAuthors: raw.highlightedAuthors,
 		};
 	}
@@ -124,19 +137,46 @@ export class SanityContentRepository implements ContentRepository {
 		}
 	}
 
-	private mapLandingPageContent(
-		raw: SanityLandingPage,
-		mostRead: StoryNavigationTeaserWithAuthor[],
-	): LandingPageContent {
+	private mapLandingPageContent(raw: SanityLandingPage, rotating: RotatingContent | null): LandingPageContent {
 		return {
 			_id: raw._id,
 			config: raw.config,
 			cards: this.mapStorylistTeasers(raw.cards),
+			collections: raw.collections.map(mapSanityCollectionTeaser),
 			campaigns: mapContentCampaigns(raw.campaigns),
-			mostRead,
+			mostRead: rotating?.mostRead ?? [],
+			mostReadLiteraryWorks: rotating?.mostReadLiteraryWorks ?? [],
 			latestReads: this.mapNavigationTeasers(raw.latestReads),
+			latestLiteraryWorks: raw.latestLiteraryWorks.map((work) => this.mapLiteraryWorkNavigationTeaser(work)),
 			highlightedAuthors: this.mapHighlightedAuthors(raw.highlightedAuthors),
 		};
+	}
+
+	// El repository de la página de inicio es el primer y único productor backend de la vista de
+	// navegación de obra: la pintan sus tarjetas, que no muestran cuerpo y por eso no piden extracto.
+	//
+	// El error que sale de acá nombra la **obra**, y es el guard el que lo envuelve nombrando la semana:
+	// sin esa distinción, el mensaje culparía a la landing por una obra mal curada que puede estar en
+	// cualquiera de las dos listas, o en el documento rotativo, que ni siquiera es una landing.
+	private mapLiteraryWorkNavigationTeaser(
+		raw: SanityLandingPage['latestLiteraryWorks'][number] | SanityRotatingContent['mostReadLiteraryWorks'][number],
+	): LiteraryWorkNavigationTeaserWithAuthors {
+		if (raw.totalReadingTime === null) {
+			// Sin el total no hay nada que mostrar en la tarjeta: es una obra a la que el backfill todavía no
+			// le calculó su tiempo de lectura.
+			throw new Error(`LiteraryWorkNavigationTeaser inválido: sin tiempo de lectura (slug "${raw.slug}")`);
+		}
+		return createLiteraryWorkNavigationTeaser({
+			_id: raw._id,
+			slug: raw.slug,
+			title: raw.title,
+			coverImage: raw.coverImage ? urlFor(raw.coverImage) : '',
+			totalReadingTime: createReadingTime(raw.totalReadingTime),
+			sectionCount: raw.sectionCount,
+			tags: mapTags(raw.tags),
+			mediaSources: mapMediaTeasers(raw.mediaSources),
+			authors: raw.authors.map(mapAuthorTeaser),
+		});
 	}
 
 	private mapStorylistTeasers(result: StorylistTeasersQueryResult): StorylistTeaser[] {

--- a/src/api/modules/content/content.repository.ts
+++ b/src/api/modules/content/content.repository.ts
@@ -22,6 +22,8 @@ export interface LandingPageReferences {
 	readonly campaigns: readonly KeyedReference[];
 	readonly cards: readonly KeyedReference[];
 	readonly latestReads: readonly KeyedReference[];
+	readonly collections: readonly KeyedReference[];
+	readonly latestLiteraryWorks: readonly KeyedReference[];
 	readonly highlightedAuthors: readonly KeyedReference[];
 }
 

--- a/src/api/modules/content/content.service.spec.ts
+++ b/src/api/modules/content/content.service.spec.ts
@@ -15,6 +15,8 @@ const latestReferences: LandingPageReferences = {
 	campaigns: [{ _key: 'campaign-1', _type: 'reference', _ref: 'campaign-1' }],
 	cards: [{ _key: 'card-1', _type: 'reference', _ref: 'card-1' }],
 	latestReads: [{ _key: 'story-1', _type: 'reference', _ref: 'story-1' }],
+	collections: [{ _key: 'collection-1', _type: 'reference', _ref: 'collection-1' }],
+	latestLiteraryWorks: [{ _key: 'work-1', _type: 'reference', _ref: 'work-1' }],
 	highlightedAuthors: [{ _key: 'highlighted-1', _type: 'reference', _ref: 'author-1' }],
 };
 
@@ -23,9 +25,12 @@ function emptyLandingPageContent(config: string): LandingPageContent {
 		_id: `landing-page-${config}`,
 		config,
 		cards: [],
+		collections: [],
 		campaigns: [],
 		mostRead: [],
+		mostReadLiteraryWorks: [],
 		latestReads: [],
+		latestLiteraryWorks: [],
 		highlightedAuthors: [],
 	};
 }
@@ -64,7 +69,7 @@ describe('getLandingPageContent', () => {
 
 describe('getRotatingContent', () => {
 	it('serves the stored rotating content', async () => {
-		const rotatingContent = { _id: 'rotatingContent', name: 'Rotación', mostRead: [] };
+		const rotatingContent = { _id: 'rotatingContent', name: 'Rotación', mostRead: [], mostReadLiteraryWorks: [] };
 		const repository = new InMemoryContentRepository({ rotatingContent });
 
 		expect(await getRotatingContent(repository)).toEqual(rotatingContent);

--- a/src/app/providers/content.mock.ts
+++ b/src/app/providers/content.mock.ts
@@ -12,9 +12,12 @@ export class StubContentApi implements ContentApi {
 			_id: '',
 			config: '',
 			cards: [],
+			collections: [],
 			campaigns: [],
 			mostRead: [],
+			mostReadLiteraryWorks: [],
 			latestReads: [],
+			latestLiteraryWorks: [],
 			highlightedAuthors: [],
 		};
 		return of(landingPageContent);

--- a/src/mocks/onoff-documents.mock.ts
+++ b/src/mocks/onoff-documents.mock.ts
@@ -1,4 +1,11 @@
-import type { Collection, ContentCampaign, LandingPage, LiteraryWork, SanityFileAsset } from '@sanity-types';
+import type {
+	Collection,
+	ContentCampaign,
+	LandingPage,
+	LiteraryWork,
+	RotatingContent,
+	SanityFileAsset,
+} from '@sanity-types';
 import { onoffAuthorDocument } from './onoff/author/author.document.projection';
 import { geometriasDelDesveloCollectionDocument } from './onoff/collection/geometrias-del-desvelo.collection.document';
 import { inventarioDeLasPasionesCollectionDocument } from './onoff/collection/inventario-de-las-pasiones.collection.document';
@@ -17,6 +24,7 @@ import {
 import { coleccionCompletaContentCampaignDocument } from './onoff/landing-page/coleccion-completa-onoff.content-campaign.document';
 import { palacioNueveFronterasContentCampaignDocument } from './onoff/landing-page/el-palacio-de-las-nueve-fronteras.content-campaign.document';
 import { onoffLandingPageDocument } from './onoff/landing-page/onoff.landing-page.document';
+import { onoffRotatingContentDocument } from './onoff/landing-page/onoff.rotating-content.document';
 import { elOdioLiteraryWorkDocument } from './onoff/literary-work/el-odio.literary-work.document';
 import { elPalacioDeLasNueveFronterasLiteraryWorkDocument } from './onoff/literary-work/el-palacio-de-las-nueve-fronteras.literary-work.document';
 import { elTratadoDeLosPlaceresLiteraryWorkDocument } from './onoff/literary-work/el-tratado-de-los-placeres.literary-work.document';
@@ -66,6 +74,8 @@ export const onoffContentCampaignDocumentsMock: ContentCampaign[] = [
 
 export const onoffLandingPageDocumentsMock: LandingPage[] = [onoffLandingPageDocument];
 
+export const onoffRotatingContentDocumentsMock: RotatingContent[] = [onoffRotatingContentDocument];
+
 // El dataset plano que consume `groq-js`: lleva todos los documentos, incluidos los de soporte y los
 // de asset. Un documento que falte no hace fallar la evaluación — la dereferencia queda en null sin
 // avisar—, así que conviene pedir el dataset entero y no armar subconjuntos por caso.
@@ -79,6 +89,7 @@ export const onoffDatasetMock: Record<string, unknown>[] = [
 	...onoffLiteraryWorkAssetDocumentsMock,
 	...onoffContentCampaignDocumentsMock,
 	...onoffLandingPageDocumentsMock,
+	...onoffRotatingContentDocumentsMock,
 ];
 
 // Escenarios de borde por spread sobre el canon, para que sigan al corpus. Cada uno estrena `_id` y

--- a/src/mocks/onoff-highlighted-authors.acl-alignment.spec.ts
+++ b/src/mocks/onoff-highlighted-authors.acl-alignment.spec.ts
@@ -17,7 +17,7 @@ function repository(): SanityContentRepository {
 	// El contenido rotativo no participa de este cruce, pero la lectura lo pide igual, así que se
 	// responde vacío en vez de dejarlo sin respuesta.
 	const { client } = stubSanityClient(
-		[[rotatingContentQuery, { _id: 'rotatingContent', name: 'Lo más leído', mostRead: [] }]],
+		[[rotatingContentQuery, { _id: 'rotatingContent', name: 'Lo más leído', mostRead: [], mostReadLiteraryWorks: [] }]],
 		onoffRawLandingPageMock,
 	);
 	return new SanityContentRepository(client);

--- a/src/mocks/onoff-landing-page.acl-alignment.spec.ts
+++ b/src/mocks/onoff-landing-page.acl-alignment.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * El cruce del corpus de la página de inicio contra su ACL. El porqué general —qué protege que las dos
+ * capas coincidan— está en el spec homónimo de `LiteraryWork`; acá interesa qué agrega este.
+ *
+ * La landing es la única pantalla que ensambla piezas de **dos documentos** y de **tres entidades**:
+ * colecciones, obras destacadas y campañas, más el contenido rotativo, que vive aparte. Cierra la cadena
+ * documento → query → raw → dominio para toda la página, que hasta ahora solo estaba cerrada para las
+ * campañas.
+ *
+ * Los teasers de colección y las vistas de navegación de obra que el repository produce acá salen de
+ * proyecciones propias de la landing, distintas de las del catálogo y del listado de obras: una entidad
+ * puede mapear bien por su camino y estar mal por éste, y los cruces de `Collection` y `LiteraryWork` no
+ * lo verían.
+ */
+import type { SanityClient } from '@sanity/client';
+import { fn } from '@test-utils';
+import { SanityContentRepository } from '../api/modules/content/content.repository.sanity';
+import { rotatingContentQuery } from '../api/_queries/content.query';
+import { onoffCollectionTeasersMock } from './onoff-collections.mock';
+import { onoffLiteraryWorkNavigationTeasersWithAuthorsMock } from './onoff-literary-work-teasers.mock';
+import { onoffRawLandingPageMock, onoffRawRotatingContentMock } from './onoff-raw-landing-page.mock';
+
+// Ver el spec homónimo de `LiteraryWork` para el porqué de sustituir el builder de imágenes.
+/* eslint-disable no-restricted-syntax -- vi.mock: el builder de imágenes de Sanity no tiene punto de inyección */
+vi.mock('@sanity/image-url', async () => {
+	const { stubImageUrlBuilderModule } = await import('@testing/sanity-image-url.stub');
+	return stubImageUrlBuilderModule();
+});
+/* eslint-enable no-restricted-syntax */
+
+function repository(): SanityContentRepository {
+	const fetch = fn((query: unknown) =>
+		Promise.resolve(query === rotatingContentQuery ? onoffRawRotatingContentMock : onoffRawLandingPageMock),
+	);
+	return new SanityContentRepository({ fetch } as unknown as SanityClient);
+}
+
+// El corpus de dominio declara el elenco entero; la landing destaca un subconjunto, elegido por su
+// documento. Se compara contra lo que el documento referencia y no contra el elenco completo.
+function expectedBySlug<T extends { slug: string }>(corpus: readonly T[], slugs: readonly string[]): T[] {
+	return slugs.map((slug) => {
+		const found = corpus.find((entry) => entry.slug === slug);
+		if (!found) {
+			throw new Error(`El corpus de dominio no declara "${slug}", que la landing del canon referencia.`);
+		}
+		return found;
+	});
+}
+
+describe('el corpus de dominio de la página de inicio coincide con el mapeo del ACL', () => {
+	it('maps the raw collections into their domain teasers', async () => {
+		const slugs = onoffRawLandingPageMock.collections.map(({ slug }) => slug);
+
+		const landingPage = await repository().fetchLandingPageContent(onoffRawLandingPageMock.slug);
+
+		expect(slugs.length).toBeGreaterThan(0);
+		expect(landingPage?.collections).toEqual(expectedBySlug(onoffCollectionTeasersMock, slugs));
+	});
+
+	it('maps the raw latest works into their domain navigation teasers', async () => {
+		const slugs = onoffRawLandingPageMock.latestLiteraryWorks.map(({ slug }) => slug);
+
+		const landingPage = await repository().fetchLandingPageContent(onoffRawLandingPageMock.slug);
+
+		expect(slugs.length).toBeGreaterThan(0);
+		expect(landingPage?.latestLiteraryWorks).toEqual(
+			expectedBySlug(onoffLiteraryWorkNavigationTeasersWithAuthorsMock, slugs),
+		);
+	});
+
+	it('maps the raw most read works into their domain navigation teasers', async () => {
+		const slugs = onoffRawRotatingContentMock.mostReadLiteraryWorks.map(({ slug }) => slug);
+
+		const rotatingContent = await repository().fetchRotatingContent();
+
+		expect(slugs.length).toBeGreaterThan(0);
+		expect(rotatingContent?.mostReadLiteraryWorks).toEqual(
+			expectedBySlug(onoffLiteraryWorkNavigationTeasersWithAuthorsMock, slugs),
+		);
+	});
+});

--- a/src/mocks/onoff-raw-landing-page.mock.ts
+++ b/src/mocks/onoff-raw-landing-page.mock.ts
@@ -1,7 +1,12 @@
-import type { LandingPageContentQueryResult } from '@sanity-types';
+import type { LandingPageContentQueryResult, RotatingContentQueryResult } from '@sanity-types';
 import { onoffRawLandingPageMock as generatedLandingPage } from './onoff/landing-page/landing-page.raw.mock';
+import { onoffRawRotatingContentMock as generatedRotatingContent } from './onoff/landing-page/rotating-content.raw.mock';
 
 export const onoffRawLandingPageMock: NonNullable<LandingPageContentQueryResult> = generatedLandingPage;
+
+// El contenido rotativo tiene agregador propio y no sub-proyección de la landing: es otro documento y
+// otra query, aunque las dos alimenten la misma pantalla.
+export const onoffRawRotatingContentMock: NonNullable<RotatingContentQueryResult> = generatedRotatingContent;
 
 // La campaña no tiene agregador propio porque no tiene query propia: es sub-proyección de la de landing, y
 // separarlas dejaría un módulo cuyo valor sale entero de este.

--- a/src/mocks/onoff/landing-page/landing-page.raw.mock.ts
+++ b/src/mocks/onoff/landing-page/landing-page.raw.mock.ts
@@ -1,12 +1,148 @@
 // Este archivo lo escribe `pnpm corpus:generate` evaluando la query GROQ real sobre los documentos del
 // corpus. No se edita a mano: cualquier cambio se pierde en la próxima corrida.
 import type { LandingPageContentQueryResult } from '@sanity-types';
-import { cuentoRawTag, dramaPsicologicoRawTag } from '../../onoff-raw-tags.mock';
+import {
+	colaborativaRawTag,
+	cuentoRawTag,
+	dramaHistoricoRawTag,
+	dramaPsicologicoRawTag,
+	filosoficoRawTag,
+	teatroRawTag,
+	tragediaRawTag,
+} from '../../onoff-raw-tags.mock';
+import geometriasDelDesveloCollectionMd from '../collection/geometrias-del-desvelo.collection.md?raw';
+import inventarioDeLasPasionesCollectionMd from '../collection/inventario-de-las-pasiones.collection.md?raw';
+import {
+	geometriasDelDesveloSpotifyDescription,
+	geometriasDelDesveloYoutubeDescription,
+} from '../media/geometrias-del-desvelo.media';
 
 export const onoffRawLandingPageMock: NonNullable<LandingPageContentQueryResult> = {
 	_id: 'onoff-landing-page-1974-24',
 	slug: '1974-24',
 	config: '1974-24',
+	collections: [
+		{
+			_id: 'onoff-collection-geometrias-del-desvelo',
+			slug: 'geometrias-del-desvelo',
+			title: 'Geometrías del desvelo',
+			description: geometriasDelDesveloCollectionMd,
+			featuredImage: {
+				_type: 'image',
+				asset: { _ref: 'image-geometriasDelDesveloCover-236x328-png', _type: 'reference' },
+			},
+			config: { showAuthors: true },
+			tags: [colaborativaRawTag],
+			mediaSources: [
+				{
+					_key: 'geometrias-spotify',
+					_type: 'spotifyPodcastEpisode',
+					title: 'La colección leída de corrido',
+					description: geometriasDelDesveloSpotifyDescription,
+					url: 'https://open.spotify.com/embed/episode/geometrias-del-desvelo',
+				},
+				{
+					_key: 'geometrias-youtube',
+					_type: 'youTubeVideo',
+					title: 'Las tres geometrías',
+					description: geometriasDelDesveloYoutubeDescription,
+					videoId: 'geometriasDelDesveloVideoId',
+				},
+			],
+			count: 3,
+			literaryWorkCoverImages: [
+				{ _type: 'image', asset: { _type: 'reference', _ref: 'image-geometriaCover-236x328-png' } },
+				{ _type: 'image', asset: { _type: 'reference', _ref: 'image-losPeldanosCover-236x328-png' } },
+				{ _type: 'image', asset: { _type: 'reference', _ref: 'image-lasEscalerasCover-236x328-png' } },
+			],
+		},
+		{
+			_id: 'onoff-collection-inventario-de-las-pasiones',
+			slug: 'inventario-de-las-pasiones',
+			title: 'El inventario de las pasiones',
+			description: inventarioDeLasPasionesCollectionMd,
+			featuredImage: null,
+			config: { showAuthors: false },
+			tags: [colaborativaRawTag],
+			mediaSources: [],
+			count: 3,
+			literaryWorkCoverImages: [
+				{ _type: 'image', asset: { _type: 'reference', _ref: 'image-elTratadoDeLosPlaceresCover-236x328-png' } },
+				{ _type: 'image', asset: { _type: 'reference', _ref: 'image-elOdioCover-236x328-png' } },
+				{ _type: 'image', asset: { _type: 'reference', _ref: 'image-lasDosAntorchasCover-236x328-png' } },
+			],
+		},
+	],
+	latestLiteraryWorks: [
+		{
+			_id: 'onoff-literary-work-geometria',
+			slug: 'geometria',
+			title: 'Geometría',
+			coverImage: { _type: 'image', asset: { _type: 'reference', _ref: 'image-geometriaCover-236x328-png' } },
+			totalReadingTime: 7,
+			sectionCount: 1,
+			tags: [cuentoRawTag, dramaPsicologicoRawTag, filosoficoRawTag],
+			mediaSources: [
+				{ _type: 'audioRecording', title: 'Lectura de "Geometría" por su autor' },
+				{ _type: 'spaceRecording', title: 'Conversación sobre el insomnio y la medida del tiempo' },
+				{ _type: 'spotifyPodcastEpisode', title: 'Episodio dedicado a "Geometría"' },
+				{ _type: 'youTubeVideo', title: 'Video ensayo sobre las coordenadas del desvelo' },
+				{ _type: 'pdfLink', title: 'Facsímil de la primera edición' },
+			],
+			authors: [
+				{
+					_id: 'author_1',
+					slug: 'francois-onoff',
+					name: 'François Onoff',
+					image: { _type: 'image', asset: { _type: 'reference', _ref: 'image-francoisOnoffPortrait-1254x1254-png' } },
+					nationality: {
+						_id: 'nationality-francia',
+						_type: 'nationality',
+						_createdAt: '2021-12-28T00:00:00Z',
+						_updatedAt: '2021-12-28T00:00:00Z',
+						_rev: 'rev-francia',
+						country: 'Francia',
+						flag: { _type: 'image', asset: { _type: 'reference', _ref: 'image-franceFlag-30x20-png' } },
+					},
+					bornOn: '1948-01-01',
+					bornOnYear: 1948,
+					diedOn: '1994-12-31',
+					diedOnYear: 1994,
+				},
+			],
+		},
+		{
+			_id: 'onoff-literary-work-neron',
+			slug: 'neron',
+			title: 'Nerón',
+			coverImage: { _type: 'image', asset: { _type: 'reference', _ref: 'image-neronCover-236x328-png' } },
+			totalReadingTime: 7,
+			sectionCount: 1,
+			tags: [teatroRawTag, tragediaRawTag, dramaHistoricoRawTag],
+			mediaSources: [],
+			authors: [
+				{
+					_id: 'author_1',
+					slug: 'francois-onoff',
+					name: 'François Onoff',
+					image: { _type: 'image', asset: { _type: 'reference', _ref: 'image-francoisOnoffPortrait-1254x1254-png' } },
+					nationality: {
+						_id: 'nationality-francia',
+						_type: 'nationality',
+						_createdAt: '2021-12-28T00:00:00Z',
+						_updatedAt: '2021-12-28T00:00:00Z',
+						_rev: 'rev-francia',
+						country: 'Francia',
+						flag: { _type: 'image', asset: { _type: 'reference', _ref: 'image-franceFlag-30x20-png' } },
+					},
+					bornOn: '1948-01-01',
+					bornOnYear: 1948,
+					diedOn: '1994-12-31',
+					diedOnYear: 1994,
+				},
+			],
+		},
+	],
 	cards: [],
 	campaigns: [
 		{

--- a/src/mocks/onoff/landing-page/onoff.landing-page.document.ts
+++ b/src/mocks/onoff/landing-page/onoff.landing-page.document.ts
@@ -1,6 +1,10 @@
 import type { LandingPage } from '@sanity-types';
 import { documentReference, documentSystemFields, slugField } from '../document/sanity-document.factory';
 import { onoffAuthorDocument } from '../author/author.document.projection';
+import { geometriasDelDesveloCollectionDocument } from '../collection/geometrias-del-desvelo.collection.document';
+import { inventarioDeLasPasionesCollectionDocument } from '../collection/inventario-de-las-pasiones.collection.document';
+import { geometriaLiteraryWorkDocument } from '../literary-work/geometria.literary-work.document';
+import { neronLiteraryWorkDocument } from '../literary-work/neron.literary-work.document';
 import { coleccionCompletaContentCampaignDocument } from './coleccion-completa-onoff.content-campaign.document';
 import { palacioNueveFronterasContentCampaignDocument } from './el-palacio-de-las-nueve-fronteras.content-campaign.document';
 
@@ -11,7 +15,11 @@ const week = '1974-24';
 
 // Sin `cards` ni `latestReads` a propósito: referencian agregados que el corpus no modela como documentos,
 // y la guarda del generador aborta ante una referencia colgada. El porqué, en el README del corpus.
-// `highlightedAuthors` sí entra: el autor que referencia existe como documento del dataset.
+// Sus reemplazos —`collections` y `latestLiteraryWorks`— sí entran, porque referencian colecciones y
+// obras, que el corpus sí modela; igual que `highlightedAuthors`, cuyo autor existe en el dataset.
+//
+// Las dos obras destacadas se eligen por capacidad, no por título: una con multimedia y una sin, para
+// que la fixture ejercite las dos ramas del mapeo de la vista de navegación.
 export const onoffLandingPageDocument: LandingPage = {
 	...documentSystemFields(`onoff-landing-page-${week}`),
 	_type: 'landingPage',
@@ -28,6 +36,14 @@ export const onoffLandingPageDocument: LandingPage = {
 			_type: 'reference',
 			_ref: palacioNueveFronterasContentCampaignDocument._id,
 		},
+	],
+	collections: [
+		{ _key: 'geometrias-del-desvelo', ...documentReference(geometriasDelDesveloCollectionDocument._id) },
+		{ _key: 'inventario-de-las-pasiones', ...documentReference(inventarioDeLasPasionesCollectionDocument._id) },
+	],
+	latestLiteraryWorks: [
+		{ _key: 'geometria', ...documentReference(geometriaLiteraryWorkDocument._id) },
+		{ _key: 'neron', ...documentReference(neronLiteraryWorkDocument._id) },
 	],
 	highlightedAuthors: [{ _key: 'francois-onoff', ...documentReference(onoffAuthorDocument._id) }],
 };

--- a/src/mocks/onoff/landing-page/onoff.rotating-content.document.ts
+++ b/src/mocks/onoff/landing-page/onoff.rotating-content.document.ts
@@ -1,0 +1,19 @@
+import type { RotatingContent } from '@sanity-types';
+import { documentReference, documentSystemFields } from '../document/sanity-document.factory';
+import { elOdioLiteraryWorkDocument } from '../literary-work/el-odio.literary-work.document';
+import { lasEscalerasLiteraryWorkDocument } from '../literary-work/las-escaleras.literary-work.document';
+
+// El `_id` va literal porque `rotatingContentQuery` filtra por `_id == 'rotatingContent'`: el schema lo
+// declara singleton y la query lo da por hecho.
+//
+// Las obras son distintas de las que destaca la landing como novedades: compartiéndolas, un mapeo que
+// cruzara los dos slots quedaría indistinguible del correcto.
+export const onoffRotatingContentDocument: RotatingContent = {
+	...documentSystemFields('rotatingContent'),
+	_type: 'rotatingContent',
+	name: 'Lo más leído de Onoff',
+	mostReadLiteraryWorks: [
+		{ _key: 'el-odio', ...documentReference(elOdioLiteraryWorkDocument._id) },
+		{ _key: 'las-escaleras', ...documentReference(lasEscalerasLiteraryWorkDocument._id) },
+	],
+};

--- a/src/mocks/onoff/landing-page/rotating-content.raw.mock.ts
+++ b/src/mocks/onoff/landing-page/rotating-content.raw.mock.ts
@@ -1,0 +1,74 @@
+// Este archivo lo escribe `pnpm corpus:generate` evaluando la query GROQ real sobre los documentos del
+// corpus. No se edita a mano: cualquier cambio se pierde en la próxima corrida.
+import type { RotatingContentQueryResult } from '@sanity-types';
+import { absurdoRawTag, alegoriaRawTag, dramaPsicologicoRawTag, novelaRawTag } from '../../onoff-raw-tags.mock';
+
+export const onoffRawRotatingContentMock: NonNullable<RotatingContentQueryResult> = {
+	_id: 'rotatingContent',
+	name: 'Lo más leído de Onoff',
+	mostReadLiteraryWorks: [
+		{
+			_id: 'onoff-literary-work-el-odio',
+			slug: 'el-odio',
+			title: 'El odio',
+			coverImage: { _type: 'image', asset: { _type: 'reference', _ref: 'image-elOdioCover-236x328-png' } },
+			totalReadingTime: 6,
+			sectionCount: 1,
+			tags: [novelaRawTag, dramaPsicologicoRawTag],
+			mediaSources: [],
+			authors: [
+				{
+					_id: 'author_1',
+					slug: 'francois-onoff',
+					name: 'François Onoff',
+					image: { _type: 'image', asset: { _type: 'reference', _ref: 'image-francoisOnoffPortrait-1254x1254-png' } },
+					nationality: {
+						_id: 'nationality-francia',
+						_type: 'nationality',
+						_createdAt: '2021-12-28T00:00:00Z',
+						_updatedAt: '2021-12-28T00:00:00Z',
+						_rev: 'rev-francia',
+						country: 'Francia',
+						flag: { _type: 'image', asset: { _type: 'reference', _ref: 'image-franceFlag-30x20-png' } },
+					},
+					bornOn: '1948-01-01',
+					bornOnYear: 1948,
+					diedOn: '1994-12-31',
+					diedOnYear: 1994,
+				},
+			],
+		},
+		{
+			_id: 'onoff-literary-work-las-escaleras',
+			slug: 'las-escaleras',
+			title: 'Las escaleras',
+			coverImage: { _type: 'image', asset: { _type: 'reference', _ref: 'image-lasEscalerasCover-236x328-png' } },
+			totalReadingTime: 9,
+			sectionCount: 1,
+			tags: [novelaRawTag, absurdoRawTag, alegoriaRawTag],
+			mediaSources: [{ _type: 'audioRecording', title: 'Lectura de "Las escaleras" por su autor' }],
+			authors: [
+				{
+					_id: 'author_1',
+					slug: 'francois-onoff',
+					name: 'François Onoff',
+					image: { _type: 'image', asset: { _type: 'reference', _ref: 'image-francoisOnoffPortrait-1254x1254-png' } },
+					nationality: {
+						_id: 'nationality-francia',
+						_type: 'nationality',
+						_createdAt: '2021-12-28T00:00:00Z',
+						_updatedAt: '2021-12-28T00:00:00Z',
+						_rev: 'rev-francia',
+						country: 'Francia',
+						flag: { _type: 'image', asset: { _type: 'reference', _ref: 'image-franceFlag-30x20-png' } },
+					},
+					bornOn: '1948-01-01',
+					bornOnYear: 1948,
+					diedOn: '1994-12-31',
+					diedOnYear: 1994,
+				},
+			],
+		},
+	],
+	mostRead: [],
+};

--- a/src/models/landing-page-content.model.ts
+++ b/src/models/landing-page-content.model.ts
@@ -1,5 +1,7 @@
-import { StorylistTeaser } from '@models/storylist.model';
+import type { CollectionTeaser } from '@models/collection.model';
 import { ContentCampaign } from '@models/content-campaign.model';
+import type { LiteraryWorkNavigationTeaserWithAuthors } from '@models/literary-work.model';
+import { StorylistTeaser } from '@models/storylist.model';
 import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 import type { AuthorTeaser } from '@models/author.model';
 import type { Tag } from '@models/tag.model';
@@ -12,18 +14,34 @@ export interface HighlightedAuthor {
 	readonly storyCount: number;
 }
 
+/**
+ * Los slots de la página de inicio conviven en dos vocabularios mientras dura la migración: `cards`,
+ * `mostRead` y `latestReads` transportan storylists e historias; `collections`, `mostReadLiteraryWorks`
+ * y `latestLiteraryWorks` transportan colecciones y obras.
+ *
+ * Los tres nuevos llevan el sufijo de entidad solo porque conviven con los viejos: `collections`
+ * conserva su nombre al contraerse, y los otros dos vuelven a `mostRead` y `latestReads`, que nombran
+ * el rol editorial del slot y no lo que lo llena.
+ *
+ * Los destacados viajan como vista de navegación y no como teaser de obra: el teaser exige el extracto
+ * del arranque y ninguna de las dos tarjetas que los pintan muestra cuerpo.
+ */
 export interface LandingPageContent {
-	_id: string;
-	config: string;
-	cards: StorylistTeaser[];
-	campaigns: ContentCampaign[];
-	mostRead: StoryNavigationTeaserWithAuthor[];
-	latestReads: StoryNavigationTeaserWithAuthor[];
+	readonly _id: string;
+	readonly config: string;
+	readonly cards: StorylistTeaser[];
+	readonly collections: readonly CollectionTeaser[];
+	readonly campaigns: ContentCampaign[];
+	readonly mostRead: StoryNavigationTeaserWithAuthor[];
+	readonly mostReadLiteraryWorks: readonly LiteraryWorkNavigationTeaserWithAuthors[];
+	readonly latestReads: StoryNavigationTeaserWithAuthor[];
+	readonly latestLiteraryWorks: readonly LiteraryWorkNavigationTeaserWithAuthors[];
 	readonly highlightedAuthors: readonly HighlightedAuthor[];
 }
 
 export interface RotatingContent {
-	_id: string;
-	name: string;
-	mostRead: StoryNavigationTeaserWithAuthor[];
+	readonly _id: string;
+	readonly name: string;
+	readonly mostRead: StoryNavigationTeaserWithAuthor[];
+	readonly mostReadLiteraryWorks: readonly LiteraryWorkNavigationTeaserWithAuthors[];
 }

--- a/src/models/literary-work.model.ts
+++ b/src/models/literary-work.model.ts
@@ -59,6 +59,42 @@ export interface LiteraryWorkNavigationTeaserWithAuthors extends LiteraryWorkBas
 	readonly mediaSources: readonly MediaTeaser[];
 }
 
+interface CreateLiteraryWorkNavigationTeaserOptions {
+	_id: string;
+	slug: string;
+	title: string;
+	coverImage: string;
+	totalReadingTime: ReadingTime;
+	sectionCount: number;
+	tags: readonly Tag[];
+	mediaSources: readonly MediaTeaser[];
+	authors: readonly AuthorTeaser[];
+}
+
+/**
+ * Construye la vista de navegación con autores haciendo cumplir las invariantes que sí puede sostener:
+ * título no vacío y al menos un autor.
+ *
+ * La de autores no es defensiva — es la misma que `createLiteraryWork` hace cumplir para el agregado
+ * completo, traducida a esta vista. La proyección la deja pasar (`coalesce(authors[]->…, [])` devuelve
+ * la lista vacía tanto para la obra sin autores como para la que los perdió al despublicarse), y las
+ * tarjetas que pintan esta vista muestran al primero sin preguntar. Sin la factory, una obra mal curada
+ * no rompe donde se puede corregir sino al renderizarse.
+ */
+export function createLiteraryWorkNavigationTeaser(
+	options: CreateLiteraryWorkNavigationTeaserOptions,
+): LiteraryWorkNavigationTeaserWithAuthors {
+	if (options.title.trim() === '') {
+		throw new Error(`LiteraryWorkNavigationTeaser inválido: título vacío (slug "${options.slug}")`);
+	}
+	if (options.authors.length === 0) {
+		throw new Error(
+			`LiteraryWorkNavigationTeaser inválido: sin autores (slug "${options.slug}") — la obra anónima referencia al author "Anónimo"`,
+		);
+	}
+	return Object.freeze({ ...options, slug: createSlug(options.slug) });
+}
+
 // "Anónimo" es un author real del catálogo: la obra anónima lo referencia explícitamente
 // en todas las capas (sin normalización en el ACL) — ver docs/LITERARY_WORK_DESIGN.md §10.
 // Se compara por slug (clave de negocio), nunca por _id (infraestructura).

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -1152,10 +1152,88 @@ export type CollectionsQueryResult = Array<{
 
 // Source: ../src/api/_queries/content.query.ts
 // Variable: rotatingContentQuery
-// Query: *[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{    _id,    name,    'mostRead': coalesce(mostRead[]->{        _id,        'slug': slug.current,        title,        'badLanguage': coalesce(badLanguage, false),        'body': [],        'originalPublication': coalesce(originalPublication, ''),        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {            _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[])}
+// Query: *[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{    _id,    name,    'mostReadLiteraryWorks': coalesce(mostReadLiteraryWorks[]->{        _id,        'slug': slug.current,        title,        coverImage,        totalReadingTime,        'sectionCount': count(content),        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),        'authors': coalesce(authors[]->{            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear        }, [])    },[]),    'mostRead': coalesce(mostRead[]->{        _id,        'slug': slug.current,        title,        'badLanguage': coalesce(badLanguage, false),        'body': [],        'originalPublication': coalesce(originalPublication, ''),        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {            _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[])}
 export type RotatingContentQueryResult = {
 	_id: 'rotatingContent';
 	name: string;
+	mostReadLiteraryWorks:
+		| Array<{
+				_id: string;
+				slug: string;
+				title: string;
+				coverImage: {
+					asset?: SanityImageAssetReference;
+					media?: unknown;
+					hotspot?: SanityImageHotspot;
+					crop?: SanityImageCrop;
+					_type: 'image';
+				} | null;
+				totalReadingTime: number | null;
+				sectionCount: number;
+				tags:
+					| Array<{
+							title: string;
+							slug: string;
+							description: string;
+					  }>
+					| Array<never>;
+				mediaSources:
+					| Array<never>
+					| Array<
+							| {
+									_type: 'audioRecording';
+									title: string;
+							  }
+							| {
+									_type: 'pdfLink';
+									title: string;
+							  }
+							| {
+									_type: 'spaceRecording';
+									title: string;
+							  }
+							| {
+									_type: 'spotifyPodcastEpisode';
+									title: string;
+							  }
+							| {
+									_type: 'youTubeVideo';
+									title: string;
+							  }
+					  >;
+				authors: Array<{
+					_id: string;
+					slug: string;
+					name: string;
+					image: {
+						asset?: SanityImageAssetReference;
+						media?: unknown;
+						hotspot?: SanityImageHotspot;
+						crop?: SanityImageCrop;
+						_type: 'image';
+					};
+					nationality: {
+						_id: string;
+						_type: 'nationality';
+						_createdAt: string;
+						_updatedAt: string;
+						_rev: string;
+						country: string;
+						flag: {
+							asset?: SanityImageAssetReference;
+							media?: unknown;
+							hotspot?: SanityImageHotspot;
+							crop?: SanityImageCrop;
+							_type: 'image';
+						};
+					};
+					bornOn: string | null;
+					bornOnYear: ComputedNumber | null;
+					diedOn: string | null;
+					diedOnYear: ComputedNumber | null;
+				}>;
+		  }>
+		| Array<never>;
 	mostRead:
 		| Array<{
 				_id: string;
@@ -1263,7 +1341,7 @@ export type LandingPageListQueryResult = Array<{
 
 // Source: ../src/api/_queries/content.query.ts
 // Variable: latestLandingPageReferencesQuery
-// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{    _id,    _type,    'slug': slug.current,    config,    'cards': coalesce(cards[],[]),    'campaigns': coalesce(campaigns[],[]),    'latestReads': coalesce(latestReads,[]),    'highlightedAuthors': coalesce(highlightedAuthors,[]),} | order(config desc, _createdAt desc)[0]
+// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{    _id,    _type,    'slug': slug.current,    config,    'cards': coalesce(cards[],[]),    'campaigns': coalesce(campaigns[],[]),    'latestReads': coalesce(latestReads,[]),    'collections': coalesce(collections,[]),    'latestLiteraryWorks': coalesce(latestLiteraryWorks,[]),    'highlightedAuthors': coalesce(highlightedAuthors,[]),} | order(config desc, _createdAt desc)[0]
 export type LatestLandingPageReferencesQueryResult = {
 	_id: string;
 	_type: 'landingPage';
@@ -1290,6 +1368,20 @@ export type LatestLandingPageReferencesQueryResult = {
 				} & StoryReference
 		  >
 		| Array<never>;
+	collections:
+		| Array<
+				{
+					_key: string;
+				} & CollectionReference
+		  >
+		| Array<never>;
+	latestLiteraryWorks:
+		| Array<
+				{
+					_key: string;
+				} & LiteraryWorkReference
+		  >
+		| Array<never>;
 	highlightedAuthors:
 		| Array<
 				{
@@ -1301,11 +1393,168 @@ export type LatestLandingPageReferencesQueryResult = {
 
 // Source: ../src/api/_queries/content.query.ts
 // Variable: landingPageContentQuery
-// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{    _id,    'slug': slug.current,    config,    'cards': coalesce(cards[]->{        _id,        title,        'slug': slug.current,        description,        featuredImage,        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'storyCoverImages': coalesce(stories[]->coverImage, []),        'count': coalesce(count(stories), 0),				config,				'tabs': [],	      'mediaSources': coalesce(mediaSources[], []),    },[]),    'campaigns': coalesce(campaigns[]->{        _id,        'title': coalesce(title, ''),        'slug': coalesce(slug.current, ''),        'url': coalesce(url, ''),        'contents': {            'xs': {                'image': contents.xs.image            },            'md': {                'image': contents.md.image            }        }    },[]),    'latestReads': coalesce(latestReads[]->{        _id,        'slug': slug.current,        title,        'badLanguage': coalesce(badLanguage, false),        'body': [],        'originalPublication': coalesce(originalPublication, ''),        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {             _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[]),    'highlightedAuthors': coalesce(highlightedAuthors[]->{        'author': {            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear,            'resources': []        },        'tags': coalesce(tags[]->{            title,            'slug': slug.current,            description        }, []),        'storyCount': count(array::unique(*[            !(_id in path('drafts.**')) &&            _type in ['story', 'literaryWork'] &&            references(^._id)        ].slug.current))    },[]),}
+// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{    _id,    'slug': slug.current,    config,    'collections': coalesce(collections[]->{        _id,        'slug': slug.current,        title,        description,        featuredImage,        'config': { 'showAuthors': coalesce(config.showAuthors, false) },        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'mediaSources': coalesce(mediaSources[]{            ...,            _type == 'spaceRecording' => {                'audioUrl': audioFile.asset->url            }        }, []),        'count': coalesce(count(literaryWorks), 0),        'literaryWorkCoverImages': coalesce(literaryWorks[0...3]->coverImage, [])    },[]),    'latestLiteraryWorks': coalesce(latestLiteraryWorks[]->{        _id,        'slug': slug.current,        title,        coverImage,        totalReadingTime,        'sectionCount': count(content),        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),        'authors': coalesce(authors[]->{            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear        }, [])    },[]),    'cards': coalesce(cards[]->{        _id,        title,        'slug': slug.current,        description,        featuredImage,        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'storyCoverImages': coalesce(stories[]->coverImage, []),        'count': coalesce(count(stories), 0),				config,				'tabs': [],	      'mediaSources': coalesce(mediaSources[], []),    },[]),    'campaigns': coalesce(campaigns[]->{        _id,        'title': coalesce(title, ''),        'slug': coalesce(slug.current, ''),        'url': coalesce(url, ''),        'contents': {            'xs': {                'image': contents.xs.image            },            'md': {                'image': contents.md.image            }        }    },[]),    'latestReads': coalesce(latestReads[]->{        _id,        'slug': slug.current,        title,        'badLanguage': coalesce(badLanguage, false),        'body': [],        'originalPublication': coalesce(originalPublication, ''),        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {             _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[]),    'highlightedAuthors': coalesce(highlightedAuthors[]->{        'author': {            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear,            'resources': []        },        'tags': coalesce(tags[]->{            title,            'slug': slug.current,            description        }, []),        'storyCount': count(array::unique(*[            !(_id in path('drafts.**')) &&            _type in ['story', 'literaryWork'] &&            references(^._id)        ].slug.current))    },[]),}
 export type LandingPageContentQueryResult = {
 	_id: string;
 	slug: string;
 	config: string;
+	collections:
+		| Array<{
+				_id: string;
+				slug: string;
+				title: string;
+				description: Markdown;
+				featuredImage: {
+					asset?: SanityImageAssetReference;
+					media?: unknown;
+					hotspot?: SanityImageHotspot;
+					crop?: SanityImageCrop;
+					_type: 'image';
+				} | null;
+				config: {
+					showAuthors: boolean | false;
+				};
+				tags:
+					| Array<{
+							title: string;
+							slug: string;
+							description: string;
+					  }>
+					| Array<never>;
+				mediaSources:
+					| Array<never>
+					| Array<
+							| {
+									title: string;
+									description: Markdown;
+									url: string;
+									_type: 'audioRecording';
+									_key: string;
+							  }
+							| {
+									title: string;
+									description: Markdown;
+									url: string;
+									_type: 'pdfLink';
+									_key: string;
+							  }
+							| {
+									title: string;
+									description: Markdown;
+									audioFile: AudioFile;
+									hostName: string;
+									hostAvatar?: HostAvatar;
+									date: string;
+									duration: string;
+									_type: 'spaceRecording';
+									_key: string;
+									audioUrl: string | null;
+							  }
+							| {
+									title: string;
+									description: Markdown;
+									url: string;
+									_type: 'spotifyPodcastEpisode';
+									_key: string;
+							  }
+							| {
+									title: string;
+									description: Markdown;
+									videoId: string;
+									_type: 'youTubeVideo';
+									_key: string;
+							  }
+					  >;
+				count: number | 0;
+				literaryWorkCoverImages:
+					| Array<never>
+					| Array<{
+							asset?: SanityImageAssetReference;
+							media?: unknown;
+							hotspot?: SanityImageHotspot;
+							crop?: SanityImageCrop;
+							_type: 'image';
+					  } | null>;
+		  }>
+		| Array<never>;
+	latestLiteraryWorks:
+		| Array<{
+				_id: string;
+				slug: string;
+				title: string;
+				coverImage: {
+					asset?: SanityImageAssetReference;
+					media?: unknown;
+					hotspot?: SanityImageHotspot;
+					crop?: SanityImageCrop;
+					_type: 'image';
+				} | null;
+				totalReadingTime: number | null;
+				sectionCount: number;
+				tags:
+					| Array<{
+							title: string;
+							slug: string;
+							description: string;
+					  }>
+					| Array<never>;
+				mediaSources:
+					| Array<never>
+					| Array<
+							| {
+									_type: 'audioRecording';
+									title: string;
+							  }
+							| {
+									_type: 'pdfLink';
+									title: string;
+							  }
+							| {
+									_type: 'spaceRecording';
+									title: string;
+							  }
+							| {
+									_type: 'spotifyPodcastEpisode';
+									title: string;
+							  }
+							| {
+									_type: 'youTubeVideo';
+									title: string;
+							  }
+					  >;
+				authors: Array<{
+					_id: string;
+					slug: string;
+					name: string;
+					image: {
+						asset?: SanityImageAssetReference;
+						media?: unknown;
+						hotspot?: SanityImageHotspot;
+						crop?: SanityImageCrop;
+						_type: 'image';
+					};
+					nationality: {
+						_id: string;
+						_type: 'nationality';
+						_createdAt: string;
+						_updatedAt: string;
+						_rev: string;
+						country: string;
+						flag: {
+							asset?: SanityImageAssetReference;
+							media?: unknown;
+							hotspot?: SanityImageHotspot;
+							crop?: SanityImageCrop;
+							_type: 'image';
+						};
+					};
+					bornOn: string | null;
+					bornOnYear: ComputedNumber | null;
+					diedOn: string | null;
+					diedOnYear: ComputedNumber | null;
+				}>;
+		  }>
+		| Array<never>;
 	cards:
 		| Array<{
 				_id: string;
@@ -2729,10 +2978,10 @@ declare module '@sanity/client' {
 		"\n*[_type == 'author' && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    name,\n    image,\n    nationality->,\n    bornOn,\n \t\tbornOnYear,\n    diedOn,\n    diedOnYear,\n    'resources': []\n}|order(name asc)": AuthorsQueryResult;
 		"\n*[_type == 'collection' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    description,\n    featuredImage,\n    'config': { 'showAuthors': coalesce(config.showAuthors, false) },\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'literaryWorks': coalesce(literaryWorks[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        coverImage,\n        totalReadingTime,\n        'sectionCount': count(content),\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),\n        'authors': coalesce(authors[]->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear\n        }, []),\n        // El cuerpo va recortado al primer bloque: la tarjeta lo pinta con line-clamp, as\xED que traer la\n        // secci\xF3n entera transporta la obra completa de cada obra del listado para mostrar dos\n        // renglones. El corte es una **heur\xEDstica de doble salto de l\xEDnea**, no una garant\xEDa de que el\n        // fragmento sea un p\xE1rrafo v\xE1lido: GROQ parte texto, no conoce la gram\xE1tica de Markdown. El\n        // split va anidado porque el contenido puede llegar con CRLF \u2014el corpus del repo lo hace en\n        // Windows\u2014 y ah\xED un corte por doble LF a secas devolver\xEDa el cuerpo entero. Las barras van\n        // dobles porque la query vive en un template literal: una barra sola la consumir\xEDa JavaScript\n        // y GROQ recibir\xEDa un salto de l\xEDnea real dentro de la cadena, que no parsea.\n        //\n        // Se toma el primer bloque **no vac\xEDo**: un cuerpo que arranca con un rengl\xF3n en blanco es\n        // contenido v\xE1lido \u2014nada en el schema lo impide\u2014 y con el \xEDndice pelado dar\xEDa un extracto\n        // vac\xEDo, que el mapper tratar\xEDa como obra mal curada y tumbar\xEDa la colecci\xF3n entera.\n        'excerpt': content[0...1]{\n            _key,\n            title,\n            'body': string::split(string::split(body, \"\\r\\n\\r\\n\")[0], \"\\n\\n\")[@ != \"\"][0]\n        }\n    }, [])\n}[0]": CollectionBySlugQueryResult;
 		"\n*[_type == 'collection' && !(_id in path('drafts.**'))]\n| order(title asc)\n{\n    _id,\n    'slug': slug.current,\n    title,\n    description,\n    featuredImage,\n    'config': { 'showAuthors': coalesce(config.showAuthors, false) },\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'count': coalesce(count(literaryWorks), 0),\n    'literaryWorkCoverImages': coalesce(literaryWorks[0...3]->coverImage, [])\n}": CollectionsQueryResult;
-		"\n*[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{\n    _id,\n    name,\n    'mostRead': coalesce(mostRead[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        'badLanguage': coalesce(badLanguage, false),\n        'body': [],\n        'originalPublication': coalesce(originalPublication, ''),\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[])\n}": RotatingContentQueryResult;
+		"\n*[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{\n    _id,\n    name,\n    'mostReadLiteraryWorks': coalesce(mostReadLiteraryWorks[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        coverImage,\n        totalReadingTime,\n        'sectionCount': count(content),\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),\n        'authors': coalesce(authors[]->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear\n        }, [])\n    },[]),\n    'mostRead': coalesce(mostRead[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        'badLanguage': coalesce(badLanguage, false),\n        'body': [],\n        'originalPublication': coalesce(originalPublication, ''),\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[])\n}": RotatingContentQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current in $slugs]{\n\t\t_id,\n\t\t'slug': slug.current,\n\t\tconfig,\n}": LandingPageListQueryResult;
-		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{\n    _id,\n    _type,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[],[]),\n    'campaigns': coalesce(campaigns[],[]),\n    'latestReads': coalesce(latestReads,[]),\n    'highlightedAuthors': coalesce(highlightedAuthors,[]),\n} | order(config desc, _createdAt desc)[0]\n": LatestLandingPageReferencesQueryResult;
-		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{\n    _id,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[]->{\n        _id,\n        title,\n        'slug': slug.current,\n        description,\n        featuredImage,\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCoverImages': coalesce(stories[]->coverImage, []),\n        'count': coalesce(count(stories), 0),\n\t\t\t\tconfig,\n\t\t\t\t'tabs': [],\n\t      'mediaSources': coalesce(mediaSources[], []),\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'image': contents.xs.image\n            },\n            'md': {\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'latestReads': coalesce(latestReads[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        'badLanguage': coalesce(badLanguage, false),\n        'body': [],\n        'originalPublication': coalesce(originalPublication, ''),\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> { \n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[]),\n    'highlightedAuthors': coalesce(highlightedAuthors[]->{\n        'author': {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear,\n            'resources': []\n        },\n        'tags': coalesce(tags[]->{\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCount': count(array::unique(*[\n            !(_id in path('drafts.**')) &&\n            _type in ['story', 'literaryWork'] &&\n            references(^._id)\n        ].slug.current))\n    },[]),\n}": LandingPageContentQueryResult;
+		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{\n    _id,\n    _type,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[],[]),\n    'campaigns': coalesce(campaigns[],[]),\n    'latestReads': coalesce(latestReads,[]),\n    'collections': coalesce(collections,[]),\n    'latestLiteraryWorks': coalesce(latestLiteraryWorks,[]),\n    'highlightedAuthors': coalesce(highlightedAuthors,[]),\n} | order(config desc, _createdAt desc)[0]\n": LatestLandingPageReferencesQueryResult;
+		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{\n    _id,\n    'slug': slug.current,\n    config,\n    'collections': coalesce(collections[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        description,\n        featuredImage,\n        'config': { 'showAuthors': coalesce(config.showAuthors, false) },\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'mediaSources': coalesce(mediaSources[]{\n            ...,\n            _type == 'spaceRecording' => {\n                'audioUrl': audioFile.asset->url\n            }\n        }, []),\n        'count': coalesce(count(literaryWorks), 0),\n        'literaryWorkCoverImages': coalesce(literaryWorks[0...3]->coverImage, [])\n    },[]),\n    'latestLiteraryWorks': coalesce(latestLiteraryWorks[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        coverImage,\n        totalReadingTime,\n        'sectionCount': count(content),\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),\n        'authors': coalesce(authors[]->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear\n        }, [])\n    },[]),\n    'cards': coalesce(cards[]->{\n        _id,\n        title,\n        'slug': slug.current,\n        description,\n        featuredImage,\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCoverImages': coalesce(stories[]->coverImage, []),\n        'count': coalesce(count(stories), 0),\n\t\t\t\tconfig,\n\t\t\t\t'tabs': [],\n\t      'mediaSources': coalesce(mediaSources[], []),\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'image': contents.xs.image\n            },\n            'md': {\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'latestReads': coalesce(latestReads[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        'badLanguage': coalesce(badLanguage, false),\n        'body': [],\n        'originalPublication': coalesce(originalPublication, ''),\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> { \n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[]),\n    'highlightedAuthors': coalesce(highlightedAuthors[]->{\n        'author': {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear,\n            'resources': []\n        },\n        'tags': coalesce(tags[]->{\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCount': count(array::unique(*[\n            !(_id in path('drafts.**')) &&\n            _type in ['story', 'literaryWork'] &&\n            references(^._id)\n        ].slug.current))\n    },[]),\n}": LandingPageContentQueryResult;
 		"\n*[_type == 'contributor' && !(_id in path('drafts.**'))]\n{\n\tname,\n\t'slug': slug.current,\n\tarea,\n\tlink {\n\t\thandle,\n\t\turl\n\t},\n\tnotes\n}|order(name asc)\n": AllContributorsQueryResult;
 		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            description\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                description\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'content': coalesce(content[]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }, [])\n}[0]": LiteraryWorkBySlugQueryResult;
 		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            description\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                description\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'section': content[$section...$sectionEnd]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }\n}[0]": LiteraryWorkSectionBySlugQueryResult;


### PR DESCRIPTION
**Slice 3 de 6** de #2266. Apilado sobre #2381 — **mergear los anteriores primero**.

Las queries proyectan los campos aditivos que el Studio ya declara y el dominio los expone, **sin retirar todavía nada**. Los dos vocabularios conviven hasta que el último lector migre: es la misma estrategia con la que los campos entraron al Studio en el PR anterior del issue, aplicada ahora al contrato.

Nada del frontend cambia en este slice. La página de inicio sigue leyendo `cards`, `mostRead` y `latestReads`; los campos nuevos viajan y todavía no los consume nadie.

## Nombres provisorios

`collections` es un nombre nuevo y convive sin problema con `cards`. Los otros dos no: `mostRead` y `latestReads` **conservan su nombre y cambian de tipo**, así que no pueden coexistir consigo mismos. Durante la transición se llaman `mostReadLiteraryWorks` y `latestLiteraryWorks`, y el slice de contracción los devuelve a `mostRead` y `latestReads` — que nombran el rol editorial del slot y no lo que lo llena.

## Por qué la vista de navegación y no el teaser de obra

El alcance del issue pedía `LiteraryWorkTeaser[]`, pero esa vista exige `excerpt` —el arranque de la sección de apertura, saneado a HTML— y **ninguno de los dos consumidores renderiza extracto**: su antecesor declaraba `paragraphs: Array<never>` justamente por eso. Con la vista de navegación la proyección GROQ se simplifica en vez de complicarse (no hay que recortar el cuerpo ni sanear Markdown por obra destacada) y el payload de la landing baja.

## Una invariante que la proyección no puede sostener

La vista estrena factory de dominio, que exige **al menos un autor**. `coalesce(authors[]->…, [])` devuelve la lista vacía tanto para la obra sin autores como para la que los perdió al despublicarse, y las tarjetas de la página de inicio muestran al primero sin preguntar: sin la factory, una obra mal curada rompe al renderizarse —un 500 en la home entera— en vez de fallar donde se puede corregir. Es la misma regla que `createLiteraryWork` ya hace cumplir para el agregado completo, traducida a la vista angosta.

El error que sale del mapeo nombra la **obra**; el guard del repository lo envuelve nombrando la **semana**. Sin esa distinción el mensaje culparía a la landing por una obra que puede estar en cualquiera de las dos listas, o en el documento rotativo, que ni siquiera es una landing.

## Corpus

El canon estrena el documento de contenido rotativo y su target de generación, y la landing ya puede declarar sus colecciones y sus obras destacadas: los campos nuevos referencian colecciones y obras, que el corpus sí modela, y ése era exactamente el motivo por el que no podía declarar `cards` ni `latestReads`.

Las obras del contenido rotativo son distintas de las que destaca la landing: compartiéndolas, un mapeo que cruzara los dos slots quedaría indistinguible del correcto.

## Plan de pruebas

- `typecheck`, `test` (2503 casos), `lint`, `stylelint` y `build` en verde.
- Cruce nuevo corpus ↔ ACL de la página de inicio, que cierra documento → query → raw → dominio para las tres entidades que ensambla.
- El spec del adaptador suma: el orden de las colecciones, la vista de navegación sin extracto, la colección mal curada, la obra sin tiempo de lectura, la obra sin autores, y que el error nombre la semana con la obra como causa.

Parte de #2266.
