### PR TITLE
[#1508] - Render server-side de los decks y estado vacío

### DIFF
--- a/e2e/seo/home.spec.ts
+++ b/e2e/seo/home.spec.ts
@@ -25,6 +25,7 @@ import {
 	checkPrimaryHeading,
 	checkPrimaryContentLength,
 	checkNoSkeletonMarkers,
+	checkInternalLink,
 	checkJsonLdBlocks,
 } from '../_utils/seo-invariants';
 import { SCHEMA_IDS, SITEWIDE_SCHEMA_IDS } from '../_utils/seo-fixtures';
@@ -80,15 +81,15 @@ test('home — invariantes de indexado para crawlers (ssr, h1 real, contenido pr
 		checkRobotsIndexable(html),
 		checkPrimaryHeading(html),
 		checkPrimaryContentLength(html),
+		// Que no haya esqueletos dice que los decks no difieren; que haya un enlace a una obra dice que
+		// además trajeron contenido. Sin esto, una página que sirviera los decks vacíos pasaría igual.
+		checkInternalLink(html, '/read/'),
 		...(await checkJsonLdBlocks(html, SITEWIDE_SCHEMA_IDS)),
 	].filter((violation): violation is SeoInvariantViolation => violation !== null);
 	expect(violations).toEqual([]);
 });
 
-// Bloqueado: los decks most-read/latest/collection-teasers usan @defer, así que el SSR sirve
-// <cuentoneta-*-skeleton data-testid="skeleton"> dentro de <main>. Activar cuando esos decks se
-// server-rendericen sin diferir.
-test.fixme('home — sin markers de skeleton en <main>', () => {
+test('home — sin markers de skeleton en <main>', () => {
 	expect(checkNoSkeletonMarkers(html)).toBeNull();
 });
 

--- a/src/app/components/author-card-teaser/author-card-teaser-skeleton.component.ts
+++ b/src/app/components/author-card-teaser/author-card-teaser-skeleton.component.ts
@@ -5,7 +5,7 @@ import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 @Component({
 	selector: 'cuentoneta-author-card-teaser-skeleton',
 	imports: [SkeletonComponent],
-	host: { class: 'block w-full' },
+	host: { class: 'block w-full', 'data-testid': 'skeleton' },
 	template: `
 		<article class="flex items-start gap-4">
 			<cuentoneta-skeleton appearance="circle" class="w-20 shrink-0 bg-neutral-300" />

--- a/src/app/components/collection-teaser-card/collection-teaser-card-skeleton.ts
+++ b/src/app/components/collection-teaser-card/collection-teaser-card-skeleton.ts
@@ -7,7 +7,7 @@ import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton
 	selector: 'cuentoneta-collection-teaser-card-skeleton',
 	imports: [SkeletonComponent, CoverImageSkeletonComponent],
 	template: `
-		<article class="flex items-start gap-5">
+		<article class="flex items-start gap-5" data-testid="skeleton">
 			<section class="flex h-[192px] flex-1 items-end justify-center overflow-hidden rounded-xl bg-neutral-100 px-3">
 				<cuentoneta-cover-image-skeleton />
 			</section>

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.spec.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.spec.ts
@@ -1,11 +1,11 @@
 // Librería de pruebas
 import { render, screen } from '@testing-library/angular';
-import { DeferBlockState } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 
 // Componentes
 import { CollectionTeasersDeck } from './collection-teasers-deck';
 import { SectionHeaderComponent } from '@components/section-header/section-header.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { CollectionTeaserCard } from '@components/collection-teaser-card/collection-teaser-card';
 import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
 
@@ -20,6 +20,7 @@ describe('CollectionTeasersDeck', () => {
 	const defaultImports = [
 		CollectionTeasersDeck,
 		SectionHeaderComponent,
+		EmptyStateComponent,
 		CollectionTeaserCard,
 		CollectionTeaserCardSkeletonComponent,
 	];
@@ -65,63 +66,53 @@ describe('CollectionTeasersDeck', () => {
 		});
 	});
 
-	describe('Comportamiento del bloque defer', () => {
-		it('should render one skeleton per grid slot while loading', async () => {
-			const { fixture } = await render(CollectionTeasersDeck, {
-				inputs: { teasers: onoffCollectionTeasersOfLength(4) },
+	describe('Estados del listado', () => {
+		it('should fill the grid with skeletons while loading', async () => {
+			await render(CollectionTeasersDeck, {
+				inputs: { teasers: onoffCollectionTeasersOfLength(4), loading: true },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
 
-			const [deferBlockFixture] = await fixture.getDeferBlocks();
-			await deferBlockFixture.render(DeferBlockState.Loading);
-
-			expect(screen.getAllByRole('article')).toHaveLength(4);
+			expect(screen.getAllByTestId('skeleton')).toHaveLength(4);
+			expect(cardLinks()).toHaveLength(0);
 		});
 
 		it('should render one card per teaser when data is available', async () => {
-			const { fixture } = await render(CollectionTeasersDeck, {
+			await render(CollectionTeasersDeck, {
 				inputs: { teasers: onoffCollectionTeasersOfLength(3) },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
 
-			const [deferBlockFixture] = await fixture.getDeferBlocks();
-			await deferBlockFixture.render(DeferBlockState.Complete);
-
 			expect(cardLinks()).toHaveLength(3);
 			expect(screen.getByText('Colección 1')).toBeInTheDocument();
 			expect(screen.getByText('Colección 3')).toBeInTheDocument();
+			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
 		});
 
 		it('should link each card to the collection page', async () => {
 			const [teaser] = onoffCollectionTeasersOfLength(1);
-			const { fixture } = await render(CollectionTeasersDeck, {
+			await render(CollectionTeasersDeck, {
 				inputs: { teasers: [teaser] },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
 
-			const [deferBlockFixture] = await fixture.getDeferBlocks();
-			await deferBlockFixture.render(DeferBlockState.Complete);
-
 			expect(cardLinks()[0]).toHaveAttribute('href', `/collection/${teaser.slug}`);
 		});
 
-		it('should transition from loading to complete state', async () => {
-			const { fixture } = await render(CollectionTeasersDeck, {
-				inputs: { teasers: onoffCollectionTeasersOfLength(4) },
+		// Sin colecciones y sin carga la sección no queda en blanco debajo de su encabezado.
+		it('should explain the emptiness when there is nothing to show', async () => {
+			await render(CollectionTeasersDeck, {
+				inputs: { teasers: [] },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
 
-			const [deferBlockFixture] = await fixture.getDeferBlocks();
-
-			await deferBlockFixture.render(DeferBlockState.Loading);
-			expect(screen.getAllByRole('article')).toHaveLength(4);
-
-			await deferBlockFixture.render(DeferBlockState.Complete);
-			expect(cardLinks()).toHaveLength(4);
+			expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+			expect(cardLinks()).toHaveLength(0);
+			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
 		});
 	});
 

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
@@ -45,7 +45,7 @@ export const Primary: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Colecciones derivadas del canon de Onoff mediante el selector del agregador de mocks; la grilla arma una fila por cada dos tarjetas desde viewport <code>sm</code>.</p><p>Las cuatro salen de la misma colección canónica, así que comparten portada, prosa y etiqueta: la grilla se ve más pareja de lo que se verá con contenido real, y no ejercita portadas dispares ni descripciones de largo distinto. Se corrige al ampliar el corpus con colecciones propias.</p><p><strong>Usos:</strong> la grilla de colecciones del Design System v3 (todavía sin consumidor en páginas).</p>`,
+				story: `<p>Colecciones derivadas del canon de Onoff mediante el selector del agregador de mocks; la grilla arma una fila por cada dos tarjetas desde viewport <code>sm</code>.</p><p>Las cuatro salen de la misma colección canónica, así que comparten portada, prosa y etiqueta: la grilla se ve más pareja de lo que se verá con contenido real, y no ejercita portadas dispares ni descripciones de largo distinto. Se corrige al ampliar el corpus con colecciones propias.</p><p><strong>Usos:</strong> la sección de colecciones de la página de inicio.</p>`,
 			},
 		},
 	},

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.stories.ts
@@ -1,8 +1,6 @@
-import { argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
 
 import { CollectionTeasersDeck } from './collection-teasers-deck';
-import { SectionHeaderComponent } from '@components/section-header/section-header.component';
-import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
 import { onoffCollectionTeasersOfLength } from '@mocks/onoff-collections.mock';
 
 // Un solo dataset compartido por todas las stories: mismas colecciones en cada estado hace que el
@@ -12,16 +10,11 @@ const deckTeasers = onoffCollectionTeasersOfLength(4);
 const meta: Meta<CollectionTeasersDeck> = {
 	component: CollectionTeasersDeck,
 	title: 'Componentes V3/CollectionTeasersDeck',
-	decorators: [
-		moduleMetadata({
-			imports: [SectionHeaderComponent, CollectionTeaserCardSkeletonComponent],
-		}),
-	],
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>El <strong>CollectionTeasersDeck</strong> es el bloque de sección que agrupa colecciones en el Design System v3: un <a href="./?path=/docs/componentes-v3-sectionheader--docs" target="_top"><strong>SectionHeader</strong></a> con el título "Colecciones", su bajada y el enlace al índice de colecciones, sobre una grilla responsiva de una columna en mobile y dos desde <code>sm</code>, con una tarjeta por colección resuelta por <a href="./?path=/docs/componentes-v3-collectionteasercard--docs" target="_top"><strong>CollectionTeaserCard</strong></a>.</p><p>Está tipado contra el modelo de dominio <strong>Collection</strong> vía su proyección <code>CollectionTeaser</code>; mientras difiere la carga dibuja los skeletons de <strong>CollectionTeaserCardSkeleton</strong> dentro de su bloque <code>@defer</code>, y sin colecciones queda solo el encabezado.</p></div>`,
+				component: `<div><p>El <strong>CollectionTeasersDeck</strong> es el bloque de sección que agrupa colecciones en el Design System v3: un <a href="./?path=/docs/componentes-v3-sectionheader--docs" target="_top"><strong>SectionHeader</strong></a> con el título "Colecciones", su bajada y el enlace al índice de colecciones, sobre una grilla responsiva de una columna en mobile y dos desde <code>sm</code>, con una tarjeta por colección resuelta por <a href="./?path=/docs/componentes-v3-collectionteasercard--docs" target="_top"><strong>CollectionTeaserCard</strong></a>.</p><p>Está tipado contra el modelo de dominio <strong>Collection</strong> vía su proyección <code>CollectionTeaser</code>; el estado de carga entra por input, porque el dueño del recurso es la página: cargando dibuja los skeletons de <strong>CollectionTeaserCardSkeleton</strong>, con colecciones la grilla, y sin colecciones el aviso de <a href="./?path=/docs/componentes-v3-emptystate--docs" target="_top"><strong>EmptyState</strong></a>.</p></div>`,
 			},
 		},
 	},
@@ -30,6 +23,11 @@ const meta: Meta<CollectionTeasersDeck> = {
 			control: { type: 'object' },
 			description: 'Colecciones a mostrar en la grilla; vacío deja solo el encabezado',
 			table: { type: { summary: 'readonly CollectionTeaser[]' }, defaultValue: { summary: '[]' } },
+		},
+		loading: {
+			control: { type: 'boolean' },
+			description: 'Estado de carga del recurso que alimenta la grilla; lo decide la página',
+			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
 		},
 	},
 };
@@ -53,32 +51,13 @@ export const Primary: Story = {
 	},
 };
 
-// La rama de carga replica el shell del deck (encabezado + grilla internos): es lo que el usuario
-// ve mientras corre el @defer, y replicarlo completo mantiene 1:1 el alto contra el estado real.
-// Bindings explícitos (no argsToTemplate) porque loading no es un input del componente, y
-// argsToTemplate generaría [loading]="loading" contra un destino inexistente.
-export const Estados: StoryObj<CollectionTeasersDeck & { loading: boolean }> = {
+// El switch mueve el input real del componente, así que alcanza con una sola instancia: no hay markup
+// duplicado que pueda divergir de lo que el componente dibuja.
+export const Estados: Story = {
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
 	render: (args) => ({
 		props: args,
-		template: `
-			@if (loading) {
-				<div class="flex flex-col gap-8">
-					<cuentoneta-section-header
-						heading="Colecciones"
-						subtitle="Obras agrupadas por temas, estilos y universos en común"
-						[action]="{ link: ['/', 'collection'], accessibleSuffix: 'el índice de colecciones' }"
-					/>
-					<section class="mb-8 grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2">
-						@for (_ of teasers; track $index) {
-							<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
-						}
-					</section>
-				</div>
-			} @else {
-				<cuentoneta-collection-teasers-deck [teasers]="teasers" />
-			}
-		`,
+		template: `<cuentoneta-collection-teasers-deck ${argsToTemplate(args)} />`,
 	}),
 	args: {
 		loading: true,
@@ -88,7 +67,7 @@ export const Estados: StoryObj<CollectionTeasersDeck & { loading: boolean }> = {
 		docs: {
 			description: {
 				story:
-					'Activá/desactivá "Cargando" para alternar entre el estado real y el estado de carga del deck: encabezado fijo más un esqueleto por slot de la grilla —iterando los mismos datos, la paridad con la rama real vale por construcción—.',
+					'Activá/desactivá "Cargando" para alternar entre el estado real y el de carga: encabezado fijo más un esqueleto por slot de la grilla. Vaciando además la lista aparece el tercer estado, el del aviso de vacío.',
 			},
 		},
 	},
@@ -106,7 +85,7 @@ export const Vacia: Story = {
 		docs: {
 			description: {
 				story:
-					'Sin colecciones el @defer no dispara: queda el encabezado de sección, sin tarjetas ni skeletons. Es el valor default del input teasers.',
+					'Sin colecciones queda el encabezado y, en lugar de la grilla, el aviso de que no hay nada que mostrar: un hueco en blanco se leería como contenido que no terminó de cargar. Es el valor default del input teasers.',
 			},
 		},
 	},

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.ts
@@ -2,12 +2,13 @@ import { Component, input } from '@angular/core';
 import type { CollectionTeaser } from '@models/collection.model';
 import { AppRoutes } from '../../app.routes';
 import { SectionHeaderComponent, type SectionHeaderAction } from '@components/section-header/section-header.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { CollectionTeaserCard } from '@components/collection-teaser-card/collection-teaser-card';
 import { CollectionTeaserCardSkeletonComponent } from '@components/collection-teaser-card/collection-teaser-card-skeleton';
 
 @Component({
 	selector: 'cuentoneta-collection-teasers-deck',
-	imports: [SectionHeaderComponent, CollectionTeaserCard, CollectionTeaserCardSkeletonComponent],
+	imports: [SectionHeaderComponent, EmptyStateComponent, CollectionTeaserCard, CollectionTeaserCardSkeletonComponent],
 	template: `
 		<cuentoneta-section-header
 			[heading]="sectionHeading"
@@ -15,17 +16,21 @@ import { CollectionTeaserCardSkeletonComponent } from '@components/collection-te
 			subtitle="Obras agrupadas por temas, estilos y universos en común"
 		/>
 
-		<section class="mb-8 grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2">
-			@defer (when teasers().length > 0) {
-				@for (collection of teasers(); track collection.slug) {
-					<cuentoneta-collection-teaser-card [collection]="collection" class="card w-full" />
-				}
-			} @loading (minimum 500ms) {
+		@if (loading()) {
+			<section class="mb-8 grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2">
 				@for (_ of [].constructor(skeletonCount); track $index) {
 					<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
 				}
-			}
-		</section>
+			</section>
+		} @else if (teasers().length > 0) {
+			<section class="mb-8 grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2">
+				@for (collection of teasers(); track collection.slug) {
+					<cuentoneta-collection-teaser-card [collection]="collection" class="card w-full" />
+				}
+			</section>
+		} @else {
+			<cuentoneta-empty-state message="Todavía no hay colecciones para mostrar esta semana." class="mb-8" />
+		}
 	`,
 	host: {
 		class: 'flex flex-col gap-8',
@@ -43,4 +48,6 @@ export class CollectionTeasersDeck {
 	};
 
 	public readonly teasers = input<readonly CollectionTeaser[]>([]);
+	/** El dueño del recurso es la página, así que el estado de carga entra por input. */
+	public readonly loading = input(false);
 }

--- a/src/app/components/collection-teasers-deck/collection-teasers-deck.ts
+++ b/src/app/components/collection-teasers-deck/collection-teasers-deck.ts
@@ -16,20 +16,22 @@ import { CollectionTeaserCardSkeletonComponent } from '@components/collection-te
 			subtitle="Obras agrupadas por temas, estilos y universos en común"
 		/>
 
-		@if (loading()) {
-			<section class="mb-8 grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2">
-				@for (_ of [].constructor(skeletonCount); track $index) {
-					<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
-				}
-			</section>
-		} @else if (teasers().length > 0) {
-			<section class="mb-8 grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2">
-				@for (collection of teasers(); track collection.slug) {
-					<cuentoneta-collection-teaser-card [collection]="collection" class="card w-full" />
+		<!-- La grilla se declara una sola vez para las dos ramas: que el esqueleto caiga exactamente en la
+		misma caja que la tarjeta es lo que evita el salto al terminar de cargar. -->
+		@if (loading() || teasers().length > 0) {
+			<section class="grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2">
+				@if (loading()) {
+					@for (_ of [].constructor(skeletonCount); track $index) {
+						<cuentoneta-collection-teaser-card-skeleton class="card w-full" />
+					}
+				} @else {
+					@for (collection of teasers(); track collection.slug) {
+						<cuentoneta-collection-teaser-card [collection]="collection" class="card w-full" />
+					}
 				}
 			</section>
 		} @else {
-			<cuentoneta-empty-state message="Todavía no hay colecciones para mostrar esta semana." class="mb-8" />
+			<cuentoneta-empty-state message="Todavía no hay colecciones para mostrar esta semana." />
 		}
 	`,
 	host: {

--- a/src/app/components/empty-state/empty-state.component.spec.ts
+++ b/src/app/components/empty-state/empty-state.component.spec.ts
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/angular';
+
+import { EmptyStateComponent } from './empty-state.component';
+
+describe('EmptyStateComponent', () => {
+	it('should display the message it receives', async () => {
+		await render(EmptyStateComponent, {
+			inputs: { message: 'Todavía no hay obras publicadas esta semana' },
+		});
+
+		expect(screen.getByText('Todavía no hay obras publicadas esta semana')).toBeInTheDocument();
+	});
+
+	// El mensaje es texto de la página, no una alerta: quien llega lo lee en su lugar, y anunciarlo
+	// interrumpiría la lectura por algo que no es un cambio de estado.
+	it('should announce nothing beyond its text', async () => {
+		await render(EmptyStateComponent, {
+			inputs: { message: 'Todavía no hay obras publicadas esta semana' },
+		});
+
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+	});
+});

--- a/src/app/components/empty-state/empty-state.component.stories.ts
+++ b/src/app/components/empty-state/empty-state.component.stories.ts
@@ -1,0 +1,59 @@
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
+
+import { EmptyStateComponent } from './empty-state.component';
+
+const meta: Meta<EmptyStateComponent> = {
+	component: EmptyStateComponent,
+	title: 'Componentes V3/EmptyState',
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: `<div><p>El <strong>EmptyState</strong> avisa que una sección no tiene nada que mostrar. Ocupa el lugar de la grilla, con el mismo ancho que ella, para que la sección no quede en blanco debajo de su encabezado.</p><p>Solo recibe el mensaje: sin ícono ni acción, porque todavía no hay un caso que los pida. El texto no se anuncia como alerta ni como estado — es texto de la página, que se lee en su lugar y no interrumpe.</p></div>`,
+			},
+		},
+	},
+	argTypes: {
+		message: {
+			control: { type: 'text' },
+			description: 'Qué falta y por qué, en los términos de la sección que lo monta',
+			table: { type: { summary: 'string' } },
+		},
+	},
+};
+export default meta;
+type Story = StoryObj<EmptyStateComponent>;
+
+export const Primary: Story = {
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-empty-state ${argsToTemplate(args)} />`,
+	}),
+	args: { message: 'Todavía no hay obras publicadas esta semana' },
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>El mensaje de las dos secciones de obras de la página de inicio cuando la semana no trae contenido.</p><p><strong>Usos:</strong> cualquier sección cuya lista puede venir vacía.</p>`,
+			},
+		},
+	},
+};
+
+export const MensajeLargo: Story = {
+	name: 'Mensaje largo',
+	render: (args) => ({
+		props: args,
+		template: `<cuentoneta-empty-state ${argsToTemplate(args)} />`,
+	}),
+	args: {
+		message:
+			'Todavía no hay colecciones publicadas esta semana. Mientras tanto, podés recorrer el catálogo completo y descubrir obras de autores y autoras de distintas épocas.',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `<p>Con un mensaje de varias líneas la caja crece y el texto sigue centrado. Es lo que fija que el alto mínimo sea un piso y no una altura fija.</p><p><strong>Usos:</strong> revisar el bloque antes de redactar un mensaje largo.</p>`,
+			},
+		},
+	},
+};

--- a/src/app/components/empty-state/empty-state.component.ts
+++ b/src/app/components/empty-state/empty-state.component.ts
@@ -1,0 +1,19 @@
+import { Component, input } from '@angular/core';
+
+/**
+ * Aviso de que una sección no tiene nada que mostrar, según el Design System v3.
+ *
+ * Ocupa el lugar de la grilla para que la sección no quede en blanco debajo de su encabezado: sin él,
+ * un listado vacío se lee como contenido que no terminó de cargar.
+ */
+@Component({
+	selector: 'cuentoneta-empty-state',
+	template: `<p class="font-inter text-base text-neutral-600">{{ message() }}</p>`,
+	host: {
+		class: 'flex min-h-24 items-center justify-center rounded-lg bg-neutral-100 px-6 py-8 text-center',
+		'data-testid': 'empty-state',
+	},
+})
+export class EmptyStateComponent {
+	public readonly message = input.required<string>();
+}

--- a/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/angular';
-import { DeferBlockState } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 
 import { HighlightedAuthorsComponent } from './highlighted-authors.component';
 import { SectionHeaderComponent } from '@components/section-header/section-header.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { AuthorCardTeaserComponent } from '@components/author-card-teaser/author-card-teaser.component';
 import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-teaser/author-card-teaser-skeleton.component';
 
@@ -17,6 +17,7 @@ describe('HighlightedAuthorsComponent', () => {
 	const defaultImports = [
 		HighlightedAuthorsComponent,
 		SectionHeaderComponent,
+		EmptyStateComponent,
 		AuthorCardTeaserComponent,
 		AuthorCardTeaserSkeletonComponent,
 	];
@@ -55,34 +56,28 @@ describe('HighlightedAuthorsComponent', () => {
 		});
 	});
 
-	describe('Comportamiento del bloque defer', () => {
+	describe('Estados del listado', () => {
 		// Se afirma sobre el marcador de esqueleto, y con menos destacados que el tope: la tarjeta real y el
 		// esqueleto son ambos `<article>`, así que contar artículos con la grilla llena se cumpliría igual
-		// aunque el bloque hubiera resuelto. La cantidad no sigue al input a propósito — la grilla en carga
-		// dibuja la sección llena aunque todavía no haya llegado ningún destacado.
+		// aunque ya hubiera cargado. La cantidad no sigue al input a propósito — la grilla en carga dibuja
+		// la sección llena aunque todavía no haya llegado ningún destacado.
 		it('should fill the grid with skeletons while loading, regardless of how many arrived', async () => {
-			const { fixture } = await render(HighlightedAuthorsComponent, {
-				inputs: { authors: onoffHighlightedAuthorsOfLength(3) },
+			await render(HighlightedAuthorsComponent, {
+				inputs: { authors: onoffHighlightedAuthorsOfLength(3), loading: true },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
-
-			const [deferBlockFixture] = await fixture.getDeferBlocks();
-			await deferBlockFixture.render(DeferBlockState.Loading);
 
 			expect(screen.getAllByTestId('skeleton')).toHaveLength(6);
 		});
 
 		it('should render one card per highlighted author when data is available', async () => {
 			const highlighted = onoffHighlightedAuthorsOfLength(6);
-			const { fixture } = await render(HighlightedAuthorsComponent, {
+			await render(HighlightedAuthorsComponent, {
 				inputs: { authors: highlighted },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
-
-			const [deferBlockFixture] = await fixture.getDeferBlocks();
-			await deferBlockFixture.render(DeferBlockState.Complete);
 
 			expect(screen.getAllByRole('article')).toHaveLength(6);
 			highlighted.forEach(({ author }) => {
@@ -94,14 +89,11 @@ describe('HighlightedAuthorsComponent', () => {
 		// apunta al perfil que le corresponde y no seis veces al mismo.
 		it('should link every card to its own author profile', async () => {
 			const highlighted = onoffHighlightedAuthorsOfLength(3);
-			const { fixture } = await render(HighlightedAuthorsComponent, {
+			await render(HighlightedAuthorsComponent, {
 				inputs: { authors: highlighted },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
-
-			const [deferBlockFixture] = await fixture.getDeferBlocks();
-			await deferBlockFixture.render(DeferBlockState.Complete);
 
 			highlighted.forEach(({ author }) => {
 				expect(screen.getByRole('link', { name: author.name })).toHaveAttribute('href', `/author/${author.slug}`);
@@ -110,36 +102,43 @@ describe('HighlightedAuthorsComponent', () => {
 
 		it('should carry the story count of each highlighted author', async () => {
 			const [highlighted] = onoffHighlightedAuthorsOfLength(1);
-			const { fixture } = await render(HighlightedAuthorsComponent, {
+			await render(HighlightedAuthorsComponent, {
 				inputs: { authors: [highlighted] },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
-
-			const [deferBlockFixture] = await fixture.getDeferBlocks();
-			await deferBlockFixture.render(DeferBlockState.Complete);
 
 			expect(screen.getByText(`${highlighted.storyCount} historias`)).toBeInTheDocument();
 		});
 
 		it('should transition from loading to complete state', async () => {
 			const highlighted = onoffHighlightedAuthorsOfLength(6);
-			const { fixture } = await render(HighlightedAuthorsComponent, {
-				inputs: { authors: highlighted },
+			const { rerender } = await render(HighlightedAuthorsComponent, {
+				inputs: { authors: highlighted, loading: true },
+				providers: defaultProviders,
+				componentImports: defaultImports,
+			});
+			const [{ author }] = highlighted;
+
+			expect(screen.getAllByTestId('skeleton')).toHaveLength(6);
+			expect(screen.queryByRole('link', { name: author.name })).not.toBeInTheDocument();
+
+			await rerender({ inputs: { authors: highlighted, loading: false } });
+
+			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
+			expect(screen.getByRole('link', { name: author.name })).toBeInTheDocument();
+		});
+
+		// Sin destacados y sin carga la sección no queda en blanco debajo de su encabezado.
+		it('should explain the emptiness when there is nothing to show', async () => {
+			await render(HighlightedAuthorsComponent, {
+				inputs: { authors: [] },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
 
-			const [deferBlockFixture] = await fixture.getDeferBlocks();
-			const [{ author }] = highlighted;
-
-			await deferBlockFixture.render(DeferBlockState.Loading);
-			expect(screen.getAllByTestId('skeleton')).toHaveLength(6);
-			expect(screen.queryByRole('link', { name: author.name })).not.toBeInTheDocument();
-
-			await deferBlockFixture.render(DeferBlockState.Complete);
+			expect(screen.getByTestId('empty-state')).toBeInTheDocument();
 			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
-			expect(screen.getByRole('link', { name: author.name })).toBeInTheDocument();
 		});
 	});
 
@@ -147,14 +146,11 @@ describe('HighlightedAuthorsComponent', () => {
 	// la grilla sin etiquetas es el estado con el que la sección sale, no un borde.
 	describe('Autor sin etiquetas', () => {
 		it('should render the card without a tag list', async () => {
-			const { fixture } = await render(HighlightedAuthorsComponent, {
+			await render(HighlightedAuthorsComponent, {
 				inputs: { authors: [onoffUntaggedHighlightedAuthor] },
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
-
-			const [deferBlockFixture] = await fixture.getDeferBlocks();
-			await deferBlockFixture.render(DeferBlockState.Complete);
 
 			expect(screen.getByText(onoffUntaggedHighlightedAuthor.author.name)).toBeInTheDocument();
 			expect(screen.queryByTestId('tags')).not.toBeInTheDocument();
@@ -162,23 +158,19 @@ describe('HighlightedAuthorsComponent', () => {
 	});
 
 	describe('Sin destacados', () => {
-		it('should render neither cards nor skeletons when the input is omitted', async () => {
+		// Omitir el input y pasarlo vacío llevan al mismo lugar: es el default del input, y el caso existe
+		// para que ese default no se vuelva un estado distinto sin que nadie lo note.
+		it.each([
+			['omitiendo el input', undefined],
+			['con la lista vacía', [] as const],
+		])('should explain the emptiness %s', async (_caso, authors) => {
 			await render(HighlightedAuthorsComponent, {
+				...(authors ? { inputs: { authors } } : {}),
 				providers: defaultProviders,
 				componentImports: defaultImports,
 			});
 
-			expect(screen.queryAllByRole('article')).toHaveLength(0);
-			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
-		});
-
-		it('should render neither cards nor skeletons when the week has nothing highlighted', async () => {
-			await render(HighlightedAuthorsComponent, {
-				inputs: { authors: [] },
-				providers: defaultProviders,
-				componentImports: defaultImports,
-			});
-
+			expect(screen.getByTestId('empty-state')).toBeInTheDocument();
 			expect(screen.queryAllByRole('article')).toHaveLength(0);
 			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
 		});

--- a/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.stories.ts
@@ -1,8 +1,6 @@
-import { argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
 
 import { HighlightedAuthorsComponent } from './highlighted-authors.component';
-import { SectionHeaderComponent } from '@components/section-header/section-header.component';
-import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-teaser/author-card-teaser-skeleton.component';
 import { onoffHighlightedAuthorsOfLength, onoffUntaggedHighlightedAuthor } from '@mocks/onoff-highlighted-authors.mock';
 
 // Un solo dataset compartido por todas las stories: los mismos destacados en cada estado hacen que el
@@ -19,16 +17,11 @@ const untaggedAuthors = highlightedAuthors.map((highlighted) => ({
 const meta: Meta<HighlightedAuthorsComponent> = {
 	component: HighlightedAuthorsComponent,
 	title: 'Componentes V3/HighlightedAuthors',
-	decorators: [
-		moduleMetadata({
-			imports: [SectionHeaderComponent, AuthorCardTeaserSkeletonComponent],
-		}),
-	],
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>El <strong>HighlightedAuthors</strong> es la sección de autores destacados de la página de inicio en el Design System v3: un <a href="./?path=/docs/componentes-v3-sectionheader--docs" target="_top"><strong>SectionHeader</strong></a> con el título "Autores/as destacados/as", su bajada y el enlace al índice de autores, más una grilla responsiva de una columna en mobile, dos desde <code>sm</code> y tres desde <code>lg</code>, con una vista previa por autor resuelta por <a href="./?path=/docs/componentes-v3-authorcardteaser--docs" target="_top"><strong>AuthorCardTeaser</strong></a>.</p><p>Está tipado contra <strong>HighlightedAuthor</strong>, la proyección de curación semanal del contenido de la página de inicio, que compone el teaser del autor con las etiquetas de la tirada y su cantidad de obras. La curaduría y el tope de seis los decide el backend: el componente presenta lo que recibe, sin recortar ni ordenar. Mientras difiere la carga dibuja los skeletons de <strong>AuthorCardTeaserSkeleton</strong> dentro de su bloque <code>@defer</code>, y sin destacados queda solo el encabezado.</p></div>`,
+				component: `<div><p>El <strong>HighlightedAuthors</strong> es la sección de autores destacados de la página de inicio en el Design System v3: un <a href="./?path=/docs/componentes-v3-sectionheader--docs" target="_top"><strong>SectionHeader</strong></a> con el título "Autores/as destacados/as", su bajada y el enlace al índice de autores, más una grilla responsiva de una columna en mobile, dos desde <code>sm</code> y tres desde <code>lg</code>, con una vista previa por autor resuelta por <a href="./?path=/docs/componentes-v3-authorcardteaser--docs" target="_top"><strong>AuthorCardTeaser</strong></a>.</p><p>Está tipado contra <strong>HighlightedAuthor</strong>, la proyección de curación semanal del contenido de la página de inicio, que compone el teaser del autor con las etiquetas de la tirada y su cantidad de obras. La curaduría y el tope de seis los decide el backend: el componente presenta lo que recibe, sin recortar ni ordenar. El estado de carga entra por input, porque el dueño del recurso es la página: cargando dibuja los skeletons de <strong>AuthorCardTeaserSkeleton</strong>, con destacados la grilla, y sin destacados el aviso de <a href="./?path=/docs/componentes-v3-emptystate--docs" target="_top"><strong>EmptyState</strong></a>.</p></div>`,
 			},
 		},
 	},
@@ -37,6 +30,11 @@ const meta: Meta<HighlightedAuthorsComponent> = {
 			control: { type: 'object' },
 			description: 'Autores destacados de la semana; vacío deja solo el encabezado',
 			table: { type: { summary: 'readonly HighlightedAuthor[]' }, defaultValue: { summary: '[]' } },
+		},
+		loading: {
+			control: { type: 'boolean' },
+			description: 'Estado de carga del recurso que alimenta la grilla; lo decide la página',
+			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
 		},
 	},
 };
@@ -78,47 +76,23 @@ export const SinEtiquetas: Story = {
 	},
 };
 
-// La rama de carga replica el shell de la sección (encabezado + grilla internos): es lo que se ve
-// mientras corre el @defer. Los esqueletos son una cantidad fija, igual que en el componente: la grilla
-// en carga dibuja la sección llena aunque todavia no haya llegado ningun destacado.
-// Bindings explícitos (no argsToTemplate) porque loading no es un input del componente, y
-// argsToTemplate generaría [loading]="loading" contra un destino inexistente.
-export const Estados: StoryObj<HighlightedAuthorsComponent & { loading: boolean; skeletonCount: number }> = {
-	argTypes: {
-		loading: { control: 'boolean', name: 'Cargando' },
-		skeletonCount: { table: { disable: true } },
-	},
+// El switch mueve el input real del componente, así que alcanza con una sola instancia: no hay markup
+// duplicado que pueda divergir de lo que el componente dibuja.
+export const Estados: Story = {
+	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
 	render: (args) => ({
 		props: args,
-		template: `
-			@if (loading) {
-				<div class="flex flex-col gap-8">
-					<cuentoneta-section-header
-						heading="Autores/as destacados/as"
-						subtitle="Una selección curada de autores y autoras imprescindibles"
-						[action]="{ link: ['/', 'authors'], accessibleSuffix: 'el índice de autores' }"
-					/>
-					<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-						@for (_ of [].constructor(skeletonCount); track $index) {
-							<cuentoneta-author-card-teaser-skeleton class="w-full" data-testid="skeleton" />
-						}
-					</section>
-				</div>
-			} @else {
-				<cuentoneta-highlighted-authors [authors]="authors" />
-			}
-		`,
+		template: `<cuentoneta-highlighted-authors ${argsToTemplate(args)} />`,
 	}),
 	args: {
 		loading: true,
-		skeletonCount: SKELETON_COUNT,
 		authors: highlightedAuthors,
 	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					'Activá/desactivá "Cargando" para alternar entre el estado real y el estado de carga de la sección: encabezado fijo más la grilla llena de esqueletos. La cantidad es fija y no sigue a lo recibido, porque el esqueleto tiene que dibujar la sección completa aunque todavía no haya llegado ningún destacado. El enlace "Ver todo" no se replica: la rama de carga no navega.<br><br><strong>Usos:</strong> la sección de autores destacados de la página de inicio, mientras resuelve el contenido de la semana.',
+					'Activá/desactivá "Cargando" para alternar entre el estado real y el de carga de la sección: encabezado fijo más la grilla llena de esqueletos. La cantidad es fija y no sigue a lo recibido, porque el esqueleto tiene que dibujar la sección completa aunque todavía no haya llegado ningún destacado. Vaciando además la lista aparece el tercer estado, el del aviso de vacío.<br><br><strong>Usos:</strong> la sección de autores destacados de la página de inicio, mientras resuelve el contenido de la semana.',
 			},
 		},
 	},
@@ -136,7 +110,7 @@ export const Vacia: Story = {
 		docs: {
 			description: {
 				story:
-					'Sin destacados el @defer no dispara: queda el encabezado de sección con su enlace al índice de autores, sin tarjetas ni skeletons. Es el valor default del input authors, y el enlace sigue siendo navegable.<br><br><strong>Usos:</strong> la sección de autores destacados de la página de inicio, en una semana sin curaduría cargada.',
+					'Sin destacados queda el encabezado con su enlace al índice de autores y, en lugar de la grilla, el aviso de que no hay nada que mostrar. Es el valor default del input authors, y el enlace sigue siendo navegable.<br><br><strong>Usos:</strong> la sección de autores destacados de la página de inicio, en una semana sin curaduría cargada.',
 			},
 		},
 	},

--- a/src/app/components/highlighted-authors/highlighted-authors.component.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.ts
@@ -3,6 +3,7 @@ import { Component, input } from '@angular/core';
 import type { HighlightedAuthor } from '@models/landing-page-content.model';
 import { AppRoutes } from '../../app.routes';
 import { SectionHeaderComponent, type SectionHeaderAction } from '@components/section-header/section-header.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { AuthorCardTeaserComponent } from '@components/author-card-teaser/author-card-teaser.component';
 import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-teaser/author-card-teaser-skeleton.component';
 
@@ -15,7 +16,7 @@ import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-tease
  */
 @Component({
 	selector: 'cuentoneta-highlighted-authors',
-	imports: [SectionHeaderComponent, AuthorCardTeaserComponent, AuthorCardTeaserSkeletonComponent],
+	imports: [SectionHeaderComponent, EmptyStateComponent, AuthorCardTeaserComponent, AuthorCardTeaserSkeletonComponent],
 	template: `
 		<cuentoneta-section-header
 			[heading]="sectionHeading"
@@ -23,8 +24,14 @@ import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-tease
 			subtitle="Una selección curada de autores y autoras imprescindibles"
 		/>
 
-		<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-			@defer (when authors().length > 0) {
+		@if (loading()) {
+			<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+				@for (_ of [].constructor(skeletonCount); track $index) {
+					<cuentoneta-author-card-teaser-skeleton class="w-full" data-testid="skeleton" />
+				}
+			</section>
+		} @else if (authors().length > 0) {
+			<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
 				@for (highlighted of authors(); track highlighted.author._id) {
 					<cuentoneta-author-card-teaser
 						[author]="highlighted.author"
@@ -33,12 +40,10 @@ import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-tease
 						class="w-full"
 					/>
 				}
-			} @loading (minimum 500ms) {
-				@for (_ of [].constructor(skeletonCount); track $index) {
-					<cuentoneta-author-card-teaser-skeleton class="w-full" data-testid="skeleton" />
-				}
-			}
-		</section>
+			</section>
+		} @else {
+			<cuentoneta-empty-state message="Todavía no hay autores destacados esta semana." />
+		}
 	`,
 	host: {
 		class: 'flex flex-col gap-8',
@@ -57,4 +62,6 @@ export class HighlightedAuthorsComponent {
 	};
 
 	public readonly authors = input<readonly HighlightedAuthor[]>([]);
+	/** El dueño del recurso es la página, así que el estado de carga entra por input. */
+	public readonly loading = input(false);
 }

--- a/src/app/components/highlighted-authors/highlighted-authors.component.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.ts
@@ -24,21 +24,23 @@ import { AuthorCardTeaserSkeletonComponent } from '@components/author-card-tease
 			subtitle="Una selección curada de autores y autoras imprescindibles"
 		/>
 
-		@if (loading()) {
+		<!-- La grilla se declara una sola vez para las dos ramas: que el esqueleto caiga exactamente en la
+		misma caja que la tarjeta es lo que evita el salto al terminar de cargar. -->
+		@if (loading() || authors().length > 0) {
 			<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-				@for (_ of [].constructor(skeletonCount); track $index) {
-					<cuentoneta-author-card-teaser-skeleton class="w-full" data-testid="skeleton" />
-				}
-			</section>
-		} @else if (authors().length > 0) {
-			<section class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-				@for (highlighted of authors(); track highlighted.author._id) {
-					<cuentoneta-author-card-teaser
-						[author]="highlighted.author"
-						[tags]="highlighted.tags"
-						[storyCount]="highlighted.storyCount"
-						class="w-full"
-					/>
+				@if (loading()) {
+					@for (_ of [].constructor(skeletonCount); track $index) {
+						<cuentoneta-author-card-teaser-skeleton class="w-full" />
+					}
+				} @else {
+					@for (highlighted of authors(); track highlighted.author._id) {
+						<cuentoneta-author-card-teaser
+							[author]="highlighted.author"
+							[tags]="highlighted.tags"
+							[storyCount]="highlighted.storyCount"
+							class="w-full"
+						/>
+					}
 				}
 			</section>
 		} @else {

--- a/src/app/components/literary-work-home-card-teaser/literary-work-home-card-teaser-skeleton.component.ts
+++ b/src/app/components/literary-work-home-card-teaser/literary-work-home-card-teaser-skeleton.component.ts
@@ -11,7 +11,7 @@ import { CoverImageSkeletonComponent } from '../cover-image/cover-image-skeleton
 @Component({
 	selector: 'cuentoneta-literary-work-home-card-teaser-skeleton',
 	imports: [SkeletonComponent, CoverImageSkeletonComponent],
-	host: { class: 'block' },
+	host: { class: 'block', 'data-testid': 'skeleton' },
 	template: `
 		<article class="flex w-full max-w-82.75 flex-col items-center gap-4">
 			<div class="flex w-full items-center justify-center rounded-xl bg-neutral-100 py-5">

--- a/src/app/components/literary-works-card-deck/literary-works-card-deck.spec.ts
+++ b/src/app/components/literary-works-card-deck/literary-works-card-deck.spec.ts
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/angular';
-import { DeferBlockState } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 
 import { LiteraryWorksCardDeck } from './literary-works-card-deck';
@@ -19,33 +18,62 @@ describe('LiteraryWorksCardDeck', () => {
 		expect(container).toBeTruthy();
 	});
 
-	it('should render skeletons and then the cards', async () => {
-		const { fixture } = await render(LiteraryWorksCardDeck, {
-			inputs: defaultInputs,
-			providers: defaultProviders,
-		});
-		const deferBlockFixture = (await fixture.getDeferBlocks())[0];
+	describe('Estados del listado', () => {
+		it('should fill the grid with skeletons while loading', async () => {
+			await render(LiteraryWorksCardDeck, {
+				inputs: { ...defaultInputs, loading: true },
+				providers: defaultProviders,
+			});
 
-		await deferBlockFixture.render(DeferBlockState.Loading);
-		expect(screen.getAllByTestId('skeleton')).toHaveLength(6);
-
-		await deferBlockFixture.render(DeferBlockState.Complete);
-		literaryWorks.forEach(({ title }) => {
-			expect(screen.getByText(title)).toBeInTheDocument();
+			expect(screen.getAllByTestId('skeleton')).toHaveLength(6);
+			expect(screen.queryAllByTestId('card')).toHaveLength(0);
 		});
-		expect(screen.getAllByTestId('card')).toHaveLength(literaryWorks.length);
+
+		// Cargar gana sobre tener datos: mientras el recurso está en vuelo, lo que hay en pantalla es del
+		// listado anterior y mostrarlo como definitivo haría parpadear contenido que va a cambiar.
+		it('should show skeletons while loading even if it already holds works', async () => {
+			await render(LiteraryWorksCardDeck, {
+				inputs: { ...defaultInputs, loading: true, literaryWorks },
+				providers: defaultProviders,
+			});
+
+			expect(screen.queryAllByTestId('card')).toHaveLength(0);
+		});
+
+		it('should render one card per work once it is loaded', async () => {
+			await render(LiteraryWorksCardDeck, {
+				inputs: defaultInputs,
+				providers: defaultProviders,
+			});
+
+			literaryWorks.forEach(({ title }) => {
+				expect(screen.getByText(title)).toBeInTheDocument();
+			});
+			expect(screen.getAllByTestId('card')).toHaveLength(literaryWorks.length);
+			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
+		});
+
+		// Sin obras y sin carga la sección no queda en blanco: si lo hiciera, se leería como contenido que
+		// nunca terminó de llegar.
+		it('should explain the emptiness when there is nothing to show', async () => {
+			await render(LiteraryWorksCardDeck, {
+				inputs: { ...defaultInputs, literaryWorks: [], emptyMessage: 'Todavía no hay obras nuevas esta semana.' },
+				providers: defaultProviders,
+			});
+
+			expect(screen.getByText('Todavía no hay obras nuevas esta semana.')).toBeInTheDocument();
+			expect(screen.queryAllByTestId('card')).toHaveLength(0);
+			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
+		});
 	});
 
 	// La tarjeta enlaza a la ruta de lectura: es el único camino que la home ofrece hacia una obra desde
 	// este bloque, y de él depende que la página emita enlaces internos.
 	it('links every card to the reading route', async () => {
-		const { fixture } = await render(LiteraryWorksCardDeck, {
+		await render(LiteraryWorksCardDeck, {
 			inputs: defaultInputs,
 			providers: defaultProviders,
 		});
-		const deferBlockFixture = (await fixture.getDeferBlocks())[0];
-
-		await deferBlockFixture.render(DeferBlockState.Complete);
 
 		const hrefs = screen.getAllByRole('link').map((link) => link.getAttribute('href'));
 		literaryWorks.forEach(({ slug }) => {

--- a/src/app/components/literary-works-card-deck/literary-works-card-deck.spec.ts
+++ b/src/app/components/literary-works-card-deck/literary-works-card-deck.spec.ts
@@ -82,7 +82,7 @@ describe('LiteraryWorksCardDeck', () => {
 	});
 
 	describe('Encabezado parametrizado', () => {
-		// Desde el primer render, sin esperar al bloque diferido: el encabezado es lo que da contexto a la
+		// Desde el primer render, sin esperar al contenido: el encabezado es lo que da contexto a la
 		// grilla mientras carga.
 		it('should display the heading it receives', async () => {
 			await render(LiteraryWorksCardDeck, {

--- a/src/app/components/literary-works-card-deck/literary-works-card-deck.stories.ts
+++ b/src/app/components/literary-works-card-deck/literary-works-card-deck.stories.ts
@@ -1,8 +1,6 @@
-import { argsToTemplate, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
+import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
 
 import { LiteraryWorksCardDeck } from './literary-works-card-deck';
-import { SectionHeaderComponent } from '@components/section-header/section-header.component';
-import { LiteraryWorkHomeCardTeaserSkeletonComponent } from '@components/literary-work-home-card-teaser/literary-work-home-card-teaser-skeleton.component';
 import { onoffLiteraryWorkNavigationTeasersWithAuthorsMock } from '@mocks/onoff-literary-work-teasers.mock';
 
 // Un solo dataset compartido por todas las stories: las mismas obras en cada estado hacen que el switch
@@ -12,16 +10,11 @@ const literaryWorks = onoffLiteraryWorkNavigationTeasersWithAuthorsMock.slice(0,
 const meta: Meta<LiteraryWorksCardDeck> = {
 	component: LiteraryWorksCardDeck,
 	title: 'Componentes V3/LiteraryWorksCardDeck',
-	decorators: [
-		moduleMetadata({
-			imports: [SectionHeaderComponent, LiteraryWorkHomeCardTeaserSkeletonComponent],
-		}),
-	],
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>El <strong>LiteraryWorksCardDeck</strong> es la grilla de una tirada de obras en el Design System v3: un <a href="./?path=/docs/componentes-v3-sectionheader--docs" target="_top"><strong>SectionHeader</strong></a> opcional sobre una grilla responsiva de una columna en mobile y tres desde <code>md</code>, con una vista previa por obra resuelta por <a href="./?path=/docs/componentes-v3-literaryworkhomecardteaser--docs" target="_top"><strong>LiteraryWorkHomeCardTeaser</strong></a>.</p><p>Todo lo que distingue a una tirada de otra —su título, su bajada y a dónde lleva su acción— entra por input, así que una misma página puede montar varias y cualquier otra puede reusarlo. Con título, el host se expone como región con ese nombre, que es lo que permite localizar cada instancia sin depender de su posición; sin título ni bajada queda la grilla sola y el host no se anuncia como región. Mientras difiere la carga dibuja los skeletons dentro de su bloque <code>@defer</code>, y sin obras queda solo el encabezado.</p></div>`,
+				component: `<div><p>El <strong>LiteraryWorksCardDeck</strong> es la grilla de una tirada de obras en el Design System v3: un <a href="./?path=/docs/componentes-v3-sectionheader--docs" target="_top"><strong>SectionHeader</strong></a> opcional sobre una grilla responsiva de una columna en mobile y tres desde <code>md</code>, con una vista previa por obra resuelta por <a href="./?path=/docs/componentes-v3-literaryworkhomecardteaser--docs" target="_top"><strong>LiteraryWorkHomeCardTeaser</strong></a>.</p><p>Todo lo que distingue a una tirada de otra —su título, su bajada y a dónde lleva su acción— entra por input, así que una misma página puede montar varias y cualquier otra puede reusarlo. Con título, el host se expone como región con ese nombre, que es lo que permite localizar cada instancia sin depender de su posición; sin título ni bajada queda la grilla sola y el host no se anuncia como región. El estado de carga entra por input, porque el dueño del recurso es la página: cargando dibuja esqueletos, con obras la grilla, y sin obras el aviso de <a href="./?path=/docs/componentes-v3-emptystate--docs" target="_top"><strong>EmptyState</strong></a>.</p></div>`,
 			},
 		},
 	},
@@ -48,6 +41,16 @@ const meta: Meta<LiteraryWorksCardDeck> = {
 			control: { type: 'object' },
 			description: 'Destino del enlace "Ver todo" y el sufijo que nombra ese destino',
 			table: { type: { summary: 'SectionHeaderAction | undefined' }, defaultValue: { summary: 'undefined' } },
+		},
+		loading: {
+			control: { type: 'boolean' },
+			description: 'Estado de carga del recurso que alimenta la tirada; lo decide la página',
+			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
+		},
+		emptyMessage: {
+			control: { type: 'text' },
+			description: 'Qué decir cuando la tirada viene vacía',
+			table: { type: { summary: 'string' }, defaultValue: { summary: "'Todavía no hay obras para mostrar acá.'" } },
 		},
 	},
 };
@@ -111,30 +114,13 @@ export const SinEncabezado: Story = {
 	},
 };
 
-export const Estados: StoryObj<LiteraryWorksCardDeck & { loading: boolean }> = {
+// El switch mueve el input real del componente, así que alcanza con una sola instancia: no hay markup
+// duplicado que pueda divergir de lo que el componente dibuja.
+export const Estados: Story = {
 	argTypes: { loading: { control: 'boolean', name: 'Cargando' } },
 	render: (args) => ({
-		// El mismo tope que el componente: la rama de carga no depende de cuántas obras traiga el control.
-		props: { ...args, skeletonCount: 6 },
-		template: `
-			@if (loading) {
-				<div class="mb-8 flex flex-col gap-8">
-					<cuentoneta-section-header [heading]="heading" [subtitle]="subtitle" [action]="action" />
-					<section class="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-8">
-						@for (_ of [].constructor(skeletonCount); track $index) {
-							<cuentoneta-literary-work-home-card-teaser-skeleton />
-						}
-					</section>
-				</div>
-			} @else {
-				<cuentoneta-literary-works-card-deck
-					[literaryWorks]="literaryWorks"
-					[heading]="heading"
-					[subtitle]="subtitle"
-					[action]="action"
-				/>
-			}
-		`,
+		props: args,
+		template: `<cuentoneta-literary-works-card-deck ${argsToTemplate(args)} />`,
 	}),
 	args: {
 		loading: true,
@@ -146,7 +132,7 @@ export const Estados: StoryObj<LiteraryWorksCardDeck & { loading: boolean }> = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Activá/desactivá "Cargando" para alternar entre el estado real y el estado de carga del deck: el encabezado se sostiene y la grilla dibuja los seis esqueletos que dibuja el componente, sin depender de cuántas obras traiga el control.</p><p><strong>Usos:</strong> verificar que el encabezado no salte entre los dos estados.</p>`,
+				story: `<p>Activá/desactivá "Cargando" para alternar entre el estado real y el de carga: el encabezado se sostiene y la grilla dibuja los seis esqueletos del componente, sin depender de cuántas obras traiga el control. Vaciando además la lista de obras aparece el tercer estado, el del aviso de vacío.</p><p><strong>Usos:</strong> verificar que el encabezado no salte entre estados.</p>`,
 			},
 		},
 	},
@@ -166,7 +152,7 @@ export const Vacia: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Sin obras el <code>@defer</code> no dispara: queda el encabezado, sin tarjetas ni esqueletos. Es el valor default del input <code>literaryWorks</code>, y el estado que la página sirve una semana sin contenido nuevo.</p><p><strong>Usos:</strong> revisar qué ve alguien que llega en una semana vacía.</p>`,
+				story: `<p>Sin obras queda el encabezado y, en lugar de la grilla, el aviso de que no hay nada que mostrar: un hueco en blanco se leería como contenido que no terminó de cargar. Es el valor default del input <code>literaryWorks</code>, y el estado que la página sirve una semana sin contenido nuevo.</p><p><strong>Usos:</strong> revisar qué ve alguien que llega en una semana vacía.</p>`,
 			},
 		},
 	},

--- a/src/app/components/literary-works-card-deck/literary-works-card-deck.ts
+++ b/src/app/components/literary-works-card-deck/literary-works-card-deck.ts
@@ -1,6 +1,7 @@
 import { Component, input } from '@angular/core';
 
 import { SectionHeaderComponent, type SectionHeaderAction } from '@components/section-header/section-header.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { LiteraryWorkHomeCardTeaserComponent } from '../literary-work-home-card-teaser/literary-work-home-card-teaser.component';
 import { LiteraryWorkHomeCardTeaserSkeletonComponent } from '../literary-work-home-card-teaser/literary-work-home-card-teaser-skeleton.component';
 import type { LiteraryWorkNavigationTeaserWithAuthors } from '@models/literary-work.model';
@@ -15,14 +16,25 @@ import type { LiteraryWorkNavigationTeaserWithAuthors } from '@models/literary-w
  */
 @Component({
 	selector: 'cuentoneta-literary-works-card-deck',
-	imports: [SectionHeaderComponent, LiteraryWorkHomeCardTeaserComponent, LiteraryWorkHomeCardTeaserSkeletonComponent],
+	imports: [
+		SectionHeaderComponent,
+		EmptyStateComponent,
+		LiteraryWorkHomeCardTeaserComponent,
+		LiteraryWorkHomeCardTeaserSkeletonComponent,
+	],
 	template: `
 		@if (heading() || subtitle()) {
 			<cuentoneta-section-header [heading]="heading()" [subtitle]="subtitle()" [action]="action()" />
 		}
 
-		<section class="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-8">
-			@defer (when literaryWorks().length > 0) {
+		@if (loading()) {
+			<section class="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-8">
+				@for (_ of [].constructor(skeletonCount); track $index) {
+					<cuentoneta-literary-work-home-card-teaser-skeleton data-testid="skeleton" />
+				}
+			</section>
+		} @else if (literaryWorks().length > 0) {
+			<section class="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-8">
 				@for (literaryWork of literaryWorks(); track literaryWork.slug) {
 					<cuentoneta-literary-work-home-card-teaser
 						[literaryWork]="literaryWork"
@@ -34,12 +46,10 @@ import type { LiteraryWorkNavigationTeaserWithAuthors } from '@models/literary-w
 						data-testid="card"
 					/>
 				}
-			} @loading (minimum 500ms) {
-				@for (_ of [].constructor(skeletonCount); track $index) {
-					<cuentoneta-literary-work-home-card-teaser-skeleton data-testid="skeleton" />
-				}
-			}
-		</section>
+			</section>
+		} @else {
+			<cuentoneta-empty-state [message]="emptyMessage()" />
+		}
 	`,
 	host: {
 		class: 'mb-8 flex flex-col gap-8',
@@ -57,4 +67,7 @@ export class LiteraryWorksCardDeck {
 	public readonly heading = input<string>('');
 	public readonly subtitle = input<string>('');
 	public readonly action = input<SectionHeaderAction | undefined>(undefined);
+	/** El dueño del recurso es la página, así que el estado de carga entra por input. */
+	public readonly loading = input(false);
+	public readonly emptyMessage = input<string>('Todavía no hay obras para mostrar acá.');
 }

--- a/src/app/components/literary-works-card-deck/literary-works-card-deck.ts
+++ b/src/app/components/literary-works-card-deck/literary-works-card-deck.ts
@@ -27,24 +27,26 @@ import type { LiteraryWorkNavigationTeaserWithAuthors } from '@models/literary-w
 			<cuentoneta-section-header [heading]="heading()" [subtitle]="subtitle()" [action]="action()" />
 		}
 
-		@if (loading()) {
+		<!-- La grilla se declara una sola vez para las dos ramas: que el esqueleto caiga exactamente en la
+		misma caja que la tarjeta es lo que evita el salto al terminar de cargar. -->
+		@if (loading() || literaryWorks().length > 0) {
 			<section class="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-8">
-				@for (_ of [].constructor(skeletonCount); track $index) {
-					<cuentoneta-literary-work-home-card-teaser-skeleton data-testid="skeleton" />
-				}
-			</section>
-		} @else if (literaryWorks().length > 0) {
-			<section class="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-8">
-				@for (literaryWork of literaryWorks(); track literaryWork.slug) {
-					<cuentoneta-literary-work-home-card-teaser
-						[literaryWork]="literaryWork"
-						[order]="$index + 1"
-						[navigationParams]="{
-							navigation: 'author',
-							navigationSlug: literaryWork.authors[0].slug,
-						}"
-						data-testid="card"
-					/>
+				@if (loading()) {
+					@for (_ of [].constructor(skeletonCount); track $index) {
+						<cuentoneta-literary-work-home-card-teaser-skeleton />
+					}
+				} @else {
+					@for (literaryWork of literaryWorks(); track literaryWork.slug) {
+						<cuentoneta-literary-work-home-card-teaser
+							[literaryWork]="literaryWork"
+							[order]="$index + 1"
+							[navigationParams]="{
+								navigation: 'author',
+								navigationSlug: literaryWork.authors[0].slug,
+							}"
+							data-testid="card"
+						/>
+					}
 				}
 			</section>
 		} @else {
@@ -52,7 +54,7 @@ import type { LiteraryWorkNavigationTeaserWithAuthors } from '@models/literary-w
 		}
 	`,
 	host: {
-		class: 'mb-8 flex flex-col gap-8',
+		class: 'flex flex-col gap-8',
 		// El nombre de región es lo que deja localizar cada instancia sin depender de su posición en la
 		// página, cuando hay varias. Sin encabezado no hay nombre, y una región anónima estorba más de lo
 		// que ayuda: quien no declara título es porque anuncia la sección por su cuenta.
@@ -69,5 +71,6 @@ export class LiteraryWorksCardDeck {
 	public readonly action = input<SectionHeaderAction | undefined>(undefined);
 	/** El dueño del recurso es la página, así que el estado de carga entra por input. */
 	public readonly loading = input(false);
-	public readonly emptyMessage = input<string>('Todavía no hay obras para mostrar acá.');
+	/** Requerido: qué falta depende de la tirada, y un mensaje genérico no lo dice. */
+	public readonly emptyMessage = input.required<string>();
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -11,46 +11,50 @@
 		</section>
 	</cuentoneta-home-hero>
 
-	<div class="content horizontal-layout-spacing mt-16">
-		<section class="mb-8">
-			<cuentoneta-literary-works-card-deck
-				[literaryWorks]="latestReads()"
-				[action]="literaryWorksAction"
-				[loading]="isLoading()"
-				heading="Últimas novedades"
-				subtitle="Descubrí las obras que se sumaron recientemente a La Cuentoneta"
-				emptyMessage="Todavía no hay obras nuevas esta semana."
-			/>
-		</section>
+	<!-- El ritmo vertical entre secciones lo fija la página, no cada deck: es lo que el diseño mide. -->
+	<div class="content horizontal-layout-spacing mt-16 flex flex-col gap-24 pb-20">
+		@if (failed()) {
+			<p class="font-inter text-base text-neutral-700" data-testid="landing-error">
+				No pudimos cargar el contenido de esta semana. Probá de nuevo en un rato.
+			</p>
+		} @else {
+			<section>
+				<cuentoneta-literary-works-card-deck
+					[literaryWorks]="latestReads()"
+					[action]="literaryWorksAction"
+					[loading]="isLoading()"
+					heading="Últimas novedades"
+					subtitle="Descubrí las obras que se sumaron recientemente a La Cuentoneta"
+					emptyMessage="Todavía no hay obras nuevas esta semana."
+				/>
+			</section>
 
-		<section class="mb-8">
-			<cuentoneta-literary-works-card-deck
-				[literaryWorks]="mostRead()"
-				[action]="literaryWorksAction"
-				[loading]="isLoading()"
-				heading="Obras más leídas"
-				subtitle="Explorá los textos más populares entre los lectores"
-				emptyMessage="Todavía no hay obras más leídas para mostrar."
-			/>
-		</section>
+			<section>
+				<cuentoneta-literary-works-card-deck
+					[literaryWorks]="mostRead()"
+					[action]="literaryWorksAction"
+					[loading]="isLoading()"
+					heading="Obras más leídas"
+					subtitle="Explorá los textos más populares entre los lectores"
+					emptyMessage="Todavía no hay obras más leídas para mostrar."
+				/>
+			</section>
 
-		<section class="mb-8">
-			<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" [loading]="isLoading()" />
-		</section>
+			<section>
+				<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" [loading]="isLoading()" />
+			</section>
 
-		<section class="mb-8">
-			<cuentoneta-collection-teasers-deck
-				[teasers]="collections()"
-				[loading]="isLoading()"
-				class="flex flex-col gap-8"
-			/>
-		</section>
+			<section>
+				<cuentoneta-collection-teasers-deck [teasers]="collections()" [loading]="isLoading()" />
+			</section>
+		}
 
 		<!--
             Intro descriptiva con texto sustantivo y citable: es lo que le da a buscadores y answer
-            engines contenido indexable más allá de las imágenes del hero.
+            engines contenido indexable más allá de las imágenes del hero. Queda fuera de la rama de
+            error porque no depende del contenido de la semana.
         -->
-		<section class="mb-8 flex flex-col gap-8">
+		<section class="flex flex-col gap-8">
 			<cuentoneta-section-header heading="Sobre La Cuentoneta" />
 
 			<div class="flex flex-col gap-4">

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,12 +1,13 @@
 <main>
 	<cuentoneta-home-hero [covers]="heroCovers()">
-		<!-- La caja se reserva por proporción para que resolver el diferido no empuje lo que sigue. -->
+		<!-- La caja se reserva por proporción para que la resolución del recurso no empuje lo que sigue. -->
 		<section class="aspect-[540/220] w-full sm:aspect-[1240/360]">
-			@defer (when campaigns().length > 0) {
-				<cuentoneta-carousel [slides]="campaigns()" />
-			} @loading (minimum 500ms) {
+			@if (isLoading()) {
 				<cuentoneta-carousel-skeleton />
+			} @else if (campaigns().length > 0) {
+				<cuentoneta-carousel [slides]="campaigns()" />
 			}
+			<!-- Sin campañas no se monta nada: un carrusel de cero diapositivas no es un estado que exista. -->
 		</section>
 	</cuentoneta-home-hero>
 
@@ -15,8 +16,10 @@
 			<cuentoneta-literary-works-card-deck
 				[literaryWorks]="latestReads()"
 				[action]="literaryWorksAction"
+				[loading]="isLoading()"
 				heading="Últimas novedades"
 				subtitle="Descubrí las obras que se sumaron recientemente a La Cuentoneta"
+				emptyMessage="Todavía no hay obras nuevas esta semana."
 			/>
 		</section>
 
@@ -24,22 +27,28 @@
 			<cuentoneta-literary-works-card-deck
 				[literaryWorks]="mostRead()"
 				[action]="literaryWorksAction"
+				[loading]="isLoading()"
 				heading="Obras más leídas"
 				subtitle="Explorá los textos más populares entre los lectores"
+				emptyMessage="Todavía no hay obras más leídas para mostrar."
 			/>
 		</section>
 
 		<section class="mb-8">
-			<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" />
+			<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" [loading]="isLoading()" />
 		</section>
 
 		<section class="mb-8">
-			<cuentoneta-collection-teasers-deck [teasers]="collections()" class="flex flex-col gap-8" />
+			<cuentoneta-collection-teasers-deck
+				[teasers]="collections()"
+				[loading]="isLoading()"
+				class="flex flex-col gap-8"
+			/>
 		</section>
 
 		<!--
-            Intro descriptiva con texto sustantivo y citable, server-rendered (sin @defer), para que
-            buscadores y answer engines tengan contenido indexable más allá de las imágenes del hero.
+            Intro descriptiva con texto sustantivo y citable: es lo que le da a buscadores y answer
+            engines contenido indexable más allá de las imágenes del hero.
         -->
 		<section class="mb-8 flex flex-col gap-8">
 			<cuentoneta-section-header heading="Sobre La Cuentoneta" />

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -13,7 +13,6 @@ import { onoffLiteraryWorkNavigationTeasersWithAuthorsMock } from '@mocks/onoff-
 import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
 import type { CollectionTeaser } from '@models/collection.model';
 import { contentCampaignMock } from '@mocks/content-campaign.mock';
-import { renderDeferBlocks } from '@testing/defer-blocks';
 import { clearAllMocks } from '@test-utils';
 
 // El doble canned del provider entrega la landing vacía; cada caso le superpone solo las secciones
@@ -102,9 +101,7 @@ describe('HomeComponent', () => {
 		// Los dos mazos marcan sus tarjetas con el mismo `card`, así que el discriminante es el nombre de
 		// región de cada uno: por orden de documento, el caso dejaría de valer al reordenar las secciones.
 		it('should hand each listing to its own deck', async () => {
-			const { fixture } = await renderHome({ latestReads, mostRead });
-
-			await renderDeferBlocks(fixture);
+			await renderHome({ latestReads, mostRead });
 
 			expect(screen.getAllByTestId('card')).toHaveLength(latestReads.length + mostRead.length);
 			(
@@ -139,11 +136,9 @@ describe('HomeComponent', () => {
 			it('should cap the listing at six, however many the week brings', async () => {
 				expect(onoffLiteraryWorkNavigationTeasersWithAuthorsMock.length).toBeGreaterThan(6);
 
-				const { fixture } = await renderHome({
+				await renderHome({
 					[section]: [...onoffLiteraryWorkNavigationTeasersWithAuthorsMock],
 				});
-
-				await renderDeferBlocks(fixture);
 
 				expect(screen.getAllByTestId('card')).toHaveLength(6);
 				onoffLiteraryWorkNavigationTeasersWithAuthorsMock.slice(6).forEach(({ title }) => {
@@ -157,9 +152,7 @@ describe('HomeComponent', () => {
 		const collections = onoffCollectionTeasersMock;
 
 		it('should render every collection of the week', async () => {
-			const { fixture } = await renderHome({ collections });
-
-			await renderDeferBlocks(fixture);
+			await renderHome({ collections });
 
 			collections.forEach(({ title }) => {
 				expect(screen.getByText(title)).toBeInTheDocument();
@@ -170,9 +163,7 @@ describe('HomeComponent', () => {
 	describe('campañas', () => {
 		it('should hand the campaigns of the week to the carousel', async () => {
 			const [firstCampaign] = contentCampaignMock;
-			const { fixture } = await renderHome({ campaigns: contentCampaignMock });
-
-			await renderDeferBlocks(fixture);
+			await renderHome({ campaigns: contentCampaignMock });
 
 			expect(screen.getByRole('region', { name: 'Content campaigns' })).toBeInTheDocument();
 			// El carrusel dibuja solo la diapositiva activa, así que la campaña observable es la primera.
@@ -197,9 +188,7 @@ describe('HomeComponent', () => {
 
 		it('should hand every highlighted author to the grid', async () => {
 			const highlightedAuthors = onoffHighlightedAuthorsOfLength(6);
-			const { fixture } = await renderHome({ highlightedAuthors });
-
-			await renderDeferBlocks(fixture);
+			await renderHome({ highlightedAuthors });
 
 			highlightedAuthors.forEach(({ author }) => {
 				expect(screen.getByText(author.name)).toBeInTheDocument();
@@ -213,10 +202,9 @@ describe('HomeComponent', () => {
 		});
 	});
 
-	// La landing sale vacía mientras la edición no cargó la semana, y es un estado que se sirve: la
-	// página tiene que sostener su estructura sin dibujar contenedores a medio llenar. Los diferidos no
-	// se fuerzan acá a propósito: lo que se afirma es que sus disparadores no disparan sin contenido, y
-	// forzarlos montaría un carrusel de cero diapositivas, un estado que la aplicación no alcanza.
+	// La landing sale vacía mientras la edición no cargó la semana, y es un estado que se sirve: la página
+	// tiene que sostener su estructura y decir qué falta, en vez de dejar huecos que se leen como carga
+	// que nunca terminó.
 	describe('semana sin contenido', () => {
 		it('should keep every section heading when the week brings nothing', async () => {
 			await renderHome();
@@ -245,13 +233,38 @@ describe('HomeComponent', () => {
 			expect(screen.getAllByRole('link', { name: 'Ver todo el catálogo de obras' })).toHaveLength(2);
 		});
 
-		// Las tres clases de tarjeta —historia, colección y autor— se dibujan como `article`, así que la
-		// ausencia de ese rol cubre a las tres a la vez.
+		// Las tres clases de tarjeta —obra, colección y autor— se dibujan como `article`, así que la
+		// ausencia de ese rol cubre a las tres a la vez. El carrusel es el único bloque que sin contenido
+		// no se monta: un carrusel de cero diapositivas no es un estado que exista.
 		it('should render neither cards nor a carousel when the week brings nothing', async () => {
 			await renderHome();
 
 			expect(screen.queryAllByRole('article')).toHaveLength(0);
 			expect(screen.queryByRole('region', { name: 'Content campaigns' })).not.toBeInTheDocument();
+		});
+
+		// Cada deck dice lo suyo: un único mensaje compartido no distinguiría qué sección quedó sin
+		// contenido, que es justamente lo que la página tiene que comunicar.
+		it('should explain what is missing in each deck', async () => {
+			await renderHome();
+
+			[
+				'Todavía no hay obras nuevas esta semana.',
+				'Todavía no hay obras más leídas para mostrar.',
+				'Todavía no hay autores destacados esta semana.',
+				'Todavía no hay colecciones para mostrar esta semana.',
+			].forEach((message) => {
+				expect(screen.getByText(message)).toBeInTheDocument();
+			});
+		});
+
+		// El HTML servido no debe llevar marcadores de esqueleto: el recurso bloquea el SSR, así que para
+		// cuando la página se serializa el estado de carga ya terminó. Es el invariante que la suite de
+		// indexado afirma sobre la página real.
+		it('should render no skeleton markers once the resource settled', async () => {
+			await renderHome();
+
+			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
 		});
 	});
 });

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,7 +1,8 @@
 import HomeComponent from './home.component';
 import { render, screen, within } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
-import { map, type Observable } from 'rxjs';
+import { map, NEVER, throwError, type Observable } from 'rxjs';
+import { RESPONSE_INIT, type Provider } from '@angular/core';
 
 import { provideContentApiMock, StubContentApi } from '../../providers/content.mock';
 import type { ContentApi } from '../../providers/content.provider';
@@ -27,16 +28,35 @@ class StubLandingPageContentApi implements ContentApi {
 	}
 }
 
-const renderHome = (content: Partial<LandingPageContent> = {}) =>
+// El contrato de la landing no tiene forma de expresar "no se pudo averiguar": el recurso libera el
+// bloqueo del SSR también cuando el stream falla, así que el fallo hay que producirlo desde el stream.
+class FailingContentApi implements ContentApi {
+	public getLandingPageContent(): Observable<LandingPageContent> {
+		return throwError(() => new Error('sin contenido de la semana'));
+	}
+}
+
+// El stream nunca emite, así que el recurso queda en carga: es el estado que el SSR ya resolvió, pero
+// que el cliente sí atraviesa al navegar hacia la página.
+class PendingContentApi implements ContentApi {
+	public getLandingPageContent(): Observable<LandingPageContent> {
+		return NEVER;
+	}
+}
+
+const renderWithApi = (api: ContentApi, providers: Provider[] = []) =>
 	render(HomeComponent, {
 		providers: [
 			provideRouter([]),
-			provideContentApiMock(new StubLandingPageContentApi(content)),
+			provideContentApiMock(api),
 			// El carrusel deriva el viewport del layout, y su token no tiene factory: sin el doble, montarlo
 			// deja el render en un fallo de inyección.
 			{ provide: LayoutService, useClass: ControllableLayoutService },
+			...providers,
 		],
 	});
+
+const renderHome = (content: Partial<LandingPageContent> = {}) => renderWithApi(new StubLandingPageContentApi(content));
 
 describe('HomeComponent', () => {
 	beforeEach(() => {
@@ -265,6 +285,61 @@ describe('HomeComponent', () => {
 			await renderHome();
 
 			expect(screen.queryAllByTestId('skeleton')).toHaveLength(0);
+		});
+	});
+
+	// El estado de carga lo decide la página y lo consumen los cuatro decks: sin este bloque, desconectar
+	// ese cableado de cualquiera de ellos no rompería nada.
+	describe('contenido en vuelo', () => {
+		it('should fill every deck with skeletons while the resource is loading', async () => {
+			await renderWithApi(new PendingContentApi());
+
+			// Seis por cada deck de obras y por el de autores, cuatro por el de colecciones.
+			expect(screen.getAllByTestId('skeleton')).toHaveLength(22);
+			expect(screen.queryAllByTestId('empty-state')).toHaveLength(0);
+		});
+
+		it('should claim nothing is missing while it is still loading', async () => {
+			await renderWithApi(new PendingContentApi());
+
+			expect(screen.queryByText('Todavía no hay obras nuevas esta semana.')).not.toBeInTheDocument();
+		});
+	});
+
+	// Un fallo del recurso llega con el contenido vacío, igual que una semana sin cargar. Distinguirlos es
+	// lo que evita que la página afirme que no hay obras cuando lo que pasó es que no se pudo averiguar.
+	describe('el contenido no se pudo cargar', () => {
+		it('should say that it could not load instead of claiming the week is empty', async () => {
+			await renderWithApi(new FailingContentApi());
+
+			expect(screen.getByTestId('landing-error')).toBeInTheDocument();
+			expect(screen.queryByText('Todavía no hay obras nuevas esta semana.')).not.toBeInTheDocument();
+			expect(screen.queryAllByTestId('empty-state')).toHaveLength(0);
+		});
+
+		// Un fallo transitorio no puede salir 200: el borde lo cachearía como si fuera la página.
+		it('should answer with a server error status', async () => {
+			const responseInit: { status?: number } = {};
+
+			await renderWithApi(new FailingContentApi(), [{ provide: RESPONSE_INIT, useValue: responseInit }]);
+
+			expect(responseInit.status).toBe(503);
+		});
+
+		it('should leave the status untouched when the content loads', async () => {
+			const responseInit: { status?: number } = {};
+
+			await renderWithApi(new StubLandingPageContentApi({}), [{ provide: RESPONSE_INIT, useValue: responseInit }]);
+
+			expect(responseInit.status).toBeUndefined();
+		});
+
+		// El texto introductorio no depende del contenido de la semana, así que la página sigue teniendo
+		// cuerpo indexable aunque el backend falle.
+		it('should keep the introductory content', async () => {
+			await renderWithApi(new FailingContentApi());
+
+			expect(screen.getByRole('heading', { name: 'Sobre La Cuentoneta', level: 2 })).toBeInTheDocument();
 		});
 	});
 });

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -32,8 +32,8 @@ const renderHome = (content: Partial<LandingPageContent> = {}) =>
 		providers: [
 			provideRouter([]),
 			provideContentApiMock(new StubLandingPageContentApi(content)),
-			// El carrusel deriva el viewport del layout, y su token no tiene factory: sin el doble,
-			// resolver el diferido de campañas deja el render en un fallo de inyección.
+			// El carrusel deriva el viewport del layout, y su token no tiene factory: sin el doble, montarlo
+			// deja el render en un fallo de inyección.
 			{ provide: LayoutService, useClass: ControllableLayoutService },
 		],
 	});
@@ -120,8 +120,8 @@ describe('HomeComponent', () => {
 			});
 		});
 
-		// Las cabeceras quedan fuera de los bloques diferidos: son lo que la página lleva servido aunque
-		// las tarjetas todavía no se hayan resuelto.
+		// Las cabeceras quedan fuera de la rama de carga: son lo que la página lleva servido aunque las
+		// tarjetas todavía no se hayan resuelto.
 		it('should render both deck headings from the very first render', async () => {
 			await renderHome({ latestReads, mostRead });
 
@@ -178,7 +178,7 @@ describe('HomeComponent', () => {
 			expect(screen.getByRole('heading', { name: 'Autores/as destacados/as', level: 2 })).toBeInTheDocument();
 		});
 
-		// La cabecera y su enlace quedan fuera del bloque diferido, así que se renderizan en el HTML servido:
+		// La cabecera y su enlace quedan fuera de la rama de carga, así que se renderizan en el HTML servido:
 		// es lo que hace que la home enlace al índice de autores sin depender de que el cliente hidrate.
 		it('should link to the authors index from the home', async () => {
 			await renderHome({ highlightedAuthors: onoffHighlightedAuthorsOfLength(6) });

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -54,6 +54,9 @@ export default class HomeComponent {
 
 	// Propiedades
 	private readonly landingPageContent = computed(() => this.landingPageResource.value());
+	// El recurso bloquea el SSR, así que en el HTML servido esto ya es falso: los decks salen con su
+	// contenido y no con esqueletos. En el cliente cubre la navegación entrante.
+	protected readonly isLoading = computed(() => this.landingPageResource.isLoading());
 	protected readonly collections = computed(() => this.landingPageContent()?.collections || []);
 	protected readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
 	protected readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,5 +1,5 @@
 // Core
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, effect, inject, RESPONSE_INIT } from '@angular/core';
 
 // Services
 import { ContentApi } from '../../providers/content.provider';
@@ -38,6 +38,7 @@ import { SectionHeaderComponent, type SectionHeaderAction } from '@components/se
 export default class HomeComponent {
 	// Services
 	private readonly contentService = inject(ContentApi);
+	private readonly responseInit = inject(RESPONSE_INIT, { optional: true });
 
 	// Las dos secciones de obras comparten destino porque comparten hub: no hay una vista filtrada de
 	// novedades ni de más leídas a la que llevar.
@@ -53,10 +54,18 @@ export default class HomeComponent {
 	});
 
 	// Propiedades
-	private readonly landingPageContent = computed(() => this.landingPageResource.value());
+	// `value()` lanza cuando el recurso quedó en error, así que se lee solo cuando hay valor: sin esta
+	// guarda, el fallo del backend rompe el render en vez de mostrar su mensaje.
+	private readonly landingPageContent = computed(() =>
+		this.landingPageResource.hasValue() ? this.landingPageResource.value() : undefined,
+	);
 	// El recurso bloquea el SSR, así que en el HTML servido esto ya es falso: los decks salen con su
 	// contenido y no con esqueletos. En el cliente cubre la navegación entrante.
 	protected readonly isLoading = computed(() => this.landingPageResource.isLoading());
+	// El bloqueo del SSR se libera también cuando el stream falla, y ahí el contenido llega vacío. Sin
+	// distinguir el fallo, la página afirmaría que no hay obras esta semana cuando lo que pasó es que no
+	// se pudo averiguar.
+	protected readonly failed = computed(() => this.landingPageResource.status() === 'error');
 	protected readonly collections = computed(() => this.landingPageContent()?.collections || []);
 	protected readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
 	protected readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
@@ -70,4 +79,13 @@ export default class HomeComponent {
 			.flatMap((collection) => (collection.imagery.kind === 'representative' ? [collection.imagery.image] : []))
 			.slice(0, 3),
 	);
+
+	// Un fallo transitorio no puede salir 200: el borde lo cachearía como si fuera la página, y la página
+	// de inicio es la más rastreada del sitio.
+	private readonly respondErrorStatusEffect = effect(() => {
+		if (!this.landingPageResource.error() || !this.responseInit) {
+			return;
+		}
+		this.responseInit.status = 503;
+	});
 }


### PR DESCRIPTION
Tercera rebanada de la migración de la página de inicio a V3. Cubre los puntos 4, 5 y 6 del alcance y **tres criterios de aceptación**: el HTML server-rendered trae las tarjetas con sus enlaces salientes, el `test.fixme` de marcadores de esqueleto queda habilitado y en verde, y cada deck resuelve su estado vacío sin quedar en blanco.

## El problema

Los cinco bloques de la página —los cuatro decks y el carrusel— resolvían su contenido con `@defer`. El recurso de la página bloquea el SSR, así que el dato ya está antes de serializar: diferir solo lograba que el HTML servido saliera con esqueletos en vez de tarjetas, **sin un solo enlace a una obra**.

Y con la lista vacía el disparador `when lista().length > 0` no llegaba a dispararse nunca, así que la sección quedaba en blanco debajo de su encabezado — que se lee como contenido que no terminó de cargar. Es el alcance heredado de #2379: las dos cosas se resuelven con el mismo cambio.

## Qué cambia

**El estado de carga entra por input**, porque el dueño del recurso es la página. Cada deck decide entre tres ramas explícitas: cargando, con contenido, o vacío. Es el mismo movimiento que en su momento se le aplicó a la página de autor.

**El aviso de vacío sale como componente propio** (`EmptyState`), con el mensaje a cargo de quien lo monta: uno genérico no distinguiría qué sección se quedó sin contenido, que es justamente lo que la página tiene que comunicar.

**El esqueleto de colecciones suma el marcador que le faltaba.** Sin `data-testid="skeleton"` el invariante no lo veía, así que habría dado por buena una página que igual servía esqueletos. Es lo que vuelve honesto al test que esta rebanada destraba.

**El carrusel también deja de diferir.** No figuraba en la tabla del issue, pero era el quinto bloque diferido bajo `<main>` y emitía su propio marcador: sin tocarlo el invariante seguía en rojo. Su rama vacía no monta nada, porque un carrusel de cero diapositivas no es un estado que exista.

## Qué se afirma ahora en la suite de indexado

Además de habilitar el test de marcadores de esqueleto, el bloque de invariantes suma `checkInternalLink(html, '/read/')`. Que no haya esqueletos dice que los decks no difieren; que haya un enlace a una obra dice que además trajeron contenido. Sin esa segunda aserción, una página que sirviera los decks vacíos pasaría igual.

## La cuarta rama: el error

Sacar los diferidos dejó un agujero que la review encontró. El recurso libera el bloqueo del SSR **también cuando el stream falla**, y ahí el contenido llega vacío: sin distinguirlo, la página afirmaba «Todavía no hay obras nuevas esta semana» ante un backend caído, con estado 200, server-rendered e indexable. Antes el fallo era silencioso; convertirlo en una afirmación falsa habría sido peor.

Ahora la página reconoce el fallo, lo dice, y responde **503** —un fallo transitorio cacheado en el borde como si fuera la página es exactamente lo que hay que evitar—, siguiendo el mismo patrón que ya usa el catálogo de colecciones. El texto introductorio queda fuera de esa rama: no depende del contenido de la semana, así que la página conserva cuerpo indexable.

## Espaciado del diseño

El ritmo vertical pasa a ser el del nodo `3971-16887`: **64 px** sobre la primera sección, **96** entre secciones y **80** al cierre. Lo fija la página en un solo lugar, en lugar de un margen propio por deck — que era lo que hacía que el ritmo dependiera de quién montara cada componente.

## Plan de pruebas

- **Gates locales:** `typecheck`, `lint`, `stylelint`, `test`, `build` y `storybook:build` en verde.
- **Verificación sobre el HTML servido, sin ejecutar JavaScript** (`curl` a `/home`): **12 tarjetas, 12 enlaces a `/read/` y cero marcadores de esqueleto**. Es exactamente el criterio de aceptación, medido sobre lo que recibe un crawler.
- **Cobertura:** los specs de los tres decks pasan de forzar `DeferBlockState` a mover el input `loading`, que además es más directo; cada uno suma su caso de vacío. En la página, el bloque «semana sin contenido» pasa a afirmar el mensaje **visible** de cada deck en vez de la mera ausencia de tarjetas, más un caso de que no queden marcadores de esqueleto. `renderDeferBlocks` desaparece de la home; el helper sigue vivo para otras páginas.
- **Catálogo:** las stories `Estados` de los tres decks pasan a mover el input real en una sola instancia, en lugar de duplicar el markup del componente en su rama de carga — que era markup que podía divergir en silencio de lo que el componente dibuja.
- **Espaciado verificado en navegador:** 64 px sobre la primera sección, 96 entre cada par y 80 al cierre, medidos sobre el DOM renderizado.

> **Un modo de falla a tener presente:** `checkInternalLink(html, '/read/')` falla si la home sale sin obras, y eso puede pasar por dato y no por código — es el caso ya conocido de la landing de la semana ausente en el dataset de e2e. El invariante es el correcto y no conviene relajarlo, pero si el gate se pone rojo ahí, lo primero a mirar es el dataset.

## Qué NO entra

El reordenamiento de secciones, el recorte de colecciones a cuatro, los gaps y anchos de las grillas y el tratamiento visual de las portadas del hero van en la cuarta y última rebanada.

Tercera de las cuatro rebanadas de #1508. El keyword de cierre va en la última: mergear ésta no completa el alcance del issue.
