### PR TITLE
[#2373] - Retirar el bloque de tests deshabilitado del spec de la página de inicio

### DIFF
--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,47 +1,11 @@
 import HomeComponent from './home.component';
 import { render, screen } from '@testing-library/angular';
-import { CommonModule, NgForOf, NgIf, NgOptimizedImage } from '@angular/common';
 import { provideRouter } from '@angular/router';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { provideContentApiMock, StubContentApi } from '../../providers/content.mock';
-import { Component, input } from '@angular/core';
-import { Storylist } from '@models/storylist.model';
 import { map, type Observable } from 'rxjs';
 import type { ContentApi } from '../../providers/content.provider';
 import type { HighlightedAuthor, LandingPageContent } from '@models/landing-page-content.model';
 import { onoffHighlightedAuthorsOfLength } from '@mocks/onoff-highlighted-authors.mock';
-
-describe.skip('HomeComponent', () => {
-	const setup = async () => {
-		return await render(HomeComponent, {
-			componentImports: [
-				CommonModule,
-				HttpClientTestingModule,
-				NgForOf,
-				NgIf,
-				NgOptimizedImage,
-				MockStorylistCardDeckComponent,
-			],
-			providers: [provideRouter([]), provideContentApiMock()],
-		});
-	};
-
-	it('should create', async () => {
-		const view = setup();
-		expect(view).toBeTruthy();
-	});
-});
-
-@Component({
-	standalone: true,
-	selector: 'cuentoneta-storylist-card-deck:not(p)',
-	imports: [],
-	template: '',
-})
-class MockStorylistCardDeckComponent {
-	public readonly storylist = input<Storylist>();
-	public readonly isLoading = input<boolean>(false);
-}
 
 // El doble canned del provider entrega la landing vacía; acá solo se le pone contenido a los destacados,
 // que es lo único que esta sección deriva.

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -10,7 +10,7 @@ import { ControllableLayoutService } from '../../providers/layout.mock';
 import type { LandingPageContent } from '@models/landing-page-content.model';
 import { onoffHighlightedAuthorsOfLength } from '@mocks/onoff-highlighted-authors.mock';
 import { onoffStoryNavigationTeasersWithAuthorMock } from '@mocks/onoff-story-teasers.mock';
-import { storylistTeaserRepresentativeMock } from '@mocks/storylist.mock';
+import { storylistTeaserRepresentativeMock, storylistTeaserSampleMock } from '@mocks/storylist.mock';
 import { contentCampaignMock } from '@mocks/content-campaign.mock';
 import { renderDeferBlocks } from '@testing/defer-blocks';
 import { clearAllMocks } from '@test-utils';
@@ -18,10 +18,12 @@ import { clearAllMocks } from '@test-utils';
 // El doble canned del provider entrega la landing vacía; cada caso le superpone solo las secciones
 // que ejercita, para que lo que no declara quede demostrablemente en cero.
 class StubLandingPageContentApi implements ContentApi {
+	private readonly canned = new StubContentApi();
+
 	constructor(private readonly content: Partial<LandingPageContent>) {}
 
 	public getLandingPageContent(): Observable<LandingPageContent> {
-		return new StubContentApi().getLandingPageContent().pipe(map((canned) => ({ ...canned, ...this.content })));
+		return this.canned.getLandingPageContent().pipe(map((canned) => ({ ...canned, ...this.content })));
 	}
 }
 
@@ -70,42 +72,29 @@ describe('HomeComponent', () => {
 			expect(screen.getByRole('heading', { level: 2, name: 'Historias más leídas' })).toBeInTheDocument();
 		});
 
-		// El corpus trae ocho obras, así que el recorte deja fuera dos identificables: sin afirmar cuáles,
-		// el caso pasaría igual si la página recortara por otro criterio.
-		it('should cap the latest reads at six, however many the week brings', async () => {
-			const { fixture } = await renderHome({ latestReads: [...onoffStoryNavigationTeasersWithAuthorMock] });
+		// Afirmar cuáles obras quedaron afuera —y no solo cuántas tarjetas hay— es lo que distingue el
+		// recorte de cualquier otro criterio que devolviera seis. De ahí que el caso empiece exigiendo que
+		// el corpus supere el tope: con uno más corto no habría descarte que observar.
+		describe.each(['latestReads', 'mostRead'] as const)('recorte de %s', (section) => {
+			it('should cap the listing at six, however many the week brings', async () => {
+				expect(onoffStoryNavigationTeasersWithAuthorMock.length).toBeGreaterThan(6);
 
-			await renderDeferBlocks(fixture);
+				const { fixture } = await renderHome({ [section]: [...onoffStoryNavigationTeasersWithAuthorMock] });
 
-			expect(screen.getAllByTestId('card')).toHaveLength(6);
-			onoffStoryNavigationTeasersWithAuthorMock.slice(6).forEach(({ title }) => {
-				expect(screen.queryByText(title)).not.toBeInTheDocument();
-			});
-		});
+				await renderDeferBlocks(fixture);
 
-		it('should cap the most read at six, however many the week brings', async () => {
-			const { fixture } = await renderHome({ mostRead: [...onoffStoryNavigationTeasersWithAuthorMock] });
-
-			await renderDeferBlocks(fixture);
-
-			expect(screen.getAllByTestId('card')).toHaveLength(6);
-			onoffStoryNavigationTeasersWithAuthorMock.slice(6).forEach(({ title }) => {
-				expect(screen.queryByText(title)).not.toBeInTheDocument();
+				expect(screen.getAllByTestId('card')).toHaveLength(6);
+				onoffStoryNavigationTeasersWithAuthorMock.slice(6).forEach(({ title }) => {
+					expect(screen.queryByText(title)).not.toBeInTheDocument();
+				});
 			});
 		});
 	});
 
 	describe('colecciones', () => {
-		// El corpus todavía no deriva teasers de `Storylist` (la landing cruda trae `cards: []`), así que
-		// las variantes salen del mismo mock heredado que usa el spec del mazo.
-		const cards = ['Geometrías del desvelo', 'El palacio de las nueve fronteras'].map((title, index) => ({
-			...storylistTeaserRepresentativeMock,
-			_id: `storylist-mock-${index + 1}`,
-			title,
-			slug: `coleccion-${index + 1}`,
-		}));
+		const cards = [storylistTeaserRepresentativeMock, storylistTeaserSampleMock];
 
-		it('should hand every collection card to the collections deck', async () => {
+		it('should render every collection of the week', async () => {
 			const { fixture } = await renderHome({ cards });
 
 			await renderDeferBlocks(fixture);
@@ -154,6 +143,7 @@ describe('HomeComponent', () => {
 				expect(screen.getByText(author.name)).toBeInTheDocument();
 			});
 		});
+
 		it('should render the section even when the week has no highlighted authors', async () => {
 			await renderHome({ highlightedAuthors: [] });
 
@@ -162,7 +152,9 @@ describe('HomeComponent', () => {
 	});
 
 	// La landing sale vacía mientras la edición no cargó la semana, y es un estado que se sirve: la
-	// página tiene que sostener su estructura sin dibujar contenedores a medio llenar.
+	// página tiene que sostener su estructura sin dibujar contenedores a medio llenar. Los diferidos no
+	// se fuerzan acá a propósito: lo que se afirma es que sus disparadores no disparan sin contenido, y
+	// forzarlos montaría un carrusel de cero diapositivas, un estado que la aplicación no alcanza.
 	describe('semana sin contenido', () => {
 		it('should keep every section heading when the week brings nothing', async () => {
 			await renderHome();
@@ -172,12 +164,12 @@ describe('HomeComponent', () => {
 			});
 		});
 
+		// Las tres clases de tarjeta —historia, colección y autor— se dibujan como `article`, así que la
+		// ausencia de ese rol cubre a las tres a la vez.
 		it('should render neither cards nor a carousel when the week brings nothing', async () => {
-			const { fixture } = await renderHome();
+			await renderHome();
 
-			await renderDeferBlocks(fixture);
-
-			expect(screen.queryAllByTestId('card')).toHaveLength(0);
+			expect(screen.queryAllByRole('article')).toHaveLength(0);
 			expect(screen.queryByRole('region', { name: 'Content campaigns' })).not.toBeInTheDocument();
 		});
 	});

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,47 +1,61 @@
 import HomeComponent from './home.component';
 import { render, screen } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
-import { provideContentApiMock, StubContentApi } from '../../providers/content.mock';
 import { map, type Observable } from 'rxjs';
-import type { ContentApi } from '../../providers/content.provider';
-import type { HighlightedAuthor, LandingPageContent } from '@models/landing-page-content.model';
-import { onoffHighlightedAuthorsOfLength } from '@mocks/onoff-highlighted-authors.mock';
 
-// El doble canned del provider entrega la landing vacía; acá solo se le pone contenido a los destacados,
-// que es lo único que esta sección deriva.
-class StubHighlightedAuthorsContentApi implements ContentApi {
-	constructor(private readonly highlightedAuthors: readonly HighlightedAuthor[]) {}
+import { provideContentApiMock, StubContentApi } from '../../providers/content.mock';
+import type { ContentApi } from '../../providers/content.provider';
+import { LayoutService } from '../../providers/layout.interface';
+import { ControllableLayoutService } from '../../providers/layout.mock';
+import type { LandingPageContent } from '@models/landing-page-content.model';
+import { onoffHighlightedAuthorsOfLength } from '@mocks/onoff-highlighted-authors.mock';
+import { clearAllMocks } from '@test-utils';
+
+// El doble canned del provider entrega la landing vacía; cada caso le superpone solo las secciones
+// que ejercita, para que lo que no declara quede demostrablemente en cero.
+class StubLandingPageContentApi implements ContentApi {
+	constructor(private readonly content: Partial<LandingPageContent>) {}
 
 	public getLandingPageContent(): Observable<LandingPageContent> {
-		return new StubContentApi()
-			.getLandingPageContent()
-			.pipe(map((content) => ({ ...content, highlightedAuthors: this.highlightedAuthors })));
+		return new StubContentApi().getLandingPageContent().pipe(map((canned) => ({ ...canned, ...this.content })));
 	}
 }
 
-describe('HomeComponent — autores destacados', () => {
-	const renderHome = (highlightedAuthors: readonly HighlightedAuthor[]) =>
-		render(HomeComponent, {
-			providers: [provideRouter([]), provideContentApiMock(new StubHighlightedAuthorsContentApi(highlightedAuthors))],
+const renderHome = (content: Partial<LandingPageContent> = {}) =>
+	render(HomeComponent, {
+		providers: [
+			provideRouter([]),
+			provideContentApiMock(new StubLandingPageContentApi(content)),
+			// El carrusel deriva el viewport del layout, y su token no tiene factory: sin el doble,
+			// resolver el diferido de campañas deja el render en un fallo de inyección.
+			{ provide: LayoutService, useClass: ControllableLayoutService },
+		],
+	});
+
+describe('HomeComponent', () => {
+	beforeEach(() => {
+		clearAllMocks();
+	});
+
+	describe('autores destacados', () => {
+		it('should render the highlighted authors section header', async () => {
+			await renderHome({ highlightedAuthors: onoffHighlightedAuthorsOfLength(6) });
+
+			expect(screen.getByRole('heading', { name: 'Autores/as destacados/as', level: 2 })).toBeInTheDocument();
 		});
 
-	it('should render the highlighted authors section header', async () => {
-		await renderHome(onoffHighlightedAuthorsOfLength(6));
+		// La cabecera y su enlace quedan fuera del bloque diferido, así que se renderizan en el HTML servido:
+		// es lo que hace que la home enlace al índice de autores sin depender de que el cliente hidrate.
+		it('should link to the authors index from the home', async () => {
+			await renderHome({ highlightedAuthors: onoffHighlightedAuthorsOfLength(6) });
 
-		expect(screen.getByRole('heading', { name: 'Autores/as destacados/as', level: 2 })).toBeInTheDocument();
-	});
+			expect(screen.getByRole('link', { name: 'Ver todos los autores' })).toHaveAttribute('href', '/authors');
+		});
 
-	// La cabecera y su enlace quedan fuera del bloque diferido, así que se renderizan en el HTML servido:
-	// es lo que hace que la home enlace al índice de autores sin depender de que el cliente hidrate.
-	it('should link to the authors index from the home', async () => {
-		await renderHome(onoffHighlightedAuthorsOfLength(6));
+		it('should render the section even when the week has no highlighted authors', async () => {
+			await renderHome({ highlightedAuthors: [] });
 
-		expect(screen.getByRole('link', { name: 'Ver todos los autores' })).toHaveAttribute('href', '/authors');
-	});
-
-	it('should render the section even when the week has no highlighted authors', async () => {
-		await renderHome([]);
-
-		expect(screen.getByRole('heading', { name: 'Autores/as destacados/as', level: 2 })).toBeInTheDocument();
+			expect(screen.getByRole('heading', { name: 'Autores/as destacados/as', level: 2 })).toBeInTheDocument();
+		});
 	});
 });

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,5 +1,5 @@
 import HomeComponent from './home.component';
-import { render, screen } from '@testing-library/angular';
+import { render, screen, within } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
 import { map, type Observable } from 'rxjs';
 
@@ -9,6 +9,8 @@ import { LayoutService } from '../../providers/layout.interface';
 import { ControllableLayoutService } from '../../providers/layout.mock';
 import type { LandingPageContent } from '@models/landing-page-content.model';
 import { onoffHighlightedAuthorsOfLength } from '@mocks/onoff-highlighted-authors.mock';
+import { onoffStoryNavigationTeasersWithAuthorMock } from '@mocks/onoff-story-teasers.mock';
+import { renderDeferBlocks } from '@testing/defer-blocks';
 import { clearAllMocks } from '@test-utils';
 
 // El doble canned del provider entrega la landing vacía; cada caso le superpone solo las secciones
@@ -35,6 +37,36 @@ const renderHome = (content: Partial<LandingPageContent> = {}) =>
 describe('HomeComponent', () => {
 	beforeEach(() => {
 		clearAllMocks();
+	});
+
+	describe('mazos de historias', () => {
+		// Rebanadas disjuntas del corpus: es lo que permite afirmar cuál de los dos listados llegó a cada
+		// mazo, y no solo cuántas tarjetas hay en total.
+		const latestReads = onoffStoryNavigationTeasersWithAuthorMock.slice(0, 3);
+		const mostRead = onoffStoryNavigationTeasersWithAuthorMock.slice(3, 6);
+
+		// Los dos mazos marcan sus tarjetas con el mismo `card`, así que el discriminante es el orden de
+		// documento: el de novedades precede al de más leídas en la plantilla, que es el orden de lectura.
+		it('should hand each listing to its own deck', async () => {
+			const { fixture } = await renderHome({ latestReads, mostRead });
+
+			await renderDeferBlocks(fixture);
+
+			const cards = screen.getAllByTestId('card');
+			expect(cards).toHaveLength(latestReads.length + mostRead.length);
+			[...latestReads, ...mostRead].forEach((story, index) => {
+				expect(within(cards[index]).getByText(story.title)).toBeInTheDocument();
+			});
+		});
+
+		// Las cabeceras quedan fuera de los bloques diferidos: son lo que la página lleva servido aunque
+		// las tarjetas todavía no se hayan resuelto.
+		it('should render both deck headings from the very first render', async () => {
+			await renderHome({ latestReads, mostRead });
+
+			expect(screen.getByRole('heading', { level: 2, name: 'Últimas novedades' })).toBeInTheDocument();
+			expect(screen.getByRole('heading', { level: 2, name: 'Historias más leídas' })).toBeInTheDocument();
+		});
 	});
 
 	describe('autores destacados', () => {

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -67,6 +67,30 @@ describe('HomeComponent', () => {
 			expect(screen.getByRole('heading', { level: 2, name: 'Últimas novedades' })).toBeInTheDocument();
 			expect(screen.getByRole('heading', { level: 2, name: 'Historias más leídas' })).toBeInTheDocument();
 		});
+
+		// El corpus trae ocho obras, así que el recorte deja fuera dos identificables: sin afirmar cuáles,
+		// el caso pasaría igual si la página recortara por otro criterio.
+		it('should cap the latest reads at six, however many the week brings', async () => {
+			const { fixture } = await renderHome({ latestReads: [...onoffStoryNavigationTeasersWithAuthorMock] });
+
+			await renderDeferBlocks(fixture);
+
+			expect(screen.getAllByTestId('card')).toHaveLength(6);
+			onoffStoryNavigationTeasersWithAuthorMock.slice(6).forEach(({ title }) => {
+				expect(screen.queryByText(title)).not.toBeInTheDocument();
+			});
+		});
+
+		it('should cap the most read at six, however many the week brings', async () => {
+			const { fixture } = await renderHome({ mostRead: [...onoffStoryNavigationTeasersWithAuthorMock] });
+
+			await renderDeferBlocks(fixture);
+
+			expect(screen.getAllByTestId('card')).toHaveLength(6);
+			onoffStoryNavigationTeasersWithAuthorMock.slice(6).forEach(({ title }) => {
+				expect(screen.queryByText(title)).not.toBeInTheDocument();
+			});
+		});
 	});
 
 	describe('autores destacados', () => {

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -10,6 +10,8 @@ import { ControllableLayoutService } from '../../providers/layout.mock';
 import type { LandingPageContent } from '@models/landing-page-content.model';
 import { onoffHighlightedAuthorsOfLength } from '@mocks/onoff-highlighted-authors.mock';
 import { onoffStoryNavigationTeasersWithAuthorMock } from '@mocks/onoff-story-teasers.mock';
+import { storylistTeaserRepresentativeMock } from '@mocks/storylist.mock';
+import { contentCampaignMock } from '@mocks/content-campaign.mock';
 import { renderDeferBlocks } from '@testing/defer-blocks';
 import { clearAllMocks } from '@test-utils';
 
@@ -93,6 +95,40 @@ describe('HomeComponent', () => {
 		});
 	});
 
+	describe('colecciones', () => {
+		// El corpus todavía no deriva teasers de `Storylist` (la landing cruda trae `cards: []`), así que
+		// las variantes salen del mismo mock heredado que usa el spec del mazo.
+		const cards = ['Geometrías del desvelo', 'El palacio de las nueve fronteras'].map((title, index) => ({
+			...storylistTeaserRepresentativeMock,
+			_id: `storylist-mock-${index + 1}`,
+			title,
+			slug: `coleccion-${index + 1}`,
+		}));
+
+		it('should hand every collection card to the collections deck', async () => {
+			const { fixture } = await renderHome({ cards });
+
+			await renderDeferBlocks(fixture);
+
+			cards.forEach(({ title }) => {
+				expect(screen.getByText(title)).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe('campañas', () => {
+		it('should hand the campaigns of the week to the carousel', async () => {
+			const [firstCampaign] = contentCampaignMock;
+			const { fixture } = await renderHome({ campaigns: contentCampaignMock });
+
+			await renderDeferBlocks(fixture);
+
+			expect(screen.getByRole('region', { name: 'Content campaigns' })).toBeInTheDocument();
+			// El carrusel dibuja solo la diapositiva activa, así que la campaña observable es la primera.
+			expect(screen.getByAltText(`Imagen de la campaña de contenido ${firstCampaign.title}`)).toBeInTheDocument();
+		});
+	});
+
 	describe('autores destacados', () => {
 		it('should render the highlighted authors section header', async () => {
 			await renderHome({ highlightedAuthors: onoffHighlightedAuthorsOfLength(6) });
@@ -108,6 +144,16 @@ describe('HomeComponent', () => {
 			expect(screen.getByRole('link', { name: 'Ver todos los autores' })).toHaveAttribute('href', '/authors');
 		});
 
+		it('should hand every highlighted author to the grid', async () => {
+			const highlightedAuthors = onoffHighlightedAuthorsOfLength(6);
+			const { fixture } = await renderHome({ highlightedAuthors });
+
+			await renderDeferBlocks(fixture);
+
+			highlightedAuthors.forEach(({ author }) => {
+				expect(screen.getByText(author.name)).toBeInTheDocument();
+			});
+		});
 		it('should render the section even when the week has no highlighted authors', async () => {
 			await renderHome({ highlightedAuthors: [] });
 

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -160,4 +160,25 @@ describe('HomeComponent', () => {
 			expect(screen.getByRole('heading', { name: 'Autores/as destacados/as', level: 2 })).toBeInTheDocument();
 		});
 	});
+
+	// La landing sale vacía mientras la edición no cargó la semana, y es un estado que se sirve: la
+	// página tiene que sostener su estructura sin dibujar contenedores a medio llenar.
+	describe('semana sin contenido', () => {
+		it('should keep every section heading when the week brings nothing', async () => {
+			await renderHome();
+
+			['Últimas novedades', 'Historias más leídas', 'Colecciones', 'Autores/as destacados/as'].forEach((name) => {
+				expect(screen.getByRole('heading', { level: 2, name })).toBeInTheDocument();
+			});
+		});
+
+		it('should render neither cards nor a carousel when the week brings nothing', async () => {
+			const { fixture } = await renderHome();
+
+			await renderDeferBlocks(fixture);
+
+			expect(screen.queryAllByTestId('card')).toHaveLength(0);
+			expect(screen.queryByRole('region', { name: 'Content campaigns' })).not.toBeInTheDocument();
+		});
+	});
 });


### PR DESCRIPTION
El spec de la página de inicio arrastraba un bloque `describe.skip` que no cubría nada y que no podía volver a habilitarse tal como estaba: montaba un componente de prueba con el selector `cuentoneta-storylist-card-deck`, que ya no existe en la aplicación; declaraba imports que la página no usa; y su único caso afirmaba sobre el resultado sin `await` de una función async, así que habría pasado con cualquier componente, incluso uno que lanzara al renderizar. Al estar salteado, ningún gate lo señalaba: el costo era de lectura, no de ejecución.

Este PR lo retira y, como pide el alcance del issue, deja en su lugar cobertura real del cableado que la página hace hoy.

## Qué cambia

- Se elimina el `describe.skip`, el componente de prueba huérfano y los imports que quedaban muertos.
- El doble del contenido de la landing se generaliza: en vez de una clase por sección, `StubLandingPageContentApi` superpone un `Partial<LandingPageContent>` sobre el canned de `StubContentApi`, y un único helper de render lo cablea junto al doble de `LayoutService` que el carrusel necesita para no romper por inyección al resolver su diferido.
- Se suma la cobertura que faltaba, sobre lo que la persona lectora ve tras resolver los bloques diferidos con el helper canónico `renderDeferBlocks`:
  - **Mazos de historias:** las dos rebanadas disjuntas del corpus llegan cada una a su mazo (novedades y más leídas), y las cabeceras están desde el primer render.
  - **Recorte a seis:** cada listado se recorta a seis y las obras que quedan afuera no se renderizan. El caso empieza afirmando que el corpus supera el tope, para que un corpus más corto no lo deje pasar en verde sin ejercitar el descarte.
  - **Colecciones, campañas y destacados:** cada porción del contenido llega a su componente.
  - **Semana sin contenido:** las cuatro cabeceras se sostienen, no hay tarjetas y no se dibuja un carrusel. Este caso no fuerza los diferidos a propósito: lo que afirma es que sus disparadores no disparan sin contenido.

Lo que dibuja cada mazo —su `@defer`, su esqueleto y sus enlaces— ya lo cubren los specs de los componentes; el spec de página afirma el cableado y no lo repite.

## Plan de pruebas

- `pnpm test` — suite completa verde: 204 archivos, 2476 tests. El spec de la home pasa de 3 casos a 12.
- `pnpm exec tsc -p tsconfig.typecheck.json --noEmit`, `pnpm lint`, `pnpm stylelint`, `pnpm check:agents` — verdes en local.
- Los once gates de CI, verdes sobre el commit final.
- Verificación de los criterios de aceptación: el archivo no contiene `describe.skip` ni `it.skip`, no queda ningún componente de prueba declarado en él, y ninguna aserción opera sobre una promesa sin resolver (todo `render`/`renderDeferBlocks` va con `await`).

Closes #2373
