### PR TITLE
[#2396] - Reparte la ficha de autor en las dos columnas del diseño v3

### DIFF
--- a/src/app/pages/author/author.page.html
+++ b/src/app/pages/author/author.page.html
@@ -1,19 +1,52 @@
-<main class="content vertical-layout-spacing horizontal-layout-spacing">
+<!-- El encabezado es fijo: sin el margen superior, la página arranca debajo de él. Los 32px de padding
+     son los que el diseño reserva sobre el contenido. -->
+<main class="mx-auto mt-header-height flex w-full max-w-310 flex-col gap-8 px-4 pt-8 pb-16 lg:flex-row lg:gap-16">
 	@if (author(); as author) {
-	<h1 class="font-inter text-4xl leading-10 font-bold text-neutral-900">{{ author.name }}</h1>
-	<div [innerHTML]="author.biography" class="source-serif-xl flex flex-col gap-4" data-testid="biography"></div>
-	<div class="flex flex-col gap-9" data-testid="literary-works">
-		@for (literaryWork of literaryWorks(); track literaryWork._id; let index = $index) {
-		<cuentoneta-literary-work-card-teaser
-			[literaryWork]="literaryWork"
-			[order]="index + 1"
-			[showExcerpt]="true"
-			[navigationParams]="{
-				navigation: 'author',
-				navigationSlug: author.slug,
-			}"
-		/>
-		}
+	<!-- Primero en el DOM y último en la fila de escritorio: el perfil es el contenido propio de la página,
+	     así que encabeza la lectura y su `h1` precede al `h2` del listado. A diferencia de la página de
+	     colección, esta columna tampoco se oculta en mobile — acá no es accesoria. -->
+	<aside class="flex w-full shrink-0 flex-col gap-6 lg:order-last lg:w-91 lg:pt-8" data-testid="author-info">
+		<cuentoneta-author-info-panel [author]="author" [biographyLines]="sidebarBiographyLines" />
+	</aside>
+
+	<cuentoneta-divider orientation="vertical" class="hidden lg:order-last lg:block" />
+
+	<div class="flex min-w-0 flex-1 flex-col gap-12 lg:pt-8">
+		<h2 class="font-inter text-4xl leading-10 font-bold text-neutral-900">{{ literaryWorksHeading() }}</h2>
+		<div class="flex flex-col gap-9" data-testid="literary-works">
+			@for (literaryWork of literaryWorks(); track literaryWork._id; let index = $index) { @if (index >= 2) {
+			<cuentoneta-divider />
+			}
+			<cuentoneta-literary-work-card-teaser
+				[literaryWork]="literaryWork"
+				[variant]="index === 0 ? 'highlighted' : 'on-white'"
+				[order]="index + 1"
+				[priority]="index === 0"
+				[showExcerpt]="true"
+				[showMultimedia]="true"
+				[tagLabel]="literaryWork.tags[0]?.title"
+				[navigationParams]="{
+					navigation: 'author',
+					navigationSlug: author.slug,
+				}"
+			/>
+			}
+		</div>
+	</div>
+	} @else {
+	<aside class="flex w-full shrink-0 flex-col gap-6 lg:order-last lg:w-91 lg:pt-8" aria-busy="true">
+		<cuentoneta-author-info-panel [biographyLines]="sidebarBiographyLines" />
+	</aside>
+
+	<cuentoneta-divider orientation="vertical" class="hidden lg:order-last lg:block" />
+
+	<div class="flex min-w-0 flex-1 flex-col gap-8" aria-busy="true">
+		<cuentoneta-skeleton appearance="line" class="h-9 w-40 bg-neutral-300" />
+		<div class="flex flex-col gap-8">
+			@for (placeholder of [1, 2, 3]; track placeholder) {
+			<cuentoneta-literary-work-card-teaser [showExcerpt]="true" [showMultimedia]="true" />
+			}
+		</div>
 	</div>
 	}
 </main>

--- a/src/app/pages/author/author.page.spec.ts
+++ b/src/app/pages/author/author.page.spec.ts
@@ -81,6 +81,29 @@ describe('AuthorPage', () => {
 		worksByAuthor.forEach((work) => expect(within(listing).getByText(work.title)).toBeInTheDocument());
 	});
 
+	// El perfil va primero en el DOM y último en la fila de escritorio. Sin eso, en mobile el lector
+	// aterriza en el listado y encuentra al autor recién al final, y el esquema de encabezados abre con el
+	// h2 en las dos anchuras.
+	it('should lead with the author profile in document order', async () => {
+		await renderPage();
+
+		const [first, second] = screen.getAllByRole('heading');
+		expect(first.tagName).toBe('H1');
+		expect(second.tagName).toBe('H2');
+	});
+
+	it('should introduce the listing with the count of works', async () => {
+		await renderPage();
+
+		expect(screen.getByRole('heading', { level: 2, name: `${worksByAuthor.length} obras` })).toBeInTheDocument();
+	});
+
+	it('should name the count in singular when the author has one work', async () => {
+		await renderPage(authorMock, new StubLiteraryWorkApi(literaryWorkMock, worksByAuthor.slice(0, 1)));
+
+		expect(screen.getByRole('heading', { level: 2, name: '1 obra' })).toBeInTheDocument();
+	});
+
 	// El destino de lectura es /read: la página salió del mundo Story y sus enlaces también.
 	it('should link each listed work to its reading page', async () => {
 		await renderPage();
@@ -111,6 +134,6 @@ describe('AuthorPage', () => {
 		await renderPage(authorMock, new StubFailingLiteraryWorkApi());
 
 		expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(authorMock.name);
-		expect(screen.getByTestId('literary-works')).toBeEmptyDOMElement();
+		expect(screen.getByRole('heading', { level: 2, name: '0 obras' })).toBeInTheDocument();
 	});
 });

--- a/src/app/pages/author/author.page.ts
+++ b/src/app/pages/author/author.page.ts
@@ -14,20 +14,26 @@ import { AuthorMetaTagsDirective } from './author-meta-tags.directive';
 import { AuthorStructuredDataDirective } from './author-structured-data.directive';
 
 // Components
+import { AuthorInfoPanelComponent } from '@components/author-info-panel/author-info-panel.component';
+import { DividerComponent } from '@components/divider/divider.component';
 import { LiteraryWorkCardTeaserComponent } from '@components/literary-work-card-teaser/literary-work-card-teaser.component';
+import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 
 @Component({
 	selector: 'cuentoneta-author',
 	templateUrl: './author.page.html',
 	providers: [{ provide: AUTHOR_HOST, useExisting: forwardRef(() => AuthorPage) }],
 	hostDirectives: [AuthorMetaTagsDirective, AuthorStructuredDataDirective],
-	imports: [LiteraryWorkCardTeaserComponent],
+	imports: [AuthorInfoPanelComponent, DividerComponent, LiteraryWorkCardTeaserComponent, SkeletonComponent],
 })
 export default class AuthorPage implements AuthorHost {
 	public readonly slug = input.required<string>();
 
 	private readonly authorApi = inject(AuthorApi);
 	private readonly literaryWorkApi = inject(LiteraryWorkApi);
+
+	// Los 160 px que el diseño reserva para la biografía en la columna, sobre un interlineado de 20.
+	protected readonly sidebarBiographyLines = 8;
 
 	// Los dos recursos bloquean el render del servidor: el nombre, la biografía y los enlaces a las obras
 	// son las invariantes que la página tiene que servir indexadas, y con un recurso progresivo el HTML se
@@ -52,4 +58,9 @@ export default class AuthorPage implements AuthorHost {
 	protected readonly literaryWorks = computed(() =>
 		this.literaryWorksResource.hasValue() ? this.literaryWorksResource.value() : [],
 	);
+
+	protected readonly literaryWorksHeading = computed(() => {
+		const total = this.literaryWorks().length;
+		return `${total} ${total === 1 ? 'obra' : 'obras'}`;
+	});
 }


### PR DESCRIPTION
Tercera de una pila de cinco. Apilada sobre #2410.

La ficha de autor adopta la disposición del diseño v3: dos columnas separadas por un divisor vertical, con el perfil a un lado y el listado de obras al otro.

Nodo de Figma: [`3233-2` — Author Profile v3](https://www.figma.com/design/A9PdBCdmoyZrN7FKMpann8/La-Cuentoneta-v3?node-id=3233-2&m=dev).

## Qué cambia

- **Listado**: la primera obra en variante destacada, divisores a partir de la tercera, extracto y multimedia visibles. Es la misma regla que ya usa la página de colección.
- **Perfil**: la columna monta el `AuthorInfoPanel` de la PR anterior, con la biografía recortada a las ocho líneas que el diseño le reserva.
- **Encabezados**: el `<h1>` es el nombre del autor, que el diseño ya muestra en grande, y el rótulo del listado es un `<h2>` que enuncia el conteo de obras.

## Dos decisiones que conviene mirar

- **El perfil va primero en el orden del documento** y se reordena visualmente en escritorio, donde el diseño lo quiere a la derecha. Al revés, en mobile el lector aterrizaría en el listado y encontraría al autor recién al final, y el esquema de encabezados abriría con el `h2` en las dos anchuras.
- **Esta columna no se oculta en mobile**, a diferencia de la de la página de colección. Ahí lo oculto es accesorio; acá son el nombre, el país y la biografía. Ocultarlos sería una regresión funcional que **ningún gate detecta**: el DOM sigue presente y la suite de indexado pasaría igual.

## Sobre el sustantivo del rótulo

El diseño rotula la columna «19 Historías». Se usa «obras», que es el término del dominio y el que ya emite la página de catálogo.

## Plan de pruebas

- Los once gates de CI.
- El spec suma el orden de los encabezados en el DOM, el rótulo con el conteo real del fixture y su forma en singular.
- El gate `build` valida las plantillas, que `typecheck` no cubre.

Parte de #2396.
