### PR TITLE
[#2287] - Sirve el catálogo de obras en /literary-work

### DIFF
--- a/src/app/pages/literary-works/literary-works.page.spec.ts
+++ b/src/app/pages/literary-works/literary-works.page.spec.ts
@@ -116,19 +116,13 @@ describe('LiteraryWorksPage', () => {
 		expect(screen.queryByTestId('catalog-error')).not.toBeInTheDocument();
 	});
 
-	// El esqueleto decide su estructura por los mismos flags de presentación que la tarjeta: la fila de
-	// autoría, las líneas del extracto y los selectores de multimedia son ramas condicionales suyas. Si el
-	// listado no se los pasa en la rama de carga, el esqueleto queda tres bloques más corto que la tarjeta
-	// que reemplaza y la lista salta de alto al resolver. Cada aserción marca uno de los tres bloques por
-	// la forma que sólo él dibuja, en vez de contra un total que caducaría al cambiar el diseño.
-	it('should give the placeholder the same blocks the resolved card carries', async () => {
+	// La fila de carga y la fila resuelta comparten la tabla, así que tienen que declarar las mismas
+	// celdas: una fila corta desalinea las columnas y mueve el encabezado al resolver.
+	it('should give the placeholder row the same cells a resolved row carries', async () => {
 		await renderPage(new PendingLiteraryWorkApi());
 
 		const [placeholder] = screen.getAllByTestId('skeleton');
-		const bars = within(placeholder).getAllByRole('status');
-		expect(bars.filter((bar) => bar.classList.contains('rounded-full'))).not.toHaveLength(0);
-		expect(bars.filter((bar) => bar.classList.contains('w-3/4'))).not.toHaveLength(0);
-		expect(bars.filter((bar) => bar.classList.contains('rounded-lg'))).not.toHaveLength(0);
+		expect(within(placeholder).getAllByRole('cell')).toHaveLength(3);
 	});
 
 	// Anunciar un conteo mientras carga o tras un fallo afirmaría que no hay obras.
@@ -136,6 +130,37 @@ describe('LiteraryWorksPage', () => {
 		await renderPage(new PendingLiteraryWorkApi());
 
 		expect(screen.getByRole('heading', { level: 1, name: 'Obras' })).toBeInTheDocument();
+	});
+
+	// La tabla es el andamio de las dos ramas, así que su encabezado se sirve desde el primer render.
+	it('should keep the column headers while the catalogue loads', async () => {
+		await renderPage(new PendingLiteraryWorkApi());
+
+		['Título', 'Autor', 'Tiempo de lectura'].forEach((name) => {
+			expect(screen.getByRole('columnheader', { name })).toBeInTheDocument();
+		});
+	});
+
+	it('should send every author of the catalogue to their profile', async () => {
+		await renderPage();
+
+		const hrefs = within(screen.getByTestId('literary-works'))
+			.getAllByRole('link')
+			.map((link) => link.getAttribute('href'));
+		onoffLiteraryWorkTeasersMock.forEach(({ authors }) => {
+			authors.forEach(({ slug }) => {
+				expect(hrefs).toContain(`/author/${slug}`);
+			});
+		});
+	});
+
+	it('should list the reading time of every work', async () => {
+		await renderPage();
+
+		const listing = within(screen.getByTestId('literary-works'));
+		onoffLiteraryWorkTeasersMock.forEach(({ totalReadingTime }) => {
+			expect(listing.getAllByText(`${totalReadingTime} min`).length).toBeGreaterThan(0);
+		});
 	});
 
 	it('should tell the reader when the catalogue fails to load', async () => {

--- a/src/app/pages/literary-works/literary-works.page.spec.ts
+++ b/src/app/pages/literary-works/literary-works.page.spec.ts
@@ -11,6 +11,7 @@ import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
 import type { LiteraryWorkApi } from '../../providers/literary-work.provider';
 import { provideLiteraryWorkApiMock, StubLiteraryWorkApi } from '../../providers/literary-work.mock';
 import type { LiteraryWork, LiteraryWorkTeaser } from '@models/literary-work.model';
+import { createSlug } from '@models/slug.model';
 import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
 import { onoffLiteraryWorkTeasersMock } from '@mocks/onoff-literary-work-teasers.mock';
 
@@ -29,7 +30,11 @@ const [canonicalTeaser] = onoffLiteraryWorkTeasersMock;
 
 const stubbing = (teasers: readonly LiteraryWorkTeaser[]) => new StubLiteraryWorkApi(canonicalWork, teasers);
 
-const withTitle = (title: string, slug: string): LiteraryWorkTeaser => ({ ...canonicalTeaser, title, slug });
+const withTitle = (title: string, slug: string): LiteraryWorkTeaser => ({
+	...canonicalTeaser,
+	title,
+	slug: createSlug(slug),
+});
 
 // Cada tarjeta enlaza dos destinos —la obra y su autoría—; el del listado es el que lleva a la lectura.
 const readingHrefs = () =>

--- a/src/app/pages/literary-works/literary-works.page.spec.ts
+++ b/src/app/pages/literary-works/literary-works.page.spec.ts
@@ -1,21 +1,99 @@
-import { render, screen } from '@testing-library/angular';
+import { render, screen, within } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
+import { RESPONSE_INIT } from '@angular/core';
+import { Observable, throwError } from 'rxjs';
 import { restoreAllMocks, spyOn } from '@test-utils';
 
 import LiteraryWorksPage from './literary-works.page';
 import { AppRoutes } from '../../app.routes';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+import type { LiteraryWorkApi } from '../../providers/literary-work.provider';
+import { provideLiteraryWorkApiMock, StubLiteraryWorkApi } from '../../providers/literary-work.mock';
+import type { LiteraryWork, LiteraryWorkTeaser } from '@models/literary-work.model';
+import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
+import { onoffLiteraryWorkTeasersMock } from '@mocks/onoff-literary-work-teasers.mock';
+
+class FailingLiteraryWorkApi implements LiteraryWorkApi {
+	public getBySlug(): Observable<LiteraryWork> {
+		return throwError(() => new Error('sin catálogo'));
+	}
+
+	public getTeasers(): Observable<LiteraryWorkTeaser[]> {
+		return throwError(() => new Error('sin catálogo'));
+	}
+}
+
+const [canonicalWork] = onoffLiteraryWorksMock;
+const [canonicalTeaser] = onoffLiteraryWorkTeasersMock;
+
+const stubbing = (teasers: readonly LiteraryWorkTeaser[]) => new StubLiteraryWorkApi(canonicalWork, teasers);
+
+const withTitle = (title: string, slug: string): LiteraryWorkTeaser => ({ ...canonicalTeaser, title, slug });
+
+// Cada tarjeta enlaza dos destinos —la obra y su autoría—; el del listado es el que lleva a la lectura.
+const readingHrefs = () =>
+	within(screen.getByTestId('literary-works'))
+		.getAllByRole('link')
+		.map((link) => link.getAttribute('href'))
+		.filter((href) => href?.startsWith('/read/'));
 
 describe('LiteraryWorksPage', () => {
 	afterEach(() => restoreAllMocks());
 
-	const renderPage = () => render(LiteraryWorksPage, { providers: [provideRouter([])] });
+	const renderPage = (api: LiteraryWorkApi = stubbing(onoffLiteraryWorkTeasersMock)) =>
+		render(LiteraryWorksPage, { providers: [provideRouter([]), provideLiteraryWorkApiMock(api)] });
 
-	it('should headline the catalogue of literary works', async () => {
+	it('should headline the catalogue with how many works it lists', async () => {
 		await renderPage();
 
-		expect(screen.getByRole('heading', { level: 1, name: 'Obras' })).toBeInTheDocument();
+		expect(
+			screen.getByRole('heading', { level: 1, name: `${onoffLiteraryWorkTeasersMock.length} Obras` }),
+		).toBeInTheDocument();
+	});
+
+	it('should put the count in singular when the catalogue lists one work', async () => {
+		await renderPage(stubbing([canonicalTeaser]));
+
+		expect(screen.getByRole('heading', { level: 1, name: '1 Obra' })).toBeInTheDocument();
+	});
+
+	it('should send every work of the catalogue to its reading page', async () => {
+		await renderPage();
+
+		const hrefs = readingHrefs();
+		expect(hrefs).toHaveLength(onoffLiteraryWorkTeasersMock.length);
+		onoffLiteraryWorkTeasersMock.forEach(({ slug }) => {
+			expect(hrefs).toContain(`/read/${slug}`);
+		});
+	});
+
+	// La colación de la query pondría `Ámbar` detrás de `Zoológico`.
+	it('should order titles with accent folding, not by code point', async () => {
+		const desordenadas = [
+			withTitle('Zoológico', 'zoologico'),
+			withTitle('Ámbar', 'ambar'),
+			withTitle('Bruma', 'bruma'),
+		];
+
+		await renderPage(stubbing(desordenadas));
+
+		expect(readingHrefs()).toEqual(['/read/ambar', '/read/bruma', '/read/zoologico']);
+	});
+
+	it('should say the catalogue is empty instead of showing placeholders', async () => {
+		const { container } = await renderPage(stubbing([]));
+
+		expect(screen.getByTestId('catalog-empty')).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- el esqueleto no expone rol ni texto: la ausencia solo se afirma por selector
+		expect(container.querySelector('cuentoneta-literary-work-card-teaser-skeleton')).toBeNull();
+	});
+
+	it('should tell the reader when the catalogue fails to load', async () => {
+		await renderPage(new FailingLiteraryWorkApi());
+
+		expect(screen.getByTestId('catalog-error')).toBeInTheDocument();
+		expect(screen.queryByTestId('literary-works')).not.toBeInTheDocument();
 	});
 
 	it('should point the canonical URL at its own route', async () => {
@@ -33,5 +111,32 @@ describe('LiteraryWorksPage', () => {
 		await renderPage();
 
 		expect(robotsSpy).toHaveBeenCalledWith('noindex, follow');
+	});
+
+	describe('código de respuesta', () => {
+		const renderWithResponseInit = (api: LiteraryWorkApi, responseInit: { status?: number }) =>
+			render(LiteraryWorksPage, {
+				providers: [
+					provideRouter([]),
+					provideLiteraryWorkApiMock(api),
+					{ provide: RESPONSE_INIT, useValue: responseInit },
+				],
+			});
+
+		it('should respond 503 when the catalogue fails', async () => {
+			const responseInit: { status?: number } = {};
+
+			await renderWithResponseInit(new FailingLiteraryWorkApi(), responseInit);
+
+			expect(responseInit.status).toBe(503);
+		});
+
+		it('should leave the status untouched when the catalogue resolves', async () => {
+			const responseInit: { status?: number } = {};
+
+			await renderWithResponseInit(stubbing(onoffLiteraryWorkTeasersMock), responseInit);
+
+			expect(responseInit.status).toBeUndefined();
+		});
 	});
 });

--- a/src/app/pages/literary-works/literary-works.page.spec.ts
+++ b/src/app/pages/literary-works/literary-works.page.spec.ts
@@ -1,8 +1,8 @@
 import { render, screen, within } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
 import { RESPONSE_INIT } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
-import { restoreAllMocks, spyOn } from '@test-utils';
+import { NEVER, Observable, throwError } from 'rxjs';
+import { clearAllMocks, restoreAllMocks, spyOn } from '@test-utils';
 
 import LiteraryWorksPage from './literary-works.page';
 import { AppRoutes } from '../../app.routes';
@@ -25,6 +25,18 @@ class FailingLiteraryWorkApi implements LiteraryWorkApi {
 	}
 }
 
+// Retener la emisión es la única forma de sostener el estado de carga a la vista: el recurso queda
+// pendiente y la página no llega a resolver ninguna de las otras tres ramas.
+class PendingLiteraryWorkApi implements LiteraryWorkApi {
+	public getBySlug(): Observable<LiteraryWork> {
+		return NEVER;
+	}
+
+	public getTeasers(): Observable<LiteraryWorkTeaser[]> {
+		return NEVER;
+	}
+}
+
 const [canonicalWork] = onoffLiteraryWorksMock;
 const [canonicalTeaser] = onoffLiteraryWorkTeasersMock;
 
@@ -44,6 +56,8 @@ const readingHrefs = () =>
 		.filter((href) => href?.startsWith('/read/'));
 
 describe('LiteraryWorksPage', () => {
+	beforeEach(() => clearAllMocks());
+
 	afterEach(() => restoreAllMocks());
 
 	const renderPage = (api: LiteraryWorkApi = stubbing(onoffLiteraryWorkTeasersMock)) =>
@@ -87,11 +101,41 @@ describe('LiteraryWorksPage', () => {
 	});
 
 	it('should say the catalogue is empty instead of showing placeholders', async () => {
-		const { container } = await renderPage(stubbing([]));
+		await renderPage(stubbing([]));
 
 		expect(screen.getByTestId('catalog-empty')).toBeInTheDocument();
-		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- el esqueleto no expone rol ni texto: la ausencia solo se afirma por selector
-		expect(container.querySelector('cuentoneta-literary-work-card-teaser-skeleton')).toBeNull();
+		expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument();
+	});
+
+	it('should stand in for the catalogue while it loads, and for nothing else', async () => {
+		await renderPage(new PendingLiteraryWorkApi());
+
+		expect(screen.getAllByTestId('skeleton')).toHaveLength(4);
+		expect(screen.queryByTestId('literary-works')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('catalog-empty')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('catalog-error')).not.toBeInTheDocument();
+	});
+
+	// El esqueleto decide su estructura por los mismos flags de presentación que la tarjeta: la fila de
+	// autoría, las líneas del extracto y los selectores de multimedia son ramas condicionales suyas. Si el
+	// listado no se los pasa en la rama de carga, el esqueleto queda tres bloques más corto que la tarjeta
+	// que reemplaza y la lista salta de alto al resolver. Cada aserción marca uno de los tres bloques por
+	// la forma que sólo él dibuja, en vez de contra un total que caducaría al cambiar el diseño.
+	it('should give the placeholder the same blocks the resolved card carries', async () => {
+		await renderPage(new PendingLiteraryWorkApi());
+
+		const [placeholder] = screen.getAllByTestId('skeleton');
+		const bars = within(placeholder).getAllByRole('status');
+		expect(bars.filter((bar) => bar.classList.contains('rounded-full'))).not.toHaveLength(0);
+		expect(bars.filter((bar) => bar.classList.contains('w-3/4'))).not.toHaveLength(0);
+		expect(bars.filter((bar) => bar.classList.contains('rounded-lg'))).not.toHaveLength(0);
+	});
+
+	// Anunciar un conteo mientras carga o tras un fallo afirmaría que no hay obras.
+	it('should withhold the count until the catalogue resolves', async () => {
+		await renderPage(new PendingLiteraryWorkApi());
+
+		expect(screen.getByRole('heading', { level: 1, name: 'Obras' })).toBeInTheDocument();
 	});
 
 	it('should tell the reader when the catalogue fails to load', async () => {
@@ -99,6 +143,7 @@ describe('LiteraryWorksPage', () => {
 
 		expect(screen.getByTestId('catalog-error')).toBeInTheDocument();
 		expect(screen.queryByTestId('literary-works')).not.toBeInTheDocument();
+		expect(screen.getByRole('heading', { level: 1, name: 'Obras' })).toBeInTheDocument();
 	});
 
 	it('should point the canonical URL at its own route', async () => {

--- a/src/app/pages/literary-works/literary-works.page.stories.ts
+++ b/src/app/pages/literary-works/literary-works.page.stories.ts
@@ -62,7 +62,7 @@ const meta: Meta<LiteraryWorksPageArgs> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>El catálogo de obras, <strong>LiteraryWorksPage</strong>, montado sobre el corpus de Onoff. Como el resto de las entradas bajo <strong>Páginas</strong>, no cataloga un componente sino el ensamblado completo: el encabezado con el conteo y la lista de tarjetas que llevan a la lectura.</p><p>El único control elige el escenario del catálogo, que es lo único que mueve la página desde afuera: no recibe parámetros de ruta ni tiene estado propio.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-literaryworkcardteaser--docs" target="_top"><strong>LiteraryWorkCardTeaser</strong></a>, la misma tarjeta que enlaza a <a href="./?path=/docs/páginas-readpage--docs" target="_top"><strong>ReadPage</strong></a>, y de su esqueleto.</p><p>El orden no es el que entrega el backend: se resuelve en la página con colación en español, porque la base compara por punto de código y mandaría al final del catálogo todo título que empiece con acento o eñe.</p><p>El encabezado fijo de la aplicación no se monta en el catálogo, así que el margen superior de la página se ve como espacio en blanco.</p></div>`,
+				component: `<div><p>El catálogo de obras, <strong>LiteraryWorksPage</strong>, montado sobre el corpus de Onoff. Como el resto de las entradas bajo <strong>Páginas</strong>, no cataloga un componente sino el ensamblado completo: el encabezado con el conteo y la lista de tarjetas que llevan a la lectura.</p><p>El único control elige el escenario del catálogo, que es lo único que mueve la página desde afuera: no recibe parámetros de ruta ni tiene estado propio.</p><p>Se compone de una sola pieza: <a href="./?path=/docs/componentes-v3-literaryworkcardteaser--docs" target="_top"><strong>LiteraryWorkCardTeaser</strong></a>, la misma tarjeta que enlaza a <a href="./?path=/docs/páginas-readpage--docs" target="_top"><strong>ReadPage</strong></a>. El esqueleto no lo monta el listado sino la propia tarjeta, cuando no recibe obra; por eso la rama de carga le pasa los mismos flags de presentación que la rama real, que es lo que hace que las dos ocupen el mismo alto.</p><p>El orden no es el que entrega el backend: se resuelve en la página con colación en español, porque la base compara por punto de código y mandaría al final del catálogo todo título que empiece con acento o eñe.</p><p>El encabezado fijo de la aplicación no se monta en el catálogo, así que el margen superior de la página se ve como espacio en blanco.</p></div>`,
 			},
 		},
 	},
@@ -95,7 +95,7 @@ export const CatalogoDelCorpus: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Las ocho obras del corpus, tal como las sirve el backend.</p><p><strong>Usos:</strong> mirar la tarjeta con datos reales —portada, autoría, extracto y tiempo de lectura— y verificar el orden alfabético con plegado de acentos.</p>`,
+				story: `<p>El corpus completo, tal como lo sirve el backend.</p><p><strong>Usos:</strong> mirar la tarjeta con datos reales —portada, autoría, extracto y tiempo de lectura— y verificar el orden alfabético con plegado de acentos.</p>`,
 			},
 		},
 	},

--- a/src/app/pages/literary-works/literary-works.page.stories.ts
+++ b/src/app/pages/literary-works/literary-works.page.stories.ts
@@ -1,0 +1,146 @@
+import { applicationConfig, type Meta, type StoryObj } from '@storybook/angular-vite';
+import { provideRouter } from '@angular/router';
+import { NEVER, of, throwError, type Observable } from 'rxjs';
+
+import type { LiteraryWork, LiteraryWorkTeaser } from '@models/literary-work.model';
+import {
+	onoffLiteraryWorkTeasersMock,
+	onoffLiteraryWorkTeasersWithMediaSourcesMock,
+} from '@mocks/onoff-literary-work-teasers.mock';
+
+import { provideLiteraryWorkApiMock } from '../../providers/literary-work.mock';
+import type { LiteraryWorkApi } from '../../providers/literary-work.provider';
+import LiteraryWorksPage from './literary-works.page';
+
+// Ninguna obra del canon declara multimedia, así que el catálogo enriquecido es el único escenario
+// donde los selectores de formato de las tarjetas tienen algo que dibujar.
+const catalogues = {
+	corpus: onoffLiteraryWorkTeasersMock,
+	multimedia: onoffLiteraryWorkTeasersWithMediaSourcesMock,
+	empty: [] as readonly LiteraryWorkTeaser[],
+} as const;
+
+type Scenario = keyof typeof catalogues | 'loading' | 'failure';
+
+class StubScenarioLiteraryWorkApi implements LiteraryWorkApi {
+	constructor(private readonly scenario: Scenario) {}
+
+	public getBySlug(): Observable<LiteraryWork> {
+		return throwError(() => new Error('El catálogo no consulta por slug'));
+	}
+
+	public getTeasers(): Observable<LiteraryWorkTeaser[]> {
+		if (this.scenario === 'failure') {
+			return throwError(() => new Error('sin catálogo'));
+		}
+		// `NEVER` deja el recurso pendiente, que es la única forma de sostener el esqueleto a la vista.
+		if (this.scenario === 'loading') {
+			return NEVER;
+		}
+		return of([...catalogues[this.scenario]]);
+	}
+}
+
+type LiteraryWorksPageArgs = { scenario: Scenario };
+
+const meta: Meta<LiteraryWorksPageArgs> = {
+	component: LiteraryWorksPage,
+	title: 'Páginas/LiteraryWorksPage',
+	// Uno por render: la página de autodocs monta todas las entradas a la vez y una instancia común
+	// dejaría que el escenario de una resolviera dentro de otra.
+	decorators: [
+		(story, context) =>
+			applicationConfig({
+				providers: [
+					provideRouter([]),
+					provideLiteraryWorkApiMock(new StubScenarioLiteraryWorkApi((context.args as LiteraryWorksPageArgs).scenario)),
+				],
+			})(story, context),
+	],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>El catálogo de obras, <strong>LiteraryWorksPage</strong>, montado sobre el corpus de Onoff. Como el resto de las entradas bajo <strong>Páginas</strong>, no cataloga un componente sino el ensamblado completo: el encabezado con el conteo y la lista de tarjetas que llevan a la lectura.</p><p>El único control elige el escenario del catálogo, que es lo único que mueve la página desde afuera: no recibe parámetros de ruta ni tiene estado propio.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-literaryworkcardteaser--docs" target="_top"><strong>LiteraryWorkCardTeaser</strong></a>, la misma tarjeta que enlaza a <a href="./?path=/docs/páginas-readpage--docs" target="_top"><strong>ReadPage</strong></a>, y de su esqueleto.</p><p>El orden no es el que entrega el backend: se resuelve en la página con colación en español, porque la base compara por punto de código y mandaría al final del catálogo todo título que empiece con acento o eñe.</p><p>El encabezado fijo de la aplicación no se monta en el catálogo, así que el margen superior de la página se ve como espacio en blanco.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		scenario: {
+			name: 'Catálogo',
+			control: { type: 'inline-radio' },
+			options: ['corpus', 'multimedia', 'loading', 'empty', 'failure'],
+			table: { type: { summary: "'corpus' | 'multimedia' | 'loading' | 'empty' | 'failure'" } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<LiteraryWorksPageArgs>;
+
+export const Playground: Story = {
+	args: { scenario: 'corpus' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El catálogo con el control vivo. Cambiá <strong>Catálogo</strong> para recorrer los cinco estados, y en particular para alternar entre <strong>corpus</strong> y <strong>loading</strong>: la lista real y la de esqueletos ocupan el mismo lugar, así que la alineación entre las dos se puede evaluar de un vistazo.</p>`,
+			},
+		},
+	},
+};
+
+export const CatalogoDelCorpus: Story = {
+	args: { scenario: 'corpus' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Las ocho obras del corpus, tal como las sirve el backend.</p><p><strong>Usos:</strong> mirar la tarjeta con datos reales —portada, autoría, extracto y tiempo de lectura— y verificar el orden alfabético con plegado de acentos.</p>`,
+			},
+		},
+	},
+};
+
+export const CatalogoConMultimedia: Story = {
+	args: { scenario: 'multimedia' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El mismo catálogo, con recursos multimedia agregados a cada obra. Es la única entrada donde los selectores de formato de las tarjetas tienen algo que dibujar: ninguna obra del corpus declara multimedia.</p><p><strong>Usos:</strong> evaluar cuánto alto suma la fila de selectores y cómo convive con el extracto recortado.</p>`,
+			},
+		},
+	},
+};
+
+export const CatalogoCargando: Story = {
+	args: { scenario: 'loading' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El catálogo mientras carga: la lista de esqueletos, en el mismo lugar y con la misma geometría que la lista real. Alternar con <strong>corpus</strong> desde el control de <strong>Playground</strong> es lo que permite verificar que una no salte respecto de la otra.</p><p>En la aplicación servida este estado no llega al HTML: el recurso bloquea el render del servidor. Se ve al navegar dentro de la aplicación.</p>`,
+			},
+		},
+	},
+};
+
+export const CatalogoVacio: Story = {
+	args: { scenario: 'empty' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Un catálogo que resolvió sin obras. Lo dice con todas las letras en vez de quedarse con los esqueletos puestos: un catálogo vacío y un catálogo cargando significan cosas opuestas y no pueden verse igual.</p>`,
+			},
+		},
+	},
+};
+
+export const CatalogoQueFalla: Story = {
+	args: { scenario: 'failure' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El catálogo no se pudo cargar. Se distingue del catálogo vacío a propósito: sin el mensaje, la página afirmaría que no hay obras cuando lo que hubo fue un fallo.</p><p>En la aplicación servida, además, la respuesta sale con código 503 para que el borde no cachee el fallo como si fuera la página.</p>`,
+			},
+		},
+	},
+};

--- a/src/app/pages/literary-works/literary-works.page.stories.ts
+++ b/src/app/pages/literary-works/literary-works.page.stories.ts
@@ -62,7 +62,7 @@ const meta: Meta<LiteraryWorksPageArgs> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>El catálogo de obras, <strong>LiteraryWorksPage</strong>, montado sobre el corpus de Onoff. Como el resto de las entradas bajo <strong>Páginas</strong>, no cataloga un componente sino el ensamblado completo: el encabezado con el conteo y la lista de tarjetas que llevan a la lectura.</p><p>El único control elige el escenario del catálogo, que es lo único que mueve la página desde afuera: no recibe parámetros de ruta ni tiene estado propio.</p><p>Se compone de una sola pieza: <a href="./?path=/docs/componentes-v3-literaryworkcardteaser--docs" target="_top"><strong>LiteraryWorkCardTeaser</strong></a>, la misma tarjeta que enlaza a <a href="./?path=/docs/páginas-readpage--docs" target="_top"><strong>ReadPage</strong></a>. El esqueleto no lo monta el listado sino la propia tarjeta, cuando no recibe obra; por eso la rama de carga le pasa los mismos flags de presentación que la rama real, que es lo que hace que las dos ocupen el mismo alto.</p><p>El orden no es el que entrega el backend: se resuelve en la página con colación en español, porque la base compara por punto de código y mandaría al final del catálogo todo título que empiece con acento o eñe.</p><p>El encabezado fijo de la aplicación no se monta en el catálogo, así que el margen superior de la página se ve como espacio en blanco.</p></div>`,
+				component: `<div><p>El catálogo de obras, <strong>LiteraryWorksPage</strong>, montado sobre el corpus de Onoff. Como el resto de las entradas bajo <strong>Páginas</strong>, no cataloga un componente sino el ensamblado completo: el encabezado con el conteo y la tabla de obras, con su título enlazado a la lectura, su autoría enlazada al perfil y su tiempo de lectura.</p><p>El único control elige el escenario del catálogo, que es lo único que mueve la página desde afuera: no recibe parámetros de ruta ni tiene estado propio.</p><p>La tabla es la misma que sirve hoy el listado que este catálogo reemplaza: se conserva a propósito, porque el rediseño de esta pantalla todavía no existe. Los títulos enlazan a <a href="./?path=/docs/páginas-readpage--docs" target="_top"><strong>ReadPage</strong></a>. La única pieza del sistema de diseño que monta es <a href="./?path=/docs/componentes-v3-skeleton--docs" target="_top"><strong>Skeleton</strong></a>, en las filas de carga.</p><p>El orden no es el que entrega el backend: se resuelve en la página con colación en español, porque la base compara por punto de código y mandaría al final del catálogo todo título que empiece con acento o eñe.</p><p>El encabezado fijo de la aplicación no se monta en el catálogo, así que el margen superior de la página se ve como espacio en blanco.</p></div>`,
 			},
 		},
 	},
@@ -84,7 +84,7 @@ export const Playground: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>El catálogo con el control vivo. Cambiá <strong>Catálogo</strong> para recorrer los cinco estados, y en particular para alternar entre <strong>corpus</strong> y <strong>loading</strong>: la lista real y la de esqueletos ocupan el mismo lugar, así que la alineación entre las dos se puede evaluar de un vistazo.</p>`,
+				story: `<p>El catálogo con el control vivo. Cambiá <strong>Catálogo</strong> para recorrer los cuatro estados, y en particular para alternar entre <strong>corpus</strong> y <strong>loading</strong>: las filas de carga ocupan la misma tabla que las resueltas, así que la alineación de las columnas entre las dos se puede evaluar de un vistazo.</p>`,
 			},
 		},
 	},
@@ -95,18 +95,7 @@ export const CatalogoDelCorpus: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>El corpus completo, tal como lo sirve el backend.</p><p><strong>Usos:</strong> mirar la tarjeta con datos reales —portada, autoría, extracto y tiempo de lectura— y verificar el orden alfabético con plegado de acentos.</p>`,
-			},
-		},
-	},
-};
-
-export const CatalogoConMultimedia: Story = {
-	args: { scenario: 'multimedia' },
-	parameters: {
-		docs: {
-			description: {
-				story: `<p>El mismo catálogo, con recursos multimedia agregados a cada obra. Es la única entrada donde los selectores de formato de las tarjetas tienen algo que dibujar: ninguna obra del corpus declara multimedia.</p><p><strong>Usos:</strong> evaluar cuánto alto suma la fila de selectores y cómo convive con el extracto recortado.</p>`,
+				story: `<p>El corpus completo, tal como lo sirve el backend.</p><p><strong>Usos:</strong> mirar la tabla con datos reales y verificar el orden alfabético con plegado de acentos.</p>`,
 			},
 		},
 	},
@@ -117,7 +106,7 @@ export const CatalogoCargando: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>El catálogo mientras carga: la lista de esqueletos, en el mismo lugar y con la misma geometría que la lista real. Alternar con <strong>corpus</strong> desde el control de <strong>Playground</strong> es lo que permite verificar que una no salte respecto de la otra.</p><p>En la aplicación servida este estado no llega al HTML: el recurso bloquea el render del servidor. Se ve al navegar dentro de la aplicación.</p>`,
+				story: `<p>El catálogo mientras carga: filas de esqueleto dentro de la misma tabla, con el encabezado de columnas ya servido. Alternar con <strong>corpus</strong> desde el control de <strong>Playground</strong> es lo que permite verificar que las columnas no se corran al resolver.</p><p>En la aplicación servida este estado no llega al HTML: el recurso bloquea el render del servidor. Se ve al navegar dentro de la aplicación.</p>`,
 			},
 		},
 	},
@@ -128,7 +117,7 @@ export const CatalogoVacio: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Un catálogo que resolvió sin obras. Lo dice con todas las letras en vez de quedarse con los esqueletos puestos: un catálogo vacío y un catálogo cargando significan cosas opuestas y no pueden verse igual.</p>`,
+				story: `<p>Un catálogo que resolvió sin obras. Lo dice con todas las letras en vez de dejar la tabla vacía: un catálogo vacío y un catálogo cargando significan cosas opuestas y no pueden verse igual.</p>`,
 			},
 		},
 	},

--- a/src/app/pages/literary-works/literary-works.page.ts
+++ b/src/app/pages/literary-works/literary-works.page.ts
@@ -12,18 +12,21 @@ import { LiteraryWorkCardTeaserComponent } from '@components/literary-work-card-
 	selector: 'cuentoneta-literary-works',
 	template: `
 		<main class="mx-auto mt-header-height flex w-full max-w-310 flex-col gap-12 px-4 pt-8 pb-16">
-			<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">
-				{{ literaryWorks().length }} {{ literaryWorks().length === 1 ? 'Obra' : 'Obras' }}
-			</h1>
+			<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">{{ headline() }}</h1>
 
 			@if (loading()) {
-				<section class="flex flex-col gap-8" aria-busy="true">
+				<section class="flex flex-col gap-8" aria-busy="true" aria-label="Cargando obras">
 					@for (placeholder of [1, 2, 3, 4]; track placeholder) {
-						<cuentoneta-literary-work-card-teaser class="w-full" />
+						<cuentoneta-literary-work-card-teaser
+							[showAuthor]="true"
+							[showExcerpt]="true"
+							[showMultimedia]="true"
+							class="w-full"
+						/>
 					}
 				</section>
 			} @else if (failed()) {
-				<p class="font-inter text-base text-neutral-700" data-testid="catalog-error">
+				<p class="font-inter text-base text-neutral-700" role="alert" data-testid="catalog-error">
 					No pudimos cargar las obras. Probá de nuevo en un rato.
 				</p>
 			} @else if (literaryWorks().length > 0) {
@@ -62,7 +65,7 @@ export default class LiteraryWorksPage {
 	// acento o eñe inicial, y Sanity no expone colación con plegado.
 	private readonly collator = new Intl.Collator('es');
 
-	public readonly literaryWorks = computed(() => {
+	protected readonly literaryWorks = computed(() => {
 		const catalog = this.catalogResource.hasValue() ? this.catalogResource.value() : [];
 		return [...catalog].sort((first, second) => this.collator.compare(first.title, second.title));
 	});
@@ -70,6 +73,16 @@ export default class LiteraryWorksPage {
 	protected readonly failed = computed(() => this.catalogResource.status() === 'error');
 
 	protected readonly loading = computed(() => this.catalogResource.isLoading());
+
+	// El conteo solo se enuncia cuando hay catálogo resuelto detrás: anunciarlo mientras carga o tras un
+	// fallo afirmaría que no hay obras, que es justo lo que la rama de error existe para desmentir.
+	protected readonly headline = computed(() => {
+		if (this.loading() || this.failed()) {
+			return 'Obras';
+		}
+		const total = this.literaryWorks().length;
+		return `${total} ${total === 1 ? 'Obra' : 'Obras'}`;
+	});
 
 	// Un fallo transitorio no puede salir 200: el borde lo cachearía como si fuera la página. No hay
 	// rama 404 — un catálogo no deja de existir.

--- a/src/app/pages/literary-works/literary-works.page.ts
+++ b/src/app/pages/literary-works/literary-works.page.ts
@@ -1,21 +1,84 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, effect, inject, RESPONSE_INIT } from '@angular/core';
 
+import { ssrBlockingRxResource } from '@app-utils/ssr-resource';
 import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
 
 import { AppRoutes } from '../../app.routes';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { LiteraryWorkApi } from '../../providers/literary-work.provider';
+import { LiteraryWorkCardTeaserComponent } from '@components/literary-work-card-teaser/literary-work-card-teaser.component';
 
 @Component({
 	selector: 'cuentoneta-literary-works',
 	template: `
 		<main class="mx-auto mt-header-height flex w-full max-w-310 flex-col gap-12 px-4 pt-8 pb-16">
-			<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">Obras</h1>
+			<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">
+				{{ literaryWorks().length }} {{ literaryWorks().length === 1 ? 'Obra' : 'Obras' }}
+			</h1>
+
+			@if (loading()) {
+				<section class="flex flex-col gap-8" aria-busy="true">
+					@for (placeholder of [1, 2, 3, 4]; track placeholder) {
+						<cuentoneta-literary-work-card-teaser class="w-full" />
+					}
+				</section>
+			} @else if (failed()) {
+				<p class="font-inter text-base text-neutral-700" data-testid="catalog-error">
+					No pudimos cargar las obras. Probá de nuevo en un rato.
+				</p>
+			} @else if (literaryWorks().length > 0) {
+				<section class="flex flex-col gap-8" data-testid="literary-works">
+					@for (literaryWork of literaryWorks(); track literaryWork.slug) {
+						<cuentoneta-literary-work-card-teaser
+							[literaryWork]="literaryWork"
+							[showAuthor]="true"
+							[showExcerpt]="true"
+							[showMultimedia]="true"
+							class="w-full"
+						/>
+					}
+				</section>
+			} @else {
+				<p class="font-inter text-base text-neutral-700" data-testid="catalog-empty">
+					Todavía no hay obras publicadas.
+				</p>
+			}
 		</main>
 	`,
 	hostDirectives: [HeadMetadataDirective],
+	imports: [LiteraryWorkCardTeaserComponent],
 })
 export default class LiteraryWorksPage {
 	private readonly headMetadata = inject(HeadMetadataDirective);
+	private readonly literaryWorkApi = inject(LiteraryWorkApi);
+	private readonly responseInit = inject(RESPONSE_INIT, { optional: true });
+
+	private readonly catalogResource = ssrBlockingRxResource({
+		stream: () => this.literaryWorkApi.getTeasers(),
+		defaultValue: [],
+	});
+
+	// El `order(title asc)` de la query compara por punto de código: manda al final todo título con
+	// acento o eñe inicial, y Sanity no expone colación con plegado.
+	private readonly collator = new Intl.Collator('es');
+
+	public readonly literaryWorks = computed(() => {
+		const catalog = this.catalogResource.hasValue() ? this.catalogResource.value() : [];
+		return [...catalog].sort((first, second) => this.collator.compare(first.title, second.title));
+	});
+
+	protected readonly failed = computed(() => this.catalogResource.status() === 'error');
+
+	protected readonly loading = computed(() => this.catalogResource.isLoading());
+
+	// Un fallo transitorio no puede salir 200: el borde lo cachearía como si fuera la página. No hay
+	// rama 404 — un catálogo no deja de existir.
+	private readonly respondErrorStatusEffect = effect(() => {
+		if (!this.catalogResource.error() || !this.responseInit) {
+			return;
+		}
+		this.responseInit.status = 503;
+	});
 
 	constructor() {
 		this.headMetadata.setTitle('Obras');

--- a/src/app/pages/literary-works/literary-works.page.ts
+++ b/src/app/pages/literary-works/literary-works.page.ts
@@ -1,4 +1,5 @@
 import { Component, computed, effect, inject, RESPONSE_INIT } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 import { ssrBlockingRxResource } from '@app-utils/ssr-resource';
 import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
@@ -6,7 +7,7 @@ import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
 import { AppRoutes } from '../../app.routes';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { LiteraryWorkApi } from '../../providers/literary-work.provider';
-import { LiteraryWorkCardTeaserComponent } from '@components/literary-work-card-teaser/literary-work-card-teaser.component';
+import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 
 @Component({
 	selector: 'cuentoneta-literary-works',
@@ -14,33 +15,64 @@ import { LiteraryWorkCardTeaserComponent } from '@components/literary-work-card-
 		<main class="mx-auto mt-header-height flex w-full max-w-310 flex-col gap-12 px-4 pt-8 pb-16">
 			<h1 class="font-inter text-2xl leading-8 font-bold text-neutral-900">{{ headline() }}</h1>
 
-			@if (loading()) {
-				<section class="flex flex-col gap-8" aria-busy="true" aria-label="Cargando obras">
-					@for (placeholder of [1, 2, 3, 4]; track placeholder) {
-						<cuentoneta-literary-work-card-teaser
-							[showAuthor]="true"
-							[showExcerpt]="true"
-							[showMultimedia]="true"
-							class="w-full"
-						/>
-					}
-				</section>
-			} @else if (failed()) {
+			@if (failed()) {
 				<p class="font-inter text-base text-neutral-700" role="alert" data-testid="catalog-error">
 					No pudimos cargar las obras. Probá de nuevo en un rato.
 				</p>
-			} @else if (literaryWorks().length > 0) {
-				<section class="flex flex-col gap-8" data-testid="literary-works">
-					@for (literaryWork of literaryWorks(); track literaryWork.slug) {
-						<cuentoneta-literary-work-card-teaser
-							[literaryWork]="literaryWork"
-							[showAuthor]="true"
-							[showExcerpt]="true"
-							[showMultimedia]="true"
-							class="w-full"
-						/>
-					}
-				</section>
+			} @else if (loading() || literaryWorks().length > 0) {
+				<div class="overflow-x-auto rounded-lg border border-neutral-200">
+					<table class="w-full border-collapse">
+						<thead class="bg-neutral-50">
+							<tr class="border-b border-neutral-200">
+								<th class="px-6 py-4 text-left text-sm font-semibold text-neutral-900">Título</th>
+								<th class="px-6 py-4 text-left text-sm font-semibold text-neutral-900">Autor</th>
+								<th class="px-6 py-4 text-left text-sm font-semibold text-neutral-900">Tiempo de lectura</th>
+							</tr>
+						</thead>
+						@if (loading()) {
+							<tbody class="divide-y divide-neutral-200" aria-busy="true" aria-label="Cargando obras">
+								@for (placeholder of [1, 2, 3, 4]; track placeholder) {
+									<tr data-testid="skeleton">
+										@for (cell of [1, 2, 3]; track cell) {
+											<td class="px-6 py-4">
+												<cuentoneta-skeleton appearance="line" class="h-5 w-full max-w-48 bg-neutral-300" />
+											</td>
+										}
+									</tr>
+								}
+							</tbody>
+						} @else {
+							<tbody class="divide-y divide-neutral-200" data-testid="literary-works">
+								@for (literaryWork of literaryWorks(); track literaryWork.slug) {
+									<tr class="transition-colors hover:bg-neutral-50">
+										<td class="px-6 py-4">
+											<a
+												[routerLink]="['/', appRoutes.Read, literaryWork.slug]"
+												class="text-blue-600 hover:text-blue-800 hover:underline"
+											>
+												{{ literaryWork.title }}
+											</a>
+										</td>
+										<td class="px-6 py-4 text-neutral-700">
+											@for (author of literaryWork.authors; track author.slug) {
+												<a
+													[routerLink]="['/', appRoutes.Author, author.slug]"
+													class="text-blue-600 hover:text-blue-800 hover:underline"
+												>
+													{{ author.name }}
+												</a>
+												@if (!$last) {
+													<span>, </span>
+												}
+											}
+										</td>
+										<td class="px-6 py-4 text-neutral-700">{{ literaryWork.totalReadingTime }} min</td>
+									</tr>
+								}
+							</tbody>
+						}
+					</table>
+				</div>
 			} @else {
 				<p class="font-inter text-base text-neutral-700" data-testid="catalog-empty">
 					Todavía no hay obras publicadas.
@@ -49,9 +81,11 @@ import { LiteraryWorkCardTeaserComponent } from '@components/literary-work-card-
 		</main>
 	`,
 	hostDirectives: [HeadMetadataDirective],
-	imports: [LiteraryWorkCardTeaserComponent],
+	imports: [RouterLink, SkeletonComponent],
 })
 export default class LiteraryWorksPage {
+	protected readonly appRoutes = AppRoutes;
+
 	private readonly headMetadata = inject(HeadMetadataDirective);
 	private readonly literaryWorkApi = inject(LiteraryWorkApi);
 	private readonly responseInit = inject(RESPONSE_INIT, { optional: true });


### PR DESCRIPTION
Segunda de cuatro PRs apiladas para trasladar el listado de obras de `/story` a `/literary-work`. **Apilada sobre #2388**, que declara la ruta y la página; mergear en orden.

Esta PR le pone el catálogo real a la página.

## Qué cambia

- El listado resuelve `LiteraryWorkApi.getTeasers()` con `ssrBlockingRxResource` y lo sirve en la **misma tabla** que usa hoy `/story` —título, autoría y tiempo de lectura—, con el título enlazado a `/read/:slug` y la autoría a su perfil. La tabla se conserva a propósito: no hay diseño para esta pantalla, así que montar la tarjeta de obra habría inventado uno.
- Encabezado con el conteo (`8 Obras` / `1 Obra`), como el catálogo de colecciones.
- Las cuatro ramas de estado: carga (filas de esqueleto dentro de la misma tabla, con el encabezado de columnas ya servido), error, catálogo con obras y catálogo vacío. El error además fija `503`.
- Entrada de Storybook con los cuatro escenarios.

## Decisiones

- **Sin `limit`/`offset`.** La página vieja pedía 2000 obras de una; el contrato vigente declara la paginación como criterio futuro del registro de filtro, y el precedente de `/collection` trae el catálogo completo. Inventar paginación acá sería expandir el contrato sin que el issue lo pida.
- **El orden lo rehace la página**, con `Intl.Collator('es')`. El `order(title asc)` de la query compara por punto de código y manda al final del catálogo todo título con acento o eñe inicial; hay un caso dedicado a eso.
- **El fallo sale 503, no 200**, para que el borde no cachee la página de error como si fuera la página.
- **La tabla no es una decisión de diseño nueva**: es la que ya existe, portada al vocabulario nuevo. El rediseño de esta pantalla no está hecho y no se adelanta acá.

## Qué queda funcionando y qué no

`/literary-work` lista todas las obras publicadas con SSR real. Sigue `noindex, follow`, sin JSON-LD, sin entrada en el sitemap y sin enlace en el encabezado: eso es de las PRs 3 y 4. `/story` queda intacto y sigue siendo el listado que usan las personas.

## Plan de pruebas

- Tier local completo verde: `tsc --noEmit`, `lint`, `stylelint`, `check:agents` y la suite entera (2493 tests).
- `storybook:build` corrido en local, porque el diff suma una entrada al catálogo.
- Conteo del encabezado en plural y singular, un enlace a `/read/:slug` por obra, enlace al perfil de cada autoría, tiempo de lectura de cada obra, orden con plegado de acentos, las cuatro ramas de estado distinguidas entre sí, y el 503 ante fallo con su control positivo.
- 16 casos de spec, incluido el que ata las dos ramas de la tabla: la fila de carga declara las mismas celdas que una fila resuelta.
- Los once gates de CI, verdes sobre el commit final.

Parte de #2287 — segunda de cuatro PRs de la pila; el cierre del issue va en la última.
Parte de #2265.
