### PR TITLE
[#1508] - Grillas, conteos y orden de secciones

### DIFF
--- a/src/app/components/home-hero/home-hero.component.spec.ts
+++ b/src/app/components/home-hero/home-hero.component.spec.ts
@@ -28,31 +28,6 @@ describe('HomeHeroComponent', () => {
 		});
 	});
 
-	describe('Portadas ilustrativas', () => {
-		const covers = ['https://cdn.sanity.io/uno.jpg', 'https://cdn.sanity.io/dos.jpg'];
-
-		it('should render one cover per image it receives', async () => {
-			await render(HomeHeroComponent, { inputs: { covers } });
-
-			expect(screen.getAllByTestId('cover-image')).toHaveLength(covers.length);
-		});
-
-		// Son decorativas: el enlace y el nombre los aporta el contenido, no la banda.
-		it('should leave the covers out of the accessibility tree', async () => {
-			await render(HomeHeroComponent, { inputs: { covers } });
-
-			screen.getAllByTestId('cover-image').forEach((cover) => expect(cover).toHaveAttribute('alt', ''));
-			expect(screen.queryAllByRole('img')).toHaveLength(0);
-		});
-
-		// Sin portadas no queda un contenedor vacío ocupando su lugar en la fila.
-		it('should render no cover strip when there are no images', async () => {
-			await render(HomeHeroComponent);
-
-			expect(screen.queryByTestId('hero-covers')).not.toBeInTheDocument();
-		});
-	});
-
 	describe('Contenido proyectado', () => {
 		it('should render what the page projects below the heading', async () => {
 			await render('<cuentoneta-home-hero><p>Carrusel de campañas</p></cuentoneta-home-hero>', {

--- a/src/app/components/home-hero/home-hero.component.stories.ts
+++ b/src/app/components/home-hero/home-hero.component.stories.ts
@@ -1,16 +1,6 @@
-import { argsToTemplate, Meta, StoryObj } from '@storybook/angular-vite';
+import { Meta, StoryObj } from '@storybook/angular-vite';
 
 import { HomeHeroComponent } from './home-hero.component';
-import { onoffImageAssets } from '@mocks/onoff-image-assets.mock';
-
-// Tres portadas distintas del canon de Onoff. No se derivan del agregador de colecciones porque hoy
-// tiene una sola colección con imagen editorial propia, y la banda quedaría mostrando la misma imagen
-// tres veces: un estado que ninguna semana real produce.
-const covers = [
-	onoffImageAssets.geometriasDelDesveloCover.path,
-	onoffImageAssets.neronCover.path,
-	onoffImageAssets.lasEscalerasCover.path,
-];
 
 const meta: Meta<HomeHeroComponent> = {
 	component: HomeHeroComponent,
@@ -21,15 +11,8 @@ const meta: Meta<HomeHeroComponent> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>El <strong>HomeHero</strong> es la banda que abre la página de inicio en el Design System v3: fondo <code>brand-200</code> a todo el ancho, con el <code>&lt;h1&gt;</code> de la página, su bajada y una muestra de portadas alineada a la derecha, y el carrusel de campañas proyectado debajo.</p><p>El fondo es full-bleed y el contenido va enmarcado adentro, así que el host vive fuera del contenedor angosto de la página. Las portadas son ilustrativas —no enlazan y su <code>alt</code> queda vacío— y las resuelve <a href="./?path=/docs/componentes-v3-coverimage--docs" target="_top"><strong>CoverImage</strong></a>; la página le pasa las de las colecciones destacadas que tienen imagen editorial propia, hasta tres, y ninguna si no hay.</p></div>`,
+				component: `<div><p>El <strong>HomeHero</strong> es la banda que abre la página de inicio en el Design System v3: fondo <code>brand-200</code> a todo el ancho, con el trazo del diseño detrás, el <code>&lt;h1&gt;</code> de la página y su bajada, y el carrusel de campañas proyectado debajo.</p><p>El fondo es full-bleed y el contenido va enmarcado adentro, así que el host vive fuera del contenedor angosto de la página. La muestra de portadas que el diseño ubica a la derecha del título está retirada hasta resolver su tratamiento visual.</p></div>`,
 			},
-		},
-	},
-	argTypes: {
-		covers: {
-			control: { type: 'object' },
-			description: 'Portadas ilustrativas de la banda; vacío deja el hero solo con su texto',
-			table: { type: { summary: 'readonly string[]' }, defaultValue: { summary: '[]' } },
 		},
 	},
 };
@@ -37,31 +20,13 @@ export default meta;
 type Story = StoryObj<HomeHeroComponent>;
 
 export const Primary: Story = {
-	render: (args) => ({
-		props: args,
-		template: `<cuentoneta-home-hero ${argsToTemplate(args)} />`,
+	render: () => ({
+		template: `<cuentoneta-home-hero />`,
 	}),
-	args: { covers },
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>La forma que sirve la página de inicio cuando la semana trae colecciones con imagen editorial: título, bajada y tres portadas.</p><p><strong>Usos:</strong> el encabezado de la página de inicio.</p>`,
-			},
-		},
-	},
-};
-
-export const SinPortadas: Story = {
-	name: 'Sin portadas',
-	render: (args) => ({
-		props: args,
-		template: `<cuentoneta-home-hero ${argsToTemplate(args)} />`,
-	}),
-	args: { covers: [] },
-	parameters: {
-		docs: {
-			description: {
-				story: `<p>Ninguna colección destacada tiene imagen editorial propia. La banda no reserva el hueco: el texto ocupa el ancho y la fila no queda coja.</p><p><strong>Usos:</strong> revisar la banda en una semana sin material ilustrativo.</p>`,
+				story: `<p>La banda tal como la sirve la página de inicio: trazo de fondo, título y bajada, con el texto ocupando el ancho.</p><p><strong>Usos:</strong> el encabezado de la página de inicio.</p>`,
 			},
 		},
 	},
@@ -69,19 +34,17 @@ export const SinPortadas: Story = {
 
 export const ConContenidoProyectado: Story = {
 	name: 'Con contenido proyectado',
-	render: (args) => ({
-		props: args,
+	render: () => ({
 		// El carrusel real se sustituye por un bloque de la misma caja: la story documenta la proyección,
 		// no el carrusel, que tiene su propia entrada de catálogo.
 		template: `
-			<cuentoneta-home-hero ${argsToTemplate(args)}>
+			<cuentoneta-home-hero>
 				<div class="flex h-90 w-full items-center justify-center rounded-[20px] bg-neutral-300 font-inter text-neutral-700">
 					Carrusel de campañas
 				</div>
 			</cuentoneta-home-hero>
 		`,
 	}),
-	args: { covers },
 	parameters: {
 		docs: {
 			description: {

--- a/src/app/components/home-hero/home-hero.component.ts
+++ b/src/app/components/home-hero/home-hero.component.ts
@@ -1,21 +1,16 @@
-import { Component, input } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
-
-import { CoverImageComponent } from '@components/cover-image/cover-image.component';
 
 /**
  * Encabezado de la página de inicio del Design System v3: la banda que abre la página —con su trazo de
- * fondo, el título, la bajada y una muestra de portadas— y el carrusel de campañas proyectado debajo.
+ * fondo, el título y la bajada— y el carrusel de campañas proyectado debajo.
  *
  * El fondo es full-bleed y el contenido va enmarcado adentro, así que el host no puede vivir dentro
  * del contenedor angosto de la página.
- *
- * Las portadas son ilustrativas: no enlazan a ningún lado y su `alt` queda vacío, porque el título y
- * la bajada ya dicen todo lo que la banda comunica.
  */
 @Component({
 	selector: 'cuentoneta-home-hero',
-	imports: [NgOptimizedImage, CoverImageComponent],
+	imports: [NgOptimizedImage],
 	template: `
 		<!--
 			El trazo del diseño viaja como imagen y no como marcado: la curva no tiene semántica y su
@@ -37,17 +32,18 @@ import { CoverImageComponent } from '@components/cover-image/cover-image.compone
 					</p>
 				</div>
 
+				<!-- TODO(#2414): restituir la muestra de portadas con el tratamiento visual del diseño.
+				Se retira hasta entonces: tres portadas planas en fila quedaban lejos del mock, que las
+				dibuja inclinadas, con lomo y sombra sobre una caja más ancha y más alta.
+
 				@if (covers().length > 0) {
-					<!--
-						La tira mide 386px rígidos y no encoge, así que solo aparece donde el hero es de dos columnas:
-						en el diseño es el adorno de esa fila, y en una columna desbordaría el ancho del teléfono.
-					-->
 					<div class="hidden shrink-0 gap-4 md:flex" data-testid="hero-covers">
 						@for (cover of covers(); track $index) {
 							<cuentoneta-cover-image [src]="cover" [priority]="$first" />
 						}
 					</div>
 				}
+				-->
 			</div>
 
 			<ng-content />
@@ -60,6 +56,6 @@ import { CoverImageComponent } from '@components/cover-image/cover-image.compone
 	},
 })
 export class HomeHeroComponent {
-	/** Portadas ilustrativas de la banda; vacío deja el hero solo con su texto. */
-	public readonly covers = input<readonly string[]>([]);
+	// TODO(#2414): vuelve junto con la muestra de portadas.
+	// public readonly covers = input<readonly string[]>([]);
 }

--- a/src/app/components/literary-works-card-deck/literary-works-card-deck.spec.ts
+++ b/src/app/components/literary-works-card-deck/literary-works-card-deck.spec.ts
@@ -67,6 +67,35 @@ describe('LiteraryWorksCardDeck', () => {
 		});
 	});
 
+	// El número es un ranking, así que solo tiene sentido donde la tirada ordena por algo. El diseño lo
+	// muestra en más leídas y no en novedades.
+	describe('Numeración de las tarjetas', () => {
+		it('should number the cards by position when asked to', async () => {
+			await render(LiteraryWorksCardDeck, {
+				inputs: { ...defaultInputs, numbered: true },
+				providers: defaultProviders,
+			});
+
+			expect(screen.getAllByTestId('order').map((order) => order.textContent?.trim())).toEqual([
+				'1',
+				'2',
+				'3',
+				'4',
+				'5',
+				'6',
+			]);
+		});
+
+		it('should number nothing by default', async () => {
+			await render(LiteraryWorksCardDeck, {
+				inputs: defaultInputs,
+				providers: defaultProviders,
+			});
+
+			expect(screen.queryAllByTestId('order')).toHaveLength(0);
+		});
+	});
+
 	// La tarjeta enlaza a la ruta de lectura: es el único camino que la home ofrece hacia una obra desde
 	// este bloque, y de él depende que la página emita enlaces internos.
 	it('links every card to the reading route', async () => {

--- a/src/app/components/literary-works-card-deck/literary-works-card-deck.stories.ts
+++ b/src/app/components/literary-works-card-deck/literary-works-card-deck.stories.ts
@@ -50,7 +50,12 @@ const meta: Meta<LiteraryWorksCardDeck> = {
 		emptyMessage: {
 			control: { type: 'text' },
 			description: 'Qué decir cuando la tirada viene vacía',
-			table: { type: { summary: 'string' }, defaultValue: { summary: "'Todavía no hay obras para mostrar acá.'" } },
+			table: { type: { summary: 'string' } },
+		},
+		numbered: {
+			control: { type: 'boolean' },
+			description: 'Numera las tarjetas por posición; es un ranking, así que solo aplica si la tirada ordena',
+			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
 		},
 	},
 };
@@ -88,11 +93,12 @@ export const MasLeidas: Story = {
 		heading: 'Obras más leídas',
 		subtitle: 'Explorá los textos más populares entre los lectores',
 		action: { link: ['/', 'literary-work'], accessibleSuffix: 'el catálogo de obras' },
+		numbered: true,
 	},
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>El mismo componente con el otro copy de la página de inicio, que es lo que demuestra la unificación: entre esta story y la anterior no cambia una sola línea de plantilla.</p><p><strong>Usos:</strong> la sección de obras más leídas de la página de inicio.</p>`,
+				story: `<p>El mismo componente con el otro copy de la página de inicio, que es lo que demuestra la unificación: entre esta story y la anterior no cambia una sola línea de plantilla, solo los argumentos.</p><p>Es además la única de las dos que numera sus tarjetas: el número es un ranking, así que la página lo activa donde la tirada ordena por algo y lo deja apagado en novedades.</p><p><strong>Usos:</strong> la sección de obras más leídas de la página de inicio.</p>`,
 			},
 		},
 	},

--- a/src/app/components/literary-works-card-deck/literary-works-card-deck.ts
+++ b/src/app/components/literary-works-card-deck/literary-works-card-deck.ts
@@ -39,7 +39,7 @@ import type { LiteraryWorkNavigationTeaserWithAuthors } from '@models/literary-w
 					@for (literaryWork of literaryWorks(); track literaryWork.slug) {
 						<cuentoneta-literary-work-home-card-teaser
 							[literaryWork]="literaryWork"
-							[order]="$index + 1"
+							[order]="numbered() ? $index + 1 : undefined"
 							[navigationParams]="{
 								navigation: 'author',
 								navigationSlug: literaryWork.authors[0].slug,
@@ -71,6 +71,8 @@ export class LiteraryWorksCardDeck {
 	public readonly action = input<SectionHeaderAction | undefined>(undefined);
 	/** El dueño del recurso es la página, así que el estado de carga entra por input. */
 	public readonly loading = input(false);
+	/** Numera las tarjetas por su posición. Es un ranking, así que solo tiene sentido si la tirada ordena. */
+	public readonly numbered = input(false);
 	/** Requerido: qué falta depende de la tirada, y un mensaje genérico no lo dice. */
 	public readonly emptyMessage = input.required<string>();
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,5 +1,5 @@
 <main>
-	<cuentoneta-home-hero [covers]="heroCovers()">
+	<cuentoneta-home-hero>
 		<!-- La caja se reserva por proporción para que la resolución del recurso no empuje lo que sigue. -->
 		<section class="aspect-[540/220] w-full sm:aspect-[1240/360]">
 			@if (isLoading()) {

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -30,18 +30,19 @@
 			</section>
 
 			<section>
+				<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" [loading]="isLoading()" />
+			</section>
+
+			<section>
 				<cuentoneta-literary-works-card-deck
 					[literaryWorks]="mostRead()"
 					[action]="literaryWorksAction"
 					[loading]="isLoading()"
+					[numbered]="true"
 					heading="Obras más leídas"
 					subtitle="Explorá los textos más populares entre los lectores"
 					emptyMessage="Todavía no hay obras más leídas para mostrar."
 				/>
-			</section>
-
-			<section>
-				<cuentoneta-highlighted-authors [authors]="highlightedAuthors()" [loading]="isLoading()" />
 			</section>
 
 			<section>

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -159,6 +159,22 @@ describe('HomeComponent', () => {
 		});
 	});
 
+	// El número es un ranking: en el diseño lo lleva más leídas y no novedades. La página es la única que
+	// puede afirmar la distinción, porque es quien decide cuál de los dos mazos ordena por algo.
+	describe('numeración de las tarjetas', () => {
+		it('should number the most read works and leave the newest ones unnumbered', async () => {
+			const literaryWorks = onoffLiteraryWorkNavigationTeasersWithAuthorsMock.slice(0, 6);
+
+			await renderHome({ latestReads: literaryWorks, mostRead: literaryWorks });
+
+			const novedades = within(screen.getByRole('region', { name: 'Últimas novedades' }));
+			const masLeidas = within(screen.getByRole('region', { name: 'Obras más leídas' }));
+
+			expect(novedades.queryAllByTestId('order')).toHaveLength(0);
+			expect(masLeidas.getAllByTestId('order')).toHaveLength(6);
+		});
+	});
+
 	// El orden lo fija el diseño, y el spec lo afirma sobre el documento porque es lo único que lo
 	// distingue: las cuatro secciones se ven iguales si solo se cuentan sus encabezados.
 	describe('orden de las secciones', () => {

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -11,7 +11,7 @@ import { ControllableLayoutService } from '../../providers/layout.mock';
 import type { LandingPageContent } from '@models/landing-page-content.model';
 import { onoffHighlightedAuthorsOfLength } from '@mocks/onoff-highlighted-authors.mock';
 import { onoffLiteraryWorkNavigationTeasersWithAuthorsMock } from '@mocks/onoff-literary-work-teasers.mock';
-import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
+import { onoffCollectionTeasersMock, onoffCollectionTeasersOfLength } from '@mocks/onoff-collections.mock';
 import { contentCampaignMock } from '@mocks/content-campaign.mock';
 import { clearAllMocks } from '@test-utils';
 
@@ -145,6 +145,32 @@ describe('HomeComponent', () => {
 			collections.forEach(({ title }) => {
 				expect(screen.getByText(title)).toBeInTheDocument();
 			});
+		});
+
+		// Mismo criterio que el recorte a seis de las obras: se afirma cuáles quedaron afuera, porque
+		// contar cuatro se cumpliría igual con cualquier otro criterio que devolviera cuatro.
+		it('should cap the grid at four, however many the week brings', async () => {
+			const manyCollections = onoffCollectionTeasersOfLength(6);
+
+			await renderHome({ collections: manyCollections });
+
+			manyCollections.slice(0, 4).forEach(({ title }) => expect(screen.getByText(title)).toBeInTheDocument());
+			manyCollections.slice(4).forEach(({ title }) => expect(screen.queryByText(title)).not.toBeInTheDocument());
+		});
+	});
+
+	// El orden lo fija el diseño, y el spec lo afirma sobre el documento porque es lo único que lo
+	// distingue: las cuatro secciones se ven iguales si solo se cuentan sus encabezados.
+	describe('orden de las secciones', () => {
+		it('should lay the sections out in the order of the design', async () => {
+			await renderHome();
+
+			const headings = screen
+				.getAllByRole('heading', { level: 2 })
+				.map((heading) => heading.textContent?.trim())
+				.filter((title) => title !== 'Sobre La Cuentoneta');
+
+			expect(headings).toEqual(['Últimas novedades', 'Autores/as destacados/as', 'Obras más leídas', 'Colecciones']);
 		});
 	});
 

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -140,6 +140,10 @@ describe('HomeComponent', () => {
 		const collections = onoffCollectionTeasersMock;
 
 		it('should render every collection of the week', async () => {
+			// El caso mide que la página no descarte nada por su cuenta, así que solo vale mientras el
+			// corpus quepa bajo el tope; si crece, lo que hay que revisar es el caso, no la página.
+			expect(collections.length).toBeLessThanOrEqual(4);
+
 			await renderHome({ collections });
 
 			collections.forEach(({ title }) => {
@@ -181,12 +185,17 @@ describe('HomeComponent', () => {
 		it('should lay the sections out in the order of the design', async () => {
 			await renderHome();
 
-			const headings = screen
-				.getAllByRole('heading', { level: 2 })
-				.map((heading) => heading.textContent?.trim())
-				.filter((title) => title !== 'Sobre La Cuentoneta');
+			const headings = screen.getAllByRole('heading', { level: 2 }).map((heading) => heading.textContent?.trim());
 
-			expect(headings).toEqual(['Últimas novedades', 'Autores/as destacados/as', 'Obras más leídas', 'Colecciones']);
+			// «Sobre La Cuentoneta» cierra la página y entra a la aserción en vez de filtrarse: si se moviera
+			// entre las secciones de contenido, filtrarlo dejaría pasar el cambio.
+			expect(headings).toEqual([
+				'Últimas novedades',
+				'Autores/as destacados/as',
+				'Obras más leídas',
+				'Colecciones',
+				'Sobre La Cuentoneta',
+			]);
 		});
 	});
 

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -12,7 +12,6 @@ import type { LandingPageContent } from '@models/landing-page-content.model';
 import { onoffHighlightedAuthorsOfLength } from '@mocks/onoff-highlighted-authors.mock';
 import { onoffLiteraryWorkNavigationTeasersWithAuthorsMock } from '@mocks/onoff-literary-work-teasers.mock';
 import { onoffCollectionTeasersMock } from '@mocks/onoff-collections.mock';
-import type { CollectionTeaser } from '@models/collection.model';
 import { contentCampaignMock } from '@mocks/content-campaign.mock';
 import { clearAllMocks } from '@test-utils';
 
@@ -78,37 +77,6 @@ describe('HomeComponent', () => {
 			await renderHome();
 
 			expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
-		});
-
-		// La imagen editorial de la colección: las que solo tienen portadas prestadas de sus obras no
-		// suben a la banda, porque esas mismas portadas ya se ven más abajo en la propia página.
-		it('should illustrate the hero with the covers of the featured collections', async () => {
-			const collections = onoffCollectionTeasersMock;
-			const editorialCovers = collections.flatMap((collection) =>
-				collection.imagery.kind === 'representative' ? [collection.imagery.image] : [],
-			);
-			expect(editorialCovers.length).toBeGreaterThan(0);
-
-			await renderHome({ collections });
-
-			const hero = within(screen.getByTestId('hero-covers'));
-			expect(hero.getAllByTestId('cover-image').map((cover) => cover.getAttribute('src'))).toEqual(
-				editorialCovers.slice(0, 3),
-			);
-		});
-
-		// El corpus tiene una sola colección con imagen editorial, así que el tope hay que ejercitarlo con
-		// una semana construida: con el corpus tal cual, el recorte nunca llega a descartar nada.
-		it('should cap the hero at three covers, however many collections bring one', async () => {
-			const withEditorialCover = onoffCollectionTeasersMock.find(
-				(collection) => collection.imagery.kind === 'representative',
-			);
-			expect(withEditorialCover).toBeDefined();
-			const collections = Array.from({ length: 5 }, () => withEditorialCover as CollectionTeaser);
-
-			await renderHome({ collections });
-
-			expect(within(screen.getByTestId('hero-covers')).getAllByTestId('cover-image')).toHaveLength(3);
 		});
 	});
 

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -72,13 +72,14 @@ export default class HomeComponent {
 	protected readonly latestReads = computed(() => this.landingPageContent()?.latestReads.slice(0, 6) || []);
 	protected readonly highlightedAuthors = computed(() => this.landingPageContent()?.highlightedAuthors ?? []);
 
+	// TODO(#2414): vuelve junto con la muestra de portadas del hero.
 	// Solo las colecciones con portada editorial propia: las que caen en `sample` prestan las portadas de
 	// sus obras, y esas ya se ven más abajo en la página. Sin ninguna, la banda va sin portadas.
-	protected readonly heroCovers = computed(() =>
-		this.collections()
-			.flatMap((collection) => (collection.imagery.kind === 'representative' ? [collection.imagery.image] : []))
-			.slice(0, 3),
-	);
+	// protected readonly heroCovers = computed(() =>
+	// 	this.collections()
+	// 		.flatMap((collection) => (collection.imagery.kind === 'representative' ? [collection.imagery.image] : []))
+	// 		.slice(0, 3),
+	// );
 
 	// Un fallo transitorio no puede salir 200: el borde lo cachearía como si fuera la página, y la página
 	// de inicio es la más rastreada del sitio.

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -66,7 +66,8 @@ export default class HomeComponent {
 	// distinguir el fallo, la página afirmaría que no hay obras esta semana cuando lo que pasó es que no
 	// se pudo averiguar.
 	protected readonly failed = computed(() => this.landingPageResource.status() === 'error');
-	protected readonly collections = computed(() => this.landingPageContent()?.collections || []);
+	// Los topes de cada sección los aplica la página y no el backend, que sirve la tirada completa.
+	protected readonly collections = computed(() => this.landingPageContent()?.collections.slice(0, 4) || []);
 	protected readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
 	protected readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);
 	protected readonly latestReads = computed(() => this.landingPageContent()?.latestReads.slice(0, 6) || []);

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -66,7 +66,8 @@ export default class HomeComponent {
 	// distinguir el fallo, la página afirmaría que no hay obras esta semana cuando lo que pasó es que no
 	// se pudo averiguar.
 	protected readonly failed = computed(() => this.landingPageResource.status() === 'error');
-	// Los topes de cada sección los aplica la página y no el backend, que sirve la tirada completa.
+	// El tope es el de la grilla del diseño, no del contrato: el backend sirve la tirada completa. La
+	// curaduría de autores destacados es la excepción — ese tope lo aplica el backend.
 	protected readonly collections = computed(() => this.landingPageContent()?.collections.slice(0, 4) || []);
 	protected readonly campaigns = computed(() => this.landingPageContent()?.campaigns || []);
 	protected readonly mostRead = computed(() => this.landingPageContent()?.mostRead.slice(0, 6) || []);


### PR DESCRIPTION
Cuarta y última rebanada de la migración de la página de inicio a V3. Cierra el primer criterio de aceptación del issue —que la página reproduzca el diseño en el encabezado, las cuatro secciones y sus grillas— y con él, el issue.

## Qué cambia

**El orden de las secciones pasa al del diseño:** novedades, autores destacados, obras más leídas y colecciones. El spec ya no discriminaba los dos mazos de obras por posición en el documento —eso se resolvió en la primera rebanada—, así que el reordenamiento no lo afecta. El orden pasa a tener su propio caso, porque es lo único que distingue a cuatro secciones que por conteo de encabezados se ven iguales.

**Las colecciones se recortan a cuatro**, la grilla de dos por dos del diseño.

**La numeración de las tarjetas pasa a ser opcional y solo la activa «Obras más leídas».** En el nodo de Figma el slot del número está oculto en novedades (`hidden="true"`) y visible en más leídas, y tiene sentido: es un ranking, así que solo significa algo donde la tirada ordena por algo.

**La muestra de portadas del hero se retira.** Tres portadas planas en fila quedaban lejos del diseño, que las dibuja inclinadas, con lomo y sombra, sobre una caja bastante más ancha y más alta. Resolver ese tratamiento es trabajo propio y se aborda en **#2414** (milestone 2.12.0). El marcado, el input y la derivación de la página quedan comentados con un `TODO` que apunta a ese issue; los casos de test y las stories que los ejercitaban sí se eliminan, porque un test comentado no corre y envejece sin que nadie lo note.

## Lo que ya estaba bien y se verificó

- **Los gaps de las tres grillas** ya coincidían con el diseño: 32 px en fila y columna en las cuatro secciones. Medido sobre el DOM renderizado, no leído del código.
- **Los altos fijos** de las secciones se habían eliminado antes, al corregir la superposición que reportaste sobre la rebanada del hero.
- **El hallazgo diferido sobre `aria-labelledby`** quedó sin efecto: nació porque el título de sección estaba escrito dos veces por archivo, y esa duplicación ya se resolvió declarándolo una sola vez y consumiéndolo desde el host y la plantilla. Cambiar a `aria-labelledby` exigiría plomería de ids únicos para eliminar una duplicación que ya no existe, y el precedente vigente del repo (el carrusel) usa `aria-label`.

## Discrepancia conocida, fuera de alcance

**El ancho de contenido.** El diseño trabaja con 1240 px y `.content` es `max-w-screen-lg` (1024 px), así que las tarjetas salen más angostas que en el mock: 392 px por tarjeta con tres columnas y 32 de separación dan exactamente los 1240 del diseño. Cambiar `.content` afecta a las 13 rutas, no solo a esta página, así que queda fuera de este issue y se trackea en **#2417** (milestone 2.12.0).

Con eso, las tres desviaciones respecto del diseño quedan trackeadas: **#2414** (portadas del hero), **#2402** (franja de la barra de navegación sobre el hero) y **#2417** (ancho de contenido).

## Plan de pruebas

- **Gates locales:** `typecheck`, `lint`, `stylelint`, `test`, `build` y `storybook:build` en verde.
- **Cobertura nueva:** el orden de las cuatro secciones, el recorte de colecciones a cuatro —afirmando cuáles quedan afuera, no solo cuántas quedan—, las dos ramas del input de numeración en el deck, y en la página cuál de los dos mazos numera, que es una decisión suya y hasta acá nadie la sostenía.
- **Verificado en navegador** a 1440 px: orden de secciones, cuatro tarjetas de colección y 32 px de separación en las cuatro grillas.

> **Una nota sobre el servidor de desarrollo.** Al verificar la numeración en el navegador aparecieron números en los dos mazos, contra lo que emite el HTML server-rendered y contra lo que afirman los specs. El módulo que el dev server entregaba era un parche de HMR (`/@ng/component?…`) con la plantilla anterior compilada —`("order", $index + 1)`, sin rastro del input nuevo— mientras la clase ya era la nueva. Es un artefacto del servidor de desarrollo, no del código: el HTML servido y los tests coinciden en que solo «Obras más leídas» numera.

Closes #1508.
