### PR TITLE
[#2287] - Declara indexable el listado de obras en /literary-work

### DIFF
--- a/e2e/_utils/seo-fixtures.ts
+++ b/e2e/_utils/seo-fixtures.ts
@@ -34,4 +34,6 @@ export const SCHEMA_IDS = Object.freeze({
 	breadcrumbCollection: 'breadcrumb-collection',
 	collectionCatalog: 'collection-catalog',
 	breadcrumbCollectionCatalog: 'breadcrumb-collection-catalog',
+	literaryWorkCatalog: 'literary-work-catalog',
+	breadcrumbLiteraryWorkCatalog: 'breadcrumb-literary-work-catalog',
 } as const);

--- a/e2e/_utils/seo-invariants.spec.ts
+++ b/e2e/_utils/seo-invariants.spec.ts
@@ -42,10 +42,17 @@ describe('checkNgServerContext', () => {
 		expect(checkNgServerContext(GOOD_HTML)).toBeNull();
 	});
 
-	it('viola con el deopt a CSR (ssg) e informa el valor encontrado', () => {
-		const violation = checkNgServerContext(GOOD_HTML.replace('"ssr"', '"ssg"'));
+	// Una ruta prerenderizada sirve el HTML completo igual que una renderizada por request: lo que la
+	// regla persigue es el deopt a cliente, no el modo de render.
+	it('pasa con ng-server-context="ssg" de una ruta prerenderizada', () => {
+		expect(checkNgServerContext(GOOD_HTML.replace('"ssr"', '"ssg"'))).toBeNull();
+	});
+
+	// El deopt a cliente deja el atributo puesto pero vacío, que es distinto de que falte.
+	it('viola con el deopt a CSR e informa el valor encontrado', () => {
+		const violation = checkNgServerContext(GOOD_HTML.replace('ng-server-context="ssr"', 'ng-server-context=""'));
 		expect(violation?.rule).toBe('server-render-context');
-		expect(violation?.message).toContain('ssg');
+		expect(violation?.message).toContain('se encontró ""');
 	});
 
 	it('viola cuando el atributo está ausente', () => {
@@ -231,7 +238,7 @@ describe('collectIndexableHtmlViolations', () => {
 
 	it('acumula todas las violaciones simultáneas (no fail-fast)', async () => {
 		const broken =
-			'<html ng-server-context="ssg"><head><title></title></head><body><main><div data-testid="skeleton"></div></main></body></html>';
+			'<html><head><title></title></head><body><main><div data-testid="skeleton"></div></main></body></html>';
 		const rules = (await collectIndexableHtmlViolations(broken, GOOD_EXPECTATIONS)).map((violation) => violation.rule);
 		expect(rules).toEqual(
 			expect.arrayContaining([

--- a/e2e/_utils/seo-invariants.ts
+++ b/e2e/_utils/seo-invariants.ts
@@ -34,14 +34,19 @@ function normalizedText(element: HTMLElement | null): string {
 	return (element?.text ?? '').replace(/\s+/g, ' ').trim();
 }
 
+// Angular emite `ssr` al renderizar por request y `ssg` al prerenderizar; las dos sirven el HTML
+// completo, que es lo que el crawler necesita. Lo que esta regla existe para atrapar es el deopt a
+// renderizado en el cliente, que deja el contexto vacío o ausente y la página sin cuerpo.
+const SERVER_RENDERED_CONTEXTS = ['ssr', 'ssg'];
+
 function ngServerContext(root: HTMLElement): SeoInvariantViolation | null {
 	const actual = root.querySelector('cuentoneta-root')?.getAttribute('ng-server-context');
-	if (actual === 'ssr') {
+	if (actual && SERVER_RENDERED_CONTEXTS.includes(actual)) {
 		return null;
 	}
 	return {
 		rule: 'server-render-context',
-		message: `Se esperaba ng-server-context="ssr" en <cuentoneta-root>; se encontró "${actual ?? '(ausente)'}" (deopt a CSR).`,
+		message: `Se esperaba ng-server-context "ssr" o "ssg" en <cuentoneta-root>; se encontró "${actual ?? '(ausente)'}" (deopt a CSR).`,
 	};
 }
 

--- a/e2e/seo/literary-work.spec.ts
+++ b/e2e/seo/literary-work.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests e2e de SEO para el catálogo de obras (`/literary-work`).
+ *
+ * La tanda completa corre sin `fixme`: la página no difiere nada, así que el HTML servido trae la
+ * tabla entera con el enlace a la lectura de cada obra.
+ */
+import { test, expect } from '@playwright/test';
+
+import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
+import { assertValidJsonLd } from '@testing/json-ld-validation';
+import { collectIndexableHtmlViolations } from '../_utils/seo-invariants';
+import { SCHEMA_IDS, SITEWIDE_SCHEMA_IDS } from '../_utils/seo-fixtures';
+
+const catalogPath = '/literary-work';
+const requiredJsonLdIds = [
+	...SITEWIDE_SCHEMA_IDS,
+	SCHEMA_IDS.literaryWorkCatalog,
+	SCHEMA_IDS.breadcrumbLiteraryWorkCatalog,
+];
+
+test.describe('literary-work — HTML server-rendered del catálogo', () => {
+	let html: string;
+
+	test.beforeAll(async ({ request }) => {
+		const response = await request.get(catalogPath);
+		expect(response.status(), 'el catálogo de obras no respondió 200').toBe(200);
+		html = await response.text();
+	});
+
+	test('A: meta tags en el HTML server-rendered', () => {
+		expect(getTitleText(html)).toContain('Obras');
+		expect(getMetaContent(html, 'description')).toBeTruthy();
+		expect(getMetaContent(html, 'og:title')).toBeTruthy();
+		expect(getMetaContent(html, 'og:description')).toBeTruthy();
+		expect(getMetaContent(html, 'twitter:title')).toBeTruthy();
+		expect(getMetaContent(html, 'twitter:description')).toBeTruthy();
+		expect(getCanonicalHref(html)).toContain(catalogPath);
+		expect(getMetaContent(html, 'keywords')).toBeTruthy();
+		// La ausencia de `noindex` y no la presencia de `index`, que pasaría con las dos políticas.
+		expect(getMetaContent(html, 'robots')).not.toContain('noindex');
+	});
+
+	test('B: JSON-LD CollectionPage con el listado del catálogo', async () => {
+		const catalog = parseJsonLdBlocks(html).get(SCHEMA_IDS.literaryWorkCatalog);
+		await assertValidJsonLd(catalog);
+
+		const mainEntity = catalog?.['mainEntity'] as Record<string, unknown>;
+		expect(mainEntity?.['@type']).toBe('ItemList');
+		expect(Number(mainEntity?.['numberOfItems'])).toBeGreaterThan(0);
+
+		// El catálogo vive en `/literary-work` y cada obra en `/read/<slug>`: el elemento apunta a la
+		// lectura, no al listado.
+		const [firstItem] = (mainEntity?.['itemListElement'] ?? []) as Record<string, unknown>[];
+		expect(firstItem?.['position']).toBe(1);
+		expect(String(firstItem?.['url'])).toContain('/read/');
+	});
+
+	test('B: JSON-LD BreadcrumbList', async () => {
+		const breadcrumb = parseJsonLdBlocks(html).get(SCHEMA_IDS.breadcrumbLiteraryWorkCatalog);
+		await assertValidJsonLd(breadcrumb);
+
+		expect((breadcrumb?.['itemListElement'] as unknown[])?.length).toBe(2);
+	});
+
+	test('C: bloques sitewide Organization y WebSite presentes', () => {
+		const blocks = parseJsonLdBlocks(html);
+
+		expect(blocks.get(SCHEMA_IDS.organization)?.['@type']).toBe('Organization');
+		expect(blocks.get(SCHEMA_IDS.website)?.['@type']).toBe('WebSite');
+	});
+
+	test('D: invariantes de página indexable (ssr, title, canonical, robots, h1, cuerpo, enlaces, jsonld)', async () => {
+		expect(
+			await collectIndexableHtmlViolations(html, {
+				path: catalogPath,
+				requiredJsonLdIds,
+				requiredInternalLinkPrefix: '/read/',
+				h1Pattern: /\d+ Obras?/,
+			}),
+		).toEqual([]);
+	});
+});

--- a/src/app/pages/literary-works/literary-works-host.ts
+++ b/src/app/pages/literary-works/literary-works-host.ts
@@ -1,0 +1,9 @@
+import { InjectionToken, type Signal } from '@angular/core';
+
+import { type LiteraryWorkTeaser } from '@models/literary-work.model';
+
+export interface LiteraryWorksHost {
+	readonly literaryWorks: Signal<readonly LiteraryWorkTeaser[]>;
+}
+
+export const LITERARY_WORKS_HOST = new InjectionToken<LiteraryWorksHost>('LITERARY_WORKS_HOST');

--- a/src/app/pages/literary-works/literary-works-meta-tags.directive.spec.ts
+++ b/src/app/pages/literary-works/literary-works-meta-tags.directive.spec.ts
@@ -1,0 +1,66 @@
+import { clearAllMocks, spyOn } from '@test-utils';
+import { TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+
+import { AppRoutes } from '../../app.routes';
+import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { LiteraryWorksMetaTagsDirective } from './literary-works-meta-tags.directive';
+
+describe('LiteraryWorksMetaTagsDirective', () => {
+	function instantiate(): void {
+		TestBed.runInInjectionContext(() => new LiteraryWorksMetaTagsDirective());
+	}
+
+	beforeEach(() => {
+		clearAllMocks();
+		TestBed.configureTestingModule({
+			providers: [LiteraryWorksMetaTagsDirective, HeadMetadataDirective],
+		});
+	});
+
+	it('should set the title without waiting for any data', () => {
+		const titleSpy = spyOn(TestBed.inject(Title), 'setTitle');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(titleSpy).toHaveBeenCalledWith(expect.stringContaining('Obras'));
+	});
+
+	it('should set the canonical URL of the catalogue', () => {
+		const canonicalSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setCanonicalUrl');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(AppRoutes.LiteraryWork));
+	});
+
+	it('should declare the page as indexable', () => {
+		const robotsSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setRobots');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(robotsSpy).toHaveBeenCalledWith('index, follow');
+	});
+
+	it('should set a description of its own', () => {
+		const descriptionSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setDescription');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(descriptionSpy).toHaveBeenCalledWith(expect.stringContaining('obras'));
+	});
+
+	it('should set keywords', () => {
+		const keywordsSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setKeywords');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(keywordsSpy).toHaveBeenCalledWith(expect.arrayContaining(['obras']));
+	});
+});

--- a/src/app/pages/literary-works/literary-works-meta-tags.directive.ts
+++ b/src/app/pages/literary-works/literary-works-meta-tags.directive.ts
@@ -1,0 +1,25 @@
+import { Directive, untracked } from '@angular/core';
+
+import { AppRoutes } from '../../app.routes';
+import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
+import { AbstractMetaTagsDirective } from '../../directives/abstract-meta-tags.directive';
+
+@Directive({
+	selector: '[cuentonetaLiteraryWorksMetaTags]',
+	hostDirectives: [HeadMetadataDirective],
+})
+export class LiteraryWorksMetaTagsDirective extends AbstractMetaTagsDirective {
+	// No inyecta el host: nada de lo que emite depende del catálogo, y el catálogo puede fallar.
+	protected applyMetaTags(): void {
+		untracked(() => {
+			this.head.setTitle('Obras');
+			this.head.setDescription(
+				'Todas las obras publicadas en La Cuentoneta: cuentos, poemas y relatos breves para leer en línea.',
+			);
+			this.head.setCanonicalUrl(buildCanonicalUrl(AppRoutes.LiteraryWork));
+			this.head.setRobots('index, follow');
+			this.head.setKeywords(['obras', 'cuentos', 'poemas', 'relatos', 'literatura', 'lecturas']);
+		});
+	}
+}

--- a/src/app/pages/literary-works/literary-works-structured-data.directive.spec.ts
+++ b/src/app/pages/literary-works/literary-works-structured-data.directive.spec.ts
@@ -1,0 +1,80 @@
+import { clearAllMocks } from '@test-utils';
+import { TestBed } from '@angular/core/testing';
+import { DOCUMENT } from '@angular/common';
+import { signal } from '@angular/core';
+
+import { onoffLiteraryWorkTeasersMock } from '@mocks/onoff-literary-work-teasers.mock';
+import { type LiteraryWorkTeaser } from '@models/literary-work.model';
+import { LiteraryWorksStructuredDataDirective } from './literary-works-structured-data.directive';
+import { LITERARY_WORKS_HOST } from './literary-works-host';
+
+describe('LiteraryWorksStructuredDataDirective', () => {
+	const literaryWorksSignal = signal<readonly LiteraryWorkTeaser[]>([]);
+
+	function instantiate(): void {
+		TestBed.runInInjectionContext(() => new LiteraryWorksStructuredDataDirective());
+	}
+
+	beforeEach(() => {
+		clearAllMocks();
+		literaryWorksSignal.set([]);
+		TestBed.configureTestingModule({
+			providers: [
+				LiteraryWorksStructuredDataDirective,
+				{ provide: LITERARY_WORKS_HOST, useValue: { literaryWorks: literaryWorksSignal.asReadonly() } },
+			],
+		});
+	});
+
+	afterEach(() => {
+		TestBed.inject(DOCUMENT)
+			.head.querySelectorAll('script[data-schema-id]')
+			.forEach((el) => el.remove());
+	});
+
+	it('should not emit JSON-LD while the catalogue is empty', () => {
+		instantiate();
+		TestBed.tick();
+
+		expect(TestBed.inject(DOCUMENT).head.querySelector('script[data-schema-id="literary-work-catalog"]')).toBeNull();
+	});
+
+	it('should emit the CollectionPage and breadcrumb JSON-LD when the catalogue resolves', () => {
+		literaryWorksSignal.set(onoffLiteraryWorkTeasersMock);
+
+		instantiate();
+		TestBed.tick();
+
+		const head = TestBed.inject(DOCUMENT).head;
+		expect(
+			JSON.parse(head.querySelector('script[data-schema-id="literary-work-catalog"]')?.textContent ?? '{}'),
+		).toMatchObject({ '@type': 'CollectionPage' });
+		expect(
+			JSON.parse(head.querySelector('script[data-schema-id="breadcrumb-literary-work-catalog"]')?.textContent ?? '{}'),
+		).toMatchObject({ '@type': 'BreadcrumbList' });
+	});
+
+	it('should not emit under the schema ids the collection catalogue uses', () => {
+		literaryWorksSignal.set(onoffLiteraryWorkTeasersMock);
+
+		instantiate();
+		TestBed.tick();
+
+		const head = TestBed.inject(DOCUMENT).head;
+		expect(head.querySelector('script[data-schema-id="collection-catalog"]')).toBeNull();
+		expect(head.querySelector('script[data-schema-id="breadcrumb-collection-catalog"]')).toBeNull();
+	});
+
+	it('should remove both JSON-LD blocks when destroyed', () => {
+		literaryWorksSignal.set(onoffLiteraryWorkTeasersMock);
+		instantiate();
+		TestBed.tick();
+		const head = TestBed.inject(DOCUMENT).head;
+		expect(head.querySelector('script[data-schema-id="literary-work-catalog"]')).not.toBeNull();
+
+		TestBed.resetTestingModule();
+
+		expect(head.querySelector('script[data-schema-id="literary-work-catalog"]')).toBeNull();
+		expect(head.querySelector('script[data-schema-id="breadcrumb-literary-work-catalog"]')).toBeNull();
+	});
+});

--- a/src/app/pages/literary-works/literary-works-structured-data.directive.spec.ts
+++ b/src/app/pages/literary-works/literary-works-structured-data.directive.spec.ts
@@ -54,6 +54,21 @@ describe('LiteraryWorksStructuredDataDirective', () => {
 		).toMatchObject({ '@type': 'BreadcrumbList' });
 	});
 
+	// El catálogo llega después de la instanciación al navegar dentro de la aplicación. Si la lectura
+	// del host quedara dentro del `untracked()`, el efecto no volvería a correr y la página se serviría
+	// sin JSON-LD, con el resto de los casos igual de verdes.
+	it('should emit once the catalogue resolves after it was instantiated', () => {
+		instantiate();
+		TestBed.tick();
+		const head = TestBed.inject(DOCUMENT).head;
+		expect(head.querySelector('script[data-schema-id="literary-work-catalog"]')).toBeNull();
+
+		literaryWorksSignal.set(onoffLiteraryWorkTeasersMock);
+		TestBed.tick();
+
+		expect(head.querySelector('script[data-schema-id="literary-work-catalog"]')).not.toBeNull();
+	});
+
 	it('should not emit under the schema ids the collection catalogue uses', () => {
 		literaryWorksSignal.set(onoffLiteraryWorkTeasersMock);
 

--- a/src/app/pages/literary-works/literary-works-structured-data.directive.ts
+++ b/src/app/pages/literary-works/literary-works-structured-data.directive.ts
@@ -1,0 +1,39 @@
+import { Directive, inject, untracked } from '@angular/core';
+
+import { environment } from '../../environments/environment';
+import { AbstractStructuredDataDirective } from '../../directives/abstract-structured-data.directive';
+import { LITERARY_WORKS_HOST } from './literary-works-host';
+import { buildLiteraryWorkCatalogBreadcrumb, buildLiteraryWorkCatalogSchema } from './literary-works.schema';
+
+@Directive({
+	selector: '[cuentonetaLiteraryWorksStructuredData]',
+})
+export class LiteraryWorksStructuredDataDirective extends AbstractStructuredDataDirective {
+	private readonly host = inject(LITERARY_WORKS_HOST);
+
+	private readonly pageSchemaId = 'literary-work-catalog';
+	private readonly breadcrumbSchemaId = 'breadcrumb-literary-work-catalog';
+
+	protected applyStructuredData(): void {
+		const literaryWorks = this.host.literaryWorks();
+		// Un `ItemList` vacío afirma que el sitio no tiene obras; no emitir nada no afirma nada.
+		if (literaryWorks.length === 0) {
+			return;
+		}
+		untracked(() => {
+			this.schemaOrg.setPageScopedJsonLd(
+				this.pageSchemaId,
+				buildLiteraryWorkCatalogSchema(literaryWorks, environment.website),
+			);
+			this.schemaOrg.setPageScopedJsonLd(
+				this.breadcrumbSchemaId,
+				buildLiteraryWorkCatalogBreadcrumb(environment.website),
+			);
+		});
+	}
+
+	protected removeStructuredData(): void {
+		this.schemaOrg.removeJsonLd(this.pageSchemaId);
+		this.schemaOrg.removeJsonLd(this.breadcrumbSchemaId);
+	}
+}

--- a/src/app/pages/literary-works/literary-works.page.spec.ts
+++ b/src/app/pages/literary-works/literary-works.page.spec.ts
@@ -2,12 +2,10 @@ import { render, screen, within } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
 import { RESPONSE_INIT } from '@angular/core';
 import { NEVER, Observable, throwError } from 'rxjs';
-import { clearAllMocks, restoreAllMocks, spyOn } from '@test-utils';
+import { clearAllMocks, restoreAllMocks } from '@test-utils';
 
 import LiteraryWorksPage from './literary-works.page';
-import { AppRoutes } from '../../app.routes';
-import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
-import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
+import { LITERARY_WORKS_HOST } from './literary-works-host';
 import type { LiteraryWorkApi } from '../../providers/literary-work.provider';
 import { provideLiteraryWorkApiMock, StubLiteraryWorkApi } from '../../providers/literary-work.mock';
 import type { LiteraryWork, LiteraryWorkTeaser } from '@models/literary-work.model';
@@ -171,21 +169,13 @@ describe('LiteraryWorksPage', () => {
 		expect(screen.getByRole('heading', { level: 1, name: 'Obras' })).toBeInTheDocument();
 	});
 
-	it('should point the canonical URL at its own route', async () => {
-		const canonicalSpy = spyOn(HeadMetadataDirective.prototype, 'setCanonicalUrl');
+	// La directiva de datos estructurados lee el catálogo por este token: es el contrato que le permite
+	// emitir el ItemList sin volver a resolverlo.
+	it('should expose the catalogue it lists through its host token', async () => {
+		const { fixture } = await renderPage();
 
-		await renderPage();
-
-		expect(canonicalSpy).toHaveBeenCalledWith(buildCanonicalUrl(AppRoutes.LiteraryWork));
-	});
-
-	// Ofrecer al indexado una página que todavía no lista nada gasta rastreo en una URL sin contenido.
-	it('should opt out of indexing while it lists no work', async () => {
-		const robotsSpy = spyOn(HeadMetadataDirective.prototype, 'setRobots');
-
-		await renderPage();
-
-		expect(robotsSpy).toHaveBeenCalledWith('noindex, follow');
+		const host = fixture.debugElement.injector.get(LITERARY_WORKS_HOST);
+		expect(host.literaryWorks().map(({ slug }) => `/read/${slug}`)).toEqual(readingHrefs());
 	});
 
 	describe('código de respuesta', () => {

--- a/src/app/pages/literary-works/literary-works.page.ts
+++ b/src/app/pages/literary-works/literary-works.page.ts
@@ -1,12 +1,13 @@
-import { Component, computed, effect, inject, RESPONSE_INIT } from '@angular/core';
+import { Component, computed, effect, forwardRef, inject, RESPONSE_INIT } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { ssrBlockingRxResource } from '@app-utils/ssr-resource';
-import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
 
 import { AppRoutes } from '../../app.routes';
-import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { LiteraryWorkApi } from '../../providers/literary-work.provider';
+import { LITERARY_WORKS_HOST, type LiteraryWorksHost } from './literary-works-host';
+import { LiteraryWorksMetaTagsDirective } from './literary-works-meta-tags.directive';
+import { LiteraryWorksStructuredDataDirective } from './literary-works-structured-data.directive';
 import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 
 @Component({
@@ -80,13 +81,13 @@ import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 			}
 		</main>
 	`,
-	hostDirectives: [HeadMetadataDirective],
+	providers: [{ provide: LITERARY_WORKS_HOST, useExisting: forwardRef(() => LiteraryWorksPage) }],
+	hostDirectives: [LiteraryWorksMetaTagsDirective, LiteraryWorksStructuredDataDirective],
 	imports: [RouterLink, SkeletonComponent],
 })
-export default class LiteraryWorksPage {
+export default class LiteraryWorksPage implements LiteraryWorksHost {
 	protected readonly appRoutes = AppRoutes;
 
-	private readonly headMetadata = inject(HeadMetadataDirective);
 	private readonly literaryWorkApi = inject(LiteraryWorkApi);
 	private readonly responseInit = inject(RESPONSE_INIT, { optional: true });
 
@@ -99,7 +100,7 @@ export default class LiteraryWorksPage {
 	// acento o eñe inicial, y Sanity no expone colación con plegado.
 	private readonly collator = new Intl.Collator('es');
 
-	protected readonly literaryWorks = computed(() => {
+	public readonly literaryWorks = computed(() => {
 		const catalog = this.catalogResource.hasValue() ? this.catalogResource.value() : [];
 		return [...catalog].sort((first, second) => this.collator.compare(first.title, second.title));
 	});
@@ -126,13 +127,4 @@ export default class LiteraryWorksPage {
 		}
 		this.responseInit.status = 503;
 	});
-
-	constructor() {
-		this.headMetadata.setTitle('Obras');
-		this.headMetadata.setDescription(
-			'Explorá todas las obras publicadas en La Cuentoneta: cuentos, poemas y relatos breves para leer en línea.',
-		);
-		this.headMetadata.setCanonicalUrl(buildCanonicalUrl(AppRoutes.LiteraryWork));
-		this.headMetadata.setRobots('noindex, follow');
-	}
 }

--- a/src/app/pages/literary-works/literary-works.schema.spec.ts
+++ b/src/app/pages/literary-works/literary-works.schema.spec.ts
@@ -36,22 +36,32 @@ describe('buildLiteraryWorkCatalogSchema', () => {
 		});
 	});
 
-	it('should not emit double slashes when the website URL ends in one', () => {
-		const schema = buildLiteraryWorkCatalogSchema(onoffLiteraryWorkTeasersMock, websiteUrl);
+	// La base llega con y sin barra final según el entorno; las dos tienen que producir la misma URL.
+	it('should normalize the website URL whether or not it ends in a slash', () => {
+		const withSlash = buildLiteraryWorkCatalogSchema(onoffLiteraryWorkTeasersMock, websiteUrl);
+		const withoutSlash = buildLiteraryWorkCatalogSchema(onoffLiteraryWorkTeasersMock, 'https://www.cuentoneta.ar');
 
-		expect(schema.url).not.toContain('//literary-work');
+		expect(withSlash.url).toBe(withoutSlash.url);
+		expect(withSlash.url).toBe('https://www.cuentoneta.ar/literary-work');
 	});
 });
 
 describe('buildLiteraryWorkCatalogBreadcrumb', () => {
-	it('should build the trail Inicio to Obras', async () => {
+	it('should build the trail from the home to the catalogue', () => {
 		const breadcrumb = buildLiteraryWorkCatalogBreadcrumb(websiteUrl);
 
-		await expect(assertValidJsonLd(breadcrumb)).resolves.toBeUndefined();
-		expect(breadcrumb.itemListElement).toHaveLength(2);
-		expect(breadcrumb.itemListElement).toMatchObject([
-			{ position: 1, name: 'Inicio' },
-			{ position: 2, name: 'Obras' },
+		expect(breadcrumb['itemListElement']).toEqual([
+			{ '@type': 'ListItem', position: 1, name: 'Inicio', item: { '@id': 'https://www.cuentoneta.ar/home' } },
+			{
+				'@type': 'ListItem',
+				position: 2,
+				name: 'Obras',
+				item: { '@id': 'https://www.cuentoneta.ar/literary-work' },
+			},
 		]);
+	});
+
+	it('should build a schema.org-valid BreadcrumbList', async () => {
+		await expect(assertValidJsonLd(buildLiteraryWorkCatalogBreadcrumb(websiteUrl))).resolves.toBeUndefined();
 	});
 });

--- a/src/app/pages/literary-works/literary-works.schema.spec.ts
+++ b/src/app/pages/literary-works/literary-works.schema.spec.ts
@@ -1,0 +1,57 @@
+import { onoffLiteraryWorkTeasersMock } from '@mocks/onoff-literary-work-teasers.mock';
+
+import { assertValidJsonLd } from '@testing/json-ld-validation';
+import { buildLiteraryWorkCatalogBreadcrumb, buildLiteraryWorkCatalogSchema } from './literary-works.schema';
+
+const websiteUrl = 'https://www.cuentoneta.ar/';
+
+describe('buildLiteraryWorkCatalogSchema', () => {
+	it('should build a schema.org-valid CollectionPage', async () => {
+		await expect(
+			assertValidJsonLd(buildLiteraryWorkCatalogSchema(onoffLiteraryWorkTeasersMock, websiteUrl)),
+		).resolves.toBeUndefined();
+	});
+
+	// El catálogo vive en `/literary-work` y cada obra en `/read/<slug>`: a diferencia de las colecciones,
+	// el listado y el detalle no comparten prefijo de ruta.
+	it('should build a CollectionPage whose items point at the reading route', () => {
+		const schema = buildLiteraryWorkCatalogSchema(onoffLiteraryWorkTeasersMock, websiteUrl);
+
+		expect(schema).toMatchObject({
+			'@context': 'https://schema.org',
+			'@type': 'CollectionPage',
+			name: 'Obras',
+			url: 'https://www.cuentoneta.ar/literary-work',
+			inLanguage: 'es-AR',
+			mainEntity: {
+				'@type': 'ItemList',
+				numberOfItems: onoffLiteraryWorkTeasersMock.length,
+				itemListElement: onoffLiteraryWorkTeasersMock.map((literaryWork, index) => ({
+					'@type': 'ListItem',
+					position: index + 1,
+					url: `https://www.cuentoneta.ar/read/${literaryWork.slug}`,
+					name: literaryWork.title,
+				})),
+			},
+		});
+	});
+
+	it('should not emit double slashes when the website URL ends in one', () => {
+		const schema = buildLiteraryWorkCatalogSchema(onoffLiteraryWorkTeasersMock, websiteUrl);
+
+		expect(schema.url).not.toContain('//literary-work');
+	});
+});
+
+describe('buildLiteraryWorkCatalogBreadcrumb', () => {
+	it('should build the trail Inicio to Obras', async () => {
+		const breadcrumb = buildLiteraryWorkCatalogBreadcrumb(websiteUrl);
+
+		await expect(assertValidJsonLd(breadcrumb)).resolves.toBeUndefined();
+		expect(breadcrumb.itemListElement).toHaveLength(2);
+		expect(breadcrumb.itemListElement).toMatchObject([
+			{ position: 1, name: 'Inicio' },
+			{ position: 2, name: 'Obras' },
+		]);
+	});
+});

--- a/src/app/pages/literary-works/literary-works.schema.ts
+++ b/src/app/pages/literary-works/literary-works.schema.ts
@@ -1,0 +1,43 @@
+import { Location } from '@angular/common';
+import { type BreadcrumbList, type CollectionPage, type WithContext } from 'schema-dts';
+
+import { type LiteraryWorkTeaser } from '@models/literary-work.model';
+import { buildBreadcrumbSchema } from '@utils/schema-org.builders';
+
+/**
+ * Construye el JSON-LD del catálogo de obras. El orden del `ItemList` es el del array que entra: la
+ * página ya lo resolvió. Cada elemento apunta a la lectura y no al catálogo, porque el catálogo y el
+ * detalle viven en rutas distintas.
+ */
+export function buildLiteraryWorkCatalogSchema(
+	literaryWorks: readonly LiteraryWorkTeaser[],
+	websiteUrl: string,
+): WithContext<CollectionPage> {
+	const baseUrl = Location.stripTrailingSlash(websiteUrl);
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'CollectionPage',
+		name: 'Obras',
+		url: `${baseUrl}/literary-work`,
+		inLanguage: 'es-AR',
+		mainEntity: {
+			'@type': 'ItemList',
+			numberOfItems: literaryWorks.length,
+			itemListElement: literaryWorks.map((literaryWork, index) => ({
+				'@type': 'ListItem',
+				position: index + 1,
+				url: `${baseUrl}/read/${literaryWork.slug}`,
+				name: literaryWork.title,
+			})),
+		},
+	};
+}
+
+/** Construye el `BreadcrumbList` del catálogo: Inicio → Obras. */
+export function buildLiteraryWorkCatalogBreadcrumb(websiteUrl: string): WithContext<BreadcrumbList> {
+	const baseUrl = Location.stripTrailingSlash(websiteUrl);
+	return buildBreadcrumbSchema([
+		{ name: 'Inicio', url: `${baseUrl}/home` },
+		{ name: 'Obras', url: `${baseUrl}/literary-work` },
+	]);
+}


### PR DESCRIPTION
Tercera de cuatro PRs para trasladar el listado de obras de `/story` a `/literary-work`. Las dos primeras (#2388 y #2390) ya están en `develop`, así que ésta va directo sobre `develop`.

`/literary-work` pasa a ser una página indexable.

## Qué cambia

- **Directiva de meta tags** (`LiteraryWorksMetaTagsDirective`): título, descripción, canónica, keywords y `index, follow`. No inyecta el host a propósito — nada de lo que emite depende del catálogo, y el catálogo puede fallar.
- **Directiva de datos estructurados** (`LiteraryWorksStructuredDataDirective`): publica un `CollectionPage` con un `ItemList` del catálogo y su `BreadcrumbList` (Inicio → Obras). Con el catálogo vacío no emite nada: un `ItemList` sin elementos afirma que el sitio no tiene obras, y no emitir no afirma nada.
- **Token de host** (`LITERARY_WORKS_HOST`): la página expone su catálogo ya ordenado, y la directiva de datos estructurados lo lee de ahí en vez de resolverlo de nuevo.
- **Se retira el opt-out de indexado** que la página traía desde la primera PR. Con eso el guardrail de `seo-host-directives.spec.ts` pasa a evaluarla por su rama indexable, que exige justamente el par de directivas que esta PR agrega.
- **e2e de invariantes de indexado** (`e2e/seo/literary-work.spec.ts`), sin `fixme`.

## Una diferencia de fondo con el catálogo de colecciones

En `/collection`, el catálogo y el detalle comparten prefijo: los `ListItem` apuntan a `/collection/<slug>`. Acá no. El catálogo vive en `/literary-work` y cada obra en `/read/<slug>`, así que los `ListItem` —y el `requiredInternalLinkPrefix` del e2e— apuntan a `/read/`. Hay un caso dedicado a eso en el spec del schema y otro en el e2e.

## Qué queda funcionando y qué no

`/literary-work` es indexable y pasa la tanda completa de invariantes sobre el HTML servido. Todavía no está en el sitemap, nada la enlaza y `/story` sigue respondiendo la página vieja: eso es la cuarta PR.

## Un ajuste al invariante de indexado, y por qué

El colector exigía `ng-server-context="ssr"` y trataba `"ssg"` como un deopt a renderizado en cliente. No lo es: Angular emite `ssg` al **prerenderizar**, y esa página sirve el HTML completo. Como `/literary-work` es una ruta `Prerender`, el caso D habría fallado por una razón que no tiene nada que ver con lo que la regla persigue.

Se verificó sobre el build real antes de tocar nada — la página prerenderizada del catálogo sale con sus 614 filas, sus 614 enlaces a `/read/…` y su `ItemList` completo. El invariante pasa a aceptar `ssr` o `ssg`, y sigue rechazando el caso que importa: contexto vacío o ausente, cada uno con su caso propio en el spec del colector.

## Plan de pruebas

- Tier local completo verde: `tsc --noEmit`, `lint`, `stylelint`, `check:agents`, `storybook:build` y la suite entera (2509 tests).
- `pnpm build` corrido en local para inspeccionar el HTML prerenderizado de `/literary-work`: trae la tabla completa, los enlaces a la lectura y los cuatro bloques JSON-LD.
- El caso que exige que el JSON-LD se emita cuando el catálogo resuelve **después** de la instanciación se verificó por mutación: moviendo la lectura del host dentro del `untracked()`, falla.
- El gate `e2e` es el que de verdad ejercita el spec nuevo; corre en CI sobre el build de producción.

Parte de #2287 — tercera de cuatro PRs de la pila; el cierre del issue va en la última.
Parte de #2265.
