### PR TITLE
[#2266] - La página de inicio renderiza colecciones y obras

### DIFF
--- a/e2e/seo/home.spec.ts
+++ b/e2e/seo/home.spec.ts
@@ -91,12 +91,15 @@ test.fixme('home — sin markers de skeleton en <main>', () => {
 	expect(checkNoSkeletonMarkers(html)).toBeNull();
 });
 
-test('home — D: al navegar a una story aparece el Article y el sitewide persiste', async ({ page }) => {
+// La home ya no emite ningún enlace `/story/`: sus tarjetas destacadas navegan a la ruta de lectura y
+// sus colecciones a `/collection/`. `ReadPage` emite el mismo Article, así que el invariante que este
+// caso afirma se conserva; lo que cambia es por dónde se llega.
+test('home — D: al navegar a una obra aparece el Article y el sitewide persiste', async ({ page }) => {
 	await page.goto('/home');
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);
 
-	await page.locator('a[href^="/story/"]').filter({ visible: true }).first().click();
-	await expect(page).toHaveURL(/\/story\//);
+	await page.locator('a[href^="/read/"]').filter({ visible: true }).first().click();
+	await expect(page).toHaveURL(/\/read\//);
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.article}"]`)).toHaveCount(1);
 
 	await expect(page.locator(`script[data-schema-id="${SCHEMA_IDS.organization}"]`)).toHaveCount(1);

--- a/src/app/components/carousel/carousel.component.ts
+++ b/src/app/components/carousel/carousel.component.ts
@@ -43,7 +43,7 @@ export class CarouselComponent {
 	private readonly destroyRef = inject(DestroyRef);
 
 	// Entradas
-	public readonly slides = input<ContentCampaign[]>([]);
+	public readonly slides = input<readonly ContentCampaign[]>([]);
 	public readonly transitionDuration = input<number>(600);
 	public readonly autoPlayInterval = input<number>(5000);
 

--- a/src/app/components/latest-stories-card-deck/latest-stories-card-deck.spec.ts
+++ b/src/app/components/latest-stories-card-deck/latest-stories-card-deck.spec.ts
@@ -1,46 +1,45 @@
 import { LatestStoriesCardDeck } from './latest-stories-card-deck';
 import { render, screen } from '@testing-library/angular';
-import { storyNavigationTeaserWithAuthorMock } from '@mocks/story.mock';
+import { onoffLiteraryWorkNavigationTeasersWithAuthorsMock } from '@mocks/onoff-literary-work-teasers.mock';
 import { DeferBlockState } from '@angular/core/testing';
+
+// Las obras salen del canon y las aserciones se derivan del fixture: un título clavado en prosa dejaría
+// de valer en cuanto el corpus se enriquezca.
+const literaryWorks = onoffLiteraryWorkNavigationTeasersWithAuthorsMock.slice(0, 6);
 
 describe('LatestStoriesCardDeck', () => {
 	it('should render the component', async () => {
 		const { container } = await render(LatestStoriesCardDeck, {
-			inputs: {
-				stories: [storyNavigationTeaserWithAuthorMock],
-			},
+			inputs: { literaryWorks: literaryWorks.slice(0, 1) },
 		});
 		expect(container).toBeTruthy();
 	});
 
 	it('should render skeletons and then the cards', async () => {
-		const { fixture } = await render(LatestStoriesCardDeck, {
-			inputs: {
-				stories: [
-					storyNavigationTeaserWithAuthorMock,
-					{ ...storyNavigationTeaserWithAuthorMock, title: 'Las arenas de la eternidad' },
-					{ ...storyNavigationTeaserWithAuthorMock, title: 'El instante antes del fin' },
-					{ ...storyNavigationTeaserWithAuthorMock, title: '3010: La frontera final' },
-					{ ...storyNavigationTeaserWithAuthorMock, title: 'La carta perdida de Lucy Westenra' },
-					{ ...storyNavigationTeaserWithAuthorMock, title: 'Rocky VII: La venganza de Adrian' },
-				],
-			},
-		});
+		const { fixture } = await render(LatestStoriesCardDeck, { inputs: { literaryWorks } });
 		const deferBlockFixture = (await fixture.getDeferBlocks())[0];
 
 		await deferBlockFixture.render(DeferBlockState.Loading);
-		const skeletons = screen.getAllByTestId('skeleton');
-		expect(skeletons.length).toEqual(6);
+		expect(screen.getAllByTestId('skeleton')).toHaveLength(6);
 
 		await deferBlockFixture.render(DeferBlockState.Complete);
-		const card1Title = screen.getByText(storyNavigationTeaserWithAuthorMock.title);
-		const card2Title = screen.getByText('Las arenas de la eternidad');
-		const card3Title = screen.getByText('El instante antes del fin');
-		expect(card1Title).toBeInTheDocument();
-		expect(card2Title).toBeInTheDocument();
-		expect(card3Title).toBeInTheDocument();
+		literaryWorks.forEach(({ title }) => {
+			expect(screen.getByText(title)).toBeInTheDocument();
+		});
+		expect(screen.getAllByTestId('card')).toHaveLength(literaryWorks.length);
+	});
 
-		const cards = screen.getAllByTestId('card');
-		expect(cards.length).toEqual(6);
+	// La tarjeta enlaza a la ruta de lectura: es el único camino que la home ofrece hacia una obra desde
+	// este bloque, y de él depende que la página emita enlaces internos.
+	it('links every card to the reading route', async () => {
+		const { fixture } = await render(LatestStoriesCardDeck, { inputs: { literaryWorks } });
+		const deferBlockFixture = (await fixture.getDeferBlocks())[0];
+
+		await deferBlockFixture.render(DeferBlockState.Complete);
+
+		const hrefs = screen.getAllByRole('link').map((link) => link.getAttribute('href'));
+		literaryWorks.forEach(({ slug }) => {
+			expect(hrefs.some((href) => href?.startsWith(`/read/${slug}`))).toBe(true);
+		});
 	});
 });

--- a/src/app/components/latest-stories-card-deck/latest-stories-card-deck.ts
+++ b/src/app/components/latest-stories-card-deck/latest-stories-card-deck.ts
@@ -1,12 +1,12 @@
 import { Component, input } from '@angular/core';
 
-import { StoryCardTeaserComponent } from '../story-card-teaser/story-card-teaser.component';
-import { StoryCardTeaserSkeletonComponent } from '../story-card-teaser/story-card-teaser-skeleton.component';
-import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
+import { LiteraryWorkHomeCardTeaserComponent } from '../literary-work-home-card-teaser/literary-work-home-card-teaser.component';
+import { LiteraryWorkHomeCardTeaserSkeletonComponent } from '../literary-work-home-card-teaser/literary-work-home-card-teaser-skeleton.component';
+import type { LiteraryWorkNavigationTeaserWithAuthors } from '@models/literary-work.model';
 
 @Component({
 	selector: 'cuentoneta-latest-stories-card-deck',
-	imports: [StoryCardTeaserComponent, StoryCardTeaserSkeletonComponent],
+	imports: [LiteraryWorkHomeCardTeaserComponent, LiteraryWorkHomeCardTeaserSkeletonComponent],
 	template: ` <div class="flex content-between items-center gap-4 text-neutral-500">
 			<hr class="w-6" />
 			<h2 class="h3 text-center font-source-serif italic">Últimas novedades</h2>
@@ -14,22 +14,21 @@ import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 		</div>
 
 		<section class="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-8">
-			@defer (when stories().length > 0) {
-				@for (story of stories(); track $index) {
-					<cuentoneta-story-card-teaser
-						[story]="story"
-						[showAuthor]="true"
+			@defer (when literaryWorks().length > 0) {
+				@for (literaryWork of literaryWorks(); track literaryWork.slug) {
+					<cuentoneta-literary-work-home-card-teaser
+						[literaryWork]="literaryWork"
 						[order]="$index + 1"
 						[navigationParams]="{
 							navigation: 'author',
-							navigationSlug: story.author.slug,
+							navigationSlug: literaryWork.authors[0].slug,
 						}"
 						data-testid="card"
 					/>
 				}
 			} @loading (minimum 500ms) {
-				@for (_ of [].constructor(6); track $index) {
-					<cuentoneta-story-card-teaser-skeleton [showAuthor]="true" [order]="$index + 1" data-testid="skeleton" />
+				@for (_ of [].constructor(skeletonCount); track $index) {
+					<cuentoneta-literary-work-home-card-teaser-skeleton data-testid="skeleton" />
 				}
 			}
 		</section>`,
@@ -38,5 +37,6 @@ import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 	},
 })
 export class LatestStoriesCardDeck {
-	public readonly stories = input<StoryNavigationTeaserWithAuthor[]>([]);
+	protected readonly skeletonCount = 6;
+	public readonly literaryWorks = input<readonly LiteraryWorkNavigationTeaserWithAuthors[]>([]);
 }

--- a/src/app/components/most-read-stories-card-deck/most-read-stories-card-deck.component.spec.ts
+++ b/src/app/components/most-read-stories-card-deck/most-read-stories-card-deck.component.spec.ts
@@ -1,43 +1,43 @@
 import { MostReadStoriesCardDeckComponent } from './most-read-stories-card-deck.component';
 import { render, screen } from '@testing-library/angular';
-import { storyNavigationTeaserWithAuthorMock } from '@mocks/story.mock';
+import { onoffLiteraryWorkNavigationTeasersWithAuthorsMock } from '@mocks/onoff-literary-work-teasers.mock';
 import { DeferBlockState } from '@angular/core/testing';
+
+// Las obras salen del canon y las aserciones se derivan del fixture: un título clavado en prosa dejaría
+// de valer en cuanto el corpus se enriquezca.
+const literaryWorks = onoffLiteraryWorkNavigationTeasersWithAuthorsMock.slice(0, 3);
 
 describe('MostReadStoriesCardDeckComponent', () => {
 	it('should render the component', async () => {
 		const { container } = await render(MostReadStoriesCardDeckComponent, {
-			componentInputs: {
-				stories: [storyNavigationTeaserWithAuthorMock],
-			},
+			inputs: { literaryWorks: literaryWorks.slice(0, 1) },
 		});
 		expect(container).toBeTruthy();
 	});
 
 	it('should render skeletons and then the cards', async () => {
-		const { fixture } = await render(MostReadStoriesCardDeckComponent, {
-			componentInputs: {
-				stories: [
-					storyNavigationTeaserWithAuthorMock,
-					{ ...storyNavigationTeaserWithAuthorMock, title: 'Las arenas de la eternidad' },
-					{ ...storyNavigationTeaserWithAuthorMock, title: 'El instante antes del fin' },
-				],
-			},
-		});
+		const { fixture } = await render(MostReadStoriesCardDeckComponent, { inputs: { literaryWorks } });
 		const deferBlockFixture = (await fixture.getDeferBlocks())[0];
 
 		await deferBlockFixture.render(DeferBlockState.Loading);
-		const skeletons = screen.getAllByTestId('skeleton');
-		expect(skeletons.length).toEqual(6);
+		expect(screen.getAllByTestId('skeleton')).toHaveLength(6);
 
 		await deferBlockFixture.render(DeferBlockState.Complete);
-		const card1Title = screen.getByText(storyNavigationTeaserWithAuthorMock.title);
-		const card2Title = screen.getByText('Las arenas de la eternidad');
-		const card3Title = screen.getByText('El instante antes del fin');
-		expect(card1Title).toBeInTheDocument();
-		expect(card2Title).toBeInTheDocument();
-		expect(card3Title).toBeInTheDocument();
+		literaryWorks.forEach(({ title }) => {
+			expect(screen.getByText(title)).toBeInTheDocument();
+		});
+		expect(screen.getAllByTestId('card')).toHaveLength(literaryWorks.length);
+	});
 
-		const cards = screen.getAllByTestId('card');
-		expect(cards.length).toEqual(3);
+	it('links every card to the reading route', async () => {
+		const { fixture } = await render(MostReadStoriesCardDeckComponent, { inputs: { literaryWorks } });
+		const deferBlockFixture = (await fixture.getDeferBlocks())[0];
+
+		await deferBlockFixture.render(DeferBlockState.Complete);
+
+		const hrefs = screen.getAllByRole('link').map((link) => link.getAttribute('href'));
+		literaryWorks.forEach(({ slug }) => {
+			expect(hrefs.some((href) => href?.startsWith(`/read/${slug}`))).toBe(true);
+		});
 	});
 });

--- a/src/app/components/most-read-stories-card-deck/most-read-stories-card-deck.component.ts
+++ b/src/app/components/most-read-stories-card-deck/most-read-stories-card-deck.component.ts
@@ -1,12 +1,12 @@
 import { Component, input } from '@angular/core';
 
-import { StoryCardTeaserComponent } from '../story-card-teaser/story-card-teaser.component';
-import { StoryCardTeaserSkeletonComponent } from '../story-card-teaser/story-card-teaser-skeleton.component';
-import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
+import { LiteraryWorkHomeCardTeaserComponent } from '../literary-work-home-card-teaser/literary-work-home-card-teaser.component';
+import { LiteraryWorkHomeCardTeaserSkeletonComponent } from '../literary-work-home-card-teaser/literary-work-home-card-teaser-skeleton.component';
+import type { LiteraryWorkNavigationTeaserWithAuthors } from '@models/literary-work.model';
 
 @Component({
 	selector: 'cuentoneta-most-read-stories-card-deck',
-	imports: [StoryCardTeaserComponent, StoryCardTeaserSkeletonComponent],
+	imports: [LiteraryWorkHomeCardTeaserComponent, LiteraryWorkHomeCardTeaserSkeletonComponent],
 	template: ` <div class="flex content-between items-center gap-4 text-neutral-500">
 			<hr class="w-6" />
 			<h2 class="h3 text-center font-source-serif italic">Historias más leídas</h2>
@@ -14,22 +14,21 @@ import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 		</div>
 
 		<section class="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-8">
-			@defer (when stories().length > 0) {
-				@for (story of stories(); track $index) {
-					<cuentoneta-story-card-teaser
-						[story]="story"
-						[showAuthor]="true"
+			@defer (when literaryWorks().length > 0) {
+				@for (literaryWork of literaryWorks(); track literaryWork.slug) {
+					<cuentoneta-literary-work-home-card-teaser
+						[literaryWork]="literaryWork"
 						[order]="$index + 1"
 						[navigationParams]="{
 							navigation: 'author',
-							navigationSlug: story.author.slug,
+							navigationSlug: literaryWork.authors[0].slug,
 						}"
 						data-testid="card"
 					/>
 				}
 			} @loading (minimum 500ms) {
-				@for (_ of [].constructor(6); track $index) {
-					<cuentoneta-story-card-teaser-skeleton [showAuthor]="true" [order]="$index + 1" data-testid="skeleton" />
+				@for (_ of [].constructor(skeletonCount); track $index) {
+					<cuentoneta-literary-work-home-card-teaser-skeleton data-testid="skeleton" />
 				}
 			}
 		</section>`,
@@ -38,5 +37,6 @@ import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 	},
 })
 export class MostReadStoriesCardDeckComponent {
-	public readonly stories = input<StoryNavigationTeaserWithAuthor[]>([]);
+	protected readonly skeletonCount = 6;
+	public readonly literaryWorks = input<readonly LiteraryWorkNavigationTeaserWithAuthors[]>([]);
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -19,11 +19,11 @@
 	</section>
 
 	<section class="mb-8 h-[684px] md:h-[304px]">
-		<cuentoneta-latest-stories-card-deck [stories]="latestReads()" class="flex flex-col gap-8" />
+		<cuentoneta-latest-stories-card-deck [literaryWorks]="latestReads()" class="flex flex-col gap-8" />
 	</section>
 
 	<section class="mb-8 h-[684px] md:h-[304px]">
-		<cuentoneta-most-read-stories-card-deck [stories]="mostRead()" class="flex flex-col gap-8" />
+		<cuentoneta-most-read-stories-card-deck [literaryWorks]="mostRead()" class="flex flex-col gap-8" />
 	</section>
 
 	<section class="mb-8">
@@ -31,7 +31,7 @@
 	</section>
 
 	<section class="mb-8">
-		<cuentoneta-storylist-teasers-deck [teasers]="collections()" class="flex flex-col gap-8" />
+		<cuentoneta-collection-teasers-deck [teasers]="collections()" class="flex flex-col gap-8" />
 	</section>
 
 	<!--

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -16,7 +16,7 @@ import { CarouselComponent } from '@components/carousel/carousel.component';
 import { MostReadStoriesCardDeckComponent } from '@components/most-read-stories-card-deck/most-read-stories-card-deck.component';
 import { LatestStoriesCardDeck } from '@components/latest-stories-card-deck/latest-stories-card-deck';
 import { CarouselSkeletonComponent } from '@components/carousel/carousel-skeleton.component';
-import { StorylistTeasersDeck } from '@components/storylist-teasers-deck/storylist-teasers-deck';
+import { CollectionTeasersDeck } from '@components/collection-teasers-deck/collection-teasers-deck';
 import { HighlightedAuthorsComponent } from '@components/highlighted-authors/highlighted-authors.component';
 
 @Component({
@@ -27,7 +27,7 @@ import { HighlightedAuthorsComponent } from '@components/highlighted-authors/hig
 		MostReadStoriesCardDeckComponent,
 		LatestStoriesCardDeck,
 		CarouselSkeletonComponent,
-		StorylistTeasersDeck,
+		CollectionTeasersDeck,
 		HighlightedAuthorsComponent,
 	],
 	hostDirectives: [HomeMetaTagsDirective, HomeStructuredDataDirective],
@@ -44,9 +44,11 @@ export default class HomeComponent {
 
 	// Propiedades
 	private readonly landingPageContent = computed(() => this.landingPageResource.value());
-	protected readonly collections = computed(() => this.landingPageContent()?.cards || []);
+	protected readonly collections = computed(() => this.landingPageContent()?.collections || []);
 	protected readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
-	protected readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
-	protected readonly latestReads = computed(() => this.landingPageContent()?.latestReads.slice(0, 6) || []);
+	// Los dos slots leen los campos de obra, que llevan el sufijo de entidad solo mientras conviven con
+	// los de historia. Vuelven a llamarse `mostRead` y `latestReads` cuando los viejos se retiren.
+	protected readonly mostRead = computed(() => this.landingPageContent()?.mostReadLiteraryWorks.slice(0, 6) || []);
+	protected readonly latestReads = computed(() => this.landingPageContent()?.latestLiteraryWorks.slice(0, 6) || []);
 	protected readonly highlightedAuthors = computed(() => this.landingPageContent()?.highlightedAuthors ?? []);
 }

--- a/src/app/providers/content.mock.ts
+++ b/src/app/providers/content.mock.ts
@@ -4,20 +4,27 @@ import { Observable, of } from 'rxjs';
 
 // Models
 import { LandingPageContent } from '@models/landing-page-content.model';
+import { contentCampaignMock } from '@mocks/content-campaign.mock';
+import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
+import { onoffLiteraryWorkNavigationTeasersWithAuthorsMock } from '@mocks/onoff-literary-work-teasers.mock';
 import { ContentApi } from './content.provider';
 
+// Los slots se pueblan desde el canon y no con listas vacías: un doble que devuelve nada hace que toda
+// story y todo spec que lo use rendericen el estado de carga y no afirmen nada. Los destacados se
+// reparten entre los dos slots para que un cruce entre ellos sea observable.
 export class StubContentApi implements ContentApi {
 	public getLandingPageContent(): Observable<LandingPageContent> {
+		const half = Math.ceil(onoffLiteraryWorkNavigationTeasersWithAuthorsMock.length / 2);
 		const landingPageContent: LandingPageContent = {
-			_id: '',
-			config: '',
+			_id: 'landing-page-stub',
+			config: '1974-24',
 			cards: [],
-			collections: [],
-			campaigns: [],
+			collections: onoffCollectionTeasersMock,
+			campaigns: contentCampaignMock,
 			mostRead: [],
-			mostReadLiteraryWorks: [],
+			mostReadLiteraryWorks: onoffLiteraryWorkNavigationTeasersWithAuthorsMock.slice(0, half),
 			latestReads: [],
-			latestLiteraryWorks: [],
+			latestLiteraryWorks: onoffLiteraryWorkNavigationTeasersWithAuthorsMock.slice(half),
 			highlightedAuthors: [],
 		};
 		return of(landingPageContent);


### PR DESCRIPTION
**Slice 4 de 6** de #2266. Apilado sobre #2382 — **mergear los anteriores primero**.

Los tres slots de la página de inicio pasan a leer los campos de obra y colección que el slice anterior sumó al contrato. Es el primer slice que cambia lo que se ve.

## Qué cambia en la página

El deck de storylists se reemplaza por el de **colecciones**, que ya existía y ya aceptaba `CollectionTeaser[]`.

Las dos tarjetas de destacados —últimas novedades y lo más leído— pasan a la tarjeta de obra, que enlaza a `/read/:slug` en vez de `/story/:slug`.

**Es el mínimo para que los lectores migren.** El rediseño y el renombre de los dos decks son de #2267, así que conservan su nombre y su forma; lo que cambia es qué transportan. Por lo mismo no se agrega entrada de Storybook para ellos: la entrada va con su nombre y forma definitivos, y catalogarlos acá crearía una que hay que renombrar en el PR siguiente.

`StorylistTeasersDeck` y `StorylistTeaserCard` quedan **sin consumidores**. No se borran acá: su baja es de #2184, junto con el resto de los componentes descartables.

## El doble del provider

Deja de devolver listas vacías y arma la landing desde el canon de Onoff. Un doble vacío hace que toda story y todo spec que lo use rendericen el estado de carga y no afirmen nada. Los destacados se reparten entre los dos slots para que un cruce entre ellos sea observable.

## Plan de pruebas

- `typecheck`, `test` (2505 casos), `lint`, `stylelint` y `build` en verde. `build` corre acá con más motivo que en los otros slices: es el único gate que valida plantillas de Angular, y este slice las toca.
- Los specs de los dos decks se retipan y derivan sus aserciones del fixture —títulos y slugs del canon— en vez de prosa clavada, y suman que cada tarjeta enlace a la ruta de lectura, que es de lo que depende que la página emita enlaces internos.

## El e2e se reapunta acá

El caso que navega desde la página de inicio a una obra buscaba un enlace `/story/`, y desde este cambio la página no emite ninguno. Se reapunta a la ruta de lectura en el mismo slice: el cambio que lo rompe es éste, y un slice tiene que quedar verde por su cuenta. La página de lectura emite el mismo Article, así que el invariante que el caso afirma se conserva — lo que cambia es por dónde se llega.

Parte de #2266.
