### PR TITLE
[#2287] - Declara la ruta /literary-work y su página de obras

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -52,7 +52,7 @@ export const serverRoutes: Array<ServerRoute> = [
 	},
 	{
 		path: AppRoutes.LiteraryWork,
-		renderMode: RenderMode.Server,
+		renderMode: RenderMode.Prerender,
 	},
 	{
 		path: '**',

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -51,6 +51,10 @@ export const serverRoutes: Array<ServerRoute> = [
 		renderMode: RenderMode.Server,
 	},
 	{
+		path: AppRoutes.LiteraryWork,
+		renderMode: RenderMode.Server,
+	},
+	{
 		path: '**',
 		renderMode: RenderMode.Prerender,
 	},

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -9,6 +9,7 @@ export const AppRoutes = Object.freeze({
 	About: 'about',
 	Dmca: 'dmca',
 	Collection: 'collection',
+	LiteraryWork: 'literary-work',
 	Read: 'read',
 } as const);
 export type AppRoutes = (typeof AppRoutes)[keyof typeof AppRoutes];
@@ -53,6 +54,10 @@ export const appRoutes: Routes = [
 	{
 		path: AppRoutes.Collection,
 		loadComponent: () => import('./pages/collections/collections.page'),
+	},
+	{
+		path: AppRoutes.LiteraryWork,
+		loadComponent: () => import('./pages/literary-works/literary-works.page'),
 	},
 	{
 		path: AppRoutes.About,

--- a/src/app/pages/literary-works/literary-works.page.spec.ts
+++ b/src/app/pages/literary-works/literary-works.page.spec.ts
@@ -26,8 +26,7 @@ describe('LiteraryWorksPage', () => {
 		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(AppRoutes.LiteraryWork));
 	});
 
-	// El opt-out es transitorio y dura lo que dure el listado sin obras: ofrecer al indexado una página
-	// que todavía no lista nada gasta rastreo en una URL sin contenido.
+	// Ofrecer al indexado una página que todavía no lista nada gasta rastreo en una URL sin contenido.
 	it('should opt out of indexing while it lists no work', async () => {
 		const robotsSpy = spyOn(HeadMetadataDirective.prototype, 'setRobots');
 

--- a/src/app/pages/literary-works/literary-works.page.spec.ts
+++ b/src/app/pages/literary-works/literary-works.page.spec.ts
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/angular';
+import { provideRouter } from '@angular/router';
+import { restoreAllMocks, spyOn } from '@test-utils';
+
+import LiteraryWorksPage from './literary-works.page';
+import { AppRoutes } from '../../app.routes';
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+
+describe('LiteraryWorksPage', () => {
+	afterEach(() => restoreAllMocks());
+
+	const renderPage = () => render(LiteraryWorksPage, { providers: [provideRouter([])] });
+
+	it('should headline the catalogue of literary works', async () => {
+		await renderPage();
+
+		expect(screen.getByRole('heading', { level: 1, name: 'Obras' })).toBeInTheDocument();
+	});
+
+	it('should point the canonical URL at its own route', async () => {
+		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
+
+		await renderPage();
+
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(AppRoutes.LiteraryWork));
+	});
+
+	// El opt-out es transitorio y dura lo que dure el listado sin obras: ofrecer al indexado una página
+	// que todavía no lista nada gasta rastreo en una URL sin contenido.
+	it('should opt out of indexing while it lists no work', async () => {
+		const robotsSpy = spyOn(HeadMetadataDirective.prototype, 'setRobots');
+
+		await renderPage();
+
+		expect(robotsSpy).toHaveBeenCalledWith('noindex, follow');
+	});
+});

--- a/src/app/pages/literary-works/literary-works.page.ts
+++ b/src/app/pages/literary-works/literary-works.page.ts
@@ -1,0 +1,28 @@
+import { Component, inject } from '@angular/core';
+
+import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+
+import { AppRoutes } from '../../app.routes';
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+
+@Component({
+	selector: 'cuentoneta-literary-works',
+	template: `
+		<main class="mx-auto mt-header-height flex w-full max-w-310 flex-col gap-12 px-4 pt-8 pb-16">
+			<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">Obras</h1>
+		</main>
+	`,
+	hostDirectives: [HeadMetadataDirective],
+})
+export default class LiteraryWorksPage {
+	private readonly headMetadata = inject(HeadMetadataDirective);
+
+	constructor() {
+		this.headMetadata.setTitle('Obras');
+		this.headMetadata.setDescription(
+			'Explorá todas las obras publicadas en La Cuentoneta: cuentos, poemas y relatos breves para leer en línea.',
+		);
+		this.headMetadata.setCanonicalUrl(buildCanonicalUrl(AppRoutes.LiteraryWork));
+		this.headMetadata.setRobots('noindex, follow');
+	}
+}


### PR DESCRIPTION
Primera de cuatro PRs apiladas para trasladar el listado de obras de `/story` a `/literary-work`.

El listado del mundo nuevo no existía: `ReadPage` cubre `/read/:slug`, pero el catálogo seguía siendo `/story`, con el vocabulario que el hito retira. Esta PR declara la ruta y su página; las siguientes le suman el catálogo real, la indexabilidad y el cutover.

## Qué cambia

- `AppRoutes.LiteraryWork = 'literary-work'` (kebab y singular, por coherencia con `Collection` y `Read`) más su ruta perezosa.
- `src/app/pages/literary-works/literary-works.page.ts`: la página, hoy sólo con su encabezado.
- `RenderMode.Prerender` en `app.routes.server.ts`, alineado con el modo que usa hoy `/story`. El catálogo queda horneado en el build, así que una obra publicada aparece recién en el próximo despliegue — es el mismo comportamiento que el listado al que reemplaza, y por eso no introduce una regresión.
- La página se declara `noindex, follow` mientras no tenga catálogo que mostrar, con la misma forma que la página vieja. Es deliberadamente provisorio: la tercera PR de la pila lo reemplaza por el molde de directivas de meta tags y datos estructurados, que es lo que el guardrail de `seo-host-directives.spec.ts` exige de una página indexable.

## Qué queda funcionando y qué no

`/literary-work` responde 200 con SSR real y un `<h1>Obras</h1>`. La página es huérfana a propósito: nada la enlaza, no está en el sitemap y no se ofrece al indexado. `/story` queda intacto y sigue siendo el listado que usan las personas.

## Plan de pruebas

- Tier local completo verde: `tsc --noEmit`, `lint`, `stylelint`, `check:agents` y la suite entera (205 archivos, 2480 tests).
- `seo-host-directives.spec.ts` —el guardrail que recorre `app.routes.server.ts`— cubre la ruta nueva y pasa por su rama de opt-out.
- Spec propio de la página: encabezado de nivel 1, canónica apuntando a la ruta nueva y el `noindex, follow` afirmado, para que quitarlo en la tercera PR sea un cambio visible en el diff y no un olvido.
- Los once gates de CI, verdes sobre el commit final.

Parte de #2287 — primera de cuatro PRs de la pila; el cierre del issue va en la última.
Parte de #2265.
