### PR TITLE
[#2396] - Suma los recursos web y abre la biografía en un panel deslizable

### DIFF
--- a/src/api/_utils/functions.spec.ts
+++ b/src/api/_utils/functions.spec.ts
@@ -140,6 +140,30 @@ describe('mapResources (ACL)', () => {
 		expect(result[0].url).toBe(rawResource.url);
 	});
 
+	// El recurso se pinta como `href` de un enlace: un esquema ejecutable convierte el clic en código.
+	// El Studio ya los acota al editar, pero valida la edición y no lo almacenado.
+	it.each(['javascript:alert(1)', 'data:text/html,<script>alert(1)</script>', 'vbscript:msgbox(1)'])(
+		'drops a resource whose url carries the non-navigable scheme of "%s"',
+		(url) => {
+			const [rawResource] = rawOnoffAuthor.resources;
+
+			expect(mapResources([{ ...rawResource, url }])).toEqual([]);
+		},
+	);
+
+	it('drops a resource whose url the parser cannot read', () => {
+		const [rawResource] = rawOnoffAuthor.resources;
+
+		expect(mapResources([{ ...rawResource, url: 'no es una url' }])).toEqual([]);
+	});
+
+	it('keeps a resource addressed by email, which the domain admits', () => {
+		const [rawResource] = rawOnoffAuthor.resources;
+		const url = 'mailto:contacto@onoff.example';
+
+		expect(mapResources([{ ...rawResource, url }])[0].url).toBe(url);
+	});
+
 	it('drops a resource whose url is null, the shape the dataset actually holds', () => {
 		const [rawResource] = rawOnoffAuthor.resources;
 

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -144,11 +144,25 @@ type ResourcesSubQuery = (
 )['resources'];
 type RawResource = NonNullable<ResourcesSubQuery>[number];
 
+// Los recursos se pintan como `href` de un enlace, así que el esquema decide si la URL navega o
+// ejecuta. El tipo `url` del Studio ya acota los esquemas en el punto de edición, pero valida la
+// edición y no lo almacenado — el mismo motivo por el que la ausencia de URL se filtra acá abajo.
+const NAVIGABLE_URL_SCHEMES = Object.freeze(['http:', 'https:', 'mailto:']);
+
 // El typegen deriva `url: string` del `Rule.required()` del schema, pero esa regla valida la edición
 // en el Studio, no lo ya almacenado: hay documentos persistidos sin URL. El tipo miente, y sin este
 // guard la ausencia cruza la frontera y revienta al primer consumidor que la lea como string.
 function hasUrl(resource: RawResource): boolean {
-	return typeof resource.url === 'string' && resource.url.length > 0;
+	if (typeof resource.url !== 'string' || resource.url.length === 0) {
+		return false;
+	}
+
+	try {
+		return NAVIGABLE_URL_SCHEMES.includes(new URL(resource.url).protocol);
+	} catch {
+		// Una URL que el parser rechaza no tiene esquema del cual decidir: se descarta con las demás.
+		return false;
+	}
 }
 
 export function mapResources(resources: ResourcesSubQuery): Resource[] {

--- a/src/app/components/resource/resource.component.spec.ts
+++ b/src/app/components/resource/resource.component.spec.ts
@@ -41,6 +41,28 @@ describe('ResourceComponent', () => {
 		expect(linkResourceElement).toHaveAttribute('href', url);
 	});
 
+	// El destino es una URL del CMS que se abre en otra pestaña: sin el `rel`, esa pestaña conserva una
+	// referencia a la nuestra y puede reescribir su ubicación.
+	it('should deny the opened tab a reference back', async () => {
+		await setup();
+
+		expect(screen.getByRole('link')).toHaveAttribute('rel', 'noopener noreferrer');
+	});
+
+	// El tamaño es un eje del primitivo, no una variante de quien lo monta: la columna de perfil de la
+	// página de autor reserva 40 px y el resto del sitio usa los 48 del default.
+	it('should render at the default size', async () => {
+		await setup();
+
+		expect(screen.getByRole('link')).toHaveClass('h-12', 'w-12');
+	});
+
+	it('should render at the reduced size when asked for it', async () => {
+		await render(ResourceComponent, { inputs: { resource: resourceMock, size: 'sm' } });
+
+		expect(screen.getByRole('link')).toHaveClass('h-10', 'w-10');
+	});
+
 	// El slug `recurso-original` mapea a `faSolidMedal` en iconMappers. Que el SVG del DOM sea exactamente
 	// ese ícono es lo que prueba de qué lado sale, e impide reconectar el componente a un campo del CMS.
 	// Se consulta con `hidden: true` porque el ícono es decorativo (`aria-hidden`).

--- a/src/app/components/resource/resource.component.stories.ts
+++ b/src/app/components/resource/resource.component.stories.ts
@@ -1,0 +1,84 @@
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
+import { ResourceComponent } from './resource.component';
+import { authorMock } from '@mocks/author.mock';
+import { resourceMock } from '@mocks/resource.mock';
+
+const [wikipediaResource] = authorMock.resources;
+
+// El corpus solo trae tipos que el mapa de íconos conoce, así que el caso se deriva con un slug que no
+// existe en él — con uno mapeado, la story mostraría un ícono y no lo que dice mostrar.
+const resourceWithUnknownType = {
+	...resourceMock,
+	resourceType: { ...resourceMock.resourceType, slug: 'un-tipo-que-el-frontend-no-conoce' },
+};
+
+const meta: Meta<ResourceComponent> = {
+	title: 'Componentes V3/Resource',
+	component: ResourceComponent,
+	parameters: {
+		layout: 'centered',
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>El <strong>ResourceComponent</strong> es el enlace circular a un recurso web externo: un ícono que abre el destino en otra pestaña, con el título del recurso como etiqueta accesible y como contenido de su tooltip.</p><p>El ícono <strong>no</strong> viaja desde el CMS: se resuelve del <code>slug</code> del tipo de recurso contra el mapa de íconos de la aplicación, de modo que un tipo sin ícono conocido dibuja el círculo vacío en lugar de romper.</p><p>Ofrece un eje de tamaño porque las dos superficies que lo montan reservan altos distintos: la columna de perfil de la página de autor usa 40 px y el resto del sitio los 48 del default.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		resource: {
+			control: { type: 'object' },
+			description: 'El recurso a enlazar: título, URL y tipo',
+			table: { type: { summary: 'Resource' } },
+		},
+		size: {
+			control: 'inline-radio',
+			options: ['md', 'sm'],
+			description: 'Diámetro del círculo: md = 48 px, sm = 40 px',
+			table: { type: { summary: "'md' | 'sm'" }, defaultValue: { summary: "'md'" } },
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<ResourceComponent>;
+
+export const Playground: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-resource ${argsToTemplate(args)} />`,
+	}),
+	args: { resource: wikipediaResource },
+};
+
+export const Tamanios: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<div class="flex items-center gap-4">
+			<cuentoneta-resource [resource]="resource" size="md" />
+			<cuentoneta-resource [resource]="resource" size="sm" />
+		</div>`,
+	}),
+	args: { resource: wikipediaResource },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Los dos tamaños uno al lado del otro, que es la única forma de comparar los 48 px contra los 40 sin montar las dos páginas que los usan.</p><p><strong>Usos:</strong> <code>md</code> en la ficha de obra; <code>sm</code> en la columna de perfil de la página de autor.</p>`,
+			},
+		},
+	},
+};
+
+export const TipoSinIcono: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-resource ${argsToTemplate(args)} />`,
+	}),
+	args: { resource: resourceWithUnknownType },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Un recurso cuyo tipo no tiene ícono en el mapa de la aplicación: el enlace se dibuja igual, vacío, en lugar de romper. Es lo que pasa cuando el CMS incorpora un tipo de recurso antes que el frontend su ícono.</p>`,
+			},
+		},
+	},
+};

--- a/src/app/components/resource/resource.component.ts
+++ b/src/app/components/resource/resource.component.ts
@@ -18,6 +18,9 @@ import { iconMappers } from '@models/icon.model';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { NgComponentOutlet } from '@angular/common';
 
+/** Tamaños del enlace (Design System v3): md=48px, sm=40px. */
+export type ResourceSize = 'md' | 'sm';
+
 @Component({
 	selector: 'cuentoneta-resource',
 	hostDirectives: [TooltipDirective],
@@ -26,11 +29,14 @@ import { NgComponentOutlet } from '@angular/common';
 		<a
 			[href]="resource().url"
 			[attr.title]="resource().title"
+			[class]="linkClasses()"
 			target="_blank"
-			class="flex h-12 w-12 items-center justify-center rounded-full border-1 border-solid border-neutral-200 bg-neutral-100 hover:bg-neutral-200"
+			rel="noopener noreferrer"
 		>
 			@if (icon(); as icon) {
-				<ng-container *ngComponentOutlet="NgIcon; inputs: { name: icon.name, size: '22px' }; injector: icon.injector" />
+				<ng-container
+					*ngComponentOutlet="NgIcon; inputs: { name: icon.name, size: iconSize() }; injector: icon.injector"
+				/>
 			}
 		</a>
 	`,
@@ -40,6 +46,21 @@ import { NgComponentOutlet } from '@angular/common';
 })
 export class ResourceComponent {
 	public readonly resource = input.required<Resource>();
+
+	public readonly size = input<ResourceSize>('md');
+
+	private readonly sizeMap: Record<ResourceSize, { circle: string; icon: string }> = {
+		md: { circle: 'h-12 w-12', icon: '22px' },
+		sm: { circle: 'h-10 w-10', icon: '18px' },
+	};
+
+	protected readonly iconSize = computed(() => this.sizeMap[this.size()].icon);
+
+	protected readonly linkClasses = computed(
+		() =>
+			`flex ${this.sizeMap[this.size()].circle} items-center justify-center rounded-full border-1 border-solid border-neutral-200 bg-neutral-100 hover:bg-neutral-200`,
+	);
+
 	protected readonly icon = computed(() => {
 		if (!this.resource()?.resourceType?.slug) {
 			return null;

--- a/src/app/pages/author/author.page.html
+++ b/src/app/pages/author/author.page.html
@@ -6,7 +6,13 @@
 	     así que encabeza la lectura y su `h1` precede al `h2` del listado. A diferencia de la página de
 	     colección, esta columna tampoco se oculta en mobile — acá no es accesoria. -->
 	<aside class="flex w-full shrink-0 flex-col gap-6 lg:order-last lg:w-91 lg:pt-8" data-testid="author-info">
-		<cuentoneta-author-info-panel [author]="author" [biographyLines]="sidebarBiographyLines" />
+		<cuentoneta-author-info-panel
+			(readMore)="openBiographyDrawer(biographyDrawer)"
+			[author]="author"
+			[biographyLines]="sidebarBiographyLines"
+			[showReadMore]="true"
+		/>
+		<ng-container [ngTemplateOutlet]="webResourcesBlock" />
 	</aside>
 
 	<cuentoneta-divider orientation="vertical" class="hidden lg:order-last lg:block" />
@@ -33,6 +39,34 @@
 			}
 		</div>
 	</div>
+
+	<!-- Fuera del aside a propósito: un ancestro en display:none impediría que el <dialog> se muestre. -->
+	<cuentoneta-drawer
+		(afterClosed)="isBiographyDrawerOpen.set(false)"
+		[ariaLabel]="'Biografía de ' + author.name"
+		#biographyDrawer
+		direction="right"
+	>
+		@if (isBiographyDrawerOpen()) {
+		<cuentoneta-author-info-panel [author]="author" [showName]="false" />
+		<cuentoneta-divider class="my-5" />
+		<ng-container [ngTemplateOutlet]="webResourcesBlock" />
+		}
+	</cuentoneta-drawer>
+
+	<!-- El único contenido que la columna y el panel deslizable comparten. -->
+	<ng-template #webResourcesBlock>
+		@if (author.resources.length > 0) {
+		<section class="flex flex-col gap-4" data-testid="web-resources">
+			<h2 class="font-inter text-lg font-bold text-neutral-900">Recursos web sobre el autor</h2>
+			<div class="flex flex-wrap items-center gap-3">
+				@for (resource of author.resources; track resource.url) {
+				<cuentoneta-resource [resource]="resource" size="sm" />
+				}
+			</div>
+		</section>
+		}
+	</ng-template>
 	} @else {
 	<aside class="flex w-full shrink-0 flex-col gap-6 lg:order-last lg:w-91 lg:pt-8" aria-busy="true">
 		<cuentoneta-author-info-panel [biographyLines]="sidebarBiographyLines" />

--- a/src/app/pages/author/author.page.spec.ts
+++ b/src/app/pages/author/author.page.spec.ts
@@ -1,6 +1,7 @@
 // Librería de pruebas
 import { HttpErrorResponse } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
+import userEvent from '@testing-library/user-event';
 import { Observable, throwError } from 'rxjs';
 import { render, screen, within } from '@testing-library/angular';
 
@@ -14,11 +15,12 @@ import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
 import { provideAuthorApiMock, StubAuthorApi } from '../../providers/author.mock';
 import { provideLiteraryWorkApiMock, StubLiteraryWorkApi } from '../../providers/literary-work.mock';
 import { withoutUrl } from '@testing/resource-without-url';
+import { installResizeObserverStub, setMeasuredSize, triggerResize } from '@testing/resize-observer.stub';
 
 // Modelos
 import type { AuthorProfile } from '@models/author.model';
-import type { LiteraryWork, LiteraryWorkTeaser } from '@models/literary-work.model';
 import type { LiteraryWorkApi } from '../../providers/literary-work.provider';
+import type { LiteraryWork, LiteraryWorkTeaser } from '@models/literary-work.model';
 
 const [literaryWorkMock] = onoffLiteraryWorksMock;
 
@@ -54,6 +56,8 @@ class StubFailingLiteraryWorkApi implements LiteraryWorkApi {
 }
 
 describe('AuthorPage', () => {
+	beforeEach(() => installResizeObserverStub());
+
 	// Reproduce el modo de falla del SSR: las directivas de SEO son hostDirectives de la página, así que
 	// un throw en su effect derriba el render entero y la ficha sale sin cuerpo. El ErrorHandler de
 	// test-setup relanza, con lo cual acá se manifiesta igual que en el servidor.
@@ -104,6 +108,58 @@ describe('AuthorPage', () => {
 		expect(screen.getByRole('heading', { level: 2, name: '1 obra' })).toBeInTheDocument();
 	});
 
+	// Leer el valor de un recurso en error relanza la falla. Con el listado bloqueando el SSR, ese throw
+	// derriba el render del servidor de una página indexable; el autor resuelto tiene que bastar para
+	// servir la ficha.
+	it('should still serve the profile when the works catalogue fails', async () => {
+		await renderPage(authorMock, new StubFailingLiteraryWorkApi());
+
+		expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(authorMock.name);
+		expect(screen.getByRole('heading', { level: 2, name: '0 obras' })).toBeInTheDocument();
+	});
+
+	// El contenido del panel se crea recién al abrirlo: serializarlo en el HTML del servidor duplicaría la
+	// biografía entera y los enlaces que la columna ya muestra.
+	it('should not create the drawer content before it opens', async () => {
+		await renderPage();
+
+		expect(screen.getAllByTestId('biography')).toHaveLength(1);
+	});
+
+	it('should show the full biography when the drawer opens', async () => {
+		const { detectChanges } = await renderPage();
+
+		setMeasuredSize(screen.getByTestId('biography'), { scrollHeight: 400, clientHeight: 160 });
+		triggerResize();
+		detectChanges();
+		await userEvent.click(screen.getByRole('button', { name: 'Leer más' }));
+		detectChanges();
+
+		// El segundo bloque es el del panel, y a diferencia del de la columna no lleva recorte.
+		const [, drawerBiography] = screen.getAllByTestId('biography');
+		expect(drawerBiography.className).not.toMatch(/line-clamp-/);
+
+		// El panel monta el mismo bloque de perfil que la columna: sin apagarle el nombre, la página
+		// quedaría con dos encabezados de primer nivel diciendo lo mismo.
+		expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+	});
+
+	it('should list the web resources of the author', async () => {
+		await renderPage();
+
+		const [resource] = authorMock.resources;
+		const resources = screen.getByTestId('web-resources');
+
+		expect(within(resources).getByRole('link')).toHaveAttribute('href', resource.url);
+	});
+
+	// El escenario que el diseño rotula "Few stories and info": sin recursos, el bloque no se dibuja.
+	it('should omit the web resources block when the author has none', async () => {
+		await renderPage({ ...authorMock, resources: [] });
+
+		expect(screen.queryByTestId('web-resources')).not.toBeInTheDocument();
+	});
+
 	// El destino de lectura es /read: la página salió del mundo Story y sus enlaces también.
 	it('should link each listed work to its reading page', async () => {
 		await renderPage();
@@ -125,15 +181,5 @@ describe('AuthorPage', () => {
 		expect(link.getAttribute('href')).toBe(
 			`/read/${firstWork.slug}?navigation=author&navigationSlug=${authorMock.slug}`,
 		);
-	});
-
-	// Leer el valor de un recurso en error relanza la falla. Con el listado bloqueando el SSR, ese throw
-	// derriba el render del servidor de una página indexable; el autor resuelto tiene que bastar para
-	// servir la ficha.
-	it('should still serve the profile when the works catalogue fails', async () => {
-		await renderPage(authorMock, new StubFailingLiteraryWorkApi());
-
-		expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(authorMock.name);
-		expect(screen.getByRole('heading', { level: 2, name: '0 obras' })).toBeInTheDocument();
 	});
 });

--- a/src/app/pages/author/author.page.ts
+++ b/src/app/pages/author/author.page.ts
@@ -1,5 +1,6 @@
 // Core
-import { Component, computed, forwardRef, inject, input } from '@angular/core';
+import { Component, computed, forwardRef, inject, input, signal } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 
 // Utils
 import { ssrBlockingRxResource } from '@app-utils/ssr-resource';
@@ -16,7 +17,9 @@ import { AuthorStructuredDataDirective } from './author-structured-data.directiv
 // Components
 import { AuthorInfoPanelComponent } from '@components/author-info-panel/author-info-panel.component';
 import { DividerComponent } from '@components/divider/divider.component';
+import { DrawerComponent } from '@components/drawer/drawer.component';
 import { LiteraryWorkCardTeaserComponent } from '@components/literary-work-card-teaser/literary-work-card-teaser.component';
+import { ResourceComponent } from '@components/resource/resource.component';
 import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 
 @Component({
@@ -24,13 +27,25 @@ import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 	templateUrl: './author.page.html',
 	providers: [{ provide: AUTHOR_HOST, useExisting: forwardRef(() => AuthorPage) }],
 	hostDirectives: [AuthorMetaTagsDirective, AuthorStructuredDataDirective],
-	imports: [AuthorInfoPanelComponent, DividerComponent, LiteraryWorkCardTeaserComponent, SkeletonComponent],
+	imports: [
+		AuthorInfoPanelComponent,
+		DividerComponent,
+		DrawerComponent,
+		LiteraryWorkCardTeaserComponent,
+		NgTemplateOutlet,
+		ResourceComponent,
+		SkeletonComponent,
+	],
 })
 export default class AuthorPage implements AuthorHost {
 	public readonly slug = input.required<string>();
 
 	private readonly authorApi = inject(AuthorApi);
 	private readonly literaryWorkApi = inject(LiteraryWorkApi);
+
+	// Gatea la creación del contenido del panel deslizable: sin esto, la biografía entera y los enlaces
+	// a los recursos viajarían en el HTML del servidor, duplicando lo que la columna ya muestra.
+	protected readonly isBiographyDrawerOpen = signal(false);
 
 	// Los 160 px que el diseño reserva para la biografía en la columna, sobre un interlineado de 20.
 	protected readonly sidebarBiographyLines = 8;
@@ -51,16 +66,19 @@ export default class AuthorPage implements AuthorHost {
 	});
 
 	public readonly author = computed(() => (this.authorResource.hasValue() ? this.authorResource.value() : undefined));
-
 	// El guard no es ceremonia: leer el valor de un recurso en error relanza la falla, y acá el throw
-	// saldría dentro del listado, derribando el render del servidor de una página indexable. Un catálogo
-	// que falla con el autor resuelto deja la ficha sin obras, no sin página.
+	// saldría dentro del encabezado y del listado, derribando el render del servidor de una página
+	// indexable. Un catálogo que falla con el autor resuelto deja la ficha sin obras, no sin página.
 	protected readonly literaryWorks = computed(() =>
 		this.literaryWorksResource.hasValue() ? this.literaryWorksResource.value() : [],
 	);
-
 	protected readonly literaryWorksHeading = computed(() => {
 		const total = this.literaryWorks().length;
 		return `${total} ${total === 1 ? 'obra' : 'obras'}`;
 	});
+
+	protected openBiographyDrawer(drawer: DrawerComponent): void {
+		this.isBiographyDrawerOpen.set(true);
+		drawer.open();
+	}
 }


### PR DESCRIPTION
Cuarta de una pila de cinco. Apilada sobre #2411.

Completa la columna de perfil con los recursos web del autor y el acceso a leer su biografía entera.

## Qué cambia

- **Recursos web**: bloque propio bajo el perfil, que **no se dibuja** cuando el autor no tiene ninguno — el escenario que el diseño rotula «Few stories and info». Se declara como plantilla proyectada porque es el único contenido que la columna y el panel deslizable comparten.
- **Biografía completa**: panel deslizable a la derecha, con el perfil sin recorte y sin nombre —su etiqueta accesible ya anuncia al autor— más los recursos. Su contenido se crea recién al abrirlo: serializarlo en el HTML del servidor duplicaría lo que la columna ya muestra. El acceso aparece solo si el texto desborda su recorte.
- **`ResourceComponent`** gana un eje de tamaño: el diseño pide 40 px y el enlace medía 48. Es un eje del primitivo, no una excepción de quien lo monta. De paso entra al catálogo, que es la única superficie donde los dos tamaños se pueden comparar.

## Dos correcciones de seguridad en la ruta de datos

- El `<a target="_blank">` no llevaba `rel="noopener noreferrer"`. Es deuda preexistente, pero el componente se toca acá y ahora además se expone en la columna de perfil: sin el `rel`, la pestaña abierta conserva una referencia a la nuestra y puede reescribir su ubicación.
- El mapper del ACL descartaba los recursos sin URL pero **aceptaba cualquier esquema**, y el valor se pinta como `href`: uno ejecutable convierte el clic en código. Ahora se acota a `http`/`https`/`mailto`. El tipo `url` del Studio ya los acota al editar, pero valida la edición y no lo almacenado — el mismo motivo por el que la ausencia de URL se filtra ahí.

## Sobre las dos filas de recursos del diseño

El escenario rico del diseño muestra una segunda fila de botones anchos. El modelo `Resource` no permite distinguirlas: son las mismas tres plataformas con otra apariencia, lo que parece una exploración visual duplicada del archivo. Se implementa **una sola fila**; ofrecer dos apariencias requeriría un dato nuevo en el CMS o una decisión de diseño explícita.

## Plan de pruebas

- Los once gates de CI.
- El spec de la página suma los recursos listados, su ausencia, que el contenido del panel no existe antes de abrirlo, y que con el panel abierto la página conserva **un solo** `h1`.
- El spec del ACL cubre los esquemas no navegables, la URL que el parser rechaza y el correo, que el dominio sí admite.

Parte de #2396.
