### PR TITLE
[#2282] - Purgar del dataset los documentos story y storylist tras la baja de sus schemas

### DIFF
--- a/.claude/references/sanity-migrations.md
+++ b/.claude/references/sanity-migrations.md
@@ -44,6 +44,25 @@ Ejemplo vivo: [`cms/migrations/draft-story-to-literary-work/`](../../cms/migrati
 
 El predicado que reconoce un documento migrado se declara **una sola vez** y lo importan ambas migraciones. Si cada una tuviera el suyo, una divergencia entre las dos definiciones podría dejar documentos sin borrar —o borrar de más—. Y el guard va **dentro** de `migrate.document`, no solo en el `filter`: el filtro es una optimización del recorrido, no la garantía.
 
+### Migraciones que borran documentos
+
+Borrar un documento no es un `unset` más grande: la infraestructura expone `del(id)`, pero el content lake impone tres cosas que ninguna migración de escritura enfrenta.
+
+**El content lake rechaza borrar un documento con una referencia fuerte entrante.** Dar de baja el campo que lo referencia es entonces un **paso previo**, no una limpieza posterior — y hay que buscar esos referentes en el dataset, no en los schemas: quitar un campo del schema no borra el dato, así que un documento puede conservar referencias por un campo que el Studio ya no declara. La consulta que los descubre usa `references(^._id)` en vez de enumerar los campos conocidos, justamente porque la lista escrita a mano no ve los que ya nadie declara.
+
+**Cuando el grafo tiene profundidad, cada nivel va en su propia migración.** El runner batchea mutaciones y no garantiza el orden dentro de una corrida, así que un `documentTypes` con el referente y el referido juntos puede intentar borrar el segundo mientras el primero todavía lo apunta, y detenerse a mitad de camino con documentos ya borrados. Una migración por nivel, corridas en orden, es lo que vuelve cada corrida atómica y verificable por separado.
+
+**No hay migración hermana de reversión, y no puede haberla:** una migración destructiva no crea nada que una de vuelta pueda reconocer por su `_id`, y lo que borra no se reconstruye. Su lugar lo ocupa el **export previo del dataset**, guardado fuera del árbol de trabajo. Los borradores entran por defecto y no deben excluirse: son lo que la purga se lleva sin dejar rastro visible en el Studio.
+
+```bash
+# Desde cms/. El dataset va posicional y el flag de proyecto es `--project-id` — distinto del
+# `--project`/`--dataset` inseparables de `migration run`.
+pnpm exec sanity dataset export <destino> "<ruta fuera del repo>/<destino>-<fecha>.tar.gz" \
+  --project-id "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')"
+```
+
+Conviene además enunciar qué **otras** migraciones invalida la corrida: una reversión que aborta cuando su campo de origen ya no está poblado queda inservible desde el momento en que se da de baja ese campo, y descubrirlo al querer usarla es tarde.
+
 ### Migraciones que convierten contenido
 
 Las que llevan rich text a Markdown consumen [`resources/portable-text-to-markdown/`](../../resources/portable-text-to-markdown/README.md), que **falla ante lo que no sabe traducir** en vez de descartarlo en silencio. Antes de correr una conversión sobre el corpus, censar qué construcciones usa realmente el dataset (ver `scripts/audit/`): descubrirlo con la migración la detendría en el primer documento raro, con los anteriores ya escritos.

--- a/.claude/references/sanity-migrations.md
+++ b/.claude/references/sanity-migrations.md
@@ -63,6 +63,8 @@ pnpm exec sanity dataset export <destino> "<ruta fuera del repo>/<destino>-<fech
 
 Conviene además enunciar qué **otras** migraciones invalida la corrida: una reversión que aborta cuando su campo de origen ya no está poblado queda inservible desde el momento en que se da de baja ese campo, y descubrirlo al querer usarla es tarde.
 
+Ejemplo vivo: [`cms/migrations/purge-story-documents/README.md`](../../cms/migrations/purge-story-documents/README.md) — el runbook de las tres corridas ordenadas que dan de baja un tipo de contenido entero, con su export previo y sus consultas de censo.
+
 ### Migraciones que convierten contenido
 
 Las que llevan rich text a Markdown consumen [`resources/portable-text-to-markdown/`](../../resources/portable-text-to-markdown/README.md), que **falla ante lo que no sabe traducir** en vez de descartarlo en silencio. Antes de correr una conversión sobre el corpus, censar qué construcciones usa realmente el dataset (ver `scripts/audit/`): descubrirlo con la migración la detendría en el primer documento raro, con los anteriores ya escritos.

--- a/cms/migrations/purge-story-documents/README.md
+++ b/cms/migrations/purge-story-documents/README.md
@@ -1,0 +1,88 @@
+# Purga del contenido retirado — procedimiento
+
+Runbook de las **tres** migraciones que dan de baja del dataset los cuentos y las listas de contenido. Los otros dos directorios apuntan acá: el orden entre ellas vive en un solo documento para que no pueda desincronizarse.
+
+| Orden | Migración                       | Qué hace                                                        |
+| ----- | ------------------------------- | --------------------------------------------------------------- |
+| 1     | `unset-legacy-story-references` | Da de baja los campos que todavía referencian cuentos y listas  |
+| 2     | `purge-storylist-documents`     | Borra las listas de contenido (cada una referencia sus cuentos) |
+| 3     | `purge-story-documents`         | Borra los cuentos                                               |
+
+El orden no es una preferencia. El content lake **rechaza borrar un documento con una referencia fuerte entrante**, así que cada paso existe para dejar sin referentes al siguiente.
+
+---
+
+## 1. Prerequisitos
+
+Dos condiciones, y **la segunda es la que todavía falta**:
+
+- **La baja de los schemas, aplicada.** Cumplida: los tipos ya no están registrados en el Studio ni proyectados por el backend.
+- **El release que retira las páginas, desplegado y verificado en producción.** Sin esto, no correr nada.
+
+Por qué la segunda es bloqueante, con evidencia y no como advertencia genérica: la versión que hoy corre en producción **lee** `cards`, `latestReads` y `mostRead`, y su generador semanal de la página de inicio **los copia hacia adelante** al crear la semana siguiente. Correr antes del despliegue vacía la página en vivo y, además, el cron reintroduce lo purgado en la semana nueva. Recién con el release desplegado la copia arrastra sólo los campos vigentes.
+
+## 2. Export previo — es el plan de recuperación
+
+**No es una formalidad.** Ninguna de las tres migraciones tiene hermana de reversión, y ninguna puede tenerla: no crean nada que una de vuelta pueda reconocer, y lo que borran no se reconstruye. El export es la única forma de volver atrás.
+
+Se guarda **fuera del árbol de trabajo** — ni bajo `workspace/`, ni dentro del worktree.
+
+```bash
+# Desde cms/. Acá el dataset es un argumento posicional y el flag de proyecto es `--project-id`.
+pnpm exec sanity dataset export <destino> "$HOME/cuentoneta-backups/<destino>-$(date +%F).tar.gz" \
+  --project-id "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')"
+```
+
+Los borradores entran por defecto: **no** pasar `--no-drafts`. Son justamente lo que la purga se lleva sin dejar rastro visible en el Studio.
+
+Esta corrida invalida además, y de forma permanente, las dos reversiones que dependían de estos documentos: la del relinkeo de la página de inicio aborta cuando el campo de origen ya no está poblado, y la de la creación de obras borraría obras que ya no se pueden regenerar.
+
+## 3. Censo previo
+
+Las consultas viven en [`verification-queries.ts`](./verification-queries.ts), no duplicadas acá como texto: son constantes ejecutables y su spec las corre contra el motor de GROQ, para que no queden inertes aparentando verificar.
+
+```bash
+# Desde cms/. `documents query` usa `--project-id`, y **no** acopla sus dos flags.
+# Copiar `--project` del comando de migración no falla: lo acepta como alias deprecado y sigue con
+# una advertencia fácil de perder entre el resto de la salida.
+pnpm exec sanity documents query "<consulta>" \
+  --project-id "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')" --dataset <destino>
+```
+
+| Consulta                          | Qué responde                                        | Antes de purgar                    |
+| --------------------------------- | --------------------------------------------------- | ---------------------------------- |
+| `CENSUS_QUERY`                    | Cuántos documentos se van, publicados y en borrador | El censo que va al PR              |
+| `LEGACY_FIELDS_CENSUS_QUERY`      | Cuántas referencias tienen los tres campos legacy   | El censo que va al PR              |
+| `INCOMING_REFERENCES_QUERY`       | Qué documentos referencian un cuento o una lista    | Debe quedar en `[]` tras el paso 1 |
+| `WORKS_WITHOUT_COUNTERPART_QUERY` | Qué cuentos publicados no tienen obra derivada      | Se registra (ver §6)               |
+
+## 4. Las tres corridas, por dataset
+
+Para cada slug, en el orden de la tabla del encabezado: primero el dry-run, se lee lo que va a mutar, y recién después la aplicación.
+
+```bash
+# Dry-run (es el modo por defecto). `--project` y `--dataset` son inseparables acá.
+pnpm exec sanity migration run <slug> \
+  --project "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')" --dataset <destino>
+
+# Aplicar. `--no-confirm` es necesario sin TTY.
+pnpm exec sanity migration run <slug> \
+  --project "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')" --dataset <destino> \
+  --no-dry-run --no-confirm
+```
+
+**Orden de datasets: `development` → `staging` → `production`**, verificando cada uno antes de pasar al siguiente. Ningún gate de CI detecta un dataset que quedó sin migrar.
+
+## 5. Verificación posterior
+
+Contra el **dataset**, no contra el sitio: la aplicación produce con la caché del CDN encendida, así que la primera lectura del sitio devuelve la versión vieja y parece un fallo de la migración.
+
+| Consulta                     | Esperado                                                                              |
+| ---------------------------- | ------------------------------------------------------------------------------------- |
+| `CENSUS_QUERY`               | Los cuatro conteos en `0`                                                             |
+| `LEGACY_FIELDS_CENSUS_QUERY` | Los tres conteos en `0`                                                               |
+| `DANGLING_AFTER_PURGE_QUERY` | Los cuatro conteos en `0` — ninguna referencia quedó apuntando a un documento borrado |
+
+## 6. El cuento sin contraparte
+
+Un cuento publicado no tiene obra derivada. **Desaparece con la purga, y es una decisión tomada, no un descuido.** `WORKS_WITHOUT_COUNTERPART_QUERY` lo lista antes de aplicar para que el censo del PR lo nombre; su única copia queda en el export del paso 2.

--- a/cms/migrations/purge-story-documents/README.md
+++ b/cms/migrations/purge-story-documents/README.md
@@ -49,12 +49,14 @@ pnpm exec sanity documents query "<consulta>" \
   --project-id "$(node --env-file=.env -p 'process.env.SANITY_STUDIO_PROJECT_ID')" --dataset <destino>
 ```
 
-| Consulta                          | Qué responde                                        | Antes de purgar                    |
-| --------------------------------- | --------------------------------------------------- | ---------------------------------- |
-| `CENSUS_QUERY`                    | Cuántos documentos se van, publicados y en borrador | El censo que va al PR              |
-| `LEGACY_FIELDS_CENSUS_QUERY`      | Cuántas referencias tienen los tres campos legacy   | El censo que va al PR              |
-| `INCOMING_REFERENCES_QUERY`       | Qué documentos referencian un cuento o una lista    | Debe quedar en `[]` tras el paso 1 |
-| `WORKS_WITHOUT_COUNTERPART_QUERY` | Qué cuentos publicados no tienen obra derivada      | Se registra (ver §6)               |
+| Consulta                          | Qué responde                                        | Antes de purgar         |
+| --------------------------------- | --------------------------------------------------- | ----------------------- |
+| `CENSUS_QUERY`                    | Cuántos documentos se van, publicados y en borrador | El censo que va al PR   |
+| `LEGACY_FIELDS_CENSUS_QUERY`      | Cuántas referencias tienen los tres campos legacy   | El censo que va al PR   |
+| `INCOMING_REFERENCES_QUERY`       | Qué documentos referencian un cuento o una lista    | Ver el párrafo de abajo |
+| `WORKS_WITHOUT_COUNTERPART_QUERY` | Qué cuentos publicados no tienen obra derivada      | Se registra (ver §6)    |
+
+**`INCOMING_REFERENCES_QUERY` es el gate del paso 3, y llega a `[]` recién después del paso 2.** Tras el paso 1 todavía devuelve los cuentos, porque las listas siguen presentes y cada una los referencia. Correrla **entre el paso 2 y el 3** es lo que confirma que ya no queda ningún referente y que el borrado puede proceder. Si devuelve algo, **no continuar**: hay un referente que este procedimiento no previó, y el paso siguiente no se deshace.
 
 ## 4. Las tres corridas, por dataset
 
@@ -73,15 +75,20 @@ pnpm exec sanity migration run <slug> \
 
 **Orden de datasets: `development` → `staging` → `production`**, verificando cada uno antes de pasar al siguiente. Ningún gate de CI detecta un dataset que quedó sin migrar.
 
+> [!WARNING]
+> **El sync nocturno deshace los dos primeros.** El job programado replica `production` sobre `staging` y `development` con wipe + import, todos los días. Mientras `production` conserve los documentos, purgar los otros dos dura hasta esa corrida.
+>
+> Los dos primeros datasets son entonces un **ensayo**, no un estado final: sirven para leer el dry-run y confirmar el procedimiento, y hay que darlos por buenos sabiendo que se revierten solos. El estado final de los tres llega recién cuando `production` está purgado y el sync propaga ese estado. Si hace falta que queden purgados antes, correrlos en la misma ventana entre dos corridas del sync.
+
 ## 5. Verificación posterior
 
 Contra el **dataset**, no contra el sitio: la aplicación produce con la caché del CDN encendida, así que la primera lectura del sitio devuelve la versión vieja y parece un fallo de la migración.
 
-| Consulta                     | Esperado                                                                              |
-| ---------------------------- | ------------------------------------------------------------------------------------- |
-| `CENSUS_QUERY`               | Los cuatro conteos en `0`                                                             |
-| `LEGACY_FIELDS_CENSUS_QUERY` | Los tres conteos en `0`                                                               |
-| `DANGLING_AFTER_PURGE_QUERY` | Los cuatro conteos en `0` — ninguna referencia quedó apuntando a un documento borrado |
+| Consulta                     | Esperado                                                                                            |
+| ---------------------------- | --------------------------------------------------------------------------------------------------- |
+| `CENSUS_QUERY`               | Los cuatro conteos en `0`                                                                           |
+| `LEGACY_FIELDS_CENSUS_QUERY` | Los tres conteos en `0`                                                                             |
+| `SURVIVING_REFERENCES_QUERY` | Los cuatro conteos en `0` — la purga no se llevó ninguna obra ni colección de las que debían quedar |
 
 ## 6. El cuento sin contraparte
 

--- a/cms/migrations/purge-story-documents/index.spec.ts
+++ b/cms/migrations/purge-story-documents/index.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import migration from './index';
+
+const migrateDocument = (doc: { _id: string; _type: string }) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never);
+};
+
+const deletedIds = (mutations: unknown) =>
+	(mutations as { type: string; id: string }[]).filter((mutation) => mutation.type === 'delete').map(({ id }) => id);
+
+describe('purga de los cuentos retirados', () => {
+	it('alcanza solo a los cuentos', () => {
+		expect(migration.documentTypes).toEqual(['story']);
+	});
+
+	it('emite la baja del documento publicado, y nada más', () => {
+		const mutations = migrateDocument({ _id: 'story-1', _type: 'story' });
+
+		expect(mutations).toHaveLength(1);
+		expect(deletedIds(mutations)).toEqual(['story-1']);
+	});
+
+	// `del` borra la versión que recibe: la publicada y su borrador se dan de baja cada una por su
+	// cuenta, y borrar una no debe arrastrar a la otra.
+	it('borra el borrador sin arrastrar la versión publicada', () => {
+		expect(deletedIds(migrateDocument({ _id: 'drafts.story-1', _type: 'story' }))).toEqual(['drafts.story-1']);
+	});
+
+	// El guard es la garantía y `documentTypes` la optimización: una invocación con otro alcance no
+	// debe alcanzar para borrar otra cosa. Es lo único que separa esta migración de una purga masiva.
+	it('no borra un documento de otro tipo', () => {
+		expect(migrateDocument({ _id: 'obra-1', _type: 'literaryWork' })).toEqual([]);
+		expect(migrateDocument({ _id: 'drafts.obra-1', _type: 'collection' })).toEqual([]);
+	});
+
+	// La idempotencia no vive en `migrate.document` sino en el recorrido: una segunda corrida no
+	// encuentra documentos de este tipo. Lo que sí se afirma acá es que la mutación es exactamente una
+	// baja por `_id`, sin parches que pudieran reescribir algo antes de borrarlo.
+	it('no emite ninguna otra mutación además de la baja', () => {
+		const mutations = migrateDocument({ _id: 'story-1', _type: 'story' }) as { type: string }[];
+
+		expect(mutations.map(({ type }) => type)).toEqual(['delete']);
+	});
+});

--- a/cms/migrations/purge-story-documents/index.ts
+++ b/cms/migrations/purge-story-documents/index.ts
@@ -1,0 +1,38 @@
+import { defineMigration, del } from 'sanity/migrate';
+
+const DOCUMENT_TYPE = 'story';
+
+interface StoryDocument {
+	_id: string;
+	_type: string;
+}
+
+/**
+ * Purga los cuentos, cuyo contenido ya se migró a las obras literarias en Markdown.
+ *
+ * **Es la última del orden**, y con ella el dataset queda con un solo modelo de contenido en vez de
+ * dos donde uno está apagado. Corre recién cuando ya no queda ningún referente: la baja de los campos
+ * de referencia se lleva los de la página de inicio y del contenido rotativo, y la purga de las listas
+ * los de `stories`.
+ *
+ * Sin `filter`: el recorrido tiene que alcanzar también los borradores. `del` borra la versión que
+ * recibe, así que la publicada y su borrador se dan de baja cada una por su cuenta.
+ *
+ * **No tiene migración hermana de reversión y no puede tenerla**: no crea nada que una de vuelta pueda
+ * reconocer, y lo que borra no se reconstruye. El plan de recuperación es el export previo al que
+ * apunta el runbook, que además queda como la única copia del cuento publicado sin obra derivada.
+ */
+export default defineMigration({
+	title: 'Purgar del dataset los cuentos retirados',
+	documentTypes: [DOCUMENT_TYPE],
+	migrate: {
+		document(doc: StoryDocument) {
+			// El guard es la garantía y `documentTypes` la optimización: una invocación con otro alcance
+			// —o un cambio futuro en el runner— no debe alcanzar para borrar otra cosa.
+			if (doc._type !== DOCUMENT_TYPE) {
+				return [];
+			}
+			return [del(doc._id)];
+		},
+	},
+});

--- a/cms/migrations/purge-story-documents/index.ts
+++ b/cms/migrations/purge-story-documents/index.ts
@@ -10,25 +10,20 @@ interface StoryDocument {
 /**
  * Purga los cuentos, cuyo contenido ya se migró a las obras literarias en Markdown.
  *
- * **Es la última del orden**, y con ella el dataset queda con un solo modelo de contenido en vez de
- * dos donde uno está apagado. Corre recién cuando ya no queda ningún referente: la baja de los campos
- * de referencia se lleva los de la página de inicio y del contenido rotativo, y la purga de las listas
- * los de `stories`.
+ * Última de las tres corridas del runbook (`./README.md`), que es donde vive el orden y por eso este
+ * archivo no lo repite. Con ella el dataset queda con un solo modelo de contenido en vez de dos donde
+ * uno está apagado.
  *
  * Sin `filter`: el recorrido tiene que alcanzar también los borradores. `del` borra la versión que
  * recibe, así que la publicada y su borrador se dan de baja cada una por su cuenta.
  *
- * **No tiene migración hermana de reversión y no puede tenerla**: no crea nada que una de vuelta pueda
- * reconocer, y lo que borra no se reconstruye. El plan de recuperación es el export previo al que
- * apunta el runbook, que además queda como la única copia del cuento publicado sin obra derivada.
+ * El export previo del runbook es además la única copia que queda del cuento sin obra derivada.
  */
 export default defineMigration({
 	title: 'Purgar del dataset los cuentos retirados',
 	documentTypes: [DOCUMENT_TYPE],
 	migrate: {
 		document(doc: StoryDocument) {
-			// El guard es la garantía y `documentTypes` la optimización: una invocación con otro alcance
-			// —o un cambio futuro en el runner— no debe alcanzar para borrar otra cosa.
 			if (doc._type !== DOCUMENT_TYPE) {
 				return [];
 			}

--- a/cms/migrations/purge-story-documents/verification-queries.spec.ts
+++ b/cms/migrations/purge-story-documents/verification-queries.spec.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	CENSUS_QUERY,
-	DANGLING_AFTER_PURGE_QUERY,
 	INCOMING_REFERENCES_QUERY,
 	LEGACY_FIELDS_CENSUS_QUERY,
+	SURVIVING_REFERENCES_QUERY,
 	WORKS_WITHOUT_COUNTERPART_QUERY,
 } from './verification-queries';
 
@@ -32,8 +32,20 @@ const datasetAntesDePurgar = [
 		latestLiteraryWorks: [reference('lw-from-story-story-1')],
 	},
 	{ _id: 'rotatingContent', _type: 'rotatingContent', mostRead: [reference('story-1')] },
+	// Referencia **débil**: es la única clase que el content lake no bloquea al borrar, así que un
+	// referente débil pasaría la purga sin avisar y dejaría el hueco. Es justo lo que el gate previo
+	// tiene que encontrar.
+	{ _id: 'coleccion-suelta', _type: 'collection', destacada: { ...reference('story-1'), _weak: true } },
 	{ _id: 'collection-1', _type: 'collection', literaryWorks: [reference('lw-from-story-story-1')] },
 ];
+
+// El estado posterior a los dos primeros pasos: sin los campos legacy y sin las listas.
+const sinReferentesFuertes = () => {
+	const LEGACY_FIELDS = ['cards', 'latestReads', 'mostRead'];
+	return datasetAntesDePurgar
+		.filter((doc) => doc._type !== 'storylist')
+		.map((doc) => Object.fromEntries(Object.entries(doc).filter(([key]) => !LEGACY_FIELDS.includes(key))));
+};
 
 describe('consultas de censo y verificación de la purga', () => {
 	it('censa los documentos a purgar, separando publicados de borradores', async () => {
@@ -87,15 +99,23 @@ describe('consultas de censo y verificación de la purga', () => {
 		]);
 	});
 
-	// Es la consulta que decide si la purga puede correr: tras dar de baja los campos legacy y las
-	// listas, ya no debe quedar ningún referente.
-	it('no encuentra referentes una vez dados de baja los campos legacy y las listas', async () => {
-		const LEGACY_FIELDS = ['cards', 'latestReads', 'mostRead'];
-		const sinReferentes = datasetAntesDePurgar
-			.filter((doc) => doc._type !== 'storylist')
-			.map((doc) => Object.fromEntries(Object.entries(doc).filter(([key]) => !LEGACY_FIELDS.includes(key))));
+	// Es la consulta que decide si la purga puede correr, y por eso importa que siga encontrando lo que
+	// el content lake **no** bloquea: una referencia débil deja borrar el destino sin protestar, así que
+	// un referente débil pasaría la purga sin avisar y dejaría el hueco.
+	it('sigue encontrando el referente débil, que es el que el content lake no bloquea', async () => {
+		const referenciados = (await run(INCOMING_REFERENCES_QUERY, sinReferentesFuertes())) as {
+			_id: string;
+			referentes: { _id: string }[];
+		}[];
 
-		expect(await run(INCOMING_REFERENCES_QUERY, sinReferentes)).toEqual([]);
+		expect(referenciados).toHaveLength(1);
+		expect(referenciados[0]?.referentes).toEqual([{ _id: 'coleccion-suelta', _type: 'collection' }]);
+	});
+
+	it('no encuentra ninguno una vez retirado también el referente débil', async () => {
+		const sinNinguno = sinReferentesFuertes().filter((doc) => doc._id !== 'coleccion-suelta');
+
+		expect(await run(INCOMING_REFERENCES_QUERY, sinNinguno)).toEqual([]);
 	});
 
 	it('lista el cuento publicado que no tiene obra derivada', async () => {
@@ -104,10 +124,11 @@ describe('consultas de censo y verificación de la purga', () => {
 		]);
 	});
 
-	it('encuentra las referencias que quedaron colgadas', async () => {
+	// El caso que la consulta existe para atrapar: una purga que se excedió y se llevó una obra.
+	it('delata que la purga se llevó una obra que debía sobrevivir', async () => {
 		const conColgada = datasetAntesDePurgar.filter((doc) => doc._id !== 'lw-from-story-story-1');
 
-		expect(await run(DANGLING_AFTER_PURGE_QUERY, conColgada)).toEqual({
+		expect(await run(SURVIVING_REFERENCES_QUERY, conColgada)).toEqual({
 			collections: 0,
 			latestWorks: 1,
 			mostReadWorks: 0,
@@ -116,7 +137,7 @@ describe('consultas de censo y verificación de la purga', () => {
 	});
 
 	it('no encuentra ninguna colgada sobre un dataset íntegro', async () => {
-		expect(await run(DANGLING_AFTER_PURGE_QUERY, datasetAntesDePurgar)).toEqual({
+		expect(await run(SURVIVING_REFERENCES_QUERY, datasetAntesDePurgar)).toEqual({
 			collections: 0,
 			latestWorks: 0,
 			mostReadWorks: 0,

--- a/cms/migrations/purge-story-documents/verification-queries.spec.ts
+++ b/cms/migrations/purge-story-documents/verification-queries.spec.ts
@@ -1,0 +1,126 @@
+import { evaluate, parse } from 'groq-js';
+import { describe, expect, it } from 'vitest';
+
+import {
+	CENSUS_QUERY,
+	DANGLING_AFTER_PURGE_QUERY,
+	INCOMING_REFERENCES_QUERY,
+	LEGACY_FIELDS_CENSUS_QUERY,
+	WORKS_WITHOUT_COUNTERPART_QUERY,
+} from './verification-queries';
+
+const run = async (query: string, dataset: unknown[]) => (await evaluate(parse(query), { dataset })).get();
+
+const reference = (id: string) => ({ _type: 'reference', _ref: id });
+
+// El dataset reproduce el estado previo a la purga: los dos tipos a borrar en sus dos versiones, los
+// tres campos legacy poblados, un cuento con obra derivada y otro sin ella, y una referencia colgada
+// deliberada para que el chequeo posterior tenga algo que encontrar.
+const datasetAntesDePurgar = [
+	{ _id: 'story-1', _type: 'story', slug: { current: 'geometria' } },
+	{ _id: 'story-2', _type: 'story', slug: { current: 'sin-contraparte' } },
+	{ _id: 'drafts.story-3', _type: 'story', slug: { current: 'en-borrador' } },
+	{ _id: 'lw-from-story-story-1', _type: 'literaryWork' },
+	{ _id: 'storylist-1', _type: 'storylist', stories: [reference('story-1')] },
+	{ _id: 'drafts.storylist-2', _type: 'storylist', stories: [] },
+	{
+		_id: 'landing-1974-24',
+		_type: 'landingPage',
+		cards: [reference('storylist-1')],
+		latestReads: [reference('story-1'), reference('story-2')],
+		collections: [reference('collection-1')],
+		latestLiteraryWorks: [reference('lw-from-story-story-1')],
+	},
+	{ _id: 'rotatingContent', _type: 'rotatingContent', mostRead: [reference('story-1')] },
+	{ _id: 'collection-1', _type: 'collection', literaryWorks: [reference('lw-from-story-story-1')] },
+];
+
+describe('consultas de censo y verificación de la purga', () => {
+	it('censa los documentos a purgar, separando publicados de borradores', async () => {
+		expect(await run(CENSUS_QUERY, datasetAntesDePurgar)).toEqual({
+			cuentosPublicados: 2,
+			cuentosEnBorrador: 1,
+			listasPublicadas: 1,
+			listasEnBorrador: 1,
+		});
+	});
+
+	it('da cero en el censo cuando ya no queda ninguno', async () => {
+		const purgado = datasetAntesDePurgar.filter((doc) => !['story', 'storylist'].includes(doc._type));
+
+		expect(await run(CENSUS_QUERY, purgado)).toEqual({
+			cuentosPublicados: 0,
+			cuentosEnBorrador: 0,
+			listasPublicadas: 0,
+			listasEnBorrador: 0,
+		});
+	});
+
+	it('censa las referencias legacy que bloquean la purga', async () => {
+		expect(await run(LEGACY_FIELDS_CENSUS_QUERY, datasetAntesDePurgar)).toEqual({
+			cards: 1,
+			latestReads: 2,
+			mostRead: 1,
+		});
+	});
+
+	// El `defined(...)` de cada filtro es lo que evita contar de más: sin él, un documento que no
+	// declara el campo aporta un `[null]` al recorrido y suma uno.
+	it('no cuenta de más los documentos que ya no declaran el campo', async () => {
+		const sinCampos = [
+			{ _id: 'landing-1975-01', _type: 'landingPage', collections: [] },
+			{ _id: 'rotatingContent', _type: 'rotatingContent' },
+		];
+
+		expect(await run(LEGACY_FIELDS_CENSUS_QUERY, sinCampos)).toEqual({ cards: 0, latestReads: 0, mostRead: 0 });
+	});
+
+	it('descubre qué documentos referencian un cuento o una lista', async () => {
+		const referenciados = (await run(INCOMING_REFERENCES_QUERY, datasetAntesDePurgar)) as {
+			_id: string;
+			referentes: { _id: string }[];
+		}[];
+
+		expect(referenciados.map(({ _id }) => _id).sort()).toEqual(['story-1', 'story-2', 'storylist-1']);
+		expect(referenciados.find(({ _id }) => _id === 'storylist-1')?.referentes).toEqual([
+			{ _id: 'landing-1974-24', _type: 'landingPage' },
+		]);
+	});
+
+	// Es la consulta que decide si la purga puede correr: tras dar de baja los campos legacy y las
+	// listas, ya no debe quedar ningún referente.
+	it('no encuentra referentes una vez dados de baja los campos legacy y las listas', async () => {
+		const LEGACY_FIELDS = ['cards', 'latestReads', 'mostRead'];
+		const sinReferentes = datasetAntesDePurgar
+			.filter((doc) => doc._type !== 'storylist')
+			.map((doc) => Object.fromEntries(Object.entries(doc).filter(([key]) => !LEGACY_FIELDS.includes(key))));
+
+		expect(await run(INCOMING_REFERENCES_QUERY, sinReferentes)).toEqual([]);
+	});
+
+	it('lista el cuento publicado que no tiene obra derivada', async () => {
+		expect(await run(WORKS_WITHOUT_COUNTERPART_QUERY, datasetAntesDePurgar)).toEqual([
+			{ _id: 'story-2', slug: 'sin-contraparte' },
+		]);
+	});
+
+	it('encuentra las referencias que quedaron colgadas', async () => {
+		const conColgada = datasetAntesDePurgar.filter((doc) => doc._id !== 'lw-from-story-story-1');
+
+		expect(await run(DANGLING_AFTER_PURGE_QUERY, conColgada)).toEqual({
+			collections: 0,
+			latestWorks: 1,
+			mostReadWorks: 0,
+			obrasDeColeccion: 1,
+		});
+	});
+
+	it('no encuentra ninguna colgada sobre un dataset íntegro', async () => {
+		expect(await run(DANGLING_AFTER_PURGE_QUERY, datasetAntesDePurgar)).toEqual({
+			collections: 0,
+			latestWorks: 0,
+			mostReadWorks: 0,
+			obrasDeColeccion: 0,
+		});
+	});
+});

--- a/cms/migrations/purge-story-documents/verification-queries.ts
+++ b/cms/migrations/purge-story-documents/verification-queries.ts
@@ -4,13 +4,13 @@ import { MIGRATED_ID_PREFIX } from '../story-to-literary-work/build-literary-wor
  * Las consultas del censo previo y de la verificación posterior, como constantes ejecutables en vez de
  * prosa en el README.
  *
- * El motivo lo dejó documentado el relinkeo de la landing: una consulta publicada que nadie ejecuta
- * puede estar inerte y aparentar que verifica, y sus dos defectos sólo aparecieron al correrla. Acá el
- * costo de un falso verde es mayor, porque el paso siguiente es irreversible: una consulta inerte
- * diría "ninguna referencia colgada" justo antes de una purga que no se deshace.
+ * Una consulta publicada que nadie ejecuta puede estar inerte y aparentar que verifica. Acá el costo
+ * de un falso verde es que el paso siguiente no se deshace: una consulta muerta diría "ninguna
+ * referencia colgada" justo antes de una purga irreversible. Por eso son constantes con spec, y el spec
+ * las evalúa con el motor de GROQ en vez de compararlas como texto.
  *
- * De ahí que cada conteo lleve su `defined(...)` en el filtro del documento: recorrer un campo ausente
- * con `doc.campo[]` no da una lista vacía sino `[null]`, y cuenta de más.
+ * Cada conteo lleva además su `defined(...)` en el filtro del documento: recorrer un campo ausente con
+ * `doc.campo[]` no da una lista vacía sino `[null]`, y cuenta de más.
  */
 
 /**
@@ -68,13 +68,18 @@ export const WORKS_WITHOUT_COUNTERPART_QUERY = `*[
 ]{ _id, 'slug': slug.current }`;
 
 /**
- * Referencias del dataset que dejaron de resolver, tras la purga. Debe devolver `[]`.
+ * Integridad del grafo que **sobrevive** a la purga. Los cuatro conteos deben dar `0`.
+ *
+ * No detecta referencias rotas *por* la purga: los campos que apuntaban al contenido retirado se dan
+ * de baja en el primer paso y las listas que lo referenciaban se borran en el segundo, así que cuando
+ * esta corre ya no queda ninguno. Lo que detecta es una purga que se **excedió** — si un guard fallara
+ * y la corrida se llevara una obra o una colección, acá aparecería el hueco.
  *
  * `[!defined(@->_id)]` **filtra** los miembros cuyo destino no existe. Comparar "conteo resuelto contra
  * conteo de origen" no sirve: dereferenciar conserva el `null` del destino ausente y `count()` lo
  * cuenta, así que los dos números coinciden aunque todas las referencias estén colgadas.
  */
-export const DANGLING_AFTER_PURGE_QUERY = `{
+export const SURVIVING_REFERENCES_QUERY = `{
   'collections':   count(*[_type == 'landingPage' && defined(collections)].collections[!defined(@->_id)]),
   'latestWorks':   count(*[_type == 'landingPage' && defined(latestLiteraryWorks)].latestLiteraryWorks[!defined(@->_id)]),
   'mostReadWorks': count(*[_type == 'rotatingContent' && defined(mostReadLiteraryWorks)].mostReadLiteraryWorks[!defined(@->_id)]),

--- a/cms/migrations/purge-story-documents/verification-queries.ts
+++ b/cms/migrations/purge-story-documents/verification-queries.ts
@@ -1,0 +1,82 @@
+import { MIGRATED_ID_PREFIX } from '../story-to-literary-work/build-literary-work-document';
+
+/**
+ * Las consultas del censo previo y de la verificación posterior, como constantes ejecutables en vez de
+ * prosa en el README.
+ *
+ * El motivo lo dejó documentado el relinkeo de la landing: una consulta publicada que nadie ejecuta
+ * puede estar inerte y aparentar que verifica, y sus dos defectos sólo aparecieron al correrla. Acá el
+ * costo de un falso verde es mayor, porque el paso siguiente es irreversible: una consulta inerte
+ * diría "ninguna referencia colgada" justo antes de una purga que no se deshace.
+ *
+ * De ahí que cada conteo lleve su `defined(...)` en el filtro del documento: recorrer un campo ausente
+ * con `doc.campo[]` no da una lista vacía sino `[null]`, y cuenta de más.
+ */
+
+/**
+ * Censo de los documentos que la purga se lleva, publicados y borradores por separado.
+ *
+ * Se corre **antes** para registrar cuánto se va, y **después** de cada dataset, donde los cuatro
+ * conteos deben dar `0`.
+ */
+export const CENSUS_QUERY = `{
+  'cuentosPublicados':    count(*[_type == 'story' && !(_id in path('drafts.**'))]),
+  'cuentosEnBorrador':    count(*[_type == 'story' && _id in path('drafts.**')]),
+  'listasPublicadas':     count(*[_type == 'storylist' && !(_id in path('drafts.**'))]),
+  'listasEnBorrador':     count(*[_type == 'storylist' && _id in path('drafts.**')])
+}`;
+
+/**
+ * Censo de las referencias que la primera migración da de baja. Deben dar `0` después de correrla.
+ *
+ * Son las que bloquean la purga: mientras alguna siga en pie, el content lake rechaza borrar su
+ * destino.
+ */
+export const LEGACY_FIELDS_CENSUS_QUERY = `{
+  'cards':       count(*[_type == 'landingPage' && defined(cards)].cards[]),
+  'latestReads': count(*[_type == 'landingPage' && defined(latestReads)].latestReads[]),
+  'mostRead':    count(*[_type == 'rotatingContent' && defined(mostRead)].mostRead[])
+}`;
+
+/**
+ * Qué documentos siguen referenciando un cuento o una lista. Debe devolver `[]` antes de purgar.
+ *
+ * Descubre los referentes con `references()` en vez de enumerar los campos conocidos: el dataset puede
+ * conservar campos de schemas dados de baja hace tiempo, y una lista escrita a mano no los vería —que
+ * es exactamente la clase de dato que este issue existe para encontrar—.
+ */
+export const INCOMING_REFERENCES_QUERY = `*[_type in ['story', 'storylist']]{
+  _id,
+  _type,
+  'referentes': *[references(^._id)]{ _id, _type }
+}[count(referentes) > 0]`;
+
+/**
+ * Los cuentos publicados que no tienen obra derivada: lo que la purga se lleva sin contraparte.
+ *
+ * No aborta nada — la decisión de que desaparezcan ya está tomada. Se corre para que el censo del PR
+ * los nombre, en vez de que se descubran ausentes después.
+ *
+ * El identificador esperado se deriva del prefijo que usa la migración de ida, importado y no
+ * reescrito: con dos definiciones, una divergencia haría que este censo declarara huérfano a un cuento
+ * que sí migró.
+ */
+export const WORKS_WITHOUT_COUNTERPART_QUERY = `*[
+  _type == 'story' &&
+  !(_id in path('drafts.**')) &&
+  !defined(*[_id == '${MIGRATED_ID_PREFIX}' + ^._id][0])
+]{ _id, 'slug': slug.current }`;
+
+/**
+ * Referencias del dataset que dejaron de resolver, tras la purga. Debe devolver `[]`.
+ *
+ * `[!defined(@->_id)]` **filtra** los miembros cuyo destino no existe. Comparar "conteo resuelto contra
+ * conteo de origen" no sirve: dereferenciar conserva el `null` del destino ausente y `count()` lo
+ * cuenta, así que los dos números coinciden aunque todas las referencias estén colgadas.
+ */
+export const DANGLING_AFTER_PURGE_QUERY = `{
+  'collections':   count(*[_type == 'landingPage' && defined(collections)].collections[!defined(@->_id)]),
+  'latestWorks':   count(*[_type == 'landingPage' && defined(latestLiteraryWorks)].latestLiteraryWorks[!defined(@->_id)]),
+  'mostReadWorks': count(*[_type == 'rotatingContent' && defined(mostReadLiteraryWorks)].mostReadLiteraryWorks[!defined(@->_id)]),
+  'obrasDeColeccion': count(*[_type == 'collection' && defined(literaryWorks)].literaryWorks[!defined(@->_id)])
+}`;

--- a/cms/migrations/purge-storylist-documents/README.md
+++ b/cms/migrations/purge-storylist-documents/README.md
@@ -1,0 +1,5 @@
+# Purga de las listas de contenido
+
+Borra del dataset las listas de contenido, cuyo contenido ya se traspasó a las colecciones.
+
+**Segunda de tres**, entre la baja de los campos de referencia y la purga de los cuentos: cada lista referencia sus cuentos, así que borrarla es lo que los deja sin referentes. El procedimiento completo vive en [`../purge-story-documents/README.md`](../purge-story-documents/README.md).

--- a/cms/migrations/purge-storylist-documents/index.spec.ts
+++ b/cms/migrations/purge-storylist-documents/index.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import migration from './index';
+
+const migrateDocument = (doc: { _id: string; _type: string }) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never);
+};
+
+const deletedIds = (mutations: unknown) =>
+	(mutations as { type: string; id: string }[]).filter((mutation) => mutation.type === 'delete').map(({ id }) => id);
+
+describe('purga de las listas de contenido retiradas', () => {
+	it('alcanza solo a las listas de contenido', () => {
+		expect(migration.documentTypes).toEqual(['storylist']);
+	});
+
+	it('emite la baja del documento publicado, y nada más', () => {
+		const mutations = migrateDocument({ _id: 'storylist-1', _type: 'storylist' });
+
+		expect(mutations).toHaveLength(1);
+		expect(deletedIds(mutations)).toEqual(['storylist-1']);
+	});
+
+	// `del` borra la versión que recibe: la publicada y su borrador se dan de baja cada una por su
+	// cuenta, y borrar una no debe arrastrar a la otra.
+	it('borra el borrador sin arrastrar la versión publicada', () => {
+		expect(deletedIds(migrateDocument({ _id: 'drafts.storylist-1', _type: 'storylist' }))).toEqual([
+			'drafts.storylist-1',
+		]);
+	});
+
+	// El guard es la garantía y `documentTypes` la optimización: una invocación con otro alcance no
+	// debe alcanzar para borrar otra cosa. Es lo único que separa esta migración de una purga masiva.
+	it('no borra un documento de otro tipo', () => {
+		expect(migrateDocument({ _id: 'obra-1', _type: 'literaryWork' })).toEqual([]);
+		expect(migrateDocument({ _id: 'drafts.obra-1', _type: 'collection' })).toEqual([]);
+	});
+
+	// La idempotencia no vive en `migrate.document` sino en el recorrido: una segunda corrida no
+	// encuentra documentos de este tipo. Lo que sí se afirma acá es que la mutación es exactamente una
+	// baja por `_id`, sin parches que pudieran reescribir algo antes de borrarlo.
+	it('no emite ninguna otra mutación además de la baja', () => {
+		const mutations = migrateDocument({ _id: 'storylist-1', _type: 'storylist' }) as { type: string }[];
+
+		expect(mutations.map(({ type }) => type)).toEqual(['delete']);
+	});
+});

--- a/cms/migrations/purge-storylist-documents/index.ts
+++ b/cms/migrations/purge-storylist-documents/index.ts
@@ -1,0 +1,40 @@
+import { defineMigration, del } from 'sanity/migrate';
+
+const DOCUMENT_TYPE = 'storylist';
+
+interface StorylistDocument {
+	_id: string;
+	_type: string;
+}
+
+/**
+ * Purga las listas de contenido, cuyo contenido ya se traspasó a las colecciones.
+ *
+ * **Corre después de la baja de los campos de referencia y antes de la purga de los cuentos.** El
+ * orden no es una preferencia: cada lista referencia sus cuentos con referencia fuerte, así que
+ * borrarla primero es lo que deja a los cuentos sin referentes. Va en su propia migración y no junto
+ * con la de cuentos porque el runner batchea mutaciones y no garantiza el orden dentro de una corrida:
+ * un `documentTypes` con los dos tipos podría intentar borrar un cuento todavía referenciado y
+ * detenerse a mitad de camino, con documentos ya borrados.
+ *
+ * Sin `filter`: el recorrido tiene que alcanzar también los borradores. `del` borra la versión que
+ * recibe, así que la publicada y su borrador se dan de baja cada una por su cuenta.
+ *
+ * **No tiene migración hermana de reversión y no puede tenerla**: no crea nada que una de vuelta
+ * pueda reconocer, y lo que borra no se reconstruye. El plan de recuperación es el export previo al
+ * que apunta el runbook.
+ */
+export default defineMigration({
+	title: 'Purgar del dataset las listas de contenido retiradas',
+	documentTypes: [DOCUMENT_TYPE],
+	migrate: {
+		document(doc: StorylistDocument) {
+			// El guard es la garantía y `documentTypes` la optimización: una invocación con otro alcance
+			// —o un cambio futuro en el runner— no debe alcanzar para borrar otra cosa.
+			if (doc._type !== DOCUMENT_TYPE) {
+				return [];
+			}
+			return [del(doc._id)];
+		},
+	},
+});

--- a/cms/migrations/purge-storylist-documents/index.ts
+++ b/cms/migrations/purge-storylist-documents/index.ts
@@ -10,27 +10,18 @@ interface StorylistDocument {
 /**
  * Purga las listas de contenido, cuyo contenido ya se traspasó a las colecciones.
  *
- * **Corre después de la baja de los campos de referencia y antes de la purga de los cuentos.** El
- * orden no es una preferencia: cada lista referencia sus cuentos con referencia fuerte, así que
- * borrarla primero es lo que deja a los cuentos sin referentes. Va en su propia migración y no junto
- * con la de cuentos porque el runner batchea mutaciones y no garantiza el orden dentro de una corrida:
- * un `documentTypes` con los dos tipos podría intentar borrar un cuento todavía referenciado y
- * detenerse a mitad de camino, con documentos ya borrados.
+ * Segunda de las tres corridas del runbook (`../purge-story-documents/README.md`), que es donde vive
+ * el orden y por eso este archivo no lo repite: cada lista referencia sus cuentos, así que borrarla es
+ * lo que los deja sin referentes.
  *
  * Sin `filter`: el recorrido tiene que alcanzar también los borradores. `del` borra la versión que
  * recibe, así que la publicada y su borrador se dan de baja cada una por su cuenta.
- *
- * **No tiene migración hermana de reversión y no puede tenerla**: no crea nada que una de vuelta
- * pueda reconocer, y lo que borra no se reconstruye. El plan de recuperación es el export previo al
- * que apunta el runbook.
  */
 export default defineMigration({
 	title: 'Purgar del dataset las listas de contenido retiradas',
 	documentTypes: [DOCUMENT_TYPE],
 	migrate: {
 		document(doc: StorylistDocument) {
-			// El guard es la garantía y `documentTypes` la optimización: una invocación con otro alcance
-			// —o un cambio futuro en el runner— no debe alcanzar para borrar otra cosa.
 			if (doc._type !== DOCUMENT_TYPE) {
 				return [];
 			}

--- a/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.ts
+++ b/cms/migrations/revert-relink-landing-to-collection-and-literary-work/index.ts
@@ -62,6 +62,11 @@ function unsetIfMigrationWroteIt(
  * Recorre los borradores igual que la ida, porque es lo que aquélla escribió.
  *
  * Es idempotente: un documento sin los campos nuevos no produce mutación.
+ *
+ * **Deja de servir en cuanto se dan de baja los campos de origen.** Su comparación aborta cuando el
+ * campo viejo ya no está poblado —es la primera de las dos condiciones de arriba—, así que sobre un
+ * dataset donde ya corrió `unset-legacy-story-references` no revierte nada. A partir de ahí la vuelta
+ * atrás es el export previo que describe `../purge-story-documents/README.md`.
  */
 export default defineMigration({
 	title: 'Revertir el reapuntado de referencias de la página de inicio y del contenido rotativo',

--- a/cms/migrations/unset-legacy-story-references/README.md
+++ b/cms/migrations/unset-legacy-story-references/README.md
@@ -1,0 +1,5 @@
+# Baja de los campos de referencia al contenido retirado
+
+Da de baja `cards` y `latestReads` de la página de inicio y `mostRead` del contenido rotativo. Sus schemas ya no los declaran, pero el dato quedó en el dataset y es lo que bloquea la purga: el content lake rechaza borrar un documento con una referencia fuerte entrante.
+
+**Primera de tres.** El procedimiento completo —prerequisitos, export previo, censo, orden de datasets y verificación— vive en [`../purge-story-documents/README.md`](../purge-story-documents/README.md).

--- a/cms/migrations/unset-legacy-story-references/index.spec.ts
+++ b/cms/migrations/unset-legacy-story-references/index.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import migration from './index';
+
+const migrateDocument = (doc: Record<string, unknown>) => {
+	const document = migration.migrate?.document;
+	if (!document) throw new Error('La migración no define migrate.document');
+	return document(doc as never);
+};
+
+// Se afirma también el tipo de operación: un `path` correcto con la operación equivocada dejaría el
+// campo en pie, que es justamente lo que bloquea la purga.
+const unsetPaths = (mutations: unknown) =>
+	(mutations as { path: string[]; op: { type: string } }[])
+		.filter((mutation) => mutation.op.type === 'unset')
+		.map((mutation) => mutation.path.join('.'))
+		.sort();
+
+describe('baja de los campos de referencia al contenido retirado', () => {
+	it('alcanza a la página de inicio y al contenido rotativo', () => {
+		expect(migration.documentTypes).toEqual(['landingPage', 'rotatingContent']);
+	});
+
+	it('da de baja los dos campos de la página de inicio', () => {
+		const mutations = migrateDocument({
+			_id: 'landing-1974-24',
+			_type: 'landingPage',
+			cards: [{ _ref: 'storylist-1' }],
+			latestReads: [{ _ref: 'story-1' }],
+		});
+
+		expect(unsetPaths(mutations)).toEqual(['cards', 'latestReads']);
+	});
+
+	it('da de baja el campo del contenido rotativo', () => {
+		const mutations = migrateDocument({
+			_id: 'rotatingContent',
+			_type: 'rotatingContent',
+			mostRead: [{ _ref: 'story-1' }],
+		});
+
+		expect(unsetPaths(mutations)).toEqual(['mostRead']);
+	});
+
+	// La tabla es por tipo: un campo que no pertenece al documento no se toca aunque esté presente,
+	// porque su baja pertenece a otra entrada de la tabla y no a ésta.
+	it('no cruza los campos de un tipo con los del otro', () => {
+		const landing = migrateDocument({
+			_id: 'landing-1974-24',
+			_type: 'landingPage',
+			cards: [],
+			mostRead: [{ _ref: 'story-1' }],
+		});
+		const rotating = migrateDocument({
+			_id: 'rotatingContent',
+			_type: 'rotatingContent',
+			mostRead: [],
+			latestReads: [{ _ref: 'story-1' }],
+		});
+
+		expect(unsetPaths(landing)).toEqual(['cards']);
+		expect(unsetPaths(rotating)).toEqual(['mostRead']);
+	});
+
+	// El campo se da de baja por estar presente, no por traer referencias: una landing que lo dejó
+	// vacío igual lo declara, y dejarlo sería dejar el schema viejo asomando en el documento.
+	it('da de baja el campo presente aunque no traiga referencias', () => {
+		const mutations = migrateDocument({ _id: 'landing-1974-24', _type: 'landingPage', cards: [] });
+
+		expect(unsetPaths(mutations)).toEqual(['cards']);
+	});
+
+	it('no produce mutación sobre un documento que ya no los declara', () => {
+		expect(migrateDocument({ _id: 'landing-1975-01', _type: 'landingPage', collections: [] })).toEqual([]);
+		expect(migrateDocument({ _id: 'rotatingContent', _type: 'rotatingContent' })).toEqual([]);
+	});
+
+	// El guard es la garantía, no `documentTypes`: una invocación con otro alcance —o un cambio futuro
+	// en el runner— no debe alcanzar para tocar un documento que esta migración no gobierna.
+	it('no toca un tipo ajeno, aunque traiga un campo homónimo', () => {
+		expect(migrateDocument({ _id: 'obra-1', _type: 'literaryWork', latestReads: [{ _ref: 'x' }] })).toEqual([]);
+	});
+});

--- a/cms/migrations/unset-legacy-story-references/index.ts
+++ b/cms/migrations/unset-legacy-story-references/index.ts
@@ -1,0 +1,43 @@
+import { at, defineMigration, unset } from 'sanity/migrate';
+
+// Cada entrada es un campo de referencia que su issue quitó del schema del Studio, de la proyección
+// GROQ y del puerto del backend, pero que sigue poblado en cada documento del dataset: quitar un campo
+// del schema no borra el dato.
+const LEGACY_REFERENCE_FIELDS: Readonly<Record<string, readonly string[]>> = Object.freeze({
+	landingPage: ['cards', 'latestReads'],
+	rotatingContent: ['mostRead'],
+});
+
+const DOCUMENT_TYPES = Object.keys(LEGACY_REFERENCE_FIELDS);
+
+interface LegacyReferenceDocument {
+	_id: string;
+	_type: string;
+}
+
+/**
+ * Da de baja los campos que todavía referencian los tipos de contenido retirados.
+ *
+ * **Es el paso previo que habilita la purga, no una limpieza posterior.** El content lake rechaza
+ * borrar un documento que conserva una referencia fuerte entrante, así que mientras estos tres campos
+ * apunten a los documentos viejos, ninguna migración puede borrarlos.
+ *
+ * Corre con el runner recorriendo también los borradores —de ahí la ausencia de `filter`—: una landing
+ * en borrador conserva sus referencias igual que la publicada, y dejarla afuera bloquearía la purga.
+ *
+ * Es idempotente: solo emite mutación por los campos que el documento efectivamente trae, así que una
+ * segunda corrida no produce ninguna.
+ *
+ * **Invalida para siempre la reversión del relinkeo de la landing**, que aborta cuando el campo de
+ * origen ya no está poblado. A partir de esta corrida, el plan de recuperación es el export previo.
+ */
+export default defineMigration({
+	title: 'Dar de baja los campos de referencia a los tipos de contenido retirados',
+	documentTypes: DOCUMENT_TYPES,
+	migrate: {
+		document(doc: LegacyReferenceDocument) {
+			const fields = LEGACY_REFERENCE_FIELDS[doc._type] ?? [];
+			return fields.filter((field) => field in doc).map((field) => at(field, unset()));
+		},
+	},
+});

--- a/cms/migrations/unset-legacy-story-references/index.ts
+++ b/cms/migrations/unset-legacy-story-references/index.ts
@@ -1,8 +1,8 @@
 import { at, defineMigration, unset } from 'sanity/migrate';
 
-// Cada entrada es un campo de referencia que su issue quitó del schema del Studio, de la proyección
-// GROQ y del puerto del backend, pero que sigue poblado en cada documento del dataset: quitar un campo
-// del schema no borra el dato.
+// Cada entrada es un campo de referencia que se quitó del schema del Studio, de la proyección GROQ y
+// del puerto del backend, y que aun así puede seguir presente en un documento: quitar un campo del
+// schema no borra el dato.
 const LEGACY_REFERENCE_FIELDS: Readonly<Record<string, readonly string[]>> = Object.freeze({
 	landingPage: ['cards', 'latestReads'],
 	rotatingContent: ['mostRead'],
@@ -19,7 +19,7 @@ interface LegacyReferenceDocument {
  * Da de baja los campos que todavía referencian los tipos de contenido retirados.
  *
  * **Es el paso previo que habilita la purga, no una limpieza posterior.** El content lake rechaza
- * borrar un documento que conserva una referencia fuerte entrante, así que mientras estos tres campos
+ * borrar un documento que conserva una referencia fuerte entrante, así que mientras estos campos
  * apunten a los documentos viejos, ninguna migración puede borrarlos.
  *
  * Corre con el runner recorriendo también los borradores —de ahí la ausencia de `filter`—: una landing
@@ -36,7 +36,9 @@ export default defineMigration({
 	documentTypes: DOCUMENT_TYPES,
 	migrate: {
 		document(doc: LegacyReferenceDocument) {
-			const fields = LEGACY_REFERENCE_FIELDS[doc._type] ?? [];
+			// Se pregunta por propiedad propia: un `_type` que colisione con una heredada devolvería una
+			// función en vez de undefined, y el operador de fallback no la atraparía.
+			const fields = Object.hasOwn(LEGACY_REFERENCE_FIELDS, doc._type) ? LEGACY_REFERENCE_FIELDS[doc._type] : [];
 			return fields.filter((field) => field in doc).map((field) => at(field, unset()));
 		},
 	},

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -137,7 +137,7 @@ Un **Agregado** es un cluster de objetos de dominio (entidades y objetos de valo
 
 ### Agregado: Story (Historia) — retirado
 
-> **Estado: retirado.** El document type `story` y su endpoint (`/api/story`) se dieron de baja, y sus documentos se purgaron del dataset: el catálogo de contenido narrativo hoy es exclusivamente `LiteraryWork` (ver más abajo). La purga es lo que separa un tipo apagado de un tipo que ya no está — dar de baja el schema deja los documentos en el content lake, invisibles pero presentes. Esta sección se conserva como referencia histórica del modelo que `LiteraryWork` reemplazó.
+> **Estado: retirado.** El document type `story` y su endpoint (`/api/story`) se dieron de baja: el catálogo de contenido narrativo hoy es exclusivamente `LiteraryWork` (ver más abajo). Dar de baja el schema no borra los documentos, que siguen en el content lake invisibles pero presentes; su purga tiene procedimiento propio en `cms/migrations/purge-story-documents/README.md`. Esta sección se conserva como referencia histórica del modelo que `LiteraryWork` reemplazó.
 
 **Raíz de Agregado:** `Story`
 
@@ -346,7 +346,7 @@ Borrador de perfil -> Publicación de perfil -> Perfil disponible para búsqueda
 
 ### Agregado: Storylist (Colección) — retirado
 
-> **Estado: retirado.** El document type `storylist` y su endpoint (`/api/storylist`) se dieron de baja, y sus documentos se purgaron del dataset: la curación de obras en colecciones hoy es exclusivamente `Collection` (ver más abajo). Esta sección se conserva como referencia histórica del modelo que `Collection` reemplazó.
+> **Estado: retirado.** El document type `storylist` y su endpoint (`/api/storylist`) se dieron de baja: la curación de obras en colecciones hoy es exclusivamente `Collection` (ver más abajo). Sus documentos siguen en el content lake hasta que se aplique la purga, que tiene procedimiento propio en `cms/migrations/purge-story-documents/README.md`. Esta sección se conserva como referencia histórica del modelo que `Collection` reemplazó.
 
 **Raíz de Agregado:** `Storylist`
 

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -137,7 +137,7 @@ Un **Agregado** es un cluster de objetos de dominio (entidades y objetos de valo
 
 ### Agregado: Story (Historia) — retirado
 
-> **Estado: retirado.** El document type `story` y su endpoint (`/api/story`) se dieron de baja: el catálogo de contenido narrativo hoy es exclusivamente `LiteraryWork` (ver más abajo). Esta sección se conserva como referencia histórica del modelo que `LiteraryWork` reemplazó.
+> **Estado: retirado.** El document type `story` y su endpoint (`/api/story`) se dieron de baja, y sus documentos se purgaron del dataset: el catálogo de contenido narrativo hoy es exclusivamente `LiteraryWork` (ver más abajo). La purga es lo que separa un tipo apagado de un tipo que ya no está — dar de baja el schema deja los documentos en el content lake, invisibles pero presentes. Esta sección se conserva como referencia histórica del modelo que `LiteraryWork` reemplazó.
 
 **Raíz de Agregado:** `Story`
 
@@ -346,7 +346,7 @@ Borrador de perfil -> Publicación de perfil -> Perfil disponible para búsqueda
 
 ### Agregado: Storylist (Colección) — retirado
 
-> **Estado: retirado.** El document type `storylist` y su endpoint (`/api/storylist`) se dieron de baja: la curación de obras en colecciones hoy es exclusivamente `Collection` (ver más abajo). Esta sección se conserva como referencia histórica del modelo que `Collection` reemplazó.
+> **Estado: retirado.** El document type `storylist` y su endpoint (`/api/storylist`) se dieron de baja, y sus documentos se purgaron del dataset: la curación de obras en colecciones hoy es exclusivamente `Collection` (ver más abajo). Esta sección se conserva como referencia histórica del modelo que `Collection` reemplazó.
 
 **Raíz de Agregado:** `Storylist`
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Este PR no purga nada todavía.** Aporta las migraciones, sus tests y el procedimiento; la ejecución contra los datasets queda pendiente del release, por el motivo que se explica abajo. Mergearlo no cambia ningún dato.

Dar de baja un schema del Studio no borra los documentos: tras el retiro de los dos tipos, sus documentos siguen en el dataset como contenido invisible que ninguna query alcanza y ninguna interfaz muestra. Este PR aporta lo necesario para purgarlos.

## Por qué la ejecución no entra en este PR

El issue declara dos precondiciones. La primera está cumplida —los schemas y los módulos de backend ya no existen en `develop`—. **La segunda no:** el release que retira las páginas todavía no está desplegado.

No es una formalidad, y la evidencia es dura. La versión que hoy corre en producción **lee** los tres campos legacy:

```
git show 2.10.3:src/api/_queries/content.query.ts
  'cards': coalesce(cards[],[]),
  'latestReads': coalesce(latestReads,[]),
  (rotatingContentQuery)  'mostRead': coalesce(mostRead[]->{ …
```

Y hay algo peor que vaciar la página en vivo: su generador semanal **copia esos campos hacia adelante** al crear la landing de la semana siguiente, así que el cron reintroduciría lo purgado. En `develop` esa copia ya arrastra sólo los campos vigentes.

| Entra en este PR | Después del release, a mano |
| --- | --- |
| Las tres migraciones versionadas, con su spec | El export completo del dataset, fuera del repositorio |
| Las consultas de censo y verificación, ejecutables | El dry-run real contra cada dataset y su censo |
| El runbook con los comandos exactos por dataset | La aplicación en `development` → `staging` → `production` |
| El scan de impacto en documentación | La verificación posterior contra el dataset |

## Por qué son tres migraciones y no una

Este fue el hallazgo que dio forma a la solución: **el content lake rechaza borrar un documento que conserva una referencia fuerte entrante.**

El retiro de los schemas quitó `landingPage.cards`, `landingPage.latestReads` y `rotatingContent.mostRead` del Studio, **pero eso no borró el dato**. Esas referencias siguen vivas en el content lake apuntando justo a lo que hay que purgar, y son las que hoy bloquean la baja. A ellas se suma `storylist.stories`, que vive dentro de un documento que la purga también borra.

| Orden | Migración | Qué hace |
| --- | --- | --- |
| 1 | `unset-legacy-story-references` | Da de baja los tres campos legacy, publicados y borradores |
| 2 | `purge-storylist-documents` | Borra las listas (cada una referencia sus cuentos) |
| 3 | `purge-story-documents` | Borra los cuentos |

Van separadas y no en una sola con los dos tipos porque el runner batchea mutaciones y **no garantiza el orden dentro de una corrida**: un `documentTypes` con ambos podría intentar borrar un cuento todavía referenciado y detenerse a mitad de camino, con documentos ya borrados.

Ninguna lleva `filter`, para que el recorrido alcance también los borradores.

## Irreversibilidad

Ninguna de las tres tiene hermana de reversión, y **ninguna puede tenerla**: no crean nada que una de vuelta pueda reconocer por su `_id`, y lo que borran no se reconstruye. El export previo ocupa ese lugar, y el runbook lo dice con esas palabras.

Un efecto colateral que conviene enunciar antes de descubrirlo: la primera migración deja **permanentemente inservible** la reversión del relinkeo de la landing —aborta cuando el campo de origen ya no está poblado—, y tras la purga la reversión de la creación de obras borraría obras que ya no se pueden regenerar.

## Las consultas van ejecutables, no como prosa

El censo y la verificación viven en `verification-queries.ts` con su spec sobre el motor de GROQ. El precedente del relinkeo de la landing dejó dos consultas inertes que aparentaban verificar, y sus defectos sólo aparecieron al ejecutarlas. Acá el costo de un falso verde es mayor: una consulta inerte diría "ninguna referencia colgada" justo antes de un paso que no se deshace.

Escribir el spec ya pagó: **tres de mis expectativas iniciales eran incorrectas** y las consultas tenían razón — entre ellas, que un cuento referenciado desde `latestReads` también aparece como referenciado, que es exactamente lo que la consulta debe encontrar.

`INCOMING_REFERENCES_QUERY` descubre los referentes con `references()` en vez de enumerar los cuatro campos conocidos: el dataset puede conservar campos de schemas dados de baja hace tiempo, y una lista escrita a mano no los vería — que es justo la clase de dato que este trabajo existe para encontrar.

## Documentación

La referencia de migraciones cubría crear y convertir contenido, pero no borrarlo. Se agrega una sección con las tres restricciones que este trabajo descubrió: el rechazo por referencia entrante, la necesidad de una migración por nivel del grafo, y el export como sustituto de la reversión.

## Plan de pruebas

Tier local en verde: `typecheck`, `lint`, `stylelint`, `test` y el type-check del Studio. `pnpm sanity:test` pasa con **33 archivos y 327 tests**; las tres migraciones y las consultas llegan con su spec co-locado.

Qué cubren los tests nuevos:

- **Por migración** — el camino feliz, que el borrador se da de baja sin arrastrar la versión publicada, que un tipo ajeno no se toca (el guard es la garantía, `documentTypes` la optimización) y que la única mutación emitida es una baja por `_id`, sin parches que pudieran reescribir algo antes de borrarlo.
- **La tabla por tipo** — que un campo de la página de inicio no se da de baja en el contenido rotativo ni al revés, y que el campo presente pero vacío igual se retira.
- **Las cinco consultas** — evaluadas con `groq-js` contra un dataset armado a mano con el caso positivo y el negativo de cada una, incluidas una referencia colgada y una referencia débil deliberadas.

**Verificación pendiente, y es la que no puedo hacer:** el dry-run real contra cada dataset. El runbook lo deja listo para copiar y ejecutar.

## Dos correcciones que salieron de la review, y valen la pena

La primera era un error en la **condición de salida del gate que precede al borrado irreversible**: el runbook decía que la consulta de referentes queda vacía tras el primer paso, y no es así — las listas siguen presentes y cada una referencia sus cuentos, así que llega a vacío recién tras el segundo. El propio spec del PR ya lo desmentía.

La segunda es que **el sync nocturno replica producción sobre los otros dos datasets**. Purgar `development` o `staging` antes que `production` dura hasta esa corrida: son un ensayo para leer el dry-run, no un estado final. El runbook ahora lo advierte.

Se corrigió además una consulta que no respondía lo que prometía —los campos que inspecciona apuntan a tipos que la purga no toca—: pasa a nombrarse por lo que sí verifica, que es detectar una purga que se excedió. Y el corpus del spec suma una **referencia débil**, la única clase que el content lake no bloquea al borrar y por lo tanto la que el gate previo existe para atrapar.

Closes #2282.

Parte de #2265.
