### PR TITLE
[#1508] - Hero de la página de inicio

### DIFF
--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -3,10 +3,10 @@ import { test, expect } from '@playwright/test';
 test('home: único H1 de contenido y marca en el header', async ({ page }) => {
 	await page.goto('/');
 
-	// La home debe tener exactamente un <h1> de contenido (sr-only). La marca del header
+	// La home debe tener exactamente un <h1> de contenido, el del hero. La marca del header
 	// dejó de ser <h1> (ahora es un <span>), por lo que ya no duplica el encabezado.
 	await expect(page.locator('h1')).toHaveCount(1);
-	await expect(page.locator('h1')).toHaveText('Cuentos y relatos breves para leer en línea');
+	await expect(page.locator('h1')).toHaveText(/Un espacio para explorar y descubrir nuevas obras/);
 
 	// La marca sigue presente en el header y el <title> SEO contiene la marca.
 	await expect(page.locator('header').getByText('La Cuentoneta').first()).toBeVisible();

--- a/src/app/components/home-hero/home-hero.component.spec.ts
+++ b/src/app/components/home-hero/home-hero.component.spec.ts
@@ -17,6 +17,15 @@ describe('HomeHeroComponent', () => {
 
 			expect(screen.getByText(/relatos organizados en colecciones/)).toBeInTheDocument();
 		});
+
+		// El trazo es decoración: aporta la forma del diseño y nada que leer, así que no entra al árbol de
+		// accesibilidad ni compite con el encabezado por nombrar la banda.
+		it('should draw the background stroke as decoration', async () => {
+			await render(HomeHeroComponent);
+
+			expect(screen.getByTestId('hero-weave')).toHaveAttribute('alt', '');
+			expect(screen.queryAllByRole('img')).toHaveLength(0);
+		});
 	});
 
 	describe('Portadas ilustrativas', () => {

--- a/src/app/components/home-hero/home-hero.component.spec.ts
+++ b/src/app/components/home-hero/home-hero.component.spec.ts
@@ -8,7 +8,7 @@ describe('HomeHeroComponent', () => {
 			await render(HomeHeroComponent);
 
 			expect(
-				screen.getByRole('heading', { level: 1, name: 'Un espacio para explorar y descubrir nuevas historias' }),
+				screen.getByRole('heading', { level: 1, name: 'Un espacio para explorar y descubrir nuevas obras' }),
 			).toBeInTheDocument();
 		});
 

--- a/src/app/components/home-hero/home-hero.component.spec.ts
+++ b/src/app/components/home-hero/home-hero.component.spec.ts
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/angular';
+
+import { HomeHeroComponent } from './home-hero.component';
+
+describe('HomeHeroComponent', () => {
+	describe('Renderizado del componente', () => {
+		it('should carry the page heading', async () => {
+			await render(HomeHeroComponent);
+
+			expect(
+				screen.getByRole('heading', { level: 1, name: 'Un espacio para explorar y descubrir nuevas historias' }),
+			).toBeInTheDocument();
+		});
+
+		it('should describe what the site offers', async () => {
+			await render(HomeHeroComponent);
+
+			expect(screen.getByText(/relatos organizados en colecciones/)).toBeInTheDocument();
+		});
+	});
+
+	describe('Portadas ilustrativas', () => {
+		const covers = ['https://cdn.sanity.io/uno.jpg', 'https://cdn.sanity.io/dos.jpg'];
+
+		it('should render one cover per image it receives', async () => {
+			await render(HomeHeroComponent, { inputs: { covers } });
+
+			expect(screen.getAllByTestId('cover-image')).toHaveLength(covers.length);
+		});
+
+		// Son decorativas: el enlace y el nombre los aporta el contenido, no la banda.
+		it('should leave the covers out of the accessibility tree', async () => {
+			await render(HomeHeroComponent, { inputs: { covers } });
+
+			screen.getAllByTestId('cover-image').forEach((cover) => expect(cover).toHaveAttribute('alt', ''));
+			expect(screen.queryAllByRole('img')).toHaveLength(0);
+		});
+
+		// Sin portadas no queda un contenedor vacío ocupando su lugar en la fila.
+		it('should render no cover strip when there are no images', async () => {
+			await render(HomeHeroComponent);
+
+			expect(screen.queryByTestId('hero-covers')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Contenido proyectado', () => {
+		it('should render what the page projects below the heading', async () => {
+			await render('<cuentoneta-home-hero><p>Carrusel de campañas</p></cuentoneta-home-hero>', {
+				imports: [HomeHeroComponent],
+			});
+
+			expect(screen.getByText('Carrusel de campañas')).toBeInTheDocument();
+		});
+	});
+});

--- a/src/app/components/home-hero/home-hero.component.stories.ts
+++ b/src/app/components/home-hero/home-hero.component.stories.ts
@@ -1,18 +1,23 @@
 import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
 
 import { HomeHeroComponent } from './home-hero.component';
-import { onoffCollectionTeasersOfLength } from '@mocks/onoff-collections.mock';
+import { onoffImageAssets } from '@mocks/onoff-image-assets.mock';
 
-// Las portadas salen del canon de Onoff, del mismo modo que las deriva la página: solo las colecciones
-// con imagen editorial propia, y a lo sumo tres.
-const covers = onoffCollectionTeasersOfLength(6)
-	.flatMap((collection) => (collection.imagery.kind === 'representative' ? [collection.imagery.image] : []))
-	.slice(0, 3);
+// Tres portadas distintas del canon de Onoff. No se derivan del agregador de colecciones porque hoy
+// tiene una sola colección con imagen editorial propia, y la banda quedaría mostrando la misma imagen
+// tres veces: un estado que ninguna semana real produce.
+const covers = [
+	onoffImageAssets.geometriasDelDesveloCover.path,
+	onoffImageAssets.neronCover.path,
+	onoffImageAssets.lasEscalerasCover.path,
+];
 
 const meta: Meta<HomeHeroComponent> = {
 	component: HomeHeroComponent,
 	title: 'Componentes V3/HomeHero',
 	parameters: {
+		// Sin esto el canvas enmarca la banda con su padding y esconde justo lo que la define.
+		layout: 'fullscreen',
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {

--- a/src/app/components/home-hero/home-hero.component.stories.ts
+++ b/src/app/components/home-hero/home-hero.component.stories.ts
@@ -1,0 +1,87 @@
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
+
+import { HomeHeroComponent } from './home-hero.component';
+import { onoffCollectionTeasersOfLength } from '@mocks/onoff-collections.mock';
+
+// Las portadas salen del canon de Onoff, del mismo modo que las deriva la página: solo las colecciones
+// con imagen editorial propia, y a lo sumo tres.
+const covers = onoffCollectionTeasersOfLength(6)
+	.flatMap((collection) => (collection.imagery.kind === 'representative' ? [collection.imagery.image] : []))
+	.slice(0, 3);
+
+const meta: Meta<HomeHeroComponent> = {
+	component: HomeHeroComponent,
+	title: 'Componentes V3/HomeHero',
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>El <strong>HomeHero</strong> es la banda que abre la página de inicio en el Design System v3: fondo <code>brand-200</code> a todo el ancho, con el <code>&lt;h1&gt;</code> de la página, su bajada y una muestra de portadas alineada a la derecha, y el carrusel de campañas proyectado debajo.</p><p>El fondo es full-bleed y el contenido va enmarcado adentro, así que el host vive fuera del contenedor angosto de la página. Las portadas son ilustrativas —no enlazan y su <code>alt</code> queda vacío— y las resuelve <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a>; la página le pasa las de las colecciones destacadas que tienen imagen editorial propia, hasta tres, y ninguna si no hay.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		covers: {
+			control: { type: 'object' },
+			description: 'Portadas ilustrativas de la banda; vacío deja el hero solo con su texto',
+			table: { type: { summary: 'readonly string[]' }, defaultValue: { summary: '[]' } },
+		},
+	},
+};
+export default meta;
+type Story = StoryObj<HomeHeroComponent>;
+
+export const Primary: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-home-hero ${argsToTemplate(args)} />`,
+	}),
+	args: { covers },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>La forma que sirve la página de inicio cuando la semana trae colecciones con imagen editorial: título, bajada y tres portadas.</p><p><strong>Usos:</strong> el encabezado de la página de inicio.</p>`,
+			},
+		},
+	},
+};
+
+export const SinPortadas: Story = {
+	name: 'Sin portadas',
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-home-hero ${argsToTemplate(args)} />`,
+	}),
+	args: { covers: [] },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Ninguna colección destacada tiene imagen editorial propia. La banda no reserva el hueco: el texto ocupa el ancho y la fila no queda coja.</p><p><strong>Usos:</strong> revisar la banda en una semana sin material ilustrativo.</p>`,
+			},
+		},
+	},
+};
+
+export const ConContenidoProyectado: Story = {
+	name: 'Con contenido proyectado',
+	render: (args) => ({
+		props: args,
+		// El carrusel real se sustituye por un bloque de la misma caja: la story documenta la proyección,
+		// no el carrusel, que tiene su propia entrada de catálogo.
+		template: `
+			<cuentoneta-home-hero ${argsToTemplate(args)}>
+				<div class="flex h-90 w-full items-center justify-center rounded-[20px] bg-neutral-300 font-inter text-neutral-700">
+					Carrusel de campañas
+				</div>
+			</cuentoneta-home-hero>
+		`,
+	}),
+	args: { covers },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El hueco proyectado, que en la página lo ocupa el carrusel de campañas. Muestra la separación entre el bloque de texto y lo que viene debajo, y que el fondo de la banda envuelve a los dos.</p><p><strong>Usos:</strong> verificar la caja del carrusel dentro de la banda sin montar el carrusel.</p>`,
+			},
+		},
+	},
+};

--- a/src/app/components/home-hero/home-hero.component.ts
+++ b/src/app/components/home-hero/home-hero.component.ts
@@ -1,10 +1,11 @@
 import { Component, input } from '@angular/core';
+import { NgOptimizedImage } from '@angular/common';
 
 import { CoverImageComponent } from '@components/cover-image/cover-image.component';
 
 /**
- * Encabezado de la página de inicio del Design System v3: la banda de fondo que abre la página, con
- * el título, la bajada y una muestra de portadas, y el carrusel de campañas proyectado debajo.
+ * Encabezado de la página de inicio del Design System v3: la banda que abre la página —con su trazo de
+ * fondo, el título, la bajada y una muestra de portadas— y el carrusel de campañas proyectado debajo.
  *
  * El fondo es full-bleed y el contenido va enmarcado adentro, así que el host no puede vivir dentro
  * del contenedor angosto de la página.
@@ -14,9 +15,17 @@ import { CoverImageComponent } from '@components/cover-image/cover-image.compone
  */
 @Component({
 	selector: 'cuentoneta-home-hero',
-	imports: [CoverImageComponent],
+	imports: [NgOptimizedImage, CoverImageComponent],
 	template: `
-		<div class="mx-auto flex w-full max-w-screen-lg flex-col items-center gap-20 px-5 pt-44 pb-16">
+		<!--
+			El trazo del diseño viaja como imagen y no como marcado: la curva no tiene semántica y su
+			geometría es del diseño, así que exportarla evita reproducirla a mano y que se desvíe del mock.
+			Se estira con la banda —igual que en el diseño, que la declara sin conservar proporción—, porque
+			el alto de la banda lo fija su contenido y no una relación de aspecto.
+		-->
+		<img ngSrc="./assets/svg/home-hero-weave.svg" fill priority alt="" class="object-fill" data-testid="hero-weave" />
+
+		<div class="relative z-content mx-auto flex w-full max-w-screen-lg flex-col items-center gap-20 px-5 pt-44 pb-16">
 			<div class="flex w-full flex-col items-center justify-between gap-10 lg:flex-row lg:gap-8">
 				<div class="flex flex-col gap-4">
 					<h1 class="font-source-serif text-4xl font-semibold text-neutral-900 lg:text-6xl">
@@ -45,7 +54,9 @@ import { CoverImageComponent } from '@components/cover-image/cover-image.compone
 		</div>
 	`,
 	host: {
-		class: 'block bg-brand-200',
+		// El color de fondo se conserva bajo la imagen: cubre la banda mientras el trazo no cargó, y evita
+		// un destello blanco en la primera pantalla.
+		class: 'relative isolate block overflow-hidden bg-brand-200',
 	},
 })
 export class HomeHeroComponent {

--- a/src/app/components/home-hero/home-hero.component.ts
+++ b/src/app/components/home-hero/home-hero.component.ts
@@ -1,0 +1,50 @@
+import { Component, input } from '@angular/core';
+
+import { CoverImageComponent } from '@components/cover-image/cover-image.component';
+
+/**
+ * Encabezado de la página de inicio del Design System v3: la banda de fondo que abre la página, con
+ * el título, la bajada y una muestra de portadas, y el carrusel de campañas proyectado debajo.
+ *
+ * El fondo es full-bleed y el contenido va enmarcado adentro, así que el host no puede vivir dentro
+ * del contenedor angosto de la página.
+ *
+ * Las portadas son ilustrativas: no enlazan a ningún lado y su `alt` queda vacío, porque el título y
+ * la bajada ya dicen todo lo que la banda comunica.
+ */
+@Component({
+	selector: 'cuentoneta-home-hero',
+	imports: [CoverImageComponent],
+	template: `
+		<div class="content horizontal-layout-spacing flex flex-col items-center gap-20 pt-44 pb-16">
+			<div class="flex w-full flex-col items-center justify-between gap-10 md:flex-row md:gap-8">
+				<div class="flex flex-col gap-4">
+					<h1 class="font-source-serif text-4xl font-semibold text-neutral-900 md:text-6xl">
+						Un espacio para explorar y descubrir nuevas historias
+					</h1>
+					<p class="font-inter text-xl font-medium text-neutral-600">
+						Leé, descubrí y compartí relatos organizados en colecciones creadas para acercar la lectura digital a más
+						personas.
+					</p>
+				</div>
+
+				@if (covers().length > 0) {
+					<div class="flex shrink-0 gap-4" data-testid="hero-covers">
+						@for (cover of covers(); track cover) {
+							<cuentoneta-cover-image [src]="cover" [priority]="$first" />
+						}
+					</div>
+				}
+			</div>
+
+			<ng-content />
+		</div>
+	`,
+	host: {
+		class: 'block bg-brand-200',
+	},
+})
+export class HomeHeroComponent {
+	/** Portadas ilustrativas de la banda; vacío deja el hero solo con su texto. */
+	public readonly covers = input<readonly string[]>([]);
+}

--- a/src/app/components/home-hero/home-hero.component.ts
+++ b/src/app/components/home-hero/home-hero.component.ts
@@ -16,11 +16,11 @@ import { CoverImageComponent } from '@components/cover-image/cover-image.compone
 	selector: 'cuentoneta-home-hero',
 	imports: [CoverImageComponent],
 	template: `
-		<div class="content horizontal-layout-spacing flex flex-col items-center gap-20 pt-44 pb-16">
-			<div class="flex w-full flex-col items-center justify-between gap-10 md:flex-row md:gap-8">
+		<div class="mx-auto flex w-full max-w-screen-lg flex-col items-center gap-20 px-5 pt-44 pb-16">
+			<div class="flex w-full flex-col items-center justify-between gap-10 lg:flex-row lg:gap-8">
 				<div class="flex flex-col gap-4">
-					<h1 class="font-source-serif text-4xl font-semibold text-neutral-900 md:text-6xl">
-						Un espacio para explorar y descubrir nuevas historias
+					<h1 class="font-source-serif text-4xl font-semibold text-neutral-900 lg:text-6xl">
+						Un espacio para explorar y descubrir nuevas obras
 					</h1>
 					<p class="font-inter text-xl font-medium text-neutral-600">
 						Leé, descubrí y compartí relatos organizados en colecciones creadas para acercar la lectura digital a más
@@ -29,8 +29,12 @@ import { CoverImageComponent } from '@components/cover-image/cover-image.compone
 				</div>
 
 				@if (covers().length > 0) {
-					<div class="flex shrink-0 gap-4" data-testid="hero-covers">
-						@for (cover of covers(); track cover) {
+					<!--
+						La tira mide 386px rígidos y no encoge, así que solo aparece donde el hero es de dos columnas:
+						en el diseño es el adorno de esa fila, y en una columna desbordaría el ancho del teléfono.
+					-->
+					<div class="hidden shrink-0 gap-4 md:flex" data-testid="hero-covers">
+						@for (cover of covers(); track $index) {
 							<cuentoneta-cover-image [src]="cover" [priority]="$first" />
 						}
 					</div>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,9 +1,6 @@
 <main>
 	<cuentoneta-home-hero [covers]="heroCovers()">
-		<!--
-            Las alturas fijadas para los elementos hijos de <main> tienen la finalidad de evitar
-            el rebote vertical que puede observarse en el momento de la carga inicial de la página
-        -->
+		<!-- La caja se reserva por proporción para que resolver el diferido no empuje lo que sigue. -->
 		<section class="aspect-[540/220] w-full sm:aspect-[1240/360]">
 			@defer (when campaigns().length > 0) {
 				<cuentoneta-carousel [slides]="campaigns()" />
@@ -14,6 +11,10 @@
 	</cuentoneta-home-hero>
 
 	<div class="content horizontal-layout-spacing mt-16">
+		<!--
+            Los altos fijos de las dos secciones de obras evitan el rebote vertical de la carga
+            inicial, mientras esas grillas sigan resolviéndose en un bloque diferido.
+        -->
 		<section class="mb-8 h-[684px] md:h-[304px]">
 			<cuentoneta-literary-works-card-deck
 				[literaryWorks]="latestReads()"

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -11,11 +11,7 @@
 	</cuentoneta-home-hero>
 
 	<div class="content horizontal-layout-spacing mt-16">
-		<!--
-            Los altos fijos de las dos secciones de obras evitan el rebote vertical de la carga
-            inicial, mientras esas grillas sigan resolviéndose en un bloque diferido.
-        -->
-		<section class="mb-8 h-[684px] md:h-[304px]">
+		<section class="mb-8">
 			<cuentoneta-literary-works-card-deck
 				[literaryWorks]="latestReads()"
 				[action]="literaryWorksAction"
@@ -24,7 +20,7 @@
 			/>
 		</section>
 
-		<section class="mb-8 h-[684px] md:h-[304px]">
+		<section class="mb-8">
 			<cuentoneta-literary-works-card-deck
 				[literaryWorks]="mostRead()"
 				[action]="literaryWorksAction"

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,68 +1,65 @@
-<main class="content horizontal-layout-spacing vertical-layout-spacing">
-	<!--
-        H1 de contenido de la home, oculto visualmente (sr-only) para mantener un único H1 por página
-        sin desplazar el hero. El texto introductorio sustantivo va en la sección "Sobre La Cuentoneta"
-        al final del main (contenido indexable para buscadores y answer engines).
-    -->
-	<h1 class="sr-only">Cuentos y relatos breves para leer en línea</h1>
+<main>
+	<cuentoneta-home-hero [covers]="heroCovers()">
+		<!--
+            Las alturas fijadas para los elementos hijos de <main> tienen la finalidad de evitar
+            el rebote vertical que puede observarse en el momento de la carga inicial de la página
+        -->
+		<section class="aspect-[540/220] w-full sm:aspect-[1240/360]">
+			@defer (when campaigns().length > 0) {
+				<cuentoneta-carousel [slides]="campaigns()" />
+			} @loading (minimum 500ms) {
+				<cuentoneta-carousel-skeleton />
+			}
+		</section>
+	</cuentoneta-home-hero>
 
-	<!--
-        Las alturas fijadas para los elementos hijos de <main> tienen la finalidad de evitar
-        el rebote vertical que puede observarse en el momento de la carga inicial de la página
-    -->
-	<section class="mb-8 aspect-[540/220] sm:aspect-[1240/360]">
-		@defer (when campaigns().length > 0) {
-			<cuentoneta-carousel [slides]="campaigns()" />
-		} @loading (minimum 500ms) {
-			<cuentoneta-carousel-skeleton />
-		}
-	</section>
+	<div class="content horizontal-layout-spacing mt-16">
+		<section class="mb-8 h-[684px] md:h-[304px]">
+			<cuentoneta-literary-works-card-deck
+				[literaryWorks]="latestReads()"
+				[action]="literaryWorksAction"
+				heading="Últimas novedades"
+				subtitle="Descubrí las obras que se sumaron recientemente a La Cuentoneta"
+			/>
+		</section>
 
-	<section class="mb-8 h-[684px] md:h-[304px]">
-		<cuentoneta-literary-works-card-deck
-			[literaryWorks]="latestReads()"
-			[action]="literaryWorksAction"
-			heading="Últimas novedades"
-			subtitle="Descubrí las obras que se sumaron recientemente a La Cuentoneta"
-		/>
-	</section>
+		<section class="mb-8 h-[684px] md:h-[304px]">
+			<cuentoneta-literary-works-card-deck
+				[literaryWorks]="mostRead()"
+				[action]="literaryWorksAction"
+				heading="Obras más leídas"
+				subtitle="Explorá los textos más populares entre los lectores"
+			/>
+		</section>
 
-	<section class="mb-8 h-[684px] md:h-[304px]">
-		<cuentoneta-literary-works-card-deck
-			[literaryWorks]="mostRead()"
-			[action]="literaryWorksAction"
-			heading="Obras más leídas"
-			subtitle="Explorá los textos más populares entre los lectores"
-		/>
-	</section>
+		<section class="mb-8">
+			<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" />
+		</section>
 
-	<section class="mb-8">
-		<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" />
-	</section>
+		<section class="mb-8">
+			<cuentoneta-collection-teasers-deck [teasers]="collections()" class="flex flex-col gap-8" />
+		</section>
 
-	<section class="mb-8">
-		<cuentoneta-collection-teasers-deck [teasers]="collections()" class="flex flex-col gap-8" />
-	</section>
+		<!--
+            Intro descriptiva con texto sustantivo y citable, server-rendered (sin @defer), para que
+            buscadores y answer engines tengan contenido indexable más allá de las imágenes del hero.
+        -->
+		<section class="mb-8 flex flex-col gap-8">
+			<cuentoneta-section-header heading="Sobre La Cuentoneta" />
 
-	<!--
-        Intro descriptiva con texto sustantivo y citable, server-rendered (sin @defer), para que
-        buscadores y answer engines tengan contenido indexable más allá de las imágenes del hero.
-    -->
-	<section class="mb-8 flex flex-col gap-8">
-		<cuentoneta-section-header heading="Sobre La Cuentoneta" />
-
-		<div class="flex flex-col gap-4">
-			<p class="font-inter text-base font-normal">
-				La Cuentoneta es un proyecto abierto, comunitario y sin fines de lucro que busca fomentar y hacer accesible la
-				lectura digital. Publicamos cuentos, poemas y relatos breves organizados en colecciones temáticas —antologías
-				pensadas como las playlists de Spotify o YouTube— para que descubrir y disfrutar literatura se transforme en un
-				proceso simple y entretenido.
-			</p>
-			<p class="font-inter text-base font-normal">
-				Reunimos obras de autores y autoras de distintos géneros, estilos y épocas, con soporte multimedia y foco en la
-				captura de material literario editado con fines educativos y su adaptación a texto accesible. Te invitamos a
-				leer, compartir y aprender con cada historia.
-			</p>
-		</div>
-	</section>
+			<div class="flex flex-col gap-4">
+				<p class="font-inter text-base font-normal">
+					La Cuentoneta es un proyecto abierto, comunitario y sin fines de lucro que busca fomentar y hacer accesible la
+					lectura digital. Publicamos cuentos, poemas y relatos breves organizados en colecciones temáticas —antologías
+					pensadas como las playlists de Spotify o YouTube— para que descubrir y disfrutar literatura se transforme en
+					un proceso simple y entretenido.
+				</p>
+				<p class="font-inter text-base font-normal">
+					Reunimos obras de autores y autoras de distintos géneros, estilos y épocas, con soporte multimedia y foco en
+					la captura de material literario editado con fines educativos y su adaptación a texto accesible. Te invitamos
+					a leer, compartir y aprender con cada historia.
+				</p>
+			</div>
+		</section>
+	</div>
 </main>

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -11,6 +11,7 @@ import type { LandingPageContent } from '@models/landing-page-content.model';
 import { onoffHighlightedAuthorsOfLength } from '@mocks/onoff-highlighted-authors.mock';
 import { onoffLiteraryWorkNavigationTeasersWithAuthorsMock } from '@mocks/onoff-literary-work-teasers.mock';
 import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
+import type { CollectionTeaser } from '@models/collection.model';
 import { contentCampaignMock } from '@mocks/content-campaign.mock';
 import { renderDeferBlocks } from '@testing/defer-blocks';
 import { clearAllMocks } from '@test-utils';
@@ -50,7 +51,7 @@ describe('HomeComponent', () => {
 			await renderHome();
 
 			expect(
-				screen.getByRole('heading', { level: 1, name: 'Un espacio para explorar y descubrir nuevas historias' }),
+				screen.getByRole('heading', { level: 1, name: 'Un espacio para explorar y descubrir nuevas obras' }),
 			).toBeInTheDocument();
 		});
 
@@ -75,6 +76,20 @@ describe('HomeComponent', () => {
 			expect(hero.getAllByTestId('cover-image').map((cover) => cover.getAttribute('src'))).toEqual(
 				editorialCovers.slice(0, 3),
 			);
+		});
+
+		// El corpus tiene una sola colección con imagen editorial, así que el tope hay que ejercitarlo con
+		// una semana construida: con el corpus tal cual, el recorte nunca llega a descartar nada.
+		it('should cap the hero at three covers, however many collections bring one', async () => {
+			const withEditorialCover = onoffCollectionTeasersMock.find(
+				(collection) => collection.imagery.kind === 'representative',
+			);
+			expect(withEditorialCover).toBeDefined();
+			const collections = Array.from({ length: 5 }, () => withEditorialCover as CollectionTeaser);
+
+			await renderHome({ collections });
+
+			expect(within(screen.getByTestId('hero-covers')).getAllByTestId('cover-image')).toHaveLength(3);
 		});
 	});
 

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -43,6 +43,41 @@ describe('HomeComponent', () => {
 		clearAllMocks();
 	});
 
+	describe('encabezado de la página', () => {
+		// El H1 de la página lo aporta el hero. La suite de indexado exige un H1 con texto real dentro de
+		// <main>, así que la banda no puede quedar fuera del contenido primario.
+		it('should carry a visible level 1 heading', async () => {
+			await renderHome();
+
+			expect(
+				screen.getByRole('heading', { level: 1, name: 'Un espacio para explorar y descubrir nuevas historias' }),
+			).toBeInTheDocument();
+		});
+
+		it('should carry exactly one level 1 heading', async () => {
+			await renderHome();
+
+			expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+		});
+
+		// La imagen editorial de la colección: las que solo tienen portadas prestadas de sus obras no
+		// suben a la banda, porque esas mismas portadas ya se ven más abajo en la propia página.
+		it('should illustrate the hero with the covers of the featured collections', async () => {
+			const collections = onoffCollectionTeasersMock;
+			const editorialCovers = collections.flatMap((collection) =>
+				collection.imagery.kind === 'representative' ? [collection.imagery.image] : [],
+			);
+			expect(editorialCovers.length).toBeGreaterThan(0);
+
+			await renderHome({ collections });
+
+			const hero = within(screen.getByTestId('hero-covers'));
+			expect(hero.getAllByTestId('cover-image').map((cover) => cover.getAttribute('src'))).toEqual(
+				editorialCovers.slice(0, 3),
+			);
+		});
+	});
+
 	describe('mazos de obras', () => {
 		// Rebanadas disjuntas del corpus: es lo que permite afirmar cuál de los dos listados llegó a cada
 		// mazo, y no solo cuántas tarjetas hay en total.

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -14,6 +14,7 @@ import { HomeStructuredDataDirective } from './home-structured-data.directive';
 
 // Componentes
 import { CarouselComponent } from '@components/carousel/carousel.component';
+import { HomeHeroComponent } from '@components/home-hero/home-hero.component';
 import { LiteraryWorksCardDeck } from '@components/literary-works-card-deck/literary-works-card-deck';
 import { CarouselSkeletonComponent } from '@components/carousel/carousel-skeleton.component';
 import { CollectionTeasersDeck } from '@components/collection-teasers-deck/collection-teasers-deck';
@@ -25,6 +26,7 @@ import { SectionHeaderComponent, type SectionHeaderAction } from '@components/se
 	templateUrl: './home.component.html',
 	imports: [
 		CarouselComponent,
+		HomeHeroComponent,
 		LiteraryWorksCardDeck,
 		CarouselSkeletonComponent,
 		CollectionTeasersDeck,
@@ -57,4 +59,12 @@ export default class HomeComponent {
 	protected readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
 	protected readonly latestReads = computed(() => this.landingPageContent()?.latestReads.slice(0, 6) || []);
 	protected readonly highlightedAuthors = computed(() => this.landingPageContent()?.highlightedAuthors ?? []);
+
+	// Solo las colecciones con portada editorial propia: las que caen en `sample` prestan las portadas de
+	// sus obras, y esas ya se ven más abajo en la página. Sin ninguna, la banda va sin portadas.
+	protected readonly heroCovers = computed(() =>
+		this.collections()
+			.flatMap((collection) => (collection.imagery.kind === 'representative' ? [collection.imagery.image] : []))
+			.slice(0, 3),
+	);
 }

--- a/src/assets/svg/home-hero-weave.svg
+++ b/src/assets/svg/home-hero-weave.svg
@@ -1,0 +1,11 @@
+<svg preserveAspectRatio="none" overflow="visible" style="display: block;" width="1920" height="919" viewBox="0 0 1920 919" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Background Header" clip-path="url(#clip0_0_4)">
+<rect width="1920" height="919" fill="#FBE4DF"/>
+<path id="Weave" d="M1206.14 281.42C1304.8 169.269 1308.7 76.5442 1307.66 -19.6531L1724.69 -14.1522C1746.38 42.2039 1705.02 296.709 1631.43 412.653C1458.18 685.576 1347.32 609.974 1156.29 715.705C920.788 846.047 842.347 874.426 821.869 973.5L445.648 966.385C454.737 927.605 425.094 945.661 673.874 701.243C922.653 456.826 946.249 576.866 1206.14 281.42Z" fill="#DEBDA7" fill-opacity="0.3"/>
+</g>
+<defs>
+<clipPath id="clip0_0_4">
+<rect width="1920" height="919" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
Segunda rebanada de la migración de la página de inicio a V3. Cubre el punto 1 del alcance del issue —el hero— y la decisión sobre el H1.

> **Apilado sobre #2399** (`feat/1508-encabezado-de-seccion-reutilizable`). La base apunta a esa rama mientras siga abierta; hay que mergear #2399 primero.

## Qué cambia

**La página abre con la banda del diseño.** Fondo `brand-200` a todo el ancho con el título, la bajada y una muestra de portadas, y el carrusel de campañas proyectado adentro — en el mock el carrusel vive dentro de la misma banda, no debajo. Antes la página abría directamente con el carrusel.

**El H1 pasa a ser visible.** El `sr-only` que sostenía el único H1 de la página se elimina y su rol lo toma el título del hero. Las palabras clave que cargaba no se pierden: el `<title>` del documento ya lleva ese texto literal («Cuentos y relatos breves para leer en línea | La Cuentoneta»), y la suite de indexado exige un H1 con texto real **dentro de `<main>`**, que es donde queda la banda. Un spec nuevo afirma además que sigue habiendo exactamente uno.

**`<main>` deja de ser el contenedor angosto.** Para que el fondo llegue a los bordes, las clases de contenedor bajan a un `<div>` que envuelve las secciones. El `mt-24 md:mt-36` que separaba del header fijo lo absorbe el padding superior del hero.

**Las portadas salen del contenido real.** Se derivan de las colecciones destacadas que tienen imagen editorial propia (`imagery.kind === 'representative'`), hasta tres. Las que solo tienen portadas prestadas de sus obras no suben a la banda, porque esas mismas portadas ya se ven más abajo en la página. Si ninguna tiene imagen propia, la banda va sin portadas y el texto ocupa el ancho, sin dejar un hueco reservado.

## Qué NO entra

**La franja gris de la barra de navegación sobre el hero.** El diseño extiende el fondo por detrás de la barra, pero `HeaderComponent` monta la barra fuera del outlet, `fixed` y con `bg-neutral-50` propio. Resolverlo toca el shell del sitio y su ocultado al scrollear, que afectan las 13 rutas y no solo esta página, así que va en #2402 (milestone 2.11.2).

El ancho de contenido tampoco cambia: el diseño trabaja con 1240 px y `.content` es `max-w-screen-lg` (1024). Es un cambio site-wide, fuera del alcance del issue.

El paso de `@defer` a `@if`, el estado vacío y el reordenamiento de secciones siguen en las rebanadas 3 y 4.

## Desviaciones respecto del mock

- **La tira de portadas mide 386×164 y en el mock la `HeroImage` es de 450×239.** En el nodo esa imagen es un PNG plano con tres libros inclinados, con lomo y sombra: el diseño no la compone desde el contenido. Acá se compone con portadas reales de las colecciones destacadas, y el tamaño sale de reusar `CoverImage` tal cual, así que el bloque queda más chico y sin el tratamiento del mock. **Darle ese tratamiento a las portadas vivas queda para la última rebanada del issue**, que ya lo tiene como paso propio.
- **Debajo de `md` la tira no se muestra.** El diseño solo especifica desktop, y ahí las portadas son el adorno de un layout de dos columnas que en móvil no existe. La alternativa era desbordar el ancho del teléfono.
- **El vector decorativo «Weave» del fondo no se implementa.** La banda va con el color plano `brand-200`.

## Plan de pruebas

- **Gates locales:** `typecheck`, `lint`, `stylelint`, `test`, `build` y `storybook:build` en verde. `build` se corrió en local porque el cambio reestructura el layout de la página y el typecheck no valida plantillas.
- **Cobertura nueva:** 6 casos del hero (el H1 con su copy, la bajada, una portada por imagen recibida, que las portadas queden fuera del árbol de accesibilidad, que sin imágenes no quede un contenedor vacío, y que el contenido proyectado se renderice) y 3 en la página (el H1 visible, que sea el único, y que las portadas del hero sean exactamente las de las colecciones con imagen editorial).
- **Invariantes de indexado:** `checkPrimaryHeading` mide `<h1>` con texto real dentro de `<main>` y el hero queda adentro; `checkPrimaryContentLength` solo suma texto. El test E enlaza los hubs por pertenencia, así que los enlaces nuevos no lo afectan.
- **Verificación en navegador** (dev server, Playwright), porque las dos regresiones que la review encontró eran de layout y ningún gate las detecta:
  - **375×812:** `scrollWidth` 360 contra un viewport de 375 — sin desborde horizontal. La banda mide 738 px, no una pantalla completa. Las portadas no se renderizan y hay exactamente un `<h1>` dentro de `<main>`.
  - **1440×900:** la banda mide 856 px, su fondo computa `rgb(251, 228, 223)` —el `#fbe4df` del diseño— y las tres portadas salen del contenido real, con URLs distintas.
  - Se observaron dos errores de consola, ambos **preexistentes y ajenos a este cambio**: `NG02953` (el carrusel actualiza `[width]` después de inicializar `NgOptimizedImage`) y `NG02955` (el banner del carrusel es el LCP y no está marcado `priority` en la rama de desktop). Vienen del carrusel, cuyo último cambio es anterior a esta rama.
- **Verificación manual pendiente:** el preview de Vercel, sobre todo el corte entre la barra fija y el fondo durazno — que es exactamente lo que #2402 va a resolver y se ve en la captura de arriba.

Segunda de las cuatro rebanadas de #1508. El keyword de cierre va en la última: mergear ésta no completa el alcance del issue.
