### PR TITLE
[#2266] - Retira el vocabulario viejo del contrato de la página de inicio

### DIFF
--- a/.claude/references/clean-architecture.md
+++ b/.claude/references/clean-architecture.md
@@ -94,14 +94,15 @@ El **archivo** sigue siendo `<dominio>.mock.ts` y la **factory** `provide<X>ApiM
 
 ### Backend
 
-| Rol                            | Interfaz (nombre limpio)   | Implementación real              | Doble de test                      |
-| ------------------------------ | -------------------------- | -------------------------------- | ---------------------------------- |
-| Repository de stories          | `StoryRepository`          | `SanityStoryRepository`          | `InMemoryStoryRepository`          |
-| Repository de autores          | `AuthorRepository`         | `SanityAuthorRepository`         | `InMemoryAuthorRepository`         |
-| Repository de storylists       | `StorylistRepository`      | `SanityStorylistRepository`      | `InMemoryStorylistRepository`      |
-| Repository de obras literarias | `LiteraryWorkRepository`\* | `SanityLiteraryWorkRepository`\* | `InMemoryLiteraryWorkRepository`\* |
-| Repository de colecciones      | `CollectionRepository`†    | `SanityCollectionRepository`†    | `InMemoryCollectionRepository`†    |
-| Service (impl. única)          | `StoryService`             | `StoryService` (mismo nombre)    | `InMemoryStoryService`             |
+| Rol                             | Interfaz (nombre limpio)   | Implementación real              | Doble de test                      |
+| ------------------------------- | -------------------------- | -------------------------------- | ---------------------------------- |
+| Repository de stories           | `StoryRepository`          | `SanityStoryRepository`          | `InMemoryStoryRepository`          |
+| Repository de autores           | `AuthorRepository`         | `SanityAuthorRepository`         | `InMemoryAuthorRepository`         |
+| Repository de storylists        | `StorylistRepository`      | `SanityStorylistRepository`      | `InMemoryStorylistRepository`      |
+| Repository de obras literarias  | `LiteraryWorkRepository`\* | `SanityLiteraryWorkRepository`\* | `InMemoryLiteraryWorkRepository`\* |
+| Repository de colecciones       | `CollectionRepository`†    | `SanityCollectionRepository`†    | `InMemoryCollectionRepository`†    |
+| Repository de contenido de home | `ContentRepository`‡       | `SanityContentRepository`‡       | `InMemoryContentRepository`‡       |
+| Service (impl. única)           | `StoryService`             | `StoryService` (mismo nombre)    | `InMemoryStoryService`             |
 
 - Prefijo **`Sanity*`** para implementaciones de repository respaldadas por Sanity/GROQ.
 - El doble se nombra por su comportamiento (`Stub*` / `Fake*` — `InMemory*` para almacenamiento — / `Spy*`), **jamás `Mock*`**. Un repository de test con datos cargados en memoria sí es un `InMemory*Repository` (un fake de almacenamiento); uno que devuelve una lista fija es un `Stub*Repository`.
@@ -124,6 +125,14 @@ El **archivo** sigue siendo `<dominio>.mock.ts` y la **factory** `provide<X>ApiM
 > documento de diseño de `LiteraryWork`. El adaptador expone dos lecturas —la colección por slug, que
 > transporta sus obras, y el catálogo, que devuelve teasers— y levanta un error propio ante datos que
 > no permiten construir el agregado, distinto del de "no encontrado".
+>
+> ‡ Mismo patrón otra vez, aplicado a `content` (la landing page y el contenido rotativo). Se
+> distingue con su propia marca porque, además de tener la ACL en privados, es el único de los tres
+> que **reutiliza** la ACL de otro repository: para el teaser de colección de la landing llama a
+> `mapSanityCollectionTeaser` (`collection/collection-teaser.acl.ts`) en vez de reensamblarlo — ver
+> [`sanity-acl.md`](sanity-acl.md#por-qué-existe-el-acl). El controller adoptó además el helper
+> `respond()` con errores tipados en `content.errors.ts` (`LandingPageNotFoundError`,
+> `MalformedLandingPageError`, `RotatingContentNotFoundError`), en vez de un `try/catch` ad hoc por ruta.
 
 ### Frontend
 

--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -383,7 +383,7 @@ Un **domain event** es un hecho en pasado sobre algo que **ya ocurrió**: `Story
 
 Los eventos permiten que un bounded context reaccione a otro sin llamada directa: el contexto productor registra el hecho y los consumidores se suscriben. Esto **desacopla** contextos.
 
-**Estado — roadmap (#1503).** Los domain events **no están implementados** todavía. La comunicación entre contextos hoy pasa por los **mappers del ACL** y llamadas directas a services. Esta sección documenta el patrón para el momento en que ese acoplamiento directo se vuelva una carga — por ejemplo, cuando publicar un `Story` deba propagarse a varios contextos (Página de Inicio: `mostRead`/`latestReads`; perfil de `Author`; notificaciones) que no conviene cablear en un único service. El diseño detallado (incluyendo `StoryPublished`, `StoryCreated`, `AuthorAssigned`) vive en `docs/DDD_IMPROVEMENTS.md` §2. Los nombres son ilustrativos; los autoritativos se acordarán al introducir los eventos.
+**Estado — roadmap (#1503).** Los domain events **no están implementados** todavía. La comunicación entre contextos hoy pasa por los **mappers del ACL** y llamadas directas a services. Esta sección documenta el patrón para el momento en que ese acoplamiento directo se vuelva una carga — por ejemplo, cuando publicar una obra deba propagarse a varios contextos (Página de Inicio: `mostRead`/`latestReads`; perfil de `Author`; notificaciones) que no conviene cablear en un único service. El diseño detallado (incluyendo `StoryPublished`, `StoryCreated`, `AuthorAssigned`) vive en `docs/DDD_IMPROVEMENTS.md` §2. Los nombres son ilustrativos; los autoritativos se acordarán al introducir los eventos.
 
 ## Type-state pattern
 
@@ -444,7 +444,7 @@ Un **bounded context** es un ámbito dentro del cual aplican consistentemente un
 | **Administración**         | `Contributor`                           | Colaboradores del proyecto por área                |
 | **Página de Inicio**       | `LandingPageContent`, `ContentCampaign` | Agregar contenido de varios contextos para el home |
 
-La idea clave: un mismo `Story` se modela distinto según el contexto. En **Catálogo** es la vista completa (`Story` con párrafos, epígrafes, autor completo). En **Curación**, dentro de una `Storylist`, es una proyección `StoryTeaserWithAuthor` — solo lo esencial para listar. En **Página de Inicio** es `StoryNavigationTeaserWithAuthor` dentro de `mostRead`/`latestReads`. Las **vistas polimórficas + los mappers del ACL** son las fronteras explícitas entre estos modelos. `LiteraryWork` sigue el mismo principio con sus propias vistas (`LiteraryWorkTeaser`, `LiteraryWorkNavigationTeaser`, …), aunque todavía no participa de `Storylist` ni de la Página de Inicio.
+La idea clave: un mismo concepto se modela distinto según el contexto. En **Catálogo**, `Story` es la vista completa (`Story` con párrafos, epígrafes, autor completo). En **Curación**, dentro de una `Storylist`, es una proyección `StoryTeaserWithAuthor` — solo lo esencial para listar. En **Página de Inicio**, ese mismo rol de navegación lo cubre hoy `LiteraryWork`, no `Story`: `LiteraryWorkNavigationTeaserWithAuthors` es la vista que viaja dentro de `mostRead`/`latestReads`. El rol editorial del slot no cambió; lo que cambió es qué agregado lo llena, porque la landing referencia obras y no historias. Las **vistas polimórficas + los mappers del ACL** son las fronteras explícitas entre estos modelos. `LiteraryWork` sigue el mismo principio con sus propias vistas (`LiteraryWorkTeaser`, `LiteraryWorkNavigationTeaser`, …) y hoy sí participa de la Página de Inicio; todavía no participa de `Storylist`.
 
 ### Lenguaje ubicuo
 
@@ -474,7 +474,7 @@ Elegí el modelo de consistencia **por frontera**, no por proyecto:
 | Modelo       | Cuándo aplicarlo                                        | Ejemplo en cuentoneta                                                                                                                                           |
 | ------------ | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Fuerte**   | Invariantes que deben valer de inmediato, en una unidad | Agregado `LiteraryWork`: título no vacío, ≥1 autor y ≥1 sección con posiciones contiguas siempre consistentes al construir (`createLiteraryWork`, implementado) |
-| **Eventual** | Estado best-effort donde un lag breve es aceptable      | _Futuro:_ un `StoryPublished` que actualice `mostRead`/`latestReads` del home                                                                                   |
+| **Eventual** | Estado best-effort donde un lag breve es aceptable      | El cron de "lo más leído": el ranking de `mostRead` se actualiza una vez al día, no al instante de cada lectura                                                 |
 
 **Regla:** consistencia **fuerte** _dentro_ de la frontera de un agregado; consistencia **eventual** _entre_ agregados o contextos (propagada por [domain events](#domain-events)). El pivote de la decisión es la invariante: si _debe_ ser siempre verdadera, mantenela dentro de un agregado bajo consistencia fuerte; si tolera una ventana breve de staleness, dejá que converja.
 

--- a/.claude/references/sanity-acl.md
+++ b/.claude/references/sanity-acl.md
@@ -27,12 +27,13 @@ queda contenido en el mapper; el dominio y el frontend no se enteran.
 > **Alcance de los ejemplos de este archivo.** El pipeline se ejemplifica con el módulo `story`
 > (`src/api/modules/story/`), hoy el único módulo de contenido narrativo con esta capa completa
 > (repository → mapper → service → controller), con el ACL como **mappers puros en
-> `_utils/*.functions.ts`** (ver más abajo). `LiteraryWork` y `Collection` **divergen a propósito**: su
-> ACL (la traducción raw Sanity → dominio) vive **dentro del repository** como métodos privados, no
-> como funciones en `_utils/`. No es una variación accidental — es la **dirección arquitectónica
-> objetivo**: el repository es dueño de su propia ACL y entrega el agregado de dominio listo; el
-> service recibe dominio, sin una capa de mappers intermedia. `story` y `storylist` conservan por
-> ahora el patrón mapper-en-`_utils` de los ejemplos de abajo, hasta que se migren.
+> `_utils/*.functions.ts`** (ver más abajo). `LiteraryWork`, `Collection` y `content` **divergen a
+> propósito**: su ACL (la traducción raw Sanity → dominio) vive **dentro del repository** como
+> métodos privados, no como funciones en `_utils/`. No es una variación accidental — es la
+> **dirección arquitectónica objetivo**: el repository es dueño de su propia ACL y entrega el
+> agregado de dominio listo; el service recibe dominio, sin una capa de mappers intermedia. `story`
+> y `storylist` conservan por ahora el patrón mapper-en-`_utils` de los ejemplos de abajo, hasta que
+> se migren.
 >
 > **Split de archivos de los módulos que ya divergen** — tres archivos, no uno: `<dominio>.repository.ts`
 > (el puerto, la interfaz), `<dominio>.repository.sanity.ts` (el adaptador, con la ACL en privados) y
@@ -42,9 +43,9 @@ queda contenido en el mapper; el dominio y el frontend no se enteran.
 >
 > El módulo `literary-work` está completo de punta a punta (repository → service → controller), con
 > el contrato en [`docs/LITERARY_WORK_DESIGN.md`](../../docs/LITERARY_WORK_DESIGN.md) §6.
-> `collection` también, con la misma forma: la ACL vive dentro de su repository, y el service y el
-> controller quedan del lado del dominio. Los ejemplos de código de abajo se conservan sobre `story`,
-> que sigue vigente para ese patrón.
+> `collection` y `content` también, con la misma forma: la ACL vive dentro de su repository, y el
+> service y el controller quedan del lado del dominio. Los ejemplos de código de abajo se conservan
+> sobre `story`, que sigue vigente para ese patrón.
 >
 > **Qué sí se comparte desde `_utils/`.** La divergencia no es aislarse: los repositories que la
 > adoptaron siguen usando las primitivas genéricas de traducción (`mapTags`, `mapAuthorTeaser`,
@@ -53,6 +54,15 @@ queda contenido en el mapper; el dominio y el frontend no se enteran.
 > no se delega es el **ensamblado del agregado**. Cada primitiva compartida recibe la variante nueva
 > en su tipo unión de entrada; si una proyección diverge, el mapeo deja de compilar en vez de fallar
 > en silencio.
+>
+> **Un módulo que diverge también puede compartir ACL con otro, cuando los dos proyectan el mismo
+> agregado ajeno.** `src/api/modules/collection/collection-teaser.acl.ts` (`mapSanityCollectionTeaser`,
+> `mapSharedCollectionFields`, `resolveCollectionImagery`) no es una primitiva genérica de `_utils/`
+> ni el ACL privado de un solo repository: es el ensamblado del teaser de `Collection`, y lo
+> consumen tanto `SanityCollectionRepository` (el catálogo y el detalle de colecciones) como
+> `SanityContentRepository` (las colecciones destacadas de la landing) porque las dos dereferencian
+> una `Collection` y necesitan construir exactamente la misma vista. Vive en el módulo de `collection`
+> — dueño del agregado que describe — y no en el de `content`, que solo lo consume.
 >
 > **`defineQuery` exige literales.** El typegen parsea el string de la llamada, así que una constante
 > concatenada o un template interpolado dejan de emitir tipos. Por eso dos queries con la misma
@@ -90,8 +100,9 @@ queda contenido en el mapper; el dominio y el frontend no se enteran.
 | **Service**    | `<dominio>.service.ts`        | `get*()`: llama al repository y **mapea** al dominio; lógica de negocio |
 | **Controller** | `<dominio>.controller.ts`     | Rutas Hono + `zValidator`; llama al service y responde `c.json(...)`    |
 
-El módulo **story** (`src/api/modules/story/`) es el ejemplo canónico. Todos los demás módulos
-(`author`, `storylist`, `content`, `contributor`, `sitemap`) siguen la misma forma.
+El módulo **story** (`src/api/modules/story/`) es el ejemplo canónico. `author`, `storylist`,
+`contributor` y `sitemap` siguen la misma forma; `literary-work`, `collection` y `content` divergen
+a propósito (ver la nota de arriba).
 
 ---
 
@@ -244,8 +255,11 @@ Patrones que se repiten:
   `literary-work` para su contenido en Markdown (ver la nota de divergencia arriba).
 
 Mappers principales (no exhaustivo): `mapAuthor`, `mapAuthorTeaser`, `mapResources`, `mapTags`,
-`mapStoryContent`, `mapStoryTeaser`, `mapStoryTeaserWithAuthor`, `mapStoryNavigationTeaser`,
-`mapStoryNavigationTeaserWithAuthor`, `mapLandingPageContent`, `mapContentCampaigns`.
+`mapStoryContent`, `mapStoryTeaser`, `mapStoryTeaserWithAuthor`, `mapContentCampaigns`. Los mappers de
+la landing (`mapLandingPageContent`, `mapHighlightedAuthors`, la vista de navegación de obra) ya no
+viven acá: son métodos privados de `SanityContentRepository`, siguiendo la divergencia descripta
+arriba. El que armaba los teasers de `storylist` para la landing se retiró junto con el campo que los
+alimentaba.
 
 ### Helpers de imagen (también parte de la capa de mappers)
 
@@ -320,6 +334,13 @@ la ACL (traducción raw → dominio) no queda en `_utils/functions.ts`, sino **d
 como métodos privados de `SanityLiteraryWorkRepository`. El service (`getLiteraryWorkBySlug`) recibe
 el dominio ya mapeado y elige la implementación del repository por parámetro (default: la de
 Sanity) — eso es lo que permite testearlo con el doble en memoria sin contenedor de DI.
+
+`collection` y `content` siguen la misma forma: puerto (`CollectionRepository` / `ContentRepository`),
+adaptador (`SanityCollectionRepository` / `SanityContentRepository`, con la ACL en privados) y doble
+en memoria (`InMemoryCollectionRepository` / `InMemoryContentRepository`). `content` es el caso que
+además **consume** la ACL de otro repository: para las colecciones destacadas de la landing reutiliza
+`mapSanityCollectionTeaser` de `collection/collection-teaser.acl.ts` en vez de reensamblar el teaser
+por su cuenta — ver la nota de "qué sí se comparte" al principio de este documento.
 
 ---
 

--- a/docs/CONTENT_UPDATE_STRATEGIES.md
+++ b/docs/CONTENT_UPDATE_STRATEGIES.md
@@ -45,11 +45,12 @@ Escribe en `mostReadLiteraryWorks`, con referencias a documentos `literaryWork`.
 
 ### Ubicación en el Código
 
-- **Consultas GROQ**: `src/api/_queries/content.query.ts` - `rotatingContentQuery` (lectura del documento singleton) y `literaryWorkIdsBySlugsQuery` (resolución de slugs a `_id`, paso interno de la escritura)
+- **Consultas GROQ**: `src/api/_queries/content.query.ts` - `rotatingContentQuery` (lectura del documento singleton) y `src/api/_queries/literary-work.query.ts` - `literaryWorkTeasers`, cuyo filtro opcional por slugs resuelve el lote del ranking
 - **Repositorio de acceso a datos**: `src/api/modules/content/content.repository.sanity.ts` - `SanityContentRepository.fetchRotatingContent()` y `updateMostReadLiteraryWorks(slugs)`, que resuelve los slugs y repone el orden del ranking antes de parchear
-- **Servicio**: `src/api/modules/story/story.service.ts` - `updateMostReadStories()`, que deriva los slugs de Clarity y se los pasa al repositorio
+- **Servicio**: `src/api/modules/literary-work/literary-work.service.ts` - `updateMostReadLiteraryWorks()`, que deriva los slugs de Clarity y se los pasa al repositorio
+- **Ruta**: `src/api/modules/literary-work/literary-work.controller.ts` - `GET /update-most-read`, declarada `no-store` porque el módulo sirve sus lecturas con caché de borde y una escritura servida desde el borde devolvería un 200 sin haber corrido
 
-La resolución de slugs a identificadores vive **dentro de la escritura** y no en el puerto de obras: los slugs salen de una métrica externa, así que quien orquesta no tiene de dónde sacar un identificador, y pedírselo a otro repositorio para devolvérselo a éste haría que el caso de uso cruzara dos repositorios para escribir en uno.
+La resolución de slugs a identificadores vive **dentro de la escritura** y no en el puerto de obras: los slugs salen de una métrica externa, así que quien orquesta no tiene de dónde sacar un identificador, y pedírselo a otro repositorio para devolvérselo a éste haría que el caso de uso cruzara dos repositorios para escribir en uno. Los resuelve el listado de obras y no una consulta dedicada: el registro de filtro de ese listado declara que cada criterio nuevo entra como campo opcional, y una consulta que solo tradujera slugs a identificadores sería una segunda forma de preguntar lo mismo.
 
 ### Configuración en Sanity Studio
 

--- a/docs/CONTENT_UPDATE_STRATEGIES.md
+++ b/docs/CONTENT_UPDATE_STRATEGIES.md
@@ -27,7 +27,7 @@ La aplicación implementa un patrón centralizado llamado **`rotatingContent`** 
 
 Actualmente, este documento almacena:
 
-- **Lo más leído** - Ranking actualizado automáticamente de manera diaria. Vive hoy en `mostRead`, que referencia historias y está en baja; su reemplazo es `mostReadLiteraryWorks`, ya declarado en el schema y todavía sin escritor.
+- **Lo más leído** - Ranking actualizado automáticamente de manera diaria. Vive en `mostReadLiteraryWorks`, que referencia obras (`literaryWork`); `mostRead`, que referenciaba historias, quedó en baja — el schema todavía lo declara, pero ninguna query ya lo proyecta ni el cron lo escribe.
 
 Las funcionalidades relacionadas a contenido rotativo están y deben de ser implementadas a nivel de servidor, a fin de ejecutar procedimientos en intervalos de tiempo dados, regulares o esporádicos, para garantizar que el contenido mostrado en la plataforma esté actualizado y sea coherente con la hoja de ruta de contenido del proyecto.
 
@@ -41,15 +41,15 @@ Las **historias más leídas** son un ejemplo de contenido dentro del patrón de
 
 De manera diaria se ejecuta un cron job, definido en `vercel.json` para su ejecución a las 03:30 am (GMT -3), que se encarga, partiendo de esas listas, de alojar en el documento singleton `rotatingContent` las referencias correspondientes.
 
-Hoy escribe en `mostRead`, con referencias a documentos `story`.
-
-> **Pendiente del cambio de contrato.** El destino pasará a ser `mostReadLiteraryWorks`, con referencias a `literaryWork`, y el conteo de páginas populares tendrá que contemplar los dos prefijos de URL mientras las dos rutas de lectura convivan: leer uno solo dejaría afuera la mitad del tráfico y subestimaría la lista. Nada de eso está implementado todavía.
+Escribe en `mostReadLiteraryWorks`, con referencias a documentos `literaryWork`. Como las dos rutas de lectura (`/story/:slug` y `/read/:slug`) conviven mientras dure la migración, el conteo de páginas populares de Clarity lee **los dos prefijos de URL**: quedarse con uno solo dejaría afuera la mitad del tráfico y subestimaría el ranking. Los slugs resultantes se deduplican —la obra migrada conserva el slug de su historia de origen, así que el mismo slug puede llegar por los dos caminos— y se resuelven a `_id` de `literaryWork` antes de escribir las referencias.
 
 ### Ubicación en el Código
 
-- **Consulta GROQ**: `src/api/_queries/content.query.ts` - `latestLandingPageReferencesQuery`
-- **Repositorio de acceso a datos**: `src/api/modules/content/content.repository.ts` - `fetchLatestLandingPageReferences()`
-- **Servicio**: `src/api/modules/content/content.service.ts` - `fetchRotatingContent()`
+- **Consultas GROQ**: `src/api/_queries/content.query.ts` - `rotatingContentQuery` (lectura del documento singleton) y `literaryWorkIdsBySlugsQuery` (resolución de slugs a `_id`, paso interno de la escritura)
+- **Repositorio de acceso a datos**: `src/api/modules/content/content.repository.sanity.ts` - `SanityContentRepository.fetchRotatingContent()` y `updateMostReadLiteraryWorks(slugs)`, que resuelve los slugs y repone el orden del ranking antes de parchear
+- **Servicio**: `src/api/modules/story/story.service.ts` - `updateMostReadStories()`, que deriva los slugs de Clarity y se los pasa al repositorio
+
+La resolución de slugs a identificadores vive **dentro de la escritura** y no en el puerto de obras: los slugs salen de una métrica externa, así que quien orquesta no tiene de dónde sacar un identificador, y pedírselo a otro repositorio para devolvérselo a éste haría que el caso de uso cruzara dos repositorios para escribir en uno.
 
 ### Configuración en Sanity Studio
 
@@ -64,7 +64,7 @@ El documento singleton `rotatingContent` en Sanity almacena la información de c
 }
 ```
 
-> **Convivencia de campos.** `mostReadLiteraryWorks` reemplaza a `mostRead` y por un tiempo los dos coexisten. El campo nuevo no reusa el nombre del viejo porque el Studio y la aplicación no despliegan a la vez: reusarlo dejaría una ventana en la que un lado lee lo que el otro todavía no escribe. El campo en baja se retira cuando ningún lector lo consulte.
+> **Retiro en curso.** `mostRead` ya no lo lee `rotatingContentQuery` ni lo escribe el cron: el único productor y el único consumidor pasaron a `mostReadLiteraryWorks`. El campo se conserva en el schema porque el Studio y la aplicación no despliegan a la vez, y porque su baja definitiva —dar de baja el campo del schema y limpiar los documentos ya persistidos— es un trabajo aparte, con su propio issue.
 
 ### Estructura Extensible del Documento
 
@@ -127,7 +127,7 @@ Este proceso garantiza que:
 }
 ```
 
-> **Convivencia de campos.** `collections` y `latestLiteraryWorks` reemplazan a `cards` y `latestReads`, por el mismo motivo que en `rotatingContent`. Los cuatro coexisten hasta que se retiren los dos primeros.
+> **Convivencia de campos.** `collections` y `latestLiteraryWorks` reemplazan a `cards` y `latestReads`. La query que sirve la landing (`landingPageContentQuery`) ya solo proyecta los dos vigentes; `latestLandingPageReferencesQuery` —la que arma la copia semanal— sigue proyectando los cuatro, porque los campos en baja siguen siendo editables en el Studio hasta que se retiren, y dejar de copiarlos vaciaría la landing heredada para quien todavía los edite.
 
 El tope de seis de `highlightedAuthors` lo impone el Studio sobre la edición, así que no gobierna lo ya guardado.
 
@@ -149,13 +149,13 @@ El año va primero para que el **orden lexicográfico del slug coincida con el o
 - **Utilidad de dominio compartida (kernel)**: `src/utils/week-slug.utils.ts` - `buildWeekSlug(date)`, implementación **única** del slug semanal `YYYY-WW` (ISO-8601, ver [Nomenclatura de Slugs](#nomenclatura-de-slugs)). La consumen tanto `content.service.ts` como, desde el Studio de Sanity, `cms/utils/landing-page.ts` (resolución de la landing activa en Desk Structure) — evita mantener dos implementaciones de la misma fórmula en dos proyectos pnpm distintos.
 
 - **Consultas GROQ**: `src/api/_queries/content.query.ts`
-  - `landingPageContentQuery` - Obtiene contenido de una semana específica
+  - `landingPageContentQuery` - Obtiene contenido de una semana específica (proyecta `collections` y `latestLiteraryWorks`, ya no `cards` ni `latestReads`)
   - `landingPageListQuery` - Lista landing pages existentes
-  - `latestLandingPageReferencesQuery` - Obtiene la configuración válida más reciente no futura (`config <= $currentSlug`, ordenada por `config desc`)
+  - `latestLandingPageReferencesQuery` - Obtiene la configuración válida más reciente no futura (`config <= $currentSlug`, ordenada por `config desc`); proyecta los cuatro campos, vigentes y en baja, para la copia semanal
 
-- **Repositorio de acceso a datos**: `src/api/modules/content/content.repository.ts`
+- **Repositorio de acceso a datos**: `src/api/modules/content/content.repository.ts` (puerto `ContentRepository`), implementado por `content.repository.sanity.ts` (`SanityContentRepository`) y doblado por `content.repository.mock.ts` (`InMemoryContentRepository`)
   - `fetchLandingPageContent(slug)` - Obtiene landing page por slug
-  - `fetchLandingPageList(slugs)` - Lista landing pages por slugs
+  - `fetchLandingPagesList(slugs)` - Lista landing pages por slugs
   - `fetchLatestLandingPageReferences(currentSlug)` - Obtiene la configuración base (semana actual o anterior más reciente)
   - `createLandingPages(objects)` - Crea múltiples landing pages
 
@@ -234,7 +234,7 @@ La función lanza excepciones descriptivas en los siguientes casos:
 
 ### Arquitectura en Capas
 
-El módulo de contenido sigue una arquitectura en capas para mantener la separación de responsabilidades:
+El módulo de contenido sigue una arquitectura en capas para mantener la separación de responsabilidades. A diferencia de `story`/`storylist`, la ACL (traducción raw Sanity → dominio) no vive en `_utils/functions.ts`: queda dentro del repository, como métodos privados de `SanityContentRepository` — mismo patrón que `LiteraryWork` y `Collection` (ver [`sanity-acl.md`](../.claude/references/sanity-acl.md)).
 
 ```
 ┌─────────────────────────────────────┐
@@ -251,11 +251,15 @@ El módulo de contenido sigue una arquitectura en capas para mantener la separac
 └────────────────┬────────────────────┘
                  │
 ┌────────────────▼────────────────────┐
-│   Repositorio (Acceso a Datos)      │
-│  content.repository.ts              │
+│   Repositorio (puerto + adaptador)  │
+│  content.repository.ts (puerto)     │
+│  content.repository.sanity.ts       │
+│  (ACL en privados)                  │
 │  - fetchLandingPageContent()        │
+│  - fetchRotatingContent()           │
 │  - fetchLatestLandingPageReferences()│
 │  - createLandingPages()             │
+│  - updateMostReadLiteraryWorks()    │
 └────────────────┬────────────────────┘
                  │
 ┌────────────────▼────────────────────┐
@@ -272,7 +276,10 @@ src/api/modules/content/
 ├── content.controller.ts      # Endpoints HTTP
 ├── content.service.ts         # Lógica de negocio
 ├── content.service.spec.ts    # Tests unitarios
-└── content.repository.ts      # Acceso a datos
+├── content.repository.ts      # Puerto (interfaz ContentRepository)
+├── content.repository.sanity.ts # Adaptador Sanity (SanityContentRepository), ACL en privados
+├── content.repository.mock.ts # Doble en memoria (InMemoryContentRepository)
+└── content.errors.ts          # Errores tipados (LandingPageNotFoundError, MalformedLandingPageError, RotatingContentNotFoundError)
 
 src/api/_queries/
 └── content.query.ts           # Consultas GROQ
@@ -306,9 +313,9 @@ Todos los horarios están especificados en horario GMT -3 (Buenos Aires, Argenti
 ### Actualización de Historias Más Leídas
 
 1. **Diariamente 03:15** - cron job recopila métricas de visualización
-2. **Cálculo automático** - Se ordena el ranking de historias
+2. **Cálculo automático** - Se ordena el ranking de obras
 3. **Actualización** - Documento `rotatingContent` se sincroniza
-4. **Visible en web** - Usuarios ven historias actualizadas en su próximo acceso a la landing page de La Cuentoneta
+4. **Visible en web** - Usuarios ven el ranking actualizado en su próximo acceso a la landing page de La Cuentoneta
 
 ---
 

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -444,7 +444,7 @@ interface Collection {
 
 Muestra la colección **sin transportar sus obras**, así que no puede derivar `count`: lo **recibe** como dato —la query lo trae contando referencias sin resolverlas— y exige que sea al menos uno. Es la invariante "al menos una obra" traducida a lo único que el teaser sí transporta. Las demás —título no vacío, slug válido, abanico de tres— le siguen aplicando igual.
 
-Existe como factory y no como proyección suelta porque el repository produce teasers desde la query: armarlos como objeto literal perdería esas reglas sin que nada avise.
+Existe como factory y no como proyección suelta porque el repository produce teasers desde la query: armarlos como objeto literal perdería esas reglas sin que nada avise. El ensamblado del teaser (`mapSanityCollectionTeaser`, `mapSharedCollectionFields`, `resolveCollectionImagery`) vive en `src/api/modules/collection/collection-teaser.acl.ts` — módulo compartido entre `SanityCollectionRepository` y `SanityContentRepository`, porque las dos proyectan una colección referenciada, cada una desde su propio agregado. Ver [`sanity-acl.md`](../.claude/references/sanity-acl.md).
 
 **Ciclo de Vida:**
 
@@ -459,13 +459,13 @@ Las obras se referencian directamente en el array `literaryWorks`. Cada entrada 
 
 `Collection` no define su propia noción de obra: la toma entera de `LiteraryWork`. Estas son las costuras por las que se tocan, y son las que hay que revisar de conjunto ante cualquier cambio en el vocabulario de la obra.
 
-| Capa                      | Dónde                                                        | Qué toca                                                                                                                   |
-| ------------------------- | ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| **DTO de transporte**     | `src/models/collection.dto.ts`                               | Reutiliza el schema del teaser de obra en vez de declarar uno propio                                                       |
-| **ACL**                   | `src/api/modules/collection/collection.repository.sanity.ts` | Ensambla el teaser de obra con las primitivas compartidas (`createSlug`, `createReadingTime`, `createLiteraryWorkExcerpt`) |
-| **Provider del frontend** | `src/app/providers/collection.provider.ts`                   | `toLiteraryWorkTeaser`, ACL simétrico al del backend sobre el mismo DTO                                                    |
-| **Tipos del kernel**      | `@models/*`                                                  | `Slug`, `Tag`, `Media`/`MediaTeaser`, `SanitizedHtml`, `ReadingTime` — compartidos, no duplicados                          |
-| **Schema del Studio**     | `cms/schemas/collection.ts`                                  | El campo `literaryWorks` referencia documentos `literaryWork`                                                              |
+| Capa                      | Dónde                                                 | Qué toca                                                                                                                                                                                                   |
+| ------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **DTO de transporte**     | `src/models/collection.dto.ts`                        | Reutiliza el schema del teaser de obra en vez de declarar uno propio                                                                                                                                       |
+| **ACL**                   | `src/api/modules/collection/collection-teaser.acl.ts` | Ensambla el teaser de obra con las primitivas compartidas (`createSlug`, `createReadingTime`, `createLiteraryWorkExcerpt`); lo consumen `collection.repository.sanity.ts` y `content.repository.sanity.ts` |
+| **Provider del frontend** | `src/app/providers/collection.provider.ts`            | `toLiteraryWorkTeaser`, ACL simétrico al del backend sobre el mismo DTO                                                                                                                                    |
+| **Tipos del kernel**      | `@models/*`                                           | `Slug`, `Tag`, `Media`/`MediaTeaser`, `SanitizedHtml`, `ReadingTime` — compartidos, no duplicados                                                                                                          |
+| **Schema del Studio**     | `cms/schemas/collection.ts`                           | El campo `literaryWorks` referencia documentos `literaryWork`                                                                                                                                              |
 
 **Tres diferencias con `Storylist`** (más allá de agrupar `LiteraryWork` en vez de `Story`):
 
@@ -535,13 +535,20 @@ interface ContributorLink {
 interface LandingPageContent {
 	// Identidad
 	_id: string; // Identificador único
+	config: string; // Slug de la semana vigente (YYYY-SS)
 
 	// Composición
-	cards: StorylistTeaser[]; // Colecciones destacadas
-	campaigns: ContentCampaign[]; // Campañas de marketing
-	mostRead: StoryNavigationTeaserWithAuthor[]; // Top 10 historias más leídas
-	latestReads: StoryNavigationTeaserWithAuthor[]; // Últimas historias publicadas
+	collections: readonly CollectionTeaser[]; // Colecciones destacadas
+	campaigns: readonly ContentCampaign[]; // Campañas de marketing
+	mostRead: readonly LiteraryWorkNavigationTeaserWithAuthors[]; // Top de obras más leídas
+	latestReads: readonly LiteraryWorkNavigationTeaserWithAuthors[]; // Últimas obras publicadas
 	highlightedAuthors: readonly HighlightedAuthor[]; // Hasta 6 autores destacados de la semana
+}
+
+interface RotatingContent {
+	_id: string;
+	name: string;
+	mostRead: readonly LiteraryWorkNavigationTeaserWithAuthors[]; // Ranking de obras más leídas
 }
 
 interface HighlightedAuthor {
@@ -550,6 +557,8 @@ interface HighlightedAuthor {
 	storyCount: number; // Obras del autor, contadas sobre los dos tipos de documento
 }
 ```
+
+`mostRead` y `latestReads` conservan su nombre porque nombran el **rol editorial** del slot, que no cambió — lo que cambió es lo que transportan: obras (`LiteraryWorkNavigationTeaserWithAuthors`) en lugar de historias. `collections` sí se renombró: `cards` nombraba el componente que lo pintaba, no el contenido, y hoy agrupa `CollectionTeaser` (ver [el agregado](#agregado-collection-colección-de-obras-literarias)). `RotatingContent` es la proyección que el cron de "lo más leído" persiste y expone por separado del resto de la landing — detalle del productor en [Estrategias de Actualización de Contenido](./CONTENT_UPDATE_STRATEGIES.md).
 
 **Responsabilidades:**
 

--- a/src/api/_queries/content.query.ts
+++ b/src/api/_queries/content.query.ts
@@ -1,12 +1,12 @@
 import { defineQuery } from 'groq';
 
-// Los campos de obra y colección conviven con los de historia y storylist: el Studio ya declara los dos
-// juegos y la aplicación migra sus lectores de a uno. Los viejos se retiran cuando ninguno los lea.
+// La vista de navegación de una obra: lo que las tarjetas de la página de inicio pintan. Sin extracto
+// —ningún consumidor de estos slots muestra cuerpo— y con `mediaSources` en su forma de teaser, que
+// solo lleva la plataforma y el título y no resuelve la carga con la que se reproduce el recurso.
 //
-// La vista de navegación de una obra —la que pintan las tarjetas de la página de inicio— va sin
-// extracto: ninguno de sus consumidores muestra cuerpo. Cada aparición repite el literal porque
-// `defineQuery` lo exige; lo que impide que se desincronicen es el mapeo del repository, tipado contra
-// la unión de todas ellas.
+// Cada aparición de abajo repite el literal porque `defineQuery` lo exige: el typegen parsea el string
+// de la llamada, así que una constante compartida dejaría de emitir tipos. Lo que impide que se
+// desincronicen es el mapper del repository, tipado contra la unión de todas ellas.
 
 export const rotatingContentQuery = defineQuery(`
 *[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{
@@ -36,30 +36,6 @@ export const rotatingContentQuery = defineQuery(`
             diedOn,
             diedOnYear
         }, [])
-    },[]),
-    'mostRead': coalesce(mostRead[]->{
-        _id,
-        'slug': slug.current,
-        title,
-        'badLanguage': coalesce(badLanguage, false),
-        'body': [],
-        'originalPublication': coalesce(originalPublication, ''),
-        approximateReadingTime,
-        coverImage,
-        'resources': [],
-        'mediaSources': coalesce(mediaSources[], []),
-        'author': author-> {
-            _id,
-            'slug': slug.current,
-            name,
-            image,
-            nationality->,
-						bornOn,
-						bornOnYear,
-						diedOn,
-						diedOnYear,
-            'resources': [],
-        }
     },[])
 }`);
 
@@ -70,6 +46,9 @@ export const landingPageListQuery = defineQuery(`
 		config,
 }`);
 
+// Las referencias crudas de la última semana cargada, que la generación de semanas futuras copia
+// hacia adelante. Se proyectan también los campos en baja: siguen siendo editables en el Studio hasta
+// el PR que los retira, y dejar de copiarlos vaciaría la landing vieja de las semanas nuevas.
 export const latestLandingPageReferencesQuery = defineQuery(`
 *[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{
     _id,
@@ -111,6 +90,20 @@ export const landingPageContentQuery = defineQuery(`
         'count': coalesce(count(literaryWorks), 0),
         'literaryWorkCoverImages': coalesce(literaryWorks[0...3]->coverImage, [])
     },[]),
+    'campaigns': coalesce(campaigns[]->{
+        _id,
+        'title': coalesce(title, ''),
+        'slug': coalesce(slug.current, ''),
+        'url': coalesce(url, ''),
+        'contents': {
+            'xs': {
+                'image': contents.xs.image
+            },
+            'md': {
+                'image': contents.md.image
+            }
+        }
+    },[]),
     'latestLiteraryWorks': coalesce(latestLiteraryWorks[]->{
         _id,
         'slug': slug.current,
@@ -135,61 +128,6 @@ export const landingPageContentQuery = defineQuery(`
             diedOn,
             diedOnYear
         }, [])
-    },[]),
-    'cards': coalesce(cards[]->{
-        _id,
-        title,
-        'slug': slug.current,
-        description,
-        featuredImage,
-        'tags': coalesce(tags[] -> {
-            title,
-            'slug': slug.current,
-            description
-        }, []),
-        'storyCoverImages': coalesce(stories[]->coverImage, []),
-        'count': coalesce(count(stories), 0),
-				config,
-				'tabs': [],
-	      'mediaSources': coalesce(mediaSources[], []),
-    },[]),
-    'campaigns': coalesce(campaigns[]->{
-        _id,
-        'title': coalesce(title, ''),
-        'slug': coalesce(slug.current, ''),
-        'url': coalesce(url, ''),
-        'contents': {
-            'xs': {
-                'image': contents.xs.image
-            },
-            'md': {
-                'image': contents.md.image
-            }
-        }
-    },[]),
-    'latestReads': coalesce(latestReads[]->{
-        _id,
-        'slug': slug.current,
-        title,
-        'badLanguage': coalesce(badLanguage, false),
-        'body': [],
-        'originalPublication': coalesce(originalPublication, ''),
-        approximateReadingTime,
-        coverImage,
-        'resources': [],
-        'mediaSources': coalesce(mediaSources[], []),
-        'author': author-> { 
-            _id,
-            'slug': slug.current,
-            name,
-            image,
-            nationality->,
-						bornOn,
-						bornOnYear,
-						diedOn,
-						diedOnYear,
-            'resources': [],
-        }
     },[]),
     'highlightedAuthors': coalesce(highlightedAuthors[]->{
         'author': {

--- a/src/api/_queries/required-field-defaults.query.spec.ts
+++ b/src/api/_queries/required-field-defaults.query.spec.ts
@@ -1,12 +1,6 @@
 import { evaluate, parse } from 'groq-js';
-import {
-	incompleteLegacyStoryDocument,
-	landingPageWithIncompleteStoryDocument,
-	rotatingContentWithIncompleteStoryDocument,
-	storylistWithIncompleteStoryDocument,
-} from '@mocks/onoff-documents.mock';
+import { incompleteLegacyStoryDocument, storylistWithIncompleteStoryDocument } from '@mocks/onoff-documents.mock';
 
-import { rotatingContentQuery, landingPageContentQuery } from './content.query';
 import { storyBySlugQuery, storiesBySlugsQuery } from './story.query';
 import { storylistQuery } from './storylist.query';
 
@@ -67,23 +61,6 @@ describe('storylist.query defaults', () => {
 	});
 });
 
-describe('content.query defaults', () => {
-	it('rotatingContentQuery defaults the three fields for a dereferenced story missing them', async () => {
-		const result = (await run(rotatingContentQuery, [
-			rotatingContentWithIncompleteStoryDocument,
-			incompleteLegacyStoryDocument,
-		])) as { mostRead: DefaultedFields[] };
-
-		expectDefaultedFields(result.mostRead[0]);
-	});
-
-	it('landingPageContentQuery defaults the three fields for a dereferenced story missing them', async () => {
-		const result = (await run(
-			landingPageContentQuery,
-			[landingPageWithIncompleteStoryDocument, incompleteLegacyStoryDocument],
-			{ slug: landingPageWithIncompleteStoryDocument.slug.current },
-		)) as { latestReads: DefaultedFields[] };
-
-		expectDefaultedFields(result.latestReads[0]);
-	});
-});
+// Las queries de la página de inicio ya no dereferencian cuentos: sus slots resuelven obras, cuyo
+// tiempo de lectura no se rellena con un default sino que lo rechaza el repository. Lo que queda de
+// esta invariante vive en las dos proyecciones de arriba, que son las que siguen leyendo `story`.

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -4,8 +4,6 @@ import { client } from '../_helpers/sanity-connector';
 // Funciones
 import { mapMediaSources } from './media-sources.functions';
 
-// Tipos de Sanity
-
 // Sanity utils
 import { createImageUrlBuilder, SanityImageSource } from '@sanity/image-url';
 

--- a/src/api/modules/content/content.controller.spec.ts
+++ b/src/api/modules/content/content.controller.spec.ts
@@ -22,13 +22,10 @@ function appWith(repository: ContentRepository): Hono {
 const curatedLandingPage: LandingPageContent = {
 	_id: `landing-page-${CURRENT_SLUG}`,
 	config: CURRENT_SLUG,
-	cards: [],
 	collections: [],
 	campaigns: [],
 	mostRead: [],
-	mostReadLiteraryWorks: [],
 	latestReads: [],
-	latestLiteraryWorks: [],
 	highlightedAuthors: [],
 };
 

--- a/src/api/modules/content/content.repository.mock.ts
+++ b/src/api/modules/content/content.repository.mock.ts
@@ -20,7 +20,7 @@ interface InMemoryContentOptions {
 	readonly rotatingContent?: RotatingContent | null;
 	readonly latestReferences?: LandingPageReferences | null;
 	// El catálogo contra el que se resuelven las referencias que se escriben. Sustituye al content lake:
-	// sin él, el doble solo podría reapuntar el slot a lo que ya estaba en el slot.
+	// sin él, el doble solo podría reapuntar el slot a obras que ya estaban en el slot.
 	readonly literaryWorks?: readonly LiteraryWorkNavigationTeaserWithAuthors[];
 }
 
@@ -66,13 +66,13 @@ export class InMemoryContentRepository implements ContentRepository {
 	}
 
 	// Muta la lista en vez de registrar la llamada: lo que el caso de uso promete es que la próxima
-	// lectura vea lo escrito, y eso es lo que el spec tiene que poder afirmar. Una referencia a algo que
-	// el almacenamiento no conoce no vuelve, igual que una referencia colgada no resuelve en el content
-	// lake.
+	// lectura vea lo escrito, y eso es lo que el spec tiene que poder afirmar. Las obras se resuelven
+	// contra las que ya conoce el almacenamiento; una referencia a una obra desconocida no vuelve, igual
+	// que una referencia colgada no resuelve en el content lake.
 	//
 	// Sin el singleton **lanza**, igual que el adaptador real: `patch()` sobre un documento inexistente
-	// falla en el content lake, y un doble que retornara en silencio dejaría pasar en verde a un cron que
-	// en producción se cae.
+	// falla en el content lake, y un doble que retornara en silencio dejaría pasar en verde a un cron
+	// que en producción se cae.
 	public async updateMostReadLiteraryWorks(slugs: readonly string[]): Promise<void> {
 		if (!this.rotatingContent) {
 			throw new RotatingContentNotFoundError();
@@ -80,16 +80,13 @@ export class InMemoryContentRepository implements ContentRepository {
 		const bySlug = new Map(
 			[
 				...this.literaryWorks,
-				...this.rotatingContent.mostReadLiteraryWorks,
-				...this.landingPages.flatMap(({ content }) => [
-					...content.mostReadLiteraryWorks,
-					...content.latestLiteraryWorks,
-				]),
+				...this.rotatingContent.mostRead,
+				...this.landingPages.flatMap(({ content }) => [...content.mostRead, ...content.latestReads]),
 			].map((work) => [String(work.slug), work] as const),
 		);
 		this.rotatingContent = {
 			...this.rotatingContent,
-			mostReadLiteraryWorks: slugs.flatMap((slug) => bySlug.get(slug) ?? []),
+			mostRead: slugs.flatMap((slug) => bySlug.get(slug) ?? []),
 		};
 	}
 }

--- a/src/api/modules/content/content.repository.sanity.spec.ts
+++ b/src/api/modules/content/content.repository.sanity.spec.ts
@@ -2,30 +2,20 @@ import type { SanityClient } from '@sanity/client';
 import { fn } from '@test-utils';
 import { stubSanityClient } from '@testing/sanity-client.stub';
 import {
-	onoffRawHighlightedAuthorsMock,
 	onoffRawLandingPageMock,
 	onoffRawRotatingContentMock,
 	overflowingRawHighlightedAuthors,
 	untaggedRawHighlightedAuthor,
 } from '@mocks/onoff-raw-landing-page.mock';
-import { onoffRawNavTeasersMock } from '@mocks/onoff-raw-stories.mock';
 import { mapAuthorTeaser } from '../../_utils/functions';
 import { landingPageContentQuery, rotatingContentQuery } from '../../_queries/content.query';
 import { literaryWorkTeasers } from '../../_queries/literary-work.query';
-import { MalformedLandingPageError } from './content.errors';
+import { MalformedLandingPageError, MalformedRotatingContentError } from './content.errors';
 import { SanityContentRepository } from './content.repository.sanity';
 
 const LANDING_SLUG = onoffRawLandingPageMock.slug;
 
-// El slot de obras sale del corpus; el de historias se arma acá con los teasers de navegación del
-// canon, porque el documento del corpus ya no declara el campo en baja y este spec necesita las dos
-// listas pobladas para poder distinguirlas.
-const rawRotatingContent = {
-	...onoffRawRotatingContentMock,
-	mostRead: onoffRawNavTeasersMock.slice(0, 2),
-};
-
-function repoWith(landingPage: unknown, rotatingContent: unknown = rawRotatingContent) {
+function repoWith(landingPage: unknown, rotatingContent: unknown = onoffRawRotatingContentMock) {
 	const { client, fetch } = stubSanityClient([[rotatingContentQuery, rotatingContent]], landingPage);
 	return { repository: new SanityContentRepository(client), fetch };
 }
@@ -59,14 +49,11 @@ describe('SanityContentRepository.fetchLandingPageContent', () => {
 		expect(Object.keys(result ?? {}).sort()).toEqual([
 			'_id',
 			'campaigns',
-			'cards',
 			'collections',
 			'config',
 			'highlightedAuthors',
-			'latestLiteraryWorks',
 			'latestReads',
 			'mostRead',
-			'mostReadLiteraryWorks',
 		]);
 	});
 
@@ -74,13 +61,22 @@ describe('SanityContentRepository.fetchLandingPageContent', () => {
 		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
 
 		expect(result?._id).toBe(onoffRawLandingPageMock._id);
-		expect(result?._id).not.toBe(rawRotatingContent._id);
+		expect(result?._id).not.toBe(onoffRawRotatingContentMock._id);
 	});
 
 	it('preserves the config the query returned', async () => {
 		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
 
 		expect(result?.config).toBe(onoffRawLandingPageMock.config);
+	});
+
+	it('maps every collection the query returned, in order', async () => {
+		const expected = onoffRawLandingPageMock.collections.map(({ slug }) => slug);
+
+		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
+
+		expect(expected.length).toBeGreaterThan(0);
+		expect(result?.collections.map(({ slug }) => slug)).toEqual(expected);
 	});
 
 	it('maps every campaign the query returned, in order', async () => {
@@ -94,47 +90,23 @@ describe('SanityContentRepository.fetchLandingPageContent', () => {
 
 	// Los dos slots salen de documentos distintos: cruzarlos es el defecto que ninguna aserción sobre un
 	// solo slot detectaría.
-	it('feeds the most read slot from the rotating content, not from the landing page', async () => {
+	it('feeds the latest reads from the landing page and the most read from the rotating content', async () => {
 		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
 
-		expect(result?.mostRead.map(({ slug }) => slug)).toEqual(rawRotatingContent.mostRead.map(({ slug }) => slug));
+		expect(result?.latestReads.map(({ slug }) => slug)).toEqual(
+			onoffRawLandingPageMock.latestLiteraryWorks.map(({ slug }) => slug),
+		);
+		expect(result?.mostRead.map(({ slug }) => slug)).toEqual(
+			onoffRawRotatingContentMock.mostReadLiteraryWorks.map(({ slug }) => slug),
+		);
 	});
 
-	// La rotación es un documento aparte y puede faltar sin que la landing deje de servirse: lo que se
-	// vacía es el slot, no la página.
-	it('serves an empty most read slot when the rotating content is missing', async () => {
-		const result = await repoReturning(onoffRawLandingPageMock, null).fetchLandingPageContent(LANDING_SLUG);
-
-		expect(result?.mostRead).toEqual([]);
-	});
-
-	it('returns null when the week has no landing page', async () => {
-		expect(await repoReturning(null).fetchLandingPageContent(LANDING_SLUG)).toBeNull();
-	});
-
-	// El mapeo del teaser de navegación es la única fuente de la lista vacía de etiquetas: el crudo no la
-	// trae.
-	it('sets tags to [] from the mapper, not from the raw spread', async () => {
-		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
-
-		result?.latestReads.forEach((story) => expect(story.tags).toEqual([]));
-	});
-
-	it('maps every collection the query returned, in order', async () => {
-		const expected = onoffRawLandingPageMock.collections.map(({ slug }) => slug);
-
-		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
-
-		expect(expected.length).toBeGreaterThan(0);
-		expect(result?.collections.map(({ slug }) => slug)).toEqual(expected);
-	});
-
-	// La vista de navegación de obra no declara extracto, y el teaser sí: si alguna vez volviera a
+	// La vista de navegación no declara extracto, y el teaser de obra sí: si alguna vez volviera a
 	// mapearse como teaser, el slot cargaría el cuerpo de cada obra destacada sin que nadie lo pinte.
 	it('serves the navigation view of each highlighted work, without an excerpt', async () => {
 		const result = await repoReturning(onoffRawLandingPageMock).fetchLandingPageContent(LANDING_SLUG);
 
-		const [work] = result?.latestLiteraryWorks ?? [];
+		const [work] = result?.latestReads ?? [];
 		expect(work).not.toHaveProperty('excerpt');
 		expect(Object.keys(work).sort()).toEqual([
 			'_id',
@@ -149,7 +121,20 @@ describe('SanityContentRepository.fetchLandingPageContent', () => {
 		]);
 	});
 
-	it('wraps a malformed collection instead of letting the factory error escape', async () => {
+	it('returns null when the week has no landing page', async () => {
+		expect(await repoReturning(null).fetchLandingPageContent(LANDING_SLUG)).toBeNull();
+	});
+
+	// La rotación es un documento aparte y puede faltar sin que la landing deje de servirse: lo que se
+	// vacía es el slot, no la página.
+	it('serves an empty most read slot when the rotating content is missing', async () => {
+		const result = await repoReturning(onoffRawLandingPageMock, null).fetchLandingPageContent(LANDING_SLUG);
+
+		expect(result?.mostRead).toEqual([]);
+		expect(result?.latestReads.length).toBeGreaterThan(0);
+	});
+
+	it('wraps a malformed landing page instead of letting the factory error escape', async () => {
 		const [collection, ...rest] = onoffRawLandingPageMock.collections;
 		const broken = { ...onoffRawLandingPageMock, collections: [{ ...collection, description: '' }, ...rest] };
 
@@ -171,9 +156,9 @@ describe('SanityContentRepository.fetchLandingPageContent', () => {
 		);
 	});
 
-	// La proyección devuelve la lista vacía tanto para la obra sin autores como para la que los perdió, y
-	// la tarjeta de la home muestra al primero sin preguntar: sin este rechazo, una obra mal curada tumba
-	// el render de la página entera en vez de fallar donde se puede corregir.
+	// La proyección devuelve la lista vacía tanto para la obra sin autores como para la que los perdió,
+	// y la tarjeta de la home muestra al primero sin preguntar: sin este rechazo, una obra mal curada
+	// tumba el render de la página entera en vez de fallar donde se puede corregir.
 	it('rejects a highlighted work with no authors', async () => {
 		const [work, ...rest] = onoffRawLandingPageMock.latestLiteraryWorks;
 		const broken = { ...onoffRawLandingPageMock, latestLiteraryWorks: [{ ...work, authors: [] }, ...rest] };
@@ -199,9 +184,9 @@ describe('SanityContentRepository.fetchLandingPageContent', () => {
 });
 
 describe('SanityContentRepository highlighted authors', () => {
-	const [canonical] = onoffRawHighlightedAuthorsMock;
+	const [canonical] = onoffRawLandingPageMock.highlightedAuthors;
 
-	async function highlightedAuthorsOf(highlightedAuthors: typeof onoffRawHighlightedAuthorsMock) {
+	async function highlightedAuthorsOf(highlightedAuthors: typeof onoffRawLandingPageMock.highlightedAuthors) {
 		const result = await repoReturning({ ...onoffRawLandingPageMock, highlightedAuthors }).fetchLandingPageContent(
 			LANDING_SLUG,
 		);
@@ -247,6 +232,32 @@ describe('SanityContentRepository highlighted authors', () => {
 	});
 });
 
+describe('SanityContentRepository.fetchRotatingContent', () => {
+	it('maps the rotating content to the navigation view of its works', async () => {
+		const result = await repoReturning(onoffRawLandingPageMock).fetchRotatingContent();
+
+		expect(result?.name).toBe(onoffRawRotatingContentMock.name);
+		expect(result?.mostRead.map(({ slug }) => slug)).toEqual(
+			onoffRawRotatingContentMock.mostReadLiteraryWorks.map(({ slug }) => slug),
+		);
+	});
+
+	it('returns null when the singleton is not installed', async () => {
+		expect(await repoReturning(onoffRawLandingPageMock, null).fetchRotatingContent()).toBeNull();
+	});
+
+	// El documento rotativo no es una landing: envolverlo en el error de la landing diría que está mal
+	// la semana cuando la semana está bien.
+	it('reports a malformed rotating content with its own error', async () => {
+		const [work, ...rest] = onoffRawRotatingContentMock.mostReadLiteraryWorks;
+		const broken = { ...onoffRawRotatingContentMock, mostReadLiteraryWorks: [{ ...work, authors: [] }, ...rest] };
+
+		await expect(repoReturning(onoffRawLandingPageMock, broken).fetchRotatingContent()).rejects.toThrow(
+			MalformedRotatingContentError,
+		);
+	});
+});
+
 describe('SanityContentRepository.fetchLatestLandingPageReferences', () => {
 	const raw = {
 		_id: 'landing-page-1974-24',
@@ -254,8 +265,10 @@ describe('SanityContentRepository.fetchLatestLandingPageReferences', () => {
 		slug: '1974-24',
 		config: '1974-24',
 		campaigns: [{ _key: 'campaign-1', _type: 'reference', _ref: 'campaign-1' }],
-		cards: [{ _key: 'card-1', _type: 'reference', _ref: 'card-1' }],
+		cards: [],
 		latestReads: [],
+		collections: [{ _key: 'collection-1', _type: 'reference', _ref: 'collection-1' }],
+		latestLiteraryWorks: [],
 		highlightedAuthors: [],
 	};
 
@@ -272,7 +285,7 @@ describe('SanityContentRepository.fetchLatestLandingPageReferences', () => {
 		const references = await repoReturning(raw).fetchLatestLandingPageReferences('1974-24');
 
 		expect(references?.campaigns).toEqual(raw.campaigns);
-		expect(references?.cards).toEqual(raw.cards);
+		expect(references?.collections).toEqual(raw.collections);
 	});
 
 	it('returns null when there is no earlier week to clone', async () => {

--- a/src/api/modules/content/content.repository.sanity.ts
+++ b/src/api/modules/content/content.repository.sanity.ts
@@ -1,28 +1,13 @@
 import type { SanityClient } from '@sanity/client';
-import type {
-	LandingPageContentQueryResult,
-	RotatingContentQueryResult,
-	StorylistTeasersQueryResult,
-} from '@sanity-types';
+import type { LandingPageContentQueryResult, RotatingContentQueryResult } from '@sanity-types';
 import type { HighlightedAuthor, LandingPageContent, RotatingContent } from '@models/landing-page-content.model';
-import type { StorylistTeaser } from '@models/storylist.model';
-import type { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 import {
 	createLiteraryWorkNavigationTeaser,
 	type LiteraryWorkNavigationTeaserWithAuthors,
 } from '@models/literary-work.model';
 import { createReadingTime } from '@models/reading-time.model';
-import {
-	mapAuthorTeaser,
-	mapBlockContentToTextParagraphs,
-	mapContentCampaigns,
-	mapResources,
-	mapTags,
-	urlFor,
-} from '../../_utils/functions';
-import { mapMediaSources, mapMediaTeasers } from '../../_utils/media-sources.functions';
-import { mapImagery } from '../../_utils/storylist-imagery.functions';
-import { mapSanityCollectionTeaser } from '../collection/collection-teaser.acl';
+import { mapAuthorTeaser, mapContentCampaigns, mapTags, urlFor } from '../../_utils/functions';
+import { mapMediaTeasers } from '../../_utils/media-sources.functions';
 import { client as sanityClient } from '../../_helpers/sanity-connector';
 import {
 	landingPageContentQuery,
@@ -31,6 +16,7 @@ import {
 	rotatingContentQuery,
 } from '../../_queries/content.query';
 import { literaryWorkTeasers } from '../../_queries/literary-work.query';
+import { mapSanityCollectionTeaser } from '../collection/collection-teaser.acl';
 import { MalformedLandingPageError, MalformedRotatingContentError } from './content.errors';
 import type {
 	ContentRepository,
@@ -41,6 +27,10 @@ import type {
 
 type SanityLandingPage = NonNullable<LandingPageContentQueryResult>;
 type SanityRotatingContent = NonNullable<RotatingContentQueryResult>;
+// La misma vista de obra la proyectan la landing y el contenido rotativo: el mapper se tipa contra la
+// unión para que ninguna de las dos pueda divergir sin que el typecheck lo denuncie.
+type SanityNavigationTeaser =
+	SanityLandingPage['latestLiteraryWorks'][number] | SanityRotatingContent['mostReadLiteraryWorks'][number];
 
 // El documento rotativo es único por diseño, y tanto la query que lo lee como el patch que lo escribe
 // lo fijan por este `_id`.
@@ -65,7 +55,7 @@ export class SanityContentRepository implements ContentRepository {
 			// leído desaparece de la home con un 200 y nadie se entera.
 			console.warn('SanityContentRepository: el contenido rotativo no existe; la home queda sin lo más leído');
 		}
-		return this.guard(slug, () => this.mapLandingPageContent(raw, rotating));
+		return this.guard(slug, () => this.mapLandingPageContent(raw, rotating?.mostRead ?? []));
 	}
 
 	/** Entrega la rotación de lo más leído, o `null` si el documento no está instalado. */
@@ -80,8 +70,7 @@ export class SanityContentRepository implements ContentRepository {
 			return {
 				_id: raw._id,
 				name: raw.name,
-				mostRead: this.mapNavigationTeasers(raw.mostRead),
-				mostReadLiteraryWorks: raw.mostReadLiteraryWorks.map((work) => this.mapLiteraryWorkNavigationTeaser(work)),
+				mostRead: raw.mostReadLiteraryWorks.map((work) => this.mapNavigationTeaser(work)),
 			};
 		} catch (error) {
 			throw new MalformedRotatingContentError({ cause: error });
@@ -153,33 +142,31 @@ export class SanityContentRepository implements ContentRepository {
 		}
 	}
 
-	private mapLandingPageContent(raw: SanityLandingPage, rotating: RotatingContent | null): LandingPageContent {
+	private mapLandingPageContent(
+		raw: SanityLandingPage,
+		mostRead: readonly LiteraryWorkNavigationTeaserWithAuthors[],
+	): LandingPageContent {
 		return {
 			_id: raw._id,
 			config: raw.config,
-			cards: this.mapStorylistTeasers(raw.cards),
 			collections: raw.collections.map(mapSanityCollectionTeaser),
 			campaigns: mapContentCampaigns(raw.campaigns),
-			mostRead: rotating?.mostRead ?? [],
-			mostReadLiteraryWorks: rotating?.mostReadLiteraryWorks ?? [],
-			latestReads: this.mapNavigationTeasers(raw.latestReads),
-			latestLiteraryWorks: raw.latestLiteraryWorks.map((work) => this.mapLiteraryWorkNavigationTeaser(work)),
+			mostRead,
+			latestReads: raw.latestLiteraryWorks.map((work) => this.mapNavigationTeaser(work)),
 			highlightedAuthors: this.mapHighlightedAuthors(raw.highlightedAuthors),
 		};
 	}
 
-	// El repository de la página de inicio es el primer y único productor backend de la vista de
-	// navegación de obra: la pintan sus tarjetas, que no muestran cuerpo y por eso no piden extracto.
+	// Este repository es el primer y único productor backend de la vista de navegación con autores: la
+	// pintan las tarjetas de la página de inicio, que no muestran cuerpo y por eso no piden extracto.
 	//
-	// El error que sale de acá nombra la **obra**, y es el guard el que lo envuelve nombrando la semana:
-	// sin esa distinción, el mensaje culparía a la landing por una obra mal curada que puede estar en
-	// cualquiera de las dos listas, o en el documento rotativo, que ni siquiera es una landing.
-	private mapLiteraryWorkNavigationTeaser(
-		raw: SanityLandingPage['latestLiteraryWorks'][number] | SanityRotatingContent['mostReadLiteraryWorks'][number],
-	): LiteraryWorkNavigationTeaserWithAuthors {
+	// El error que sale de acá nombra la **obra**, y es el guard de arriba el que lo envuelve nombrando
+	// la semana: sin esa distinción, el mensaje culparía a la landing por una obra mal curada que puede
+	// estar en cualquiera de las dos listas, o en el documento rotativo, que ni siquiera es una landing.
+	private mapNavigationTeaser(raw: SanityNavigationTeaser): LiteraryWorkNavigationTeaserWithAuthors {
 		if (raw.totalReadingTime === null) {
-			// Sin el total no hay nada que mostrar en la tarjeta: es una obra a la que el backfill todavía no
-			// le calculó su tiempo de lectura.
+			// Sin el total no hay nada que mostrar en la tarjeta: es una obra a la que el backfill todavía
+			// no le calculó su tiempo de lectura.
 			throw new Error(`LiteraryWorkNavigationTeaser inválido: sin tiempo de lectura (slug "${raw.slug}")`);
 		}
 		return createLiteraryWorkNavigationTeaser({
@@ -192,45 +179,6 @@ export class SanityContentRepository implements ContentRepository {
 			tags: mapTags(raw.tags),
 			mediaSources: mapMediaTeasers(raw.mediaSources),
 			authors: raw.authors.map(mapAuthorTeaser),
-		});
-	}
-
-	private mapStorylistTeasers(result: StorylistTeasersQueryResult): StorylistTeaser[] {
-		return result.map((item) => {
-			const { featuredImage, storyCoverImages, mediaSources, ...rest } = item;
-			return {
-				...rest,
-				config: { ...item.config, showAuthors: item.config?.showAuthors ?? false },
-				description: mapBlockContentToTextParagraphs(item.description),
-				tags: mapTags(item.tags),
-				stories: [],
-				tabs: [],
-				media: mapMediaSources(mediaSources),
-				imagery: mapImagery({ featuredImage, storyCoverImages }),
-			};
-		});
-	}
-
-	/**
-	 * Traduce la vista de navegación que comparten los dos slots de destacados.
-	 *
-	 * El tipo de entrada es la unión de las dos proyecciones que la producen —la de la landing y la del
-	 * contenido rotativo— para que ninguna pueda divergir sin que el typecheck lo denuncie.
-	 */
-	private mapNavigationTeasers(
-		result: SanityLandingPage['latestReads'] | SanityRotatingContent['mostRead'],
-	): StoryNavigationTeaserWithAuthor[] {
-		return result.map((item) => {
-			const { mediaSources, resources, coverImage, ...properties } = item;
-			return {
-				...properties,
-				author: mapAuthorTeaser(item.author),
-				coverImage: urlFor(coverImage),
-				media: mapMediaSources(mediaSources),
-				resources: mapResources(resources),
-				paragraphs: [],
-				tags: [],
-			};
 		});
 	}
 

--- a/src/api/modules/content/content.repository.ts
+++ b/src/api/modules/content/content.repository.ts
@@ -48,9 +48,6 @@ export interface ContentRepository {
 	 *
 	 * El orden es el ranking, así que el que se recibe es el que se escribe. Un slug que no resuelve se
 	 * descarta en silencio: la obra no existe, y no hay referencia que escribir.
-	 *
-	 * El slot de historias no tiene método propio: desde que el cron escribe obras, ningún productor lo
-	 * alimenta, y el campo sobrevive solo hasta que se retire del schema.
 	 */
 	updateMostReadLiteraryWorks(slugs: readonly string[]): Promise<void>;
 }

--- a/src/api/modules/content/content.service.spec.ts
+++ b/src/api/modules/content/content.service.spec.ts
@@ -24,13 +24,10 @@ function emptyLandingPageContent(config: string): LandingPageContent {
 	return {
 		_id: `landing-page-${config}`,
 		config,
-		cards: [],
 		collections: [],
 		campaigns: [],
 		mostRead: [],
-		mostReadLiteraryWorks: [],
 		latestReads: [],
-		latestLiteraryWorks: [],
 		highlightedAuthors: [],
 	};
 }
@@ -69,7 +66,7 @@ describe('getLandingPageContent', () => {
 
 describe('getRotatingContent', () => {
 	it('serves the stored rotating content', async () => {
-		const rotatingContent = { _id: 'rotatingContent', name: 'Rotación', mostRead: [], mostReadLiteraryWorks: [] };
+		const rotatingContent = { _id: 'rotatingContent', name: 'Rotación', mostRead: [] };
 		const repository = new InMemoryContentRepository({ rotatingContent });
 
 		expect(await getRotatingContent(repository)).toEqual(rotatingContent);
@@ -88,10 +85,6 @@ describe('addNextWeeksLandingPageContent', () => {
 
 	function repositoryWith(existingSlugs: readonly string[] = []) {
 		return new InMemoryContentRepository({ landingPages: storedWeeks(existingSlugs), latestReferences });
-	}
-
-	function weekAhead(weeks: number): string {
-		return buildWeekSlug(addWeeks(currentDate, weeks));
 	}
 
 	it('creates one landing page per missing week', async () => {
@@ -154,16 +147,18 @@ describe('addNextWeeksLandingPageContent', () => {
 		});
 	});
 
-	// El clonado enumera los campos que copia, así que un campo nuevo que quede afuera no rompe nada: el
-	// slot se vaciaría solo cada semana, sin emitir ningún error.
-	it('carries the highlighted authors over to every cloned week', async () => {
+	// El clonado enumera los campos que copia, así que un campo nuevo que quede afuera no rompe nada:
+	// el slot se vaciaría solo cada semana, sin emitir ningún error.
+	it('carries the collections, the highlighted works and the highlighted authors over to every cloned week', async () => {
 		const repository = repositoryWith();
 
 		await addNextWeeksLandingPageContent(3, repository);
 
 		expect(repository.createdLandingPages).toHaveLength(3);
 		repository.createdLandingPages.forEach((created) => {
-			expect(created.highlightedAuthors).toEqual(latestReferences.highlightedAuthors);
+			expect(created.collections).toEqual(latestReferences?.collections);
+			expect(created.latestLiteraryWorks).toEqual(latestReferences?.latestLiteraryWorks);
+			expect(created.highlightedAuthors).toEqual(latestReferences?.highlightedAuthors);
 		});
 	});
 
@@ -198,4 +193,8 @@ describe('addNextWeeksLandingPageContent', () => {
 			`Latest landing page for the '${currentSlug}' slug content not found`,
 		);
 	});
+
+	function weekAhead(weeks: number): string {
+		return buildWeekSlug(addWeeks(currentDate, weeks));
+	}
 });

--- a/src/api/modules/literary-work/literary-work.controller.spec.ts
+++ b/src/api/modules/literary-work/literary-work.controller.spec.ts
@@ -19,7 +19,7 @@ describe('literaryWorkController', () => {
 	const controller = createLiteraryWorkController(
 		new InMemoryLiteraryWorkRepository(onoffLiteraryWorksMock, onoffLiteraryWorkTeasersMock),
 		new InMemoryContentRepository({
-			rotatingContent: { _id: 'rotatingContent', name: 'Lo más leído', mostRead: [], mostReadLiteraryWorks: [] },
+			rotatingContent: { _id: 'rotatingContent', name: 'Lo más leído', mostRead: [] },
 			literaryWorks: onoffLiteraryWorkNavigationTeasersWithAuthorsMock,
 		}),
 	);

--- a/src/api/modules/literary-work/literary-work.service.spec.ts
+++ b/src/api/modules/literary-work/literary-work.service.spec.ts
@@ -103,8 +103,7 @@ describe('updateMostReadLiteraryWorks', () => {
 	const rotatingContent = {
 		_id: 'rotatingContent',
 		name: 'Lo más leído',
-		mostRead: [],
-		mostReadLiteraryWorks: [first, second],
+		mostRead: [first, second],
 	};
 
 	function popularPages(...urls: string[]) {
@@ -137,7 +136,7 @@ describe('updateMostReadLiteraryWorks', () => {
 
 		const result = await literaryWorkService.updateMostReadLiteraryWorks(content);
 
-		expect(result.mostReadLiteraryWorks.map(({ slug }) => slug)).toEqual([first.slug, second.slug]);
+		expect(result.mostRead.map(({ slug }) => slug)).toEqual([first.slug, second.slug]);
 	});
 
 	// La obra migrada conserva el slug de su historia de origen, así que el mismo slug llega por los dos
@@ -150,7 +149,7 @@ describe('updateMostReadLiteraryWorks', () => {
 
 		const result = await literaryWorkService.updateMostReadLiteraryWorks(content);
 
-		expect(result.mostReadLiteraryWorks.map(({ slug }) => slug)).toEqual([first.slug]);
+		expect(result.mostRead.map(({ slug }) => slug)).toEqual([first.slug]);
 	});
 
 	it('ignores popular pages outside the reading routes', async () => {
@@ -161,7 +160,7 @@ describe('updateMostReadLiteraryWorks', () => {
 
 		const result = await literaryWorkService.updateMostReadLiteraryWorks(content);
 
-		expect(result.mostReadLiteraryWorks.map(({ slug }) => slug)).toEqual([first.slug]);
+		expect(result.mostRead.map(({ slug }) => slug)).toEqual([first.slug]);
 	});
 
 	it('throws when the metrics service returns no popular pages', async () => {
@@ -183,7 +182,7 @@ describe('updateMostReadLiteraryWorks', () => {
 
 		const result = await literaryWorkService.updateMostReadLiteraryWorks(content);
 
-		expect(result.mostReadLiteraryWorks.map(({ slug }) => slug)).toEqual(ranked.map(({ slug }) => slug));
+		expect(result.mostRead.map(({ slug }) => slug)).toEqual(ranked.map(({ slug }) => slug));
 	});
 
 	// Clarity reporta la URL visitada, no el slug. Sin normalizar, la obra con tráfico de campaña —la
@@ -198,7 +197,7 @@ describe('updateMostReadLiteraryWorks', () => {
 
 		const result = await literaryWorkService.updateMostReadLiteraryWorks(content);
 
-		expect(result.mostReadLiteraryWorks.map(({ slug }) => slug)).toEqual([first.slug]);
+		expect(result.mostRead.map(({ slug }) => slug)).toEqual([first.slug]);
 	});
 
 	it('deduplicates a work reached through decorated and clean URLs alike', async () => {
@@ -212,7 +211,7 @@ describe('updateMostReadLiteraryWorks', () => {
 
 		const result = await literaryWorkService.updateMostReadLiteraryWorks(content);
 
-		expect(result.mostReadLiteraryWorks.map(({ slug }) => slug)).toEqual([first.slug]);
+		expect(result.mostRead.map(({ slug }) => slug)).toEqual([first.slug]);
 	});
 
 	// Cuántas obras se destacan lo decide la curaduría, no el cron: el caso de uso escribe todo el
@@ -226,7 +225,7 @@ describe('updateMostReadLiteraryWorks', () => {
 
 		const result = await literaryWorkService.updateMostReadLiteraryWorks(content);
 
-		expect(result.mostReadLiteraryWorks.map(({ slug }) => slug)).toEqual(everyWork.map(({ slug }) => slug));
+		expect(result.mostRead.map(({ slug }) => slug)).toEqual(everyWork.map(({ slug }) => slug));
 	});
 
 	it('falla cuando el contenido rotativo no está instalado', async () => {

--- a/src/api/modules/story/story.service.ts
+++ b/src/api/modules/story/story.service.ts
@@ -56,7 +56,7 @@ export async function getMostReadStoryNavigationTeasers(
 		throw new Error(`Could not fetch most read stories.`);
 	}
 
-	return result.mostReadLiteraryWorks.slice(offset, offset + limit);
+	return result.mostRead.slice(offset, offset + limit);
 }
 
 export async function getStories(limit: number = 100, offset: number = 0): Promise<StoryTeaserWithAuthor[]> {

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -46,19 +46,19 @@ describe('HomeComponent', () => {
 	describe('mazos de obras', () => {
 		// Rebanadas disjuntas del corpus: es lo que permite afirmar cuál de los dos listados llegó a cada
 		// mazo, y no solo cuántas tarjetas hay en total.
-		const latestLiteraryWorks = onoffLiteraryWorkNavigationTeasersWithAuthorsMock.slice(0, 3);
-		const mostReadLiteraryWorks = onoffLiteraryWorkNavigationTeasersWithAuthorsMock.slice(3, 6);
+		const latestReads = onoffLiteraryWorkNavigationTeasersWithAuthorsMock.slice(0, 3);
+		const mostRead = onoffLiteraryWorkNavigationTeasersWithAuthorsMock.slice(3, 6);
 
 		// Los dos mazos marcan sus tarjetas con el mismo `card`, así que el discriminante es el orden de
 		// documento: el de novedades precede al de más leídas en la plantilla, que es el orden de lectura.
 		it('should hand each listing to its own deck', async () => {
-			const { fixture } = await renderHome({ latestLiteraryWorks, mostReadLiteraryWorks });
+			const { fixture } = await renderHome({ latestReads, mostRead });
 
 			await renderDeferBlocks(fixture);
 
 			const cards = screen.getAllByTestId('card');
-			expect(cards).toHaveLength(latestLiteraryWorks.length + mostReadLiteraryWorks.length);
-			[...latestLiteraryWorks, ...mostReadLiteraryWorks].forEach((literaryWork, index) => {
+			expect(cards).toHaveLength(latestReads.length + mostRead.length);
+			[...latestReads, ...mostRead].forEach((literaryWork, index) => {
 				expect(within(cards[index]).getByText(literaryWork.title)).toBeInTheDocument();
 			});
 		});
@@ -66,7 +66,7 @@ describe('HomeComponent', () => {
 		// Las cabeceras quedan fuera de los bloques diferidos: son lo que la página lleva servido aunque
 		// las tarjetas todavía no se hayan resuelto.
 		it('should render both deck headings from the very first render', async () => {
-			await renderHome({ latestLiteraryWorks, mostReadLiteraryWorks });
+			await renderHome({ latestReads, mostRead });
 
 			expect(screen.getByRole('heading', { level: 2, name: 'Últimas novedades' })).toBeInTheDocument();
 			expect(screen.getByRole('heading', { level: 2, name: 'Historias más leídas' })).toBeInTheDocument();
@@ -75,7 +75,7 @@ describe('HomeComponent', () => {
 		// Afirmar cuáles obras quedaron afuera —y no solo cuántas tarjetas hay— es lo que distingue el
 		// recorte de cualquier otro criterio que devolviera seis. De ahí que el caso empiece exigiendo que
 		// el corpus supere el tope: con uno más corto no habría descarte que observar.
-		describe.each(['latestLiteraryWorks', 'mostReadLiteraryWorks'] as const)('recorte de %s', (section) => {
+		describe.each(['latestReads', 'mostRead'] as const)('recorte de %s', (section) => {
 			it('should cap the listing at six, however many the week brings', async () => {
 				expect(onoffLiteraryWorkNavigationTeasersWithAuthorsMock.length).toBeGreaterThan(6);
 

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -46,7 +46,7 @@ export default class HomeComponent {
 	private readonly landingPageContent = computed(() => this.landingPageResource.value());
 	protected readonly collections = computed(() => this.landingPageContent()?.collections || []);
 	protected readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
-	protected readonly mostRead = computed(() => this.landingPageContent()?.mostReadLiteraryWorks.slice(0, 6) || []);
-	protected readonly latestReads = computed(() => this.landingPageContent()?.latestLiteraryWorks.slice(0, 6) || []);
+	protected readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
+	protected readonly latestReads = computed(() => this.landingPageContent()?.latestReads.slice(0, 6) || []);
 	protected readonly highlightedAuthors = computed(() => this.landingPageContent()?.highlightedAuthors ?? []);
 }

--- a/src/app/providers/content.mock.ts
+++ b/src/app/providers/content.mock.ts
@@ -13,13 +13,10 @@ export class StubContentApi implements ContentApi {
 		const landingPageContent: LandingPageContent = {
 			_id: '',
 			config: '',
-			cards: [],
 			collections: [],
 			campaigns: [],
 			mostRead: [],
-			mostReadLiteraryWorks: [],
 			latestReads: [],
-			latestLiteraryWorks: [],
 			highlightedAuthors: [],
 		};
 		return of(landingPageContent);

--- a/src/mocks/onoff-documents.mock.ts
+++ b/src/mocks/onoff-documents.mock.ts
@@ -311,10 +311,9 @@ export const legacyStorylistDocument = {
 	slug: slugField('storylist'),
 };
 
-// Las tres proyecciones de abajo dereferencian el cuento en vez de proyectarlo directo (`stories[]->`,
-// `mostRead[]->`, `latestReads[]->`), así que necesitan un documento contenedor propio apuntando por
-// `_ref` a `incompleteLegacyStoryDocument`. Cada uno es un escenario de un solo caso, sin otro
-// consumidor, y por eso no se suma a `onoffDatasetMock`.
+// La proyección de abajo dereferencia el cuento en vez de proyectarlo directo (`stories[]->`), así que
+// necesita un documento contenedor propio apuntando por `_ref` a `incompleteLegacyStoryDocument`. Es un
+// escenario de un solo caso, sin otro consumidor, y por eso no se suma a `onoffDatasetMock`.
 
 export const storylistWithIncompleteStoryDocument = {
 	...documentSystemFields('onoff-storylist-campos-incumplidos'),
@@ -322,20 +321,4 @@ export const storylistWithIncompleteStoryDocument = {
 	slug: slugField('storylist-campos-incumplidos'),
 	title: 'Storylist de prueba',
 	stories: [documentReference(incompleteLegacyStoryDocument._id, 'story-incompleto')],
-};
-
-// El id es literal porque `rotatingContentQuery` filtra por `_id == 'rotatingContent'`: es un singleton.
-export const rotatingContentWithIncompleteStoryDocument = {
-	...documentSystemFields('rotatingContent'),
-	_type: 'rotatingContent' as const,
-	name: 'Contenido rotativo de prueba',
-	mostRead: [documentReference(incompleteLegacyStoryDocument._id, 'story-incompleto')],
-};
-
-export const landingPageWithIncompleteStoryDocument = {
-	...documentSystemFields('onoff-landing-page-campos-incumplidos'),
-	_type: 'landingPage' as const,
-	slug: slugField('landing-page-campos-incumplidos'),
-	config: '1974-24',
-	latestReads: [documentReference(incompleteLegacyStoryDocument._id, 'story-incompleto')],
 };

--- a/src/mocks/onoff-highlighted-authors.acl-alignment.spec.ts
+++ b/src/mocks/onoff-highlighted-authors.acl-alignment.spec.ts
@@ -2,7 +2,7 @@ import { stubSanityClient } from '@testing/sanity-client.stub';
 import { SanityContentRepository } from '../api/modules/content/content.repository.sanity';
 import { rotatingContentQuery } from '../api/_queries/content.query';
 import { onoffHighlightedAuthorsMock } from './onoff-highlighted-authors.mock';
-import { onoffRawLandingPageMock } from './onoff-raw-landing-page.mock';
+import { onoffRawLandingPageMock, onoffRawRotatingContentMock } from './onoff-raw-landing-page.mock';
 
 /* eslint-disable no-restricted-syntax -- vi.mock: el builder de imágenes de Sanity no tiene punto de inyección */
 vi.mock('@sanity/image-url', async () => {
@@ -14,12 +14,7 @@ vi.mock('@sanity/image-url', async () => {
 // El mapeo de los destacados es privado del repository, así que el cruce entra por su superficie
 // pública: es la misma cadena, ejercitada por donde la recorre el consumidor real.
 function repository(): SanityContentRepository {
-	// El contenido rotativo no participa de este cruce, pero la lectura lo pide igual, así que se
-	// responde vacío en vez de dejarlo sin respuesta.
-	const { client } = stubSanityClient(
-		[[rotatingContentQuery, { _id: 'rotatingContent', name: 'Lo más leído', mostRead: [], mostReadLiteraryWorks: [] }]],
-		onoffRawLandingPageMock,
-	);
+	const { client } = stubSanityClient([[rotatingContentQuery, onoffRawRotatingContentMock]], onoffRawLandingPageMock);
 	return new SanityContentRepository(client);
 }
 

--- a/src/mocks/onoff-landing-page.acl-alignment.spec.ts
+++ b/src/mocks/onoff-landing-page.acl-alignment.spec.ts
@@ -63,9 +63,7 @@ describe('el corpus de dominio de la página de inicio coincide con el mapeo del
 		const landingPage = await repository().fetchLandingPageContent(onoffRawLandingPageMock.slug);
 
 		expect(slugs.length).toBeGreaterThan(0);
-		expect(landingPage?.latestLiteraryWorks).toEqual(
-			expectedBySlug(onoffLiteraryWorkNavigationTeasersWithAuthorsMock, slugs),
-		);
+		expect(landingPage?.latestReads).toEqual(expectedBySlug(onoffLiteraryWorkNavigationTeasersWithAuthorsMock, slugs));
 	});
 
 	it('maps the raw most read works into their domain navigation teasers', async () => {
@@ -74,8 +72,6 @@ describe('el corpus de dominio de la página de inicio coincide con el mapeo del
 		const rotatingContent = await repository().fetchRotatingContent();
 
 		expect(slugs.length).toBeGreaterThan(0);
-		expect(rotatingContent?.mostReadLiteraryWorks).toEqual(
-			expectedBySlug(onoffLiteraryWorkNavigationTeasersWithAuthorsMock, slugs),
-		);
+		expect(rotatingContent?.mostRead).toEqual(expectedBySlug(onoffLiteraryWorkNavigationTeasersWithAuthorsMock, slugs));
 	});
 });

--- a/src/mocks/onoff-raw-author.mock.ts
+++ b/src/mocks/onoff-raw-author.mock.ts
@@ -1,5 +1,5 @@
 import { onoffImageAssets } from './onoff-image-assets.mock';
-import type { RotatingContentQueryResult, StoryBySlugQueryResult } from '@sanity-types';
+import type { StoryBySlugQueryResult, StorylistQueryResult } from '@sanity-types';
 import onoffBiographyMdBody from './onoff/author/francois-onoff.biography.md?raw';
 
 export const rawOnoffAuthor: NonNullable<StoryBySlugQueryResult>['author'] = {
@@ -41,7 +41,7 @@ export const rawOnoffAuthor: NonNullable<StoryBySlugQueryResult>['author'] = {
 	tags: [],
 };
 
-export const rawOnoffAuthorTeaser: NonNullable<RotatingContentQueryResult>['mostRead'][0]['author'] = {
+export const rawOnoffAuthorTeaser: NonNullable<StorylistQueryResult>['stories'][0]['author'] = {
 	_id: 'author_1',
 	slug: 'francois-onoff',
 	name: 'François Onoff',

--- a/src/mocks/onoff-raw-stories.mock.ts
+++ b/src/mocks/onoff-raw-stories.mock.ts
@@ -1,4 +1,4 @@
-import type { RotatingContentQueryResult, StoriesByAuthorSlugQueryResult, StoryBySlugQueryResult } from '@sanity-types';
+import type { StoriesByAuthorSlugQueryResult, StoryBySlugQueryResult, StorylistQueryResult } from '@sanity-types';
 import { rawOnoffAuthorTeaser } from './onoff-raw-author.mock';
 import { elOdioRawStory } from './onoff/story/el-odio.story.raw.mock';
 import { elPalacioRawStory } from './onoff/story/el-palacio-de-las-nueve-fronteras.story.raw.mock';
@@ -52,9 +52,7 @@ function toRawTeaser(raw: NonNullable<StoryBySlugQueryResult>): StoriesByAuthorS
 	};
 }
 
-function toRawNavTeaser(
-	raw: NonNullable<StoryBySlugQueryResult>,
-): NonNullable<RotatingContentQueryResult>['mostRead'][0] {
+function toRawNavTeaser(raw: NonNullable<StoryBySlugQueryResult>): NonNullable<StorylistQueryResult>['stories'][0] {
 	return {
 		_id: raw._id,
 		slug: raw.slug,
@@ -90,7 +88,7 @@ export const onoffRawTeasersMock: StoriesByAuthorSlugQueryResult = [
 	neronRawTeaser,
 ];
 
-export const onoffRawNavTeasersMock: NonNullable<RotatingContentQueryResult>['mostRead'] = [
+export const onoffRawNavTeasersMock: NonNullable<StorylistQueryResult>['stories'] = [
 	toRawNavTeaser(elPalacioRawStory),
 	toRawNavTeaser(geometriaRawStory),
 	toRawNavTeaser(losPeldanosRawStory),

--- a/src/mocks/onoff/README.md
+++ b/src/mocks/onoff/README.md
@@ -10,7 +10,7 @@ Este directorio (`src/mocks/onoff/`) es la **única ubicación** del corpus de l
 
 ## Cómo está organizado
 
-Las piezas se agrupan **por entidad**, una carpeta cada una, salvo cuando dos entidades no se pueden montar por separado: `landing-page/` lleva la landing y sus campañas juntas porque la campaña no tiene query propia —es sub-proyección de la de landing—, y una carpeta aparte quedaría con documentos y sin fixture generada. `document/` y `media/` agrupan por concern por el mismo motivo. Los mocks y fixtures conservan igualmente el infijo de entidad en el nombre, así que siguen siendo unívocos fuera de contexto; la prosa no lo lleva, porque su extensión ya la distingue:
+Las piezas se agrupan **por entidad**, una carpeta cada una, salvo cuando dos entidades no se pueden montar por separado: `landing-page/` lleva la landing, el contenido rotativo y las campañas juntos porque ninguno de los otros dos tiene query propia con su propia carpeta que valga la pena — la campaña es sub-proyección de la de landing, y el contenido rotativo comparte pantalla con la landing aunque tenga su propio documento y su propia query. `document/` y `media/` agrupan por concern por el mismo motivo. Los mocks y fixtures conservan igualmente el infijo de entidad en el nombre, así que siguen siendo unívocos fuera de contexto; la prosa no lo lleva, porque su extensión ya la distingue:
 
 ```
 onoff/
@@ -19,7 +19,8 @@ onoff/
 │                   <slug>.literary-work.mock.ts + su prosa: <slug>.md · <slug>.editorial-note.md · <slug>.epigraph.ts
 ├── collection/     <slug>.collection.document.ts · <slug>.collection.raw.mock.ts (generado) · <slug>.collection.md
 ├── landing-page/   onoff.landing-page.document.ts · <slug>.content-campaign.document.ts
-│                   landing-page.raw.mock.ts (generado)
+│                   onoff.rotating-content.document.ts
+│                   landing-page.raw.mock.ts · rotating-content.raw.mock.ts (generados)
 ├── storylist/      <slug>.storylist.raw.mock.ts
 ├── author/         francois-onoff.biography.md · author.document.projection.ts
 ├── media/          <slug>.media.ts · <slug>.media.mock.ts · <slug>.media.raw.mock.ts
@@ -42,14 +43,15 @@ Antes de esta capa de documentos el flujo corría al revés: el raw se escribía
 
 ### El generador (`pnpm corpus:generate`)
 
-`pnpm corpus:generate` → `node --import tsx ./scripts/generate-raw-corpus/generate-raw-corpus.ts`. Por cada obra, cada colección y la página de inicio, evalúa la query GROQ real (`literaryWorkBySlugQuery`, `collectionBySlugQuery`, `collectionsQuery` para el listado y `landingPageContentQuery` para la landing, que va con su semana como parámetro) con `groq-js` sobre `onoffDatasetMock` — el dataset plano de todos los documentos del corpus — y escribe el resultado en su fixture `*.raw.mock.ts`.
+`pnpm corpus:generate` → `node --import tsx ./scripts/generate-raw-corpus/generate-raw-corpus.ts`. Por cada obra, cada colección, la página de inicio y el contenido rotativo, evalúa la query GROQ real (`literaryWorkBySlugQuery`, `collectionBySlugQuery`, `collectionsQuery` para el listado, `landingPageContentQuery` para la landing —que va con su semana como parámetro— y `rotatingContentQuery` para lo más leído) con `groq-js` sobre `onoffDatasetMock` — el dataset plano de todos los documentos del corpus — y escribe el resultado en su fixture `*.raw.mock.ts`.
 
-**Archivos generados (12):**
+**Archivos generados (13):**
 
 - Las 8 `literary-work/<slug>.literary-work.raw.mock.ts`.
 - Las 2 `collection/<slug>.collection.raw.mock.ts`.
 - `collection/collection-teasers.raw.mock.ts` (resultado de `collectionsQuery`, el listado).
 - `landing-page/landing-page.raw.mock.ts` (resultado de `landingPageContentQuery`).
+- `landing-page/rotating-content.raw.mock.ts` (resultado de `rotatingContentQuery`, lo más leído).
 
 Cada uno abre con un banner de dos líneas ("Este archivo lo escribe `pnpm corpus:generate`... No se edita a mano: cualquier cambio se pierde en la próxima corrida.") y está marcado `linguist-generated=true` en `.gitattributes` — enumerados uno por uno, no por glob `*.raw.mock.ts`, porque las fixtures de `story/` y `storylist/` se siguen escribiendo a mano.
 
@@ -82,7 +84,7 @@ Las exclusiones no son todas de la misma naturaleza, y la diferencia importa: al
 
 **Todavía no:** el autor **sí** es derivable —tiene queries top-level (`authorBySlugQuery`, `authorsQuery`) y su documento ya está en el dataset—, pero el shape que hoy declara `rawOnoffAuthor` es el del autor embebido en la obra, que ninguna query devuelve sola. Generarlo exige apuntar a la query de autor y aceptar el shape que esa devuelve. Es trabajo pendiente, no un imposible: la única exclusión de esta tabla que puede desaparecer sin cambiar nada del diseño.
 
-Una sub-proyección **sí** puede generarse cuando su query tiene capa de documentos: es lo que pasa con `ContentCampaign`, que se deriva del resultado generado de la landing page (ver [Corpus raw: página de inicio](#corpus-raw-página-de-inicio-y-contentcampaign-generado)). Lo que la vuelve inderivable no es ser sub-proyección, sino que ninguna query la devuelva.
+Una sub-proyección **sí** puede generarse cuando su query tiene capa de documentos: es lo que pasa con `ContentCampaign`, que se deriva del resultado generado de la landing page (ver [Corpus raw: página de inicio](#corpus-raw-página-de-inicio-contenido-rotativo-y-contentcampaign-generado)). Lo que la vuelve inderivable no es ser sub-proyección, sino que ninguna query la devuelva.
 
 > Las fichas Markdown por obra (metadata + reseña) que vivían en `tools/story-mocks/onoff/` se retiraron en #1653: los mocks TS de este directorio son ahora la fuente.
 
@@ -162,19 +164,21 @@ Contraparte cruda del corpus de dominio `LiteraryWork`, tipada contra `NonNullab
   - `unmaterializedRawLiteraryWork` — `totalReadingTime` y `content[].readingTime` en `null` (ejercita el fallback puro de lectura del repository y el backfill, que es el único que persiste).
 - **Autor raw:** `rawOnoffAuthor` (reusado del corpus raw de Story, estructuralmente idéntico).
 
-## Corpus raw: página de inicio y `ContentCampaign` (generado)
+## Corpus raw: página de inicio, contenido rotativo y `ContentCampaign` (generado)
 
 `landing-page/landing-page.raw.mock.ts` (`onoffRawLandingPageMock`) es el resultado de `landingPageContentQuery` sobre la capa de documentos de `landing-page/`: un documento de landing y los dos de campaña que referencia. La semana de la landing —su `config` y su `slug`— es la del timestamp de sistema del corpus, para que el elenco siga hablando de un solo momento; el target del generador **la lee del documento** en vez de declararla por su cuenta, porque es el parámetro de entrada de la query y no una de las capas que los cruces comparan.
 
 El documento de landing es el único que no lleva su slug en el nombre del archivo (`onoff.landing-page.document.ts`): su slug es una semana, y nombrarlo así obligaría a renombrar el archivo cada vez que el corpus se moviera de fecha.
 
-**La landing no declara `cards` ni `latestReads`.** Esos campos referencian `storylist` y `story`, que el corpus no modela como documentos (ver [Qué queda fuera de la generación](#qué-queda-fuera-de-la-generación)): declararlos dejaría referencias colgadas y la guarda del generador abortaría. La query los resuelve a `[]`, y la fixture lo afirma.
+**La landing declara `collections` y `latestLiteraryWorks`, no `cards` ni `latestReads`.** Los dos últimos referencian `storylist` y `story`, que el corpus no modela como documentos (ver [Qué queda fuera de la generación](#qué-queda-fuera-de-la-generación)): declararlos dejaría referencias colgadas y la guarda del generador abortaría. Sus reemplazos no tienen ese problema, porque referencian `collection` y `literaryWork`, que sí están en el dataset — y `landingPageContentQuery` ya no proyecta los campos en baja, así que la fixture generada tampoco los transporta.
 
 **Se genera el resultado entero de la query, no solo `campaigns`.** Un archivo generado afirma "esto es lo que la query devuelve", y recortar obligaría al gate de frescura a replicar el mismo recorte para poder comparar: la transformación quedaría afirmada por sí misma.
 
 - **Agregador:** `../onoff-raw-landing-page.mock.ts`, que expone `onoffRawLandingPageMock` —el generado alcanzable desde afuera de `src/mocks/`— y `onoffRawContentCampaignsMock`, derivado de `….campaigns` (mismo patrón que `geometriaRawMediaSources` derivando de la cara de obra). La campaña no tiene agregador propio por el mismo motivo por el que no tiene carpeta propia: sin query propia, un módulo aparte sacaría su valor entero de este. Vive un nivel arriba porque lo importan specs de `src/api/`, desde donde la regla de ESLint prohíbe alcanzar `@mocks/onoff/**`; y declara consts propias en vez de re-exportar, que la prohibición de barrels rechaza.
 - **Cruce contra el ACL:** `../onoff-content-campaigns.acl-alignment.spec.ts`. El corpus de dominio (`../content-campaign.mock.ts`) se sigue escribiendo a mano en vez de derivarse del mapper: derivarlo lo volvería una tautología del ACL y ninguna regresión del mapeo se notaría en sus consumidores.
 - **Los literales de `title`, `slug` y `url` se duplican a propósito** entre el documento y el mock de dominio. Compartirlos por un módulo neutral dejaría al cruce sin filo: una fuente única mueve las dos capas a la vez y la comparación no podría fallar nunca. La prosa larga sí se comparte; las imágenes también, pero por sus dos caras (`ref` y `path`), que no son el mismo valor.
+
+**Contenido rotativo:** `landing-page/rotating-content.raw.mock.ts` (`onoffRawRotatingContentMock`) es el resultado de `rotatingContentQuery` sobre `landing-page/onoff.rotating-content.document.ts` — otro documento y otra query, aunque las dos alimenten la misma pantalla que la landing. Referencia dos obras (`el-odio`, `las-escaleras`) **distintas** de las que la landing destaca como novedades: compartir el elenco entre los dos slots volvería indistinguible, en el cruce contra el ACL, un mapeo que los confundiera. Tiene agregador propio en `../onoff-raw-landing-page.mock.ts` (`onoffRawRotatingContentMock`, re-exportado) en vez de vivir como sub-proyección de la landing, porque es la contraparte cruda de un documento y una query independientes.
 
 ## Imágenes: el puente a los assets locales
 

--- a/src/mocks/onoff/landing-page/landing-page.raw.mock.ts
+++ b/src/mocks/onoff/landing-page/landing-page.raw.mock.ts
@@ -73,6 +73,48 @@ export const onoffRawLandingPageMock: NonNullable<LandingPageContentQueryResult>
 			],
 		},
 	],
+	campaigns: [
+		{
+			_id: 'onoff-content-campaign-coleccion-completa-onoff',
+			title: 'Diez tapas, una sola obra',
+			slug: 'coleccion-completa-onoff',
+			url: '../author/francois-onoff',
+			contents: {
+				xs: {
+					image: {
+						_type: 'image',
+						asset: { _type: 'reference', _ref: 'image-0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b-540x220-png' },
+					},
+				},
+				md: {
+					image: {
+						_type: 'image',
+						asset: { _type: 'reference', _ref: 'image-2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d-1240x360-png' },
+					},
+				},
+			},
+		},
+		{
+			_id: 'onoff-content-campaign-el-palacio-de-las-nueve-fronteras',
+			title: 'El palacio de las nueve fronteras',
+			slug: 'el-palacio-de-las-nueve-fronteras',
+			url: '../story/el-palacio-de-las-nueve-fronteras',
+			contents: {
+				xs: {
+					image: {
+						_type: 'image',
+						asset: { _type: 'reference', _ref: 'image-1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c-540x220-png' },
+					},
+				},
+				md: {
+					image: {
+						_type: 'image',
+						asset: { _type: 'reference', _ref: 'image-3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e-1240x360-png' },
+					},
+				},
+			},
+		},
+	],
 	latestLiteraryWorks: [
 		{
 			_id: 'onoff-literary-work-geometria',
@@ -143,50 +185,6 @@ export const onoffRawLandingPageMock: NonNullable<LandingPageContentQueryResult>
 			],
 		},
 	],
-	cards: [],
-	campaigns: [
-		{
-			_id: 'onoff-content-campaign-coleccion-completa-onoff',
-			title: 'Diez tapas, una sola obra',
-			slug: 'coleccion-completa-onoff',
-			url: '../author/francois-onoff',
-			contents: {
-				xs: {
-					image: {
-						_type: 'image',
-						asset: { _type: 'reference', _ref: 'image-0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b-540x220-png' },
-					},
-				},
-				md: {
-					image: {
-						_type: 'image',
-						asset: { _type: 'reference', _ref: 'image-2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d-1240x360-png' },
-					},
-				},
-			},
-		},
-		{
-			_id: 'onoff-content-campaign-el-palacio-de-las-nueve-fronteras',
-			title: 'El palacio de las nueve fronteras',
-			slug: 'el-palacio-de-las-nueve-fronteras',
-			url: '../story/el-palacio-de-las-nueve-fronteras',
-			contents: {
-				xs: {
-					image: {
-						_type: 'image',
-						asset: { _type: 'reference', _ref: 'image-1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c-540x220-png' },
-					},
-				},
-				md: {
-					image: {
-						_type: 'image',
-						asset: { _type: 'reference', _ref: 'image-3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e-1240x360-png' },
-					},
-				},
-			},
-		},
-	],
-	latestReads: [],
 	highlightedAuthors: [
 		{
 			author: {

--- a/src/mocks/onoff/landing-page/rotating-content.raw.mock.ts
+++ b/src/mocks/onoff/landing-page/rotating-content.raw.mock.ts
@@ -70,5 +70,4 @@ export const onoffRawRotatingContentMock: NonNullable<RotatingContentQueryResult
 			],
 		},
 	],
-	mostRead: [],
 };

--- a/src/models/landing-page-content.model.ts
+++ b/src/models/landing-page-content.model.ts
@@ -1,8 +1,6 @@
 import type { CollectionTeaser } from '@models/collection.model';
 import { ContentCampaign } from '@models/content-campaign.model';
 import type { LiteraryWorkNavigationTeaserWithAuthors } from '@models/literary-work.model';
-import { StorylistTeaser } from '@models/storylist.model';
-import { StoryNavigationTeaserWithAuthor } from '@models/story.model';
 import type { AuthorTeaser } from '@models/author.model';
 import type { Tag } from '@models/tag.model';
 
@@ -14,34 +12,23 @@ export interface HighlightedAuthor {
 	readonly storyCount: number;
 }
 
-/**
- * Los slots de la página de inicio conviven en dos vocabularios mientras dura la migración: `cards`,
- * `mostRead` y `latestReads` transportan storylists e historias; `collections`, `mostReadLiteraryWorks`
- * y `latestLiteraryWorks` transportan colecciones y obras.
- *
- * Los tres nuevos llevan el sufijo de entidad solo porque conviven con los viejos: `collections`
- * conserva su nombre al contraerse, y los otros dos vuelven a `mostRead` y `latestReads`, que nombran
- * el rol editorial del slot y no lo que lo llena.
- *
- * Los destacados viajan como vista de navegación y no como teaser de obra: el teaser exige el extracto
- * del arranque y ninguna de las dos tarjetas que los pintan muestra cuerpo.
- */
+// Los destacados viajan como vista de navegación y no como teaser de obra: el teaser exige el extracto
+// del arranque, y ninguna de las dos tarjetas de la página de inicio pinta cuerpo.
+//
+// `mostRead` y `latestReads` conservan su nombre porque nombran el rol editorial del slot, que no
+// cambió. `collections` sí se renombró: `cards` nombraba el componente que lo pintaba.
 export interface LandingPageContent {
 	readonly _id: string;
 	readonly config: string;
-	readonly cards: StorylistTeaser[];
 	readonly collections: readonly CollectionTeaser[];
-	readonly campaigns: ContentCampaign[];
-	readonly mostRead: StoryNavigationTeaserWithAuthor[];
-	readonly mostReadLiteraryWorks: readonly LiteraryWorkNavigationTeaserWithAuthors[];
-	readonly latestReads: StoryNavigationTeaserWithAuthor[];
-	readonly latestLiteraryWorks: readonly LiteraryWorkNavigationTeaserWithAuthors[];
+	readonly campaigns: readonly ContentCampaign[];
+	readonly mostRead: readonly LiteraryWorkNavigationTeaserWithAuthors[];
+	readonly latestReads: readonly LiteraryWorkNavigationTeaserWithAuthors[];
 	readonly highlightedAuthors: readonly HighlightedAuthor[];
 }
 
 export interface RotatingContent {
 	readonly _id: string;
 	readonly name: string;
-	readonly mostRead: StoryNavigationTeaserWithAuthor[];
-	readonly mostReadLiteraryWorks: readonly LiteraryWorkNavigationTeaserWithAuthors[];
+	readonly mostRead: readonly LiteraryWorkNavigationTeaserWithAuthors[];
 }

--- a/src/models/literary-work.model.ts
+++ b/src/models/literary-work.model.ts
@@ -72,14 +72,14 @@ interface CreateLiteraryWorkNavigationTeaserOptions {
 }
 
 /**
- * Construye la vista de navegación con autores haciendo cumplir las invariantes que sí puede sostener:
- * título no vacío y al menos un autor.
+ * Construye la vista de navegación con autores haciendo cumplir las invariantes que sí puede
+ * sostener: título no vacío y al menos un autor.
  *
  * La de autores no es defensiva — es la misma que `createLiteraryWork` hace cumplir para el agregado
  * completo, traducida a esta vista. La proyección la deja pasar (`coalesce(authors[]->…, [])` devuelve
  * la lista vacía tanto para la obra sin autores como para la que los perdió al despublicarse), y las
- * tarjetas que pintan esta vista muestran al primero sin preguntar. Sin la factory, una obra mal curada
- * no rompe donde se puede corregir sino al renderizarse.
+ * tarjetas que pintan esta vista muestran al primero sin preguntar. Sin la factory, una obra mal
+ * curada no rompe donde se puede corregir sino al renderizarse.
  */
 export function createLiteraryWorkNavigationTeaser(
 	options: CreateLiteraryWorkNavigationTeaserOptions,

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -1152,7 +1152,7 @@ export type CollectionsQueryResult = Array<{
 
 // Source: ../src/api/_queries/content.query.ts
 // Variable: rotatingContentQuery
-// Query: *[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{    _id,    name,    'mostReadLiteraryWorks': coalesce(mostReadLiteraryWorks[]->{        _id,        'slug': slug.current,        title,        coverImage,        totalReadingTime,        'sectionCount': count(content),        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),        'authors': coalesce(authors[]->{            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear        }, [])    },[]),    'mostRead': coalesce(mostRead[]->{        _id,        'slug': slug.current,        title,        'badLanguage': coalesce(badLanguage, false),        'body': [],        'originalPublication': coalesce(originalPublication, ''),        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {            _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[])}
+// Query: *[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{    _id,    name,    'mostReadLiteraryWorks': coalesce(mostReadLiteraryWorks[]->{        _id,        'slug': slug.current,        title,        coverImage,        totalReadingTime,        'sectionCount': count(content),        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),        'authors': coalesce(authors[]->{            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear        }, [])    },[])}
 export type RotatingContentQueryResult = {
 	_id: 'rotatingContent';
 	name: string;
@@ -1234,100 +1234,6 @@ export type RotatingContentQueryResult = {
 				}>;
 		  }>
 		| Array<never>;
-	mostRead:
-		| Array<{
-				_id: string;
-				slug: string;
-				title: string;
-				badLanguage: boolean;
-				body: Array<never>;
-				originalPublication: string;
-				approximateReadingTime: ComputedNumber;
-				coverImage: {
-					asset?: SanityImageAssetReference;
-					media?: unknown;
-					hotspot?: SanityImageHotspot;
-					crop?: SanityImageCrop;
-					_type: 'image';
-				};
-				resources: Array<never>;
-				mediaSources:
-					| Array<never>
-					| Array<
-							| {
-									title: string;
-									description: Markdown;
-									url: string;
-									_type: 'audioRecording';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									url: string;
-									_type: 'pdfLink';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									audioFile: AudioFile;
-									hostName: string;
-									hostAvatar?: HostAvatar;
-									date: string;
-									duration: string;
-									_type: 'spaceRecording';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									url: string;
-									_type: 'spotifyPodcastEpisode';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									videoId: string;
-									_type: 'youTubeVideo';
-									_key: string;
-							  }
-					  >;
-				author: {
-					_id: string;
-					slug: string;
-					name: string;
-					image: {
-						asset?: SanityImageAssetReference;
-						media?: unknown;
-						hotspot?: SanityImageHotspot;
-						crop?: SanityImageCrop;
-						_type: 'image';
-					};
-					nationality: {
-						_id: string;
-						_type: 'nationality';
-						_createdAt: string;
-						_updatedAt: string;
-						_rev: string;
-						country: string;
-						flag: {
-							asset?: SanityImageAssetReference;
-							media?: unknown;
-							hotspot?: SanityImageHotspot;
-							crop?: SanityImageCrop;
-							_type: 'image';
-						};
-					};
-					bornOn: string | null;
-					bornOnYear: ComputedNumber | null;
-					diedOn: string | null;
-					diedOnYear: ComputedNumber | null;
-					resources: Array<never>;
-				};
-		  }>
-		| Array<never>;
 } | null;
 
 // Source: ../src/api/_queries/content.query.ts
@@ -1393,7 +1299,7 @@ export type LatestLandingPageReferencesQueryResult = {
 
 // Source: ../src/api/_queries/content.query.ts
 // Variable: landingPageContentQuery
-// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{    _id,    'slug': slug.current,    config,    'collections': coalesce(collections[]->{        _id,        'slug': slug.current,        title,        description,        featuredImage,        'config': { 'showAuthors': coalesce(config.showAuthors, false) },        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'mediaSources': coalesce(mediaSources[]{            ...,            _type == 'spaceRecording' => {                'audioUrl': audioFile.asset->url            }        }, []),        'count': coalesce(count(literaryWorks), 0),        'literaryWorkCoverImages': coalesce(literaryWorks[0...3]->coverImage, [])    },[]),    'latestLiteraryWorks': coalesce(latestLiteraryWorks[]->{        _id,        'slug': slug.current,        title,        coverImage,        totalReadingTime,        'sectionCount': count(content),        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),        'authors': coalesce(authors[]->{            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear        }, [])    },[]),    'cards': coalesce(cards[]->{        _id,        title,        'slug': slug.current,        description,        featuredImage,        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'storyCoverImages': coalesce(stories[]->coverImage, []),        'count': coalesce(count(stories), 0),				config,				'tabs': [],	      'mediaSources': coalesce(mediaSources[], []),    },[]),    'campaigns': coalesce(campaigns[]->{        _id,        'title': coalesce(title, ''),        'slug': coalesce(slug.current, ''),        'url': coalesce(url, ''),        'contents': {            'xs': {                'image': contents.xs.image            },            'md': {                'image': contents.md.image            }        }    },[]),    'latestReads': coalesce(latestReads[]->{        _id,        'slug': slug.current,        title,        'badLanguage': coalesce(badLanguage, false),        'body': [],        'originalPublication': coalesce(originalPublication, ''),        approximateReadingTime,        coverImage,        'resources': [],        'mediaSources': coalesce(mediaSources[], []),        'author': author-> {             _id,            'slug': slug.current,            name,            image,            nationality->,						bornOn,						bornOnYear,						diedOn,						diedOnYear,            'resources': [],        }    },[]),    'highlightedAuthors': coalesce(highlightedAuthors[]->{        'author': {            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear,            'resources': []        },        'tags': coalesce(tags[]->{            title,            'slug': slug.current,            description        }, []),        'storyCount': count(array::unique(*[            !(_id in path('drafts.**')) &&            _type in ['story', 'literaryWork'] &&            references(^._id)        ].slug.current))    },[]),}
+// Query: *[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{    _id,    'slug': slug.current,    config,    'collections': coalesce(collections[]->{        _id,        'slug': slug.current,        title,        description,        featuredImage,        'config': { 'showAuthors': coalesce(config.showAuthors, false) },        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'mediaSources': coalesce(mediaSources[]{            ...,            _type == 'spaceRecording' => {                'audioUrl': audioFile.asset->url            }        }, []),        'count': coalesce(count(literaryWorks), 0),        'literaryWorkCoverImages': coalesce(literaryWorks[0...3]->coverImage, [])    },[]),    'campaigns': coalesce(campaigns[]->{        _id,        'title': coalesce(title, ''),        'slug': coalesce(slug.current, ''),        'url': coalesce(url, ''),        'contents': {            'xs': {                'image': contents.xs.image            },            'md': {                'image': contents.md.image            }        }    },[]),    'latestLiteraryWorks': coalesce(latestLiteraryWorks[]->{        _id,        'slug': slug.current,        title,        coverImage,        totalReadingTime,        'sectionCount': count(content),        'tags': coalesce(tags[] -> {            title,            'slug': slug.current,            description        }, []),        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),        'authors': coalesce(authors[]->{            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear        }, [])    },[]),    'highlightedAuthors': coalesce(highlightedAuthors[]->{        'author': {            _id,            'slug': slug.current,            name,            image,            nationality->,            bornOn,            bornOnYear,            diedOn,            diedOnYear,            'resources': []        },        'tags': coalesce(tags[]->{            title,            'slug': slug.current,            description        }, []),        'storyCount': count(array::unique(*[            !(_id in path('drafts.**')) &&            _type in ['story', 'literaryWork'] &&            references(^._id)        ].slug.current))    },[]),}
 export type LandingPageContentQueryResult = {
 	_id: string;
 	slug: string;
@@ -1477,6 +1383,34 @@ export type LandingPageContentQueryResult = {
 					  } | null>;
 		  }>
 		| Array<never>;
+	campaigns:
+		| Array<{
+				_id: string;
+				title: string | '';
+				slug: string | '';
+				url: string | '';
+				contents: {
+					xs: {
+						image: {
+							asset?: SanityImageAssetReference;
+							media?: unknown;
+							hotspot?: SanityImageHotspot;
+							crop?: SanityImageCrop;
+							_type: 'image';
+						} | null;
+					};
+					md: {
+						image: {
+							asset?: SanityImageAssetReference;
+							media?: unknown;
+							hotspot?: SanityImageHotspot;
+							crop?: SanityImageCrop;
+							_type: 'image';
+						} | null;
+					};
+				};
+		  }>
+		| Array<never>;
 	latestLiteraryWorks:
 		| Array<{
 				_id: string;
@@ -1553,207 +1487,6 @@ export type LandingPageContentQueryResult = {
 					diedOn: string | null;
 					diedOnYear: ComputedNumber | null;
 				}>;
-		  }>
-		| Array<never>;
-	cards:
-		| Array<{
-				_id: string;
-				title: string;
-				slug: string;
-				description: BlockContent;
-				featuredImage: {
-					asset?: SanityImageAssetReference;
-					media?: unknown;
-					hotspot?: SanityImageHotspot;
-					crop?: SanityImageCrop;
-					_type: 'image';
-				} | null;
-				tags:
-					| Array<{
-							title: string;
-							slug: string;
-							description: string;
-					  }>
-					| Array<never>;
-				storyCoverImages:
-					| Array<{
-							asset?: SanityImageAssetReference;
-							media?: unknown;
-							hotspot?: SanityImageHotspot;
-							crop?: SanityImageCrop;
-							_type: 'image';
-					  }>
-					| Array<never>;
-				count: number | 0;
-				config: {
-					showAuthors?: boolean;
-				} | null;
-				tabs: Array<never>;
-				mediaSources:
-					| Array<never>
-					| Array<
-							| {
-									title: string;
-									description: Markdown;
-									url: string;
-									_type: 'audioRecording';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									url: string;
-									_type: 'pdfLink';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									audioFile: AudioFile;
-									hostName: string;
-									hostAvatar?: HostAvatar;
-									date: string;
-									duration: string;
-									_type: 'spaceRecording';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									url: string;
-									_type: 'spotifyPodcastEpisode';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									videoId: string;
-									_type: 'youTubeVideo';
-									_key: string;
-							  }
-					  >;
-		  }>
-		| Array<never>;
-	campaigns:
-		| Array<{
-				_id: string;
-				title: string | '';
-				slug: string | '';
-				url: string | '';
-				contents: {
-					xs: {
-						image: {
-							asset?: SanityImageAssetReference;
-							media?: unknown;
-							hotspot?: SanityImageHotspot;
-							crop?: SanityImageCrop;
-							_type: 'image';
-						} | null;
-					};
-					md: {
-						image: {
-							asset?: SanityImageAssetReference;
-							media?: unknown;
-							hotspot?: SanityImageHotspot;
-							crop?: SanityImageCrop;
-							_type: 'image';
-						} | null;
-					};
-				};
-		  }>
-		| Array<never>;
-	latestReads:
-		| Array<{
-				_id: string;
-				slug: string;
-				title: string;
-				badLanguage: boolean;
-				body: Array<never>;
-				originalPublication: string;
-				approximateReadingTime: ComputedNumber;
-				coverImage: {
-					asset?: SanityImageAssetReference;
-					media?: unknown;
-					hotspot?: SanityImageHotspot;
-					crop?: SanityImageCrop;
-					_type: 'image';
-				};
-				resources: Array<never>;
-				mediaSources:
-					| Array<never>
-					| Array<
-							| {
-									title: string;
-									description: Markdown;
-									url: string;
-									_type: 'audioRecording';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									url: string;
-									_type: 'pdfLink';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									audioFile: AudioFile;
-									hostName: string;
-									hostAvatar?: HostAvatar;
-									date: string;
-									duration: string;
-									_type: 'spaceRecording';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									url: string;
-									_type: 'spotifyPodcastEpisode';
-									_key: string;
-							  }
-							| {
-									title: string;
-									description: Markdown;
-									videoId: string;
-									_type: 'youTubeVideo';
-									_key: string;
-							  }
-					  >;
-				author: {
-					_id: string;
-					slug: string;
-					name: string;
-					image: {
-						asset?: SanityImageAssetReference;
-						media?: unknown;
-						hotspot?: SanityImageHotspot;
-						crop?: SanityImageCrop;
-						_type: 'image';
-					};
-					nationality: {
-						_id: string;
-						_type: 'nationality';
-						_createdAt: string;
-						_updatedAt: string;
-						_rev: string;
-						country: string;
-						flag: {
-							asset?: SanityImageAssetReference;
-							media?: unknown;
-							hotspot?: SanityImageHotspot;
-							crop?: SanityImageCrop;
-							_type: 'image';
-						};
-					};
-					bornOn: string | null;
-					bornOnYear: ComputedNumber | null;
-					diedOn: string | null;
-					diedOnYear: ComputedNumber | null;
-					resources: Array<never>;
-				};
 		  }>
 		| Array<never>;
 	highlightedAuthors:
@@ -2978,10 +2711,10 @@ declare module '@sanity/client' {
 		"\n*[_type == 'author' && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    name,\n    image,\n    nationality->,\n    bornOn,\n \t\tbornOnYear,\n    diedOn,\n    diedOnYear,\n    'resources': []\n}|order(name asc)": AuthorsQueryResult;
 		"\n*[_type == 'collection' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    description,\n    featuredImage,\n    'config': { 'showAuthors': coalesce(config.showAuthors, false) },\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'literaryWorks': coalesce(literaryWorks[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        coverImage,\n        totalReadingTime,\n        'sectionCount': count(content),\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),\n        'authors': coalesce(authors[]->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear\n        }, []),\n        // El cuerpo va recortado al primer bloque: la tarjeta lo pinta con line-clamp, as\xED que traer la\n        // secci\xF3n entera transporta la obra completa de cada obra del listado para mostrar dos\n        // renglones. El corte es una **heur\xEDstica de doble salto de l\xEDnea**, no una garant\xEDa de que el\n        // fragmento sea un p\xE1rrafo v\xE1lido: GROQ parte texto, no conoce la gram\xE1tica de Markdown. El\n        // split va anidado porque el contenido puede llegar con CRLF \u2014el corpus del repo lo hace en\n        // Windows\u2014 y ah\xED un corte por doble LF a secas devolver\xEDa el cuerpo entero. Las barras van\n        // dobles porque la query vive en un template literal: una barra sola la consumir\xEDa JavaScript\n        // y GROQ recibir\xEDa un salto de l\xEDnea real dentro de la cadena, que no parsea.\n        //\n        // Se toma el primer bloque **no vac\xEDo**: un cuerpo que arranca con un rengl\xF3n en blanco es\n        // contenido v\xE1lido \u2014nada en el schema lo impide\u2014 y con el \xEDndice pelado dar\xEDa un extracto\n        // vac\xEDo, que el mapper tratar\xEDa como obra mal curada y tumbar\xEDa la colecci\xF3n entera.\n        'excerpt': content[0...1]{\n            _key,\n            title,\n            'body': string::split(string::split(body, \"\\r\\n\\r\\n\")[0], \"\\n\\n\")[@ != \"\"][0]\n        }\n    }, [])\n}[0]": CollectionBySlugQueryResult;
 		"\n*[_type == 'collection' && !(_id in path('drafts.**'))]\n| order(title asc)\n{\n    _id,\n    'slug': slug.current,\n    title,\n    description,\n    featuredImage,\n    'config': { 'showAuthors': coalesce(config.showAuthors, false) },\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'count': coalesce(count(literaryWorks), 0),\n    'literaryWorkCoverImages': coalesce(literaryWorks[0...3]->coverImage, [])\n}": CollectionsQueryResult;
-		"\n*[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{\n    _id,\n    name,\n    'mostReadLiteraryWorks': coalesce(mostReadLiteraryWorks[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        coverImage,\n        totalReadingTime,\n        'sectionCount': count(content),\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),\n        'authors': coalesce(authors[]->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear\n        }, [])\n    },[]),\n    'mostRead': coalesce(mostRead[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        'badLanguage': coalesce(badLanguage, false),\n        'body': [],\n        'originalPublication': coalesce(originalPublication, ''),\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[])\n}": RotatingContentQueryResult;
+		"\n*[_type == 'rotatingContent' && _id == 'rotatingContent'][0]{\n    _id,\n    name,\n    'mostReadLiteraryWorks': coalesce(mostReadLiteraryWorks[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        coverImage,\n        totalReadingTime,\n        'sectionCount': count(content),\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),\n        'authors': coalesce(authors[]->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear\n        }, [])\n    },[])\n}": RotatingContentQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current in $slugs]{\n\t\t_id,\n\t\t'slug': slug.current,\n\t\tconfig,\n}": LandingPageListQueryResult;
 		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && config <= $currentSlug]{\n    _id,\n    _type,\n    'slug': slug.current,\n    config,\n    'cards': coalesce(cards[],[]),\n    'campaigns': coalesce(campaigns[],[]),\n    'latestReads': coalesce(latestReads,[]),\n    'collections': coalesce(collections,[]),\n    'latestLiteraryWorks': coalesce(latestLiteraryWorks,[]),\n    'highlightedAuthors': coalesce(highlightedAuthors,[]),\n} | order(config desc, _createdAt desc)[0]\n": LatestLandingPageReferencesQueryResult;
-		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{\n    _id,\n    'slug': slug.current,\n    config,\n    'collections': coalesce(collections[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        description,\n        featuredImage,\n        'config': { 'showAuthors': coalesce(config.showAuthors, false) },\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'mediaSources': coalesce(mediaSources[]{\n            ...,\n            _type == 'spaceRecording' => {\n                'audioUrl': audioFile.asset->url\n            }\n        }, []),\n        'count': coalesce(count(literaryWorks), 0),\n        'literaryWorkCoverImages': coalesce(literaryWorks[0...3]->coverImage, [])\n    },[]),\n    'latestLiteraryWorks': coalesce(latestLiteraryWorks[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        coverImage,\n        totalReadingTime,\n        'sectionCount': count(content),\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),\n        'authors': coalesce(authors[]->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear\n        }, [])\n    },[]),\n    'cards': coalesce(cards[]->{\n        _id,\n        title,\n        'slug': slug.current,\n        description,\n        featuredImage,\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCoverImages': coalesce(stories[]->coverImage, []),\n        'count': coalesce(count(stories), 0),\n\t\t\t\tconfig,\n\t\t\t\t'tabs': [],\n\t      'mediaSources': coalesce(mediaSources[], []),\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'image': contents.xs.image\n            },\n            'md': {\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'latestReads': coalesce(latestReads[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        'badLanguage': coalesce(badLanguage, false),\n        'body': [],\n        'originalPublication': coalesce(originalPublication, ''),\n        approximateReadingTime,\n        coverImage,\n        'resources': [],\n        'mediaSources': coalesce(mediaSources[], []),\n        'author': author-> { \n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n\t\t\t\t\t\tbornOn,\n\t\t\t\t\t\tbornOnYear,\n\t\t\t\t\t\tdiedOn,\n\t\t\t\t\t\tdiedOnYear,\n            'resources': [],\n        }\n    },[]),\n    'highlightedAuthors': coalesce(highlightedAuthors[]->{\n        'author': {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear,\n            'resources': []\n        },\n        'tags': coalesce(tags[]->{\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCount': count(array::unique(*[\n            !(_id in path('drafts.**')) &&\n            _type in ['story', 'literaryWork'] &&\n            references(^._id)\n        ].slug.current))\n    },[]),\n}": LandingPageContentQueryResult;
+		"\n*[_type == 'landingPage' && !(_id in path('drafts.**')) && slug.current == $slug][0]{\n    _id,\n    'slug': slug.current,\n    config,\n    'collections': coalesce(collections[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        description,\n        featuredImage,\n        'config': { 'showAuthors': coalesce(config.showAuthors, false) },\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'mediaSources': coalesce(mediaSources[]{\n            ...,\n            _type == 'spaceRecording' => {\n                'audioUrl': audioFile.asset->url\n            }\n        }, []),\n        'count': coalesce(count(literaryWorks), 0),\n        'literaryWorkCoverImages': coalesce(literaryWorks[0...3]->coverImage, [])\n    },[]),\n    'campaigns': coalesce(campaigns[]->{\n        _id,\n        'title': coalesce(title, ''),\n        'slug': coalesce(slug.current, ''),\n        'url': coalesce(url, ''),\n        'contents': {\n            'xs': {\n                'image': contents.xs.image\n            },\n            'md': {\n                'image': contents.md.image\n            }\n        }\n    },[]),\n    'latestLiteraryWorks': coalesce(latestLiteraryWorks[]->{\n        _id,\n        'slug': slug.current,\n        title,\n        coverImage,\n        totalReadingTime,\n        'sectionCount': count(content),\n        'tags': coalesce(tags[] -> {\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'mediaSources': coalesce(mediaSources[]{ _type, title }, []),\n        'authors': coalesce(authors[]->{\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear\n        }, [])\n    },[]),\n    'highlightedAuthors': coalesce(highlightedAuthors[]->{\n        'author': {\n            _id,\n            'slug': slug.current,\n            name,\n            image,\n            nationality->,\n            bornOn,\n            bornOnYear,\n            diedOn,\n            diedOnYear,\n            'resources': []\n        },\n        'tags': coalesce(tags[]->{\n            title,\n            'slug': slug.current,\n            description\n        }, []),\n        'storyCount': count(array::unique(*[\n            !(_id in path('drafts.**')) &&\n            _type in ['story', 'literaryWork'] &&\n            references(^._id)\n        ].slug.current))\n    },[]),\n}": LandingPageContentQueryResult;
 		"\n*[_type == 'contributor' && !(_id in path('drafts.**'))]\n{\n\tname,\n\t'slug': slug.current,\n\tarea,\n\tlink {\n\t\thandle,\n\t\turl\n\t},\n\tnotes\n}|order(name asc)\n": AllContributorsQueryResult;
 		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            description\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                description\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'content': coalesce(content[]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }, [])\n}[0]": LiteraryWorkBySlugQueryResult;
 		"\n*[_type == 'literaryWork' && slug.current == $slug && !(_id in path('drafts.**'))]\n{\n    _id,\n    'slug': slug.current,\n    title,\n    coverImage,\n    editorialNote,\n    'badLanguage': coalesce(badLanguage, false),\n    'originalPublication': coalesce(originalPublication, ''),\n    'publishedAt': coalesce(publishedAt, _createdAt),\n    totalReadingTime,\n    'sectionCount': count(content),\n    'tags': coalesce(tags[] -> {\n        title,\n        'slug': slug.current,\n        description\n    }, []),\n    'mediaSources': coalesce(mediaSources[]{\n        ...,\n        _type == 'spaceRecording' => {\n            'audioUrl': audioFile.asset->url\n        }\n    }, []),\n    'resources': coalesce(resources[]{\n        title,\n        url,\n        resourceType->{\n            'slug': slug.current,\n            title,\n            description\n        }\n    }, []),\n    'authors': coalesce(authors[]-> {\n        _id,\n        'slug': slug.current,\n        name,\n        image,\n        nationality->,\n        biography,\n        bornOn,\n        bornOnYear,\n        diedOn,\n        diedOnYear,\n        'resources': coalesce(resources[]{\n            title,\n            url,\n            resourceType->{\n                'slug': slug.current,\n                title,\n                description\n            }\n        }, []),\n        'tags': []\n    }, []),\n    'section': content[$section...$sectionEnd]{\n        _key,\n        title,\n        'epigraphs': coalesce(epigraphs[]{ text, reference }, []),\n        body,\n        readingTime\n    }\n}[0]": LiteraryWorkSectionBySlugQueryResult;


### PR DESCRIPTION
**Slice 6 de 6** de #2266 — el último. Apilado sobre #2384. **Cierra el issue.**

Ya no queda ningún lector de `cards`, `mostRead` ni `latestReads` en su forma de historia y storylist: la página de inicio migró sus tres slots (#2383) y el cron migró su escritura (#2384). Se retiran del dominio, de las queries y de la ACL.

Los dos campos que llevaban sufijo de entidad solo para poder convivir vuelven a llamarse **`mostRead`** y **`latestReads`**, que nombran el rol editorial del slot y no lo que lo llena. `collections` conserva su nombre: `cards` nombraba el componente que lo pintaba.

## Los campos del Studio no se tocan

Siguen declarados, y el generador de semanas los sigue copiando hacia adelante. Mientras un editor pueda cargarlos, dejar de copiarlos vaciaría la landing vieja de las semanas nuevas. Su baja es un PR de limpieza posterior, candidato a acompañar a #2184.

Por eso `LandingPageReferences` —la forma que el generador clona— conserva `cards` y `latestReads` aunque el dominio ya no los exponga: son cosas distintas, y ésta habla de referencias sin resolver.

## Cobertura que se retira con su sujeto

Se van los dos casos que guardaban los `coalesce` de la proyección de *historia* dentro de las queries de contenido, que ya no dereferencian historias, y los dos documentos de escenario que los alimentaban. Lo que queda de esa invariante vive en las dos proyecciones que sí siguen leyendo `story`.

## Documentación

Cierra el scan de impacto: el modelo de dominio publica la forma nueva de `LandingPageContent` y de `RotatingContent`; las estrategias de contenido describen el productor real —dos prefijos de URL, deduplicación y referencias a obras—; y las referencias mueven `content` a la lista de módulos cuyo repository es dueño de su ACL, nombrando el módulo de teaser de colección como lo que sí se comparte entre repositories de aggregate distinto.

## Notas de despliegue — leer antes de mergear la cadena

La migración que puebla los campos nuevos a partir de los viejos **sigue pendiente en todos los datasets**. En `staging` se poblaron a mano los campos de la semana vigente para destrabar el e2e, pero eso no la sustituye: quedan 304 `cards`, 235 `latestReads` y 19 `mostRead` sin contraparte.

**Antes de desplegar a production hay que correrla ahí.** Si el código llega primero, las queries proyectan campos vacíos y la página queda sin colecciones ni destacados.

Al preparar la corrida en `staging` apareció que 4 referencias apuntaban a documentos que ya no existen. Como la referencia derivada es fuerte, el content lake habría rechazado la transacción entera, y **el dry-run no lo detecta**. Conviene sumar esa verificación como paso previo del procedimiento.

## Plan de pruebas

- `typecheck`, `test` (2516 casos), `lint`, `stylelint`, `build` y `check:agents` en verde.
- El árbol final de esta cadena es **idéntico** al de #2375, que ya pasó los once gates de CI, e2e incluido. Lo verifiqué con un diff vacío contra ese commit.

Closes #2266.

Parte de #2265.
