### PR TITLE
[#2287] - Redirige /story al listado nuevo y completa el cutover

### DIFF
--- a/e2e/seo/home.spec.ts
+++ b/e2e/seo/home.spec.ts
@@ -6,11 +6,11 @@
  *       link canonical, robots indexable y keywords.
  *  - B+C. Datos estructurados sitewide: bloques JSON-LD Organization y WebSite (la home no
  *         tiene una entidad propia, solo los sitewide del app initializer).
- *  - E. Enlaces a los hubs del catálogo (/story y /authors), que son la vía por la que el
- *       crawler alcanza el corpus.
+ *  - E. Enlaces a los hubs del catálogo (/literary-work y /authors), que son la vía por la que
+ *       el crawler alcanza el corpus.
  *
  * Sobre el DOM hidratado, vía navegación in-app (router):
- *  - D. Al navegar de la home a una story, los bloques sitewide persisten y aparece el Article;
+ *  - D. Al navegar de la home a una obra, los bloques sitewide persisten y aparece el Article;
  *       sin duplicar canonical ni <title>.
  */
 import { test, expect } from '@playwright/test';
@@ -61,13 +61,14 @@ test('home — B/C: bloques JSON-LD sitewide Organization y WebSite', async () =
 
 // Los hubs concentran los enlaces a todo el corpus, y hasta este cambio ninguna página los
 // enlazaba: el crawler solo los conocía por el sitemap. Se afirma sobre el HTML crudo porque lo
-// que importa es que estén sin ejecutar JS. Igualdad exacta del href: /story/<slug> no cuenta.
+// que importa es que estén sin ejecutar JS. Igualdad exacta del href: el enlace a una obra puntual
+// no cuenta como enlace al hub.
 test('home — E: enlaza los hubs del catálogo en el HTML server-rendered', async () => {
 	const hrefs = parseHtml(html)
 		.querySelectorAll('a')
 		.map((anchor) => anchor.getAttribute('href'));
 
-	expect(hrefs).toContain('/story');
+	expect(hrefs).toContain('/literary-work');
 	expect(hrefs).toContain('/authors');
 });
 

--- a/e2e/seo/sitemap.spec.ts
+++ b/e2e/seo/sitemap.spec.ts
@@ -50,6 +50,7 @@ test('sitemap — B: cubre las páginas estáticas y los tres tipos de contenido
 	expect(locs).toContain(`${origin}/about`);
 	expect(locs).toContain(`${origin}/dmca`);
 	expect(locs).toContain(`${origin}/collection`);
+	expect(locs).toContain(`${origin}/literary-work`);
 	expect(locs.some((loc) => loc.includes('/story/'))).toBe(true);
 	expect(locs.some((loc) => loc.includes('/author/'))).toBe(true);
 	expect(locs.some((loc) => loc.includes('/storylist/'))).toBe(true);

--- a/e2e/seo/story-listing-redirect.spec.ts
+++ b/e2e/seo/story-listing-redirect.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * El listado de obras se mudó de `/story` a `/literary-work`. Lo que se afirma acá es que la mudanza
+ * viaja en la respuesta HTTP: un crawler que no ejecuta JavaScript solo ve el 301, y es el 301 lo que
+ * traslada lo que la ruta vieja tenga indexado.
+ */
+import { test, expect } from '@playwright/test';
+
+import { STABLE_SLUGS } from '../_utils/seo-fixtures';
+
+// Una redirección HTTP no ejercita nada distinto en un segundo motor, y el gate es el más caro.
+test.skip(({ browserName }) => browserName !== 'chromium');
+
+test('story-listing — el listado viejo responde 301 permanente al nuevo', async ({ request }) => {
+	const response = await request.get('/story', { maxRedirects: 0 });
+
+	expect(response.status()).toBe(301);
+	expect(response.headers()['location']).toBe('/literary-work');
+});
+
+// La instancia real declara `strict: false`, así que la barra final entra por la misma ruta. Se
+// afirma acá y no solo en el spec del handler, que reconstruye su propio Hono: si alguien pasara la
+// instancia a `strict: true`, esta variante caería en el estático y aquel spec seguiría verde.
+test('story-listing — el listado viejo con barra final también redirige', async ({ request }) => {
+	const response = await request.get('/story/', { maxRedirects: 0 });
+
+	expect(response.status()).toBe(301);
+	expect(response.headers()['location']).toBe('/literary-work');
+});
+
+// El detalle de una obra tiene su propio traslado, en otro tren: si esta redirección se lo llevara
+// puesto, cada obra publicada dejaría de responder.
+test('story-listing — el detalle de una obra sigue respondiendo', async ({ request }) => {
+	const response = await request.get(`/story/${STABLE_SLUGS.story}`, { maxRedirects: 0 });
+
+	expect(response.status()).toBe(200);
+});

--- a/src/api/_middleware/legacy-story-listing-redirect.middleware.spec.ts
+++ b/src/api/_middleware/legacy-story-listing-redirect.middleware.spec.ts
@@ -1,0 +1,36 @@
+import { Hono } from 'hono';
+import { legacyStoryListingRedirect } from './legacy-story-listing-redirect.middleware';
+
+describe('legacyStoryListingRedirect', () => {
+	// `strict: false` es el modo de la instancia real, y es lo que hace que `/story/` entre por la
+	// misma ruta que `/story`.
+	function appUnderTest(): Hono {
+		const app = new Hono({ strict: false });
+		app.on('GET', '/story', legacyStoryListingRedirect);
+		app.get('/story/:slug', (c) => c.text('detalle de la obra'));
+		return app;
+	}
+
+	it('should answer the retired listing with a permanent redirect', async () => {
+		const response = await appUnderTest().request('/story');
+
+		expect(response.status).toBe(301);
+		expect(response.headers.get('Location')).toBe('/literary-work');
+	});
+
+	it('should redirect the listing with a trailing slash too', async () => {
+		const response = await appUnderTest().request('/story/');
+
+		expect(response.status).toBe(301);
+		expect(response.headers.get('Location')).toBe('/literary-work');
+	});
+
+	// El detalle de una obra tiene su propio traslado, en otro tren: si esta redirección se lo llevara
+	// puesto, cada obra publicada dejaría de responder y el listado se comería su tráfico.
+	it('should leave the detail of a work untouched', async () => {
+		const response = await appUnderTest().request('/story/el-palacio-de-las-nueve-fronteras');
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe('detalle de la obra');
+	});
+});

--- a/src/api/_middleware/legacy-story-listing-redirect.middleware.ts
+++ b/src/api/_middleware/legacy-story-listing-redirect.middleware.ts
@@ -1,0 +1,13 @@
+import type { Handler } from 'hono';
+
+/**
+ * El listado de obras se mudó de `/story` a `/literary-work`. La mudanza tiene que viajar en la
+ * respuesta HTTP y no en el router del cliente: un crawler que no ejecuta JavaScript solo ve el 301,
+ * y es el 301 —no un alias— lo que traslada lo que la ruta vieja tenga indexado.
+ *
+ * Es un handler terminal y no un middleware: responde en vez de ceder a `next()`, a diferencia del
+ * resto de esta carpeta.
+ *
+ * El destino va como literal porque `src/api/**` no importa `AppRoutes`, que es del frontend.
+ */
+export const legacyStoryListingRedirect: Handler = (c) => c.redirect('/literary-work', 301);

--- a/src/api/modules/sitemap/sitemap.service.spec.ts
+++ b/src/api/modules/sitemap/sitemap.service.spec.ts
@@ -80,6 +80,7 @@ describe('SitemapService', () => {
 				{ loc: 'https://test.cuentoneta.ar/about' },
 				{ loc: 'https://test.cuentoneta.ar/dmca' },
 				{ loc: 'https://test.cuentoneta.ar/collection' },
+				{ loc: 'https://test.cuentoneta.ar/literary-work' },
 			]);
 		});
 

--- a/src/api/modules/sitemap/sitemap.service.ts
+++ b/src/api/modules/sitemap/sitemap.service.ts
@@ -20,6 +20,7 @@ export async function getSitemapUrls(): Promise<SitemapUrl[]> {
 		{ loc: `${BASE_URL}/about` },
 		{ loc: `${BASE_URL}/dmca` },
 		{ loc: `${BASE_URL}/collection` },
+		{ loc: `${BASE_URL}/literary-work` },
 
 		// Páginas de cuentos
 		...stories.map((s) => ({ loc: `${BASE_URL}/story/${s.slug}`, lastmod: s.lastmod })),

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -32,7 +32,7 @@ describe('HeaderComponent', () => {
 
 	it('should link the catalog pages from the navbar', async () => {
 		await renderHeader();
-		expect(screen.getByText(/Obras/)).toHaveProperty('href', expect.stringMatching(/\/story$/));
+		expect(screen.getByText(/Obras/)).toHaveProperty('href', expect.stringMatching(/\/literary-work$/));
 		expect(screen.getByText(/Colecciones/)).toHaveProperty('href', expect.stringMatching(/\/collection$/));
 		expect(screen.getByText(/Autores/)).toHaveProperty('href', expect.stringMatching(/\/authors$/));
 	});

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -84,7 +84,7 @@ export class HeaderComponent {
 	protected readonly appRoutes = AppRoutes;
 	protected readonly navLinks: InternalLink[] = [
 		{ label: 'Inicio', path: `/${AppRoutes.Home}` },
-		{ label: 'Obras', path: `/${AppRoutes.Story}` },
+		{ label: 'Obras', path: `/${AppRoutes.LiteraryWork}` },
 		{ label: 'Colecciones', path: `/${AppRoutes.Collection}` },
 		{ label: 'Autores', path: `/${AppRoutes.Authors}` },
 		{ label: 'Nosotros', path: `/${AppRoutes.About}` },

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import sitemapController from './api/modules/sitemap/sitemap.controller';
 import { getAllowedHosts } from './api/_helpers/environment';
 import { noindexNonProduction } from './api/_middleware/noindex.middleware';
 import { ssrCacheControl } from './api/_middleware/ssr-cache-control.middleware';
+import { legacyStoryListingRedirect } from './api/_middleware/legacy-story-listing-redirect.middleware';
 
 /**
  * Inicializa Hono y exporta la instancia de la aplicación
@@ -34,6 +35,12 @@ app.route('/api', apiRoutes);
 // Acotado a GET: solo esas respuestas son cacheables por el borde, y un POST que devolviera 200
 // con el marcador no debe recibir headers de caché.
 app.on('GET', '/read/*', ssrCacheControl);
+
+// El listado de obras se mudó. Va antes de `serveStatic` y del catch-all SSR porque los dos son
+// `use('*')`: la ruta vieja está prerenderizada, así que el build deja un `index.html` que el
+// estático serviría, y si llegara al catch-all se renderizaría — en cualquiera de los dos casos el
+// 301 no se emite nunca.
+app.on('GET', '/story', legacyStoryListingRedirect);
 
 /**
  * Sirve los archivos estáticos desde el directorio /browser


### PR DESCRIPTION
Cuarta y última PR de la pila que traslada el listado de obras de `/story` a `/literary-work`. Las tres anteriores (#2388, #2390, #2391) ya están en `develop`: construyeron la ruta, el catálogo y su indexabilidad. Ésta hace el cutover, y es la única donde cambia el comportamiento visible.

## Qué cambia

- **`/story` responde 301 permanente a `/literary-work`**, como middleware de Hono registrado antes de `serveStatic` y del catch-all SSR.
- **La entrada «Obras» del encabezado** lleva al listado nuevo, para que la navegación no pase por la redirección en cada click.
- **`/literary-work` entra al sitemap** como página estática, junto a `/collection`.

## Tres cosas que vale mirar

**El orden de registro del 301 no es preferencia.** `serveStatic` y el catch-all SSR son `use('*')`, y `/story` está prerenderizada: el build deja un `index.html` que el estático serviría, y si la request llegara al catch-all se renderizaría. En cualquiera de los dos casos el 301 no se emite nunca.

**El middleware se extrae en vez de escribirse inline** porque `src/server.ts` no es testeable en Vitest —instancia el motor de Angular y resuelve el directorio del navegador desde la ruta del módulo—, y un 301 sin test unitario no es una opción.

**El alcance es lo que más caro sale si se rompe.** `/story` y `/story/` redirigen; `/story/:slug` **no**. El detalle de una obra tiene su propio traslado y viaja en otro tren, así que hay un caso dedicado a que siga respondiendo 200, tanto en el spec del middleware como en el e2e.

## Lo que deliberadamente no entra

El bloque dinámico del sitemap (`/story/<slug>`) y su query siguen intactos: las obras de detalle son alcance de #2270. `/story` queda además declarada `RenderMode.Prerender` — el build seguirá prerenderizando una página que el 301 vuelve inalcanzable. Es inocuo y muere con #2268; no se toca acá para no invadir su alcance.

## Plan de pruebas

- Tier local completo verde: `tsc --noEmit`, `lint`, `stylelint`, `check:agents` y la suite entera (2512 tests).
- Spec del handler: 301 y `Location` sobre `/story`, lo mismo sobre `/story/`, y el detalle de una obra llegando a su handler con 200.
- e2e sobre el sitio servido: la redirección se pide sin seguirla (`maxRedirects: 0`), en sus dos formas; el detalle sigue en 200; el sitemap contiene `/literary-work`; y la home enlaza al listado nuevo en el HTML crudo.
- Los once gates de CI, verdes sobre el commit final. El que importa acá es `e2e`: es el único que ejercita el 301 contra el build de producción, donde el orden de registro frente al estático y al catch-all SSR es observable.

Closes #2287.
Parte de #2265.
