### PR TITLE
[#2396] - Fija la columna de perfil, tipifica el fallo y cataloga la página

### DIFF
--- a/e2e/_utils/collection-fixtures.ts
+++ b/e2e/_utils/collection-fixtures.ts
@@ -8,12 +8,6 @@
 import type { APIRequestContext } from '@playwright/test';
 
 import { collectionTeaserListDtoSchema, type CollectionTeaserDto } from '@models/collection.dto';
-import { VIEWPORT_WIDTHS_NUMERIC } from '@utils/screen.utils';
-
-// La columna lateral y el panel deslizable viven tras `hidden lg:flex`, así que hace falta superar el
-// breakpoint `lg`. Se toma el ancho de `xl` y no el borde exacto porque `setViewportSize` fija el tamaño
-// de la ventana con la barra de scroll incluida: al ras del breakpoint, el ancho útil queda por debajo.
-export const DESKTOP_VIEWPORT = Object.freeze({ width: VIEWPORT_WIDTHS_NUMERIC.xl, height: 900 });
 
 const CATALOG_ROUTE = '/api/collection';
 

--- a/e2e/_utils/viewports.ts
+++ b/e2e/_utils/viewports.ts
@@ -1,0 +1,13 @@
+/**
+ * Tamaños de ventana compartidos por los e2e que dependen de una disposición concreta.
+ */
+import { VIEWPORT_WIDTHS_NUMERIC } from '@utils/screen.utils';
+
+/**
+ * Ancho que garantiza la disposición de escritorio: la que reparte el contenido en dos columnas y monta
+ * lo que solo existe a partir del breakpoint `lg`.
+ *
+ * Se toma el ancho de `xl` y no el borde exacto de `lg` porque `setViewportSize` fija el tamaño de la
+ * ventana con la barra de scroll incluida: al ras del breakpoint, el ancho útil queda por debajo.
+ */
+export const DESKTOP_VIEWPORT = Object.freeze({ width: VIEWPORT_WIDTHS_NUMERIC.xl, height: 900 });

--- a/e2e/author-profile.spec.ts
+++ b/e2e/author-profile.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Acceso a la biografía completa del autor y comportamiento de la columna de perfil al scrollear.
+ *
+ * Son los dos comportamientos de la página que ningún otro gate alcanza: el desborde del recorte depende
+ * de medidas reales —el spec unitario se las fija a mano porque happy-dom no computa layout— y el sticky
+ * no existe fuera de un navegador con viewport.
+ */
+import { expect, test } from '@playwright/test';
+
+import { STABLE_SLUGS } from './_utils/seo-fixtures';
+import { DESKTOP_VIEWPORT } from './_utils/viewports';
+
+const READ_MORE = 'Leer más';
+const authorPath = `/author/${STABLE_SLUGS.author}`;
+
+// Holgado a propósito: el `beforeAll` corre una sola vez y su veredicto decide si el caso del panel corre
+// o se saltea, así que conviene esperar de más antes que declarar ausente un contenido que está.
+const FIXTURE_TIMEOUT = 15_000;
+
+let readMoreIsVisible = false;
+
+test.beforeAll(async ({ browser }) => {
+	// El estado del fixture se resuelve una sola vez: sin esto, una biografía corta produciría el mismo
+	// fallo en cada caso de abajo en vez de una vez, acá.
+	const page = await browser.newPage({ viewport: DESKTOP_VIEWPORT });
+	await page.goto(authorPath);
+	// Se espera al control en vez de preguntar si está: el recorte se mide después de hidratar, así que
+	// una lectura instantánea devuelve "no desborda" en una página que todavía no terminó de resolverse.
+	readMoreIsVisible = await page
+		.getByTestId('author-info')
+		.getByRole('button', { name: READ_MORE })
+		.waitFor({ state: 'visible', timeout: FIXTURE_TIMEOUT })
+		.then(() => true)
+		.catch(() => false);
+	await page.close();
+});
+
+// Guarda como caso propio, no como `skip` silencioso: un dataset sin el fixture es un problema de la
+// infraestructura de test, no un motivo para que el gate quede verde sin haber mirado nada.
+test('author — la biografía del autor estable desborda el recorte y ofrece leerla entera', () => {
+	expect(
+		readMoreIsVisible,
+		`la biografía de "${STABLE_SLUGS.author}" no desborda el recorte: el caso del panel no verificaría nada`,
+	).toBe(true);
+});
+
+test('author — el panel muestra la biografía completa', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta la guarda de arriba; repetirla acá sería el mismo fallo dos veces
+	test.skip(!readMoreIsVisible, 'la biografía del autor estable no desborda el recorte');
+
+	await page.setViewportSize(DESKTOP_VIEWPORT);
+	await page.goto(authorPath);
+	const columnBiography = await page.getByTestId('author-info').getByTestId('biography').innerHTML();
+
+	await page.getByTestId('author-info').getByRole('button', { name: READ_MORE }).click();
+	const drawer = page.getByRole('dialog');
+	await expect(drawer).toBeVisible();
+
+	// Se compara el marcado y no el texto: la biografía llega saneada del backend y el panel la pinta tal
+	// cual, así que la igualdad afirma que el panel muestra lo mismo que la columna recorta visualmente.
+	// El recorte de la columna es visual, de modo que un `toContainText` pasaría igual con ocho líneas.
+	expect(await drawer.getByTestId('biography').innerHTML()).toBe(columnBiography);
+});
+
+test('author — la columna de perfil acompaña el scroll del listado', async ({ page }) => {
+	await page.setViewportSize(DESKTOP_VIEWPORT);
+	await page.goto(authorPath);
+
+	const profileColumn = page.getByTestId('author-info');
+	const scrolled = 1500;
+
+	// El listado tiene que dar para scrollear tanto: si la página entra entera, la columna no se movería y
+	// el caso pasaría sin haber probado el sticky.
+	const scrollableHeight = await page.evaluate(() => document.documentElement.scrollHeight - window.innerHeight);
+	expect(scrollableHeight, 'la página no tiene scroll: el caso no probaría nada').toBeGreaterThan(scrolled);
+
+	// `mouse.wheel` no mueve el documento en Firefox, así que el scroll se pide por API: lo que el caso
+	// mide es dónde queda la columna, no cómo se llegó hasta ahí.
+	await page.evaluate((to) => window.scrollTo(0, to), scrolled);
+	await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThanOrEqual(scrolled);
+
+	// La posición esperada sale del token, no de un literal: así el caso también atrapa un desfasaje entre
+	// el `top-*` de la columna y el alto real del encabezado fijo, no solo la ausencia del sticky.
+	const headerHeight = await page.evaluate(() =>
+		parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--spacing-header-height')),
+	);
+	expect(headerHeight, 'el token del alto del encabezado no resuelve a un número').toBeGreaterThan(0);
+
+	// `boundingBox` es relativo al viewport: sin sticky la columna se habría ido con el flujo y su tope
+	// estaría muy por encima de cero. Pegada, queda justo bajo el encabezado.
+	const box = await profileColumn.boundingBox();
+	expect(box?.y, 'la columna de perfil no quedó pegada bajo el encabezado fijo').toBeCloseTo(headerHeight, 0);
+});

--- a/e2e/collection-content.spec.ts
+++ b/e2e/collection-content.spec.ts
@@ -9,7 +9,8 @@
  */
 import { expect, test, type Page } from '@playwright/test';
 
-import { DESKTOP_VIEWPORT, fetchCollectionCatalog, type CollectionCatalogEntry } from './_utils/collection-fixtures';
+import { fetchCollectionCatalog, type CollectionCatalogEntry } from './_utils/collection-fixtures';
+import { DESKTOP_VIEWPORT } from './_utils/viewports';
 import { STABLE_SLUGS } from './_utils/seo-fixtures';
 
 const ROUTE = `/collection/${STABLE_SLUGS.collection}`;

--- a/e2e/collection-description-drawer.spec.ts
+++ b/e2e/collection-description-drawer.spec.ts
@@ -11,11 +11,11 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
 
 import {
-	DESKTOP_VIEWPORT,
 	fetchCollectionCatalog,
 	pickMostDescriptiveCollection,
 	type CollectionCatalogEntry,
 } from './_utils/collection-fixtures';
+import { DESKTOP_VIEWPORT } from './_utils/viewports';
 
 const READ_MORE = 'Leer más';
 

--- a/e2e/read.spec.ts
+++ b/e2e/read.spec.ts
@@ -13,7 +13,8 @@ import { expect, test, type Page } from '@playwright/test';
 import type { LiteraryWorkDto } from '@models/literary-work.dto';
 
 import { fetchLiteraryWork } from './_utils/read-fixtures';
-import { DESKTOP_VIEWPORT, fetchCollectionCatalog, type CollectionCatalogEntry } from './_utils/collection-fixtures';
+import { fetchCollectionCatalog, type CollectionCatalogEntry } from './_utils/collection-fixtures';
+import { DESKTOP_VIEWPORT } from './_utils/viewports';
 import { STABLE_SLUGS } from './_utils/seo-fixtures';
 
 const ROUTE = `/read/${STABLE_SLUGS.literaryWork}`;

--- a/src/app/pages/author/author.page.html
+++ b/src/app/pages/author/author.page.html
@@ -4,8 +4,13 @@
 	@if (author(); as author) {
 	<!-- Primero en el DOM y último en la fila de escritorio: el perfil es el contenido propio de la página,
 	     así que encabeza la lectura y su `h1` precede al `h2` del listado. A diferencia de la página de
-	     colección, esta columna tampoco se oculta en mobile — acá no es accesoria. -->
-	<aside class="flex w-full shrink-0 flex-col gap-6 lg:order-last lg:w-91 lg:pt-8" data-testid="author-info">
+	     colección, esta columna tampoco se oculta en mobile — acá no es accesoria.
+	     El `self-start` no es opcional: dentro de un flex con `align-items: stretch` la columna iguala el
+	     alto del contenedor y el sticky nunca llega a pegarse. -->
+	<aside
+		class="flex w-full shrink-0 flex-col gap-6 lg:sticky lg:top-header-height lg:order-last lg:w-91 lg:self-start lg:pt-8"
+		data-testid="author-info"
+	>
 		<cuentoneta-author-info-panel
 			(readMore)="openBiographyDrawer(biographyDrawer)"
 			[author]="author"
@@ -54,7 +59,6 @@
 		}
 	</cuentoneta-drawer>
 
-	<!-- El único contenido que la columna y el panel deslizable comparten. -->
 	<ng-template #webResourcesBlock>
 		@if (author.resources.length > 0) {
 		<section class="flex flex-col gap-4" data-testid="web-resources">
@@ -67,8 +71,16 @@
 		</section>
 		}
 	</ng-template>
+	} @else if (notFound()) {
+	<section class="flex w-full flex-col gap-4">
+		<h1>No encontramos este autor</h1>
+		<p>El autor que buscás no existe o ya no está disponible.</p>
+	</section>
 	} @else {
-	<aside class="flex w-full shrink-0 flex-col gap-6 lg:order-last lg:w-91 lg:pt-8" aria-busy="true">
+	<aside
+		class="flex w-full shrink-0 flex-col gap-6 lg:sticky lg:top-header-height lg:order-last lg:w-91 lg:self-start lg:pt-8"
+		aria-busy="true"
+	>
 		<cuentoneta-author-info-panel [biographyLines]="sidebarBiographyLines" />
 	</aside>
 

--- a/src/app/pages/author/author.page.spec.ts
+++ b/src/app/pages/author/author.page.spec.ts
@@ -1,4 +1,5 @@
 // Librería de pruebas
+import { RESPONSE_INIT } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import userEvent from '@testing-library/user-event';
@@ -18,7 +19,8 @@ import { withoutUrl } from '@testing/resource-without-url';
 import { installResizeObserverStub, setMeasuredSize, triggerResize } from '@testing/resize-observer.stub';
 
 // Modelos
-import type { AuthorProfile } from '@models/author.model';
+import type { AuthorProfile, AuthorTeaser } from '@models/author.model';
+import type { AuthorApi } from '../../providers/author.provider';
 import type { LiteraryWorkApi } from '../../providers/literary-work.provider';
 import type { LiteraryWork, LiteraryWorkTeaser } from '@models/literary-work.model';
 
@@ -41,6 +43,20 @@ function renderPage(author: AuthorProfile = authorMock, literaryWorkApi?: Litera
 			),
 		],
 	});
+}
+
+// Los `Stub*` nunca fallan: sin un doble que lance, un caso de error montado sobre ellos daría verde sin
+// ejercitar nada.
+class StubFailingAuthorApi implements AuthorApi {
+	constructor(private readonly status: number) {}
+
+	public getAll(): Observable<AuthorTeaser[]> {
+		return throwError(() => new HttpErrorResponse({ status: this.status, statusText: 'error' }));
+	}
+
+	public getBySlug(): Observable<AuthorProfile> {
+		return throwError(() => new HttpErrorResponse({ status: this.status, statusText: 'error' }));
+	}
 }
 
 // El catálogo puede fallar con el autor resolviendo bien: es la combinación que un doble que devuelve
@@ -181,5 +197,35 @@ describe('AuthorPage', () => {
 		expect(link.getAttribute('href')).toBe(
 			`/read/${firstWork.slug}?navigation=author&navigationSlug=${authorMock.slug}`,
 		);
+	});
+
+	describe('estados de error', () => {
+		const renderFailing = (status: number, responseInit: ResponseInit) =>
+			render(AuthorPage, {
+				inputs: { slug: authorMock.slug },
+				providers: [
+					provideRouter([]),
+					provideAuthorApiMock(new StubFailingAuthorApi(status)),
+					provideLiteraryWorkApiMock(new StubLiteraryWorkApi(literaryWorkMock, onoffLiteraryWorkTeasersMock)),
+					{ provide: RESPONSE_INIT, useValue: responseInit },
+				],
+			});
+
+		it('should render the not-found state and mark the SSR response as 404', async () => {
+			const responseInit: ResponseInit = {};
+			await renderFailing(404, responseInit);
+
+			expect(await screen.findByText(/no encontramos este autor/i)).toBeTruthy();
+			expect(responseInit.status).toBe(404);
+		});
+
+		// Un 200 acá lo cachearía el borde como si fuera la ficha, sin purga que lo desaloje.
+		it('should mark the SSR response as 503 when the failure is not a 404', async () => {
+			const responseInit: ResponseInit = {};
+			await renderFailing(500, responseInit);
+
+			expect(await screen.findByText(/no encontramos este autor/i)).toBeTruthy();
+			expect(responseInit.status).toBe(503);
+		});
 	});
 });

--- a/src/app/pages/author/author.page.stories.ts
+++ b/src/app/pages/author/author.page.stories.ts
@@ -1,0 +1,163 @@
+import { applicationConfig, type Meta, type StoryObj } from '@storybook/angular-vite';
+import { provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError, type Observable } from 'rxjs';
+
+import type { AuthorProfile, AuthorTeaser } from '@models/author.model';
+import type { LiteraryWork, LiteraryWorkTeaser } from '@models/literary-work.model';
+import { createMarkdown } from '@models/markdown.model';
+import { markdownToSanitizedHtml } from '@utils/markdown-pipeline.utils';
+import { authorMock, authorTeaserMock } from '@mocks/author.mock';
+import { onoffLiteraryWorkTeasersMock } from '@mocks/onoff-literary-work-teasers.mock';
+import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
+
+import { provideAuthorApiMock } from '../../providers/author.mock';
+import { provideLiteraryWorkApiMock } from '../../providers/literary-work.mock';
+import type { AuthorApi } from '../../providers/author.provider';
+import type { LiteraryWorkApi, LiteraryWorkTeaserFilter } from '../../providers/literary-work.provider';
+import AuthorPage from './author.page';
+
+const [literaryWork] = onoffLiteraryWorksMock;
+
+// El escenario que el diseño rotula "Few stories and info": biografía que entra en el recorte y sin
+// recursos web, de modo que ni el acceso a leerla entera ni el bloque de recursos se dibujan.
+const authorWithLittleInfo: AuthorProfile = {
+	...authorMock,
+	slug: `${authorMock.slug}-poca-info`,
+	resources: [],
+	biography: markdownToSanitizedHtml(
+		createMarkdown(
+			'**François Onoff** (Lyon, 1948 - París, 1994) fue un escritor y editor francés, fundador de la editorial que lleva su apellido.',
+		),
+	),
+};
+
+// Un autor cargado en el CMS sin obras publicadas todavía: alcanzable en producción, y el único lugar
+// donde el listado vacío y el rótulo «0 obras» se pueden mirar.
+const authorWithoutWorks: AuthorProfile = { ...authorMock, slug: `${authorMock.slug}-sin-obras` };
+
+const roster: readonly AuthorProfile[] = [authorMock, authorWithLittleInfo, authorWithoutWorks];
+
+// Resuelve por slug contra el corpus, en vez de devolver siempre el mismo autor: así el control mueve la
+// página entera, y un slug que no existe cae en el estado de autor inexistente, que también es parte de
+// lo que hay que poder mirar. El doble del provider no sirve acá porque nunca falla.
+class CorpusAuthorApi implements AuthorApi {
+	public getBySlug(slug: string): Observable<AuthorProfile> {
+		const author = roster.find((candidate) => candidate.slug === slug);
+		return author ? of(author) : throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' }));
+	}
+
+	public getAll(): Observable<AuthorTeaser[]> {
+		return of([authorTeaserMock]);
+	}
+}
+
+// El corpus embebe un solo autor, así que filtrar por el slug real de cada variante devolvería siempre
+// una lista vacía. El doble reparte por slug: las dos fichas con obras comparten el listado del corpus, y
+// la del autor sin obras es la única que recibe la lista vacía.
+class CorpusLiteraryWorkApi implements LiteraryWorkApi {
+	public getBySlug(): Observable<LiteraryWork> {
+		return of(literaryWork);
+	}
+
+	public getTeasers(filter: LiteraryWorkTeaserFilter = {}): Observable<LiteraryWorkTeaser[]> {
+		return of(filter.author === authorWithoutWorks.slug ? [] : [...onoffLiteraryWorkTeasersMock]);
+	}
+}
+
+const corpusSlugLabels = {
+	[authorMock.slug]: authorMock.name,
+	[authorWithLittleInfo.slug]: `${authorWithLittleInfo.name} (poca información)`,
+	[authorWithoutWorks.slug]: `${authorWithoutWorks.name} (sin obras)`,
+};
+
+type AuthorPageArgs = { slug: string };
+
+const meta: Meta<AuthorPageArgs> = {
+	component: AuthorPage,
+	title: 'Páginas/AuthorPage',
+	decorators: [
+		applicationConfig({
+			providers: [
+				provideRouter([]),
+				provideAuthorApiMock(new CorpusAuthorApi()),
+				provideLiteraryWorkApiMock(new CorpusLiteraryWorkApi()),
+			],
+		}),
+	],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>La ficha de un autor, <strong>AuthorPage</strong>, montada sobre el corpus de Onoff. Como el resto de las entradas bajo <strong>Páginas</strong>, no cataloga un componente sino el ensamblado completo: las dos columnas, el listado de obras del autor y la columna de perfil con su acceso a la biografía entera.</p><p>El único control reproduce lo que la ruta le entrega: <code>slug</code>, qué autor se abre. Un slug que no existe cae en el estado de autor inexistente.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-literaryworkcardteaser--docs" target="_top"><strong>LiteraryWorkCardTeaser</strong></a> (el listado), <a href="./?path=/docs/componentes-v3-authorinfopanel--docs" target="_top"><strong>AuthorInfoPanel</strong></a> (la columna y el contenido del panel deslizable), <strong>Resource</strong> (los enlaces web) y <a href="./?path=/docs/componentes-v3-drawer--docs" target="_top"><strong>Drawer</strong></a>.</p><p>Dos cosas solo se ven acá, porque dependen de medidas reales: el acceso <strong>"Leer más"</strong> aparece únicamente si la biografía desborda su recorte de ocho líneas, y la columna de perfil acompaña el scroll del listado en lugar de irse con el flujo.</p><p>El encabezado fijo de la aplicación no se monta en el catálogo, así que el margen superior de la página se ve como espacio en blanco.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		slug: {
+			name: 'Autor',
+			control: { type: 'select', labels: corpusSlugLabels },
+			options: roster.map(({ slug }) => slug),
+			table: { type: { summary: 'string' } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<AuthorPageArgs>;
+
+export const Playground: Story = {
+	args: { slug: authorMock.slug },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>La página completa con el control vivo. Cambiá <strong>Autor</strong> para recorrer los dos escenarios que el diseño cubre.</p>`,
+			},
+		},
+	},
+};
+
+export const ConRecursosYBiografiaLarga: Story = {
+	args: { slug: authorMock.slug },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El escenario que el diseño rotula <strong>"Many stories and info"</strong>: la biografía no entra en el recorte de ocho líneas, así que la columna ofrece <strong>"Leer más"</strong>, y al pedirlo se abre el panel deslizable con el texto entero y los enlaces web.</p><p><strong>Usos:</strong> autores con ficha completa cargada en el CMS.</p>`,
+			},
+		},
+	},
+};
+
+export const SinRecursosNiBiografiaLarga: Story = {
+	args: { slug: authorWithLittleInfo.slug },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El escenario que el diseño rotula <strong>"Few stories and info"</strong>: la biografía entra completa en su recorte y el autor no tiene recursos web, así que ni el acceso a leerla entera ni el bloque de enlaces se dibujan — que es exactamente lo que tiene que pasar.</p><p><strong>Usos:</strong> autores recién incorporados, con la ficha mínima.</p>`,
+			},
+		},
+	},
+};
+
+export const SinObrasPublicadas: Story = {
+	args: { slug: authorWithoutWorks.slug },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Un autor cargado en el CMS al que todavía no se le publicó ninguna obra: el rótulo enuncia <strong>«0 obras»</strong> y la columna del listado queda vacía, con el perfil intacto.</p><p><strong>Usos:</strong> autores incorporados por adelantado, antes de que su primera obra salga.</p>`,
+			},
+		},
+	},
+};
+
+export const AutorInexistente: Story = {
+	args: { slug: 'un-autor-que-no-existe' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El estado de autor inexistente. En la aplicación servida, además, la respuesta sale con el código que corresponde: 404 cuando el autor no existe y 503 ante cualquier otro fallo, para que un error transitorio no se cachee como si fuera la ficha.</p>`,
+			},
+		},
+	},
+};

--- a/src/app/pages/author/author.page.ts
+++ b/src/app/pages/author/author.page.ts
@@ -1,5 +1,6 @@
 // Core
-import { Component, computed, forwardRef, inject, input, signal } from '@angular/core';
+import { Component, computed, effect, forwardRef, inject, input, RESPONSE_INIT, signal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { NgTemplateOutlet } from '@angular/common';
 
 // Utils
@@ -42,6 +43,7 @@ export default class AuthorPage implements AuthorHost {
 
 	private readonly authorApi = inject(AuthorApi);
 	private readonly literaryWorkApi = inject(LiteraryWorkApi);
+	private readonly responseInit = inject(RESPONSE_INIT, { optional: true });
 
 	// Gatea la creación del contenido del panel deslizable: sin esto, la biografía entera y los enlaces
 	// a los recursos viajarían en el HTML del servidor, duplicando lo que la columna ya muestra.
@@ -72,6 +74,18 @@ export default class AuthorPage implements AuthorHost {
 	protected readonly literaryWorks = computed(() =>
 		this.literaryWorksResource.hasValue() ? this.literaryWorksResource.value() : [],
 	);
+	protected readonly notFound = computed(() => this.authorResource.status() === 'error');
+
+	// Un fallo transitorio no puede salir 200: el borde cachearía una página vacía como si fuera la ficha
+	// del autor. Solo la ausencia real del autor es un 404.
+	private readonly respondErrorStatusEffect = effect(() => {
+		const error = this.authorResource.error();
+		if (!error || !this.responseInit) {
+			return;
+		}
+		this.responseInit.status = error instanceof HttpErrorResponse && error.status === 404 ? 404 : 503;
+	});
+
 	protected readonly literaryWorksHeading = computed(() => {
 		const total = this.literaryWorks().length;
 		return `${total} ${total === 1 ? 'obra' : 'obras'}`;


### PR DESCRIPTION
Última de una pila de cinco. Apilada sobre #2412. Cierra #2396.

Cierra el trabajo con el comportamiento de scroll del prototipo, los estados de error de la ruta y la cobertura que ningún gate alcanzaba.

## Qué cambia

- **Scroll**: al recorrer el listado, la columna de perfil acompaña en lugar de irse con el flujo. El `self-start` no es decorativo: dentro de un flex con `align-items: stretch` la columna iguala el alto del contenedor y el sticky **nunca llega a pegarse**. El divisor hermano no lo lleva, porque es justo su estiramiento el que le da altura junto a una columna corta pegada.
- **Estados de error**: un autor inexistente respondía 200 con esqueleto, que el borde puede cachear como si fuera la ficha. Ahora la ausencia real sale 404 y cualquier otro fallo 503, para que un error transitorio no se cachee.
- **E2E propio**: cubre los dos comportamientos que ningún otro gate alcanza — el desborde del recorte depende de medidas reales (el spec unitario se las fija a mano porque happy-dom no computa layout) y el sticky no existe fuera de un navegador con viewport. La posición esperada sale del token del encabezado, así que el caso también atrapa un desfasaje del `top-*`, no solo la ausencia del sticky.
- **Catálogo de la página**: la única superficie donde se pueden mirar los escenarios del diseño sin levantar la aplicación, incluidos el autor sin obras publicadas y el inexistente. El doble del provider no sirve para eso porque nunca falla: la entrada resuelve por slug contra el corpus.
- **El ancho de escritorio de los e2e** pasa a un módulo propio. Vivía junto a los fixtures de colección, con un comentario que describía una columna oculta en mobile — que no es el caso de la de autor.

## Hallazgos verificados contra el dataset

- **La migración `author-biography-to-markdown` ya corrió en `production`.** El issue la daba por pendiente. De 326 autores publicados con biografía, ninguno la conserva como Portable Text; lo mismo en `staging`, que es el dataset de los e2e.
- **`StoryCardTeaser` todavía tiene un consumidor**: la página `storylist`. El issue anticipaba que quedaría sin ninguno; su borrado sigue siendo alcance de #2268, que ahora tiene un bloqueante menos.

## Deuda que este trabajo expone, registrada aparte

- **#2400** — «Otros autores sugeridos», el tercer bloque de la columna de perfil. Queda fuera porque su criterio de recomendación no existe y el issue pedía explícitamente no inventarlo acá.
- **#2407** — un 503 muestra hoy «no existe», en esta página y en la de colección.
- **#2408** — la duplicación entre los dos paneles de información, a extraer cuando aparezca un tercer consumidor.
- **Sin issue**: el catálogo por autor no tiene paginación —declarada como pendiente en la propia query GROQ— y ahora bloquea el SSR. Para el corpus actual es inocuo; con un autor prolífico el HTML del servidor crece sin límite. Conviene revisarlo cuando el catálogo gane `limit`/`offset`.

## Plan de pruebas

- Los once gates de CI sobre la pila completa.
- El spec de la página suma las dos ramas de error con un doble que lanza: los `Stub*` nunca fallan, así que un caso montado sobre ellos daría verde sin ejercitar nada.
- Se verificó empíricamente que el caso del catálogo caído falla sin el guard de lectura del recurso: no es un riesgo teórico.

Closes #2396.
