### PR TITLE
[#2419] - Afirma que la página de lectura enlaza al perfil del autor una sola vez

### DIFF
--- a/e2e/_utils/seo-invariants.spec.ts
+++ b/e2e/_utils/seo-invariants.spec.ts
@@ -218,10 +218,23 @@ describe('getInternalLinkHrefs', () => {
 		expect(getInternalLinkHrefs(html, '/author/')).toEqual(['/author/jorge-luis-borges', '/author/jorge-luis-borges']);
 	});
 
+	it('devuelve los href en orden de documento', () => {
+		const html = '<main><a href="/author/segundo">b</a><a href="/author/primero">a</a></main>';
+		expect(getInternalLinkHrefs(html, '/author/')).toEqual(['/author/segundo', '/author/primero']);
+	});
+
 	it('ignora enlaces fuera de main', () => {
 		expect(getInternalLinkHrefs('<header><a href="/story/x">x</a></header><main><p>ok</p></main>', '/story/')).toEqual(
 			[],
 		);
+	});
+
+	// Un ancla sin destino no es un enlace: cuenta como cero, no como una entrada vacía que descuadre
+	// el conteo de la página.
+	it('ignora las anclas sin href', () => {
+		expect(getInternalLinkHrefs('<main><a>sin destino</a><a href="/author/x">x</a></main>', '/author/')).toEqual([
+			'/author/x',
+		]);
 	});
 
 	it('devuelve lista vacía cuando ningún enlace matchea el prefijo', () => {

--- a/e2e/_utils/seo-invariants.spec.ts
+++ b/e2e/_utils/seo-invariants.spec.ts
@@ -10,6 +10,7 @@ import {
 	checkTitle,
 	collectEmptyBodyViolations,
 	collectIndexableHtmlViolations,
+	getInternalLinkHrefs,
 	type IndexableHtmlExpectations,
 } from './seo-invariants';
 
@@ -202,6 +203,29 @@ describe('checkInternalLink', () => {
 		expect(checkInternalLink('<header><a href="/story/x">x</a></header><main><p>ok</p></main>', '/story/')?.rule).toBe(
 			'internal-link',
 		);
+	});
+});
+
+describe('getInternalLinkHrefs', () => {
+	it('devuelve el href cuando hay un enlace con el prefijo dentro de main', () => {
+		expect(getInternalLinkHrefs(GOOD_HTML, '/author/')).toEqual(['/author/jorge-luis-borges']);
+	});
+
+	// El caso que la guarda de la página de lectura existe para atrapar: el destino repetido no
+	// colapsa, porque son dos enlaces y cada uno necesita su propio nombre accesible.
+	it('devuelve una entrada por enlace aunque repitan destino', () => {
+		const html = GOOD_HTML.replace('</main>', '<a href="/author/jorge-luis-borges">Ver más</a></main>');
+		expect(getInternalLinkHrefs(html, '/author/')).toEqual(['/author/jorge-luis-borges', '/author/jorge-luis-borges']);
+	});
+
+	it('ignora enlaces fuera de main', () => {
+		expect(getInternalLinkHrefs('<header><a href="/story/x">x</a></header><main><p>ok</p></main>', '/story/')).toEqual(
+			[],
+		);
+	});
+
+	it('devuelve lista vacía cuando ningún enlace matchea el prefijo', () => {
+		expect(getInternalLinkHrefs(GOOD_HTML, '/story/')).toEqual([]);
 	});
 });
 

--- a/e2e/_utils/seo-invariants.ts
+++ b/e2e/_utils/seo-invariants.ts
@@ -128,9 +128,15 @@ function noSkeletonMarkers(root: HTMLElement): SeoInvariantViolation | null {
 	return null;
 }
 
-function internalLink(root: HTMLElement, prefix: string): SeoInvariantViolation | null {
+function hrefsWithPrefix(root: HTMLElement, prefix: string): string[] {
 	const anchors = root.querySelector('main')?.querySelectorAll('a') ?? [];
-	if (anchors.some((anchor) => anchor.getAttribute('href')?.startsWith(prefix))) {
+	return anchors
+		.map((anchor) => anchor.getAttribute('href'))
+		.filter((href): href is string => href !== undefined && href.startsWith(prefix));
+}
+
+function internalLink(root: HTMLElement, prefix: string): SeoInvariantViolation | null {
+	if (hrefsWithPrefix(root, prefix).length > 0) {
 		return null;
 	}
 	return {
@@ -218,6 +224,16 @@ function emptyBodyViolations(root: HTMLElement, minLength?: number): SeoInvarian
 
 export function checkInternalLink(html: string, prefix: string): SeoInvariantViolation | null {
 	return internalLink(parseHtml(html), prefix);
+}
+
+/**
+ * Los `href` de `<main>` que empiezan en `prefix`, en orden de documento y con los repetidos
+ * incluidos: es la misma consulta sobre la que se apoya el check de presencia, expuesta para que una
+ * página pueda además afirmar *cuántos* enlaces sirve. Cuántos son correctos depende de la página, así
+ * que esa política queda en cada spec y no en `IndexableHtmlExpectations`.
+ */
+export function getInternalLinkHrefs(html: string, prefix: string): string[] {
+	return hrefsWithPrefix(parseHtml(html), prefix);
 }
 
 export function checkJsonLdBlocks(html: string, ids: readonly string[]): Promise<SeoInvariantViolation[]> {

--- a/e2e/_utils/seo-invariants.ts
+++ b/e2e/_utils/seo-invariants.ts
@@ -5,7 +5,7 @@
  * plano y en happy-dom), sin importar Playwright ni Vitest. Lo consumen tanto los specs de e2e (gate
  * de CI) como el script de smoke post-deploy, para que ambos afirmen las mismas invariantes sin drift.
  *
- * La API pública (`check*` + `collectIndexableHtmlViolations`) toma `string`; internamente cada check
+ * Todo lo exportado toma `string` y parsea por su cuenta; internamente cada check
  * consulta el DOM por selector CSS, así afirma el elemento exacto (p. ej. `ng-server-context` vive en
  * `<cuentoneta-root>`, no en cualquier parte del HTML). Los checks de contenido (heading, contenido
  * primario, skeleton, enlaces internos) se acotan a `<main>`: el chrome global (header/footer) vive en
@@ -228,9 +228,9 @@ export function checkInternalLink(html: string, prefix: string): SeoInvariantVio
 
 /**
  * Los `href` de `<main>` que empiezan en `prefix`, en orden de documento y con los repetidos
- * incluidos: es la misma consulta sobre la que se apoya el check de presencia, expuesta para que una
- * página pueda además afirmar *cuántos* enlaces sirve. Cuántos son correctos depende de la página, así
- * que esa política queda en cada spec y no en `IndexableHtmlExpectations`.
+ * incluidos: un destino que aparece dos veces devuelve dos entradas, porque son dos enlaces. Los
+ * anchors sin `href` no cuentan. Permite afirmar *cuántos* enlaces sirve una página; cuántos son
+ * correctos lo decide cada spec.
  */
 export function getInternalLinkHrefs(html: string, prefix: string): string[] {
 	return hrefsWithPrefix(parseHtml(html), prefix);

--- a/e2e/literary-work.spec.ts
+++ b/e2e/literary-work.spec.ts
@@ -201,6 +201,30 @@ test('literary-work — sin contexto, el pie sugiere más obras del autor', asyn
 	await expect(authorAccess.first()).toBeVisible();
 });
 
+// Una vez hidratada, la página sí sirve dos enlaces al mismo perfil: el del hero y el del pie. Dos
+// destinos idénticos con el mismo nombre accesible es el defecto que ya se corrigió una vez en las
+// tarjetas, así que lo que se afirma es que se distinguen entre sí —no contra literales de copy, que
+// la curaduría puede cambiar sin que el criterio deje de valer.
+test('literary-work — los dos enlaces al perfil del autor tienen nombres accesibles distintos', async ({ page }) => {
+	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta su guarda; repetirla acá sería el mismo fallo dos veces
+	test.skip(!mediaWork, `"${MEDIA_ROUTE}" no está en el dataset`);
+
+	await openWork(page, MEDIA_ROUTE);
+	await settleSuggestions(page, `Más obras de ${mediaWork?.authors[0]?.name}`);
+
+	const profileLinks = page.locator(`a[href^="/author/${mediaWork?.authors[0]?.slug}"]`);
+	await expect(profileLinks).toHaveCount(2);
+
+	const names = await profileLinks.evaluateAll((links) =>
+		links.map((link) => (link.getAttribute('aria-label') ?? link.textContent ?? '').replace(/\s+/g, ' ').trim()),
+	);
+	expect(
+		names.every((name) => name.length > 0),
+		`algún enlace al perfil no tiene nombre: ${names}`,
+	).toBe(true);
+	expect(new Set(names).size, `los dos enlaces al perfil se anuncian igual: ${names}`).toBe(2);
+});
+
 // El único cableado que ningún unitario ve: la tarjeta de la colección EMITE los query params de contexto
 // y la página los CONSUME. Entrar directo con la URL armada probaría la mitad de consumo, que el spec
 // unitario ya cubre.

--- a/e2e/literary-work.spec.ts
+++ b/e2e/literary-work.spec.ts
@@ -201,10 +201,9 @@ test('literary-work — sin contexto, el pie sugiere más obras del autor', asyn
 	await expect(authorAccess.first()).toBeVisible();
 });
 
-// Una vez hidratada, la página sí sirve dos enlaces al mismo perfil: el del hero y el del pie. Dos
-// destinos idénticos con el mismo nombre accesible es el defecto que ya se corrigió una vez en las
-// tarjetas, así que lo que se afirma es que se distinguen entre sí —no contra literales de copy, que
-// la curaduría puede cambiar sin que el criterio deje de valer.
+// Una vez hidratada, la página sí sirve dos enlaces al mismo perfil: el del hero y el del pie. Se
+// afirma que se distinguen entre sí y no que digan tal o cual cosa: la copy es curaduría y puede
+// cambiar sin que el criterio —dos destinos iguales no pueden anunciarse igual— deje de valer.
 test('literary-work — los dos enlaces al perfil del autor tienen nombres accesibles distintos', async ({ page }) => {
 	// eslint-disable-next-line playwright/no-skipped-test -- la ausencia del fixture ya la reporta su guarda; repetirla acá sería el mismo fallo dos veces
 	test.skip(!mediaWork, `"${MEDIA_ROUTE}" no está en el dataset`);
@@ -213,8 +212,14 @@ test('literary-work — los dos enlaces al perfil del autor tienen nombres acces
 	await settleSuggestions(page, `Más obras de ${mediaWork?.authors[0]?.name}`);
 
 	const profileLinks = page.locator(`a[href^="/author/${mediaWork?.authors[0]?.slug}"]`);
-	await expect(profileLinks).toHaveCount(2);
+	await expect(
+		profileLinks,
+		'se esperan dos enlaces al perfil, el del hero y el del pie: con una sola obra del autor el bloque de sugerencias no se monta',
+	).toHaveCount(2);
 
+	// El nombre se aproxima con `aria-label ?? textContent`, que alcanza para estos dos enlaces, pero
+	// omite `aria-labelledby`, el `alt` de una imagen descendiente y `title`. Un enlace que se nombre
+	// por esas vías necesitaría el accname real, no esta aproximación.
 	const names = await profileLinks.evaluateAll((links) =>
 		links.map((link) => (link.getAttribute('aria-label') ?? link.textContent ?? '').replace(/\s+/g, ' ').trim()),
 	);

--- a/e2e/seo/literary-work.spec.ts
+++ b/e2e/seo/literary-work.spec.ts
@@ -33,7 +33,6 @@ test('literary-work — A: una obra inexistente responde 404 real en SSR', async
 
 test.describe('literary-work — HTML server-rendered de una obra existente', () => {
 	let html: string;
-	let primaryAuthorSlug: string | undefined;
 
 	test.beforeAll(async ({ request }) => {
 		const response = await request.get(literaryWorkPath);
@@ -41,7 +40,6 @@ test.describe('literary-work — HTML server-rendered de una obra existente', ()
 		// sin nombrar la causa. Se afirma en vez de saltearse: es el skip el que ya dejó un verde engañoso.
 		expect(response.status(), `No existe literaryWork con slug "${STABLE_SLUGS.literaryWork}" en el dataset`).toBe(200);
 		html = await response.text();
-		primaryAuthorSlug = (await fetchLiteraryWork(request, STABLE_SLUGS.literaryWork))?.authors[0]?.slug;
 	});
 
 	test('B: meta tags en el HTML server-rendered', () => {
@@ -95,19 +93,30 @@ test.describe('literary-work — HTML server-rendered de una obra existente', ()
 		).toEqual([]);
 	});
 
-	// Un segundo enlace al mismo perfil le da al crawler dos rutas equivalentes y, en el DOM, dos
-	// destinos que el lector de pantalla anuncia igual salvo que cada uno traiga su propio nombre
-	// accesible. El pie sugiere más obras del autor, pero su bloque es diferido sin `hydrate`: en el
-	// HTML servido está el marcador de posición y no el enlace. Si ese diferido pasara a hidratarse, la
-	// cuenta sube y este caso lo reporta.
-	test('F: enlaza al perfil del autor una sola vez', () => {
-		expect(getInternalLinkHrefs(html, '/author/')).toEqual([`/author/${primaryAuthorSlug}`]);
-	});
-
 	test('E: H1 único con contenido real y cuerpo saneado', () => {
 		expect(html.match(/<h1[^>]*>/g) ?? []).toHaveLength(1);
 		expect(html).toContain('<article');
 		// El markdown crudo no cruza al frontend: sin ** literales dentro del artículo.
 		expect(html).not.toMatch(/<article[^>]*>[\s\S]*\*\*[\s\S]*<\/article>/);
+	});
+
+	// Un segundo enlace al mismo perfil le da al crawler dos rutas equivalentes, y en el DOM dos
+	// destinos que el lector de pantalla anuncia igual salvo que cada uno traiga su propio nombre
+	// accesible. Acá se exige uno solo, que es más estricto que pedir nombres distinguibles: el pie
+	// sugiere más obras del autor, pero su bloque es diferido sin `hydrate`, así que en el HTML servido
+	// hay marcador de posición y no enlace. Si ese diferido pasara a hidratarse, la corrección no es
+	// subir el número: es traer acá el criterio de nombres distinguibles que hoy vive en el spec de la
+	// página hidratada.
+	//
+	// El slug se resuelve en el caso y no en el `beforeAll`: el resto de la tanda solo necesita el HTML
+	// ya capturado, y un endpoint caído no tiene por qué tumbarla entera.
+	test('F: enlaza al perfil del autor una sola vez', async ({ request }) => {
+		const primaryAuthorSlug = (await fetchLiteraryWork(request, STABLE_SLUGS.literaryWork))?.authors[0]?.slug;
+		expect(
+			primaryAuthorSlug,
+			`el API no sirve "${STABLE_SLUGS.literaryWork}": no habría con qué comparar`,
+		).toBeDefined();
+
+		expect(getInternalLinkHrefs(html, '/author/')).toEqual([`/author/${primaryAuthorSlug}`]);
 	});
 });

--- a/e2e/seo/literary-work.spec.ts
+++ b/e2e/seo/literary-work.spec.ts
@@ -10,6 +10,7 @@
  *       y BreadcrumbList.
  *  - D. Bloques sitewide Organization y WebSite.
  *  - E. La tanda completa de invariantes de una página indexable, H1 único y cuerpo saneado.
+ *  - F. Un único enlace al perfil del autor.
  *
  * El contenido de prueba lo cura el equipo en los datasets (development local / staging CI).
  */
@@ -18,8 +19,9 @@ import type { Article, BreadcrumbList, WithContext } from 'schema-dts';
 
 import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
 import { assertValidJsonLd } from '@testing/json-ld-validation';
-import { collectIndexableHtmlViolations } from '../_utils/seo-invariants';
+import { collectIndexableHtmlViolations, getInternalLinkHrefs } from '../_utils/seo-invariants';
 import { STABLE_SLUGS, SCHEMA_IDS, SITEWIDE_SCHEMA_IDS } from '../_utils/seo-fixtures';
+import { fetchLiteraryWork } from '../_utils/literary-work-fixtures';
 
 const literaryWorkPath = `/literary-work/${STABLE_SLUGS.literaryWork}`;
 const requiredJsonLdIds = [...SITEWIDE_SCHEMA_IDS, SCHEMA_IDS.article, SCHEMA_IDS.breadcrumbLiteraryWork];
@@ -31,6 +33,7 @@ test('literary-work — A: una obra inexistente responde 404 real en SSR', async
 
 test.describe('literary-work — HTML server-rendered de una obra existente', () => {
 	let html: string;
+	let primaryAuthorSlug: string | undefined;
 
 	test.beforeAll(async ({ request }) => {
 		const response = await request.get(literaryWorkPath);
@@ -38,6 +41,7 @@ test.describe('literary-work — HTML server-rendered de una obra existente', ()
 		// sin nombrar la causa. Se afirma en vez de saltearse: es el skip el que ya dejó un verde engañoso.
 		expect(response.status(), `No existe literaryWork con slug "${STABLE_SLUGS.literaryWork}" en el dataset`).toBe(200);
 		html = await response.text();
+		primaryAuthorSlug = (await fetchLiteraryWork(request, STABLE_SLUGS.literaryWork))?.authors[0]?.slug;
 	});
 
 	test('B: meta tags en el HTML server-rendered', () => {
@@ -89,6 +93,15 @@ test.describe('literary-work — HTML server-rendered de una obra existente', ()
 				requiredInternalLinkPrefix: '/author/',
 			}),
 		).toEqual([]);
+	});
+
+	// Un segundo enlace al mismo perfil le da al crawler dos rutas equivalentes y, en el DOM, dos
+	// destinos que el lector de pantalla anuncia igual salvo que cada uno traiga su propio nombre
+	// accesible. El pie sugiere más obras del autor, pero su bloque es diferido sin `hydrate`: en el
+	// HTML servido está el marcador de posición y no el enlace. Si ese diferido pasara a hidratarse, la
+	// cuenta sube y este caso lo reporta.
+	test('F: enlaza al perfil del autor una sola vez', () => {
+		expect(getInternalLinkHrefs(html, '/author/')).toEqual([`/author/${primaryAuthorSlug}`]);
 	});
 
 	test('E: H1 único con contenido real y cuerpo saneado', () => {


### PR DESCRIPTION
## Qué cambia

La suite de indexado de la página de lectura solo exigía que existiera **al menos** un enlace con prefijo `/author/`, así que un segundo enlace al mismo perfil pasaba inadvertido. La guarda que vigilaba ese riesgo vivía en el spec de la página de cuento y se fue con ella.

Se afirma ahora, en las dos superficies donde el criterio tiene contenido distinto:

- **HTML servido** (`e2e/seo/literary-work.spec.ts`): exactamente **un** enlace `/author/`, y apunta al autor principal según el API. El hero lo emite; el bloque de sugerencias del pie está diferido sin `hydrate`, así que en SSR aporta el marcador de posición y ningún enlace. Se afirma la lista completa y no el conteo, para que el fallo reporte los destinos encontrados.
- **DOM hidratado** (`e2e/literary-work.spec.ts`): ahí sí hay dos al mismo perfil —el del hero y el `Ver más de <autor>` del pie— y lo que se afirma es que se **distinguen entre sí**, comparando los nombres accesibles entre ellos y no contra literales de copy, que la curaduría puede cambiar sin que el criterio deje de valer.

## Dónde vive el conteo

`getInternalLinkHrefs` se extrae al core compartido (`e2e/_utils/seo-invariants.ts`), y el check de presencia pasa a apoyarse en ella para que presencia y conteo no puedan divergir en su noción de enlace interno. Eso trae gratis el acotado a `<main>` y el parseo con `node-html-parser` en vez de un regex sobre el string.

**`IndexableHtmlExpectations` queda intacto a propósito.** Cuántos enlaces son correctos depende de la página —en `/collection/` o `/literary-works/`, que listan obras, ningún número fijo lo es—, así que meter el conteo en el contrato compartido obligaría a los seis specs y al smoke a tomar posición sobre una invariante que no es suya. La consulta se comparte; la política queda local al spec de la página.

## Nota sobre el issue

El issue apunta a `e2e/seo/read.spec.ts`, que ya no existe: se renombró a `e2e/seo/literary-work.spec.ts` en `2503c37a`. El trabajo va sobre el archivo actual.

## Plan de pruebas

- **Los once gates en verde**, `e2e` incluido, más los tres deploys de Vercel.
- `e2e/_utils/seo-invariants.spec.ts` queda en 47 casos, con 6 nuevos sobre `getInternalLinkHrefs`: href único, destino repetido que **no** colapsa, orden de documento (con destinos distintos, para que sea observable), anclas sin `href` ignoradas, enlaces fuera de `<main>` ignorados y lista vacía sin coincidencias.
- Los dos casos e2e nuevos **corrieron y pasaron**, no quedaron salteados.
- El conteo de uno se verificó además contra las plantillas, por dos vías independientes: el único `routerLink` a `/author/` que la página monta en SSR es el del hero, y las dos ramas del bloque de sugerencias están en `@defer (on viewport)` plano, que sirve solo el `@placeholder`. Aun si ese bloque llegara al SSR, `AuthorReadingSuggestionsComponent` no pasa `showAuthor` (default `false`), así que sus tarjetas tampoco emitirían enlaces al perfil.
- Localmente quedan rojos los casos B y E de `e2e/seo/literary-work.spec.ts`, ajenos a este diff: el build local es no-indexable y sirve `robots: noindex, nofollow`. Los dos casos están byte-idénticos a `develop` y pasan en CI.

Closes #2419.
