### PR TITLE
[#2431] - Pide al CDN de Sanity el tamaño en el que la imagen se pinta

### DIFF
--- a/.claude/references/angular-components.md
+++ b/.claude/references/angular-components.md
@@ -270,6 +270,7 @@ export function provideFooInitializer() {
 - `@for` **requiere `track`**.
 - **Self-closing tags** para elementos sin contenido proyectado (`<cuentoneta-tag ... />`).
 - **`ngSrc`** (de `NgOptimizedImage`) para imágenes, no `src` crudo; declarar `width`/`height`.
+- **La transformación de una imagen de Sanity no se escribe en el componente.** La resuelve el `IMAGE_LOADER` que `app.config.ts` registra (`src/app/providers/sanity-image-loader.ts`): envolver la URL a mano duplica los parámetros, porque el loader corre igual. Lo que el componente sí controla es de dónde salen los anchos del `srcset` — de `width`/`height`, que producen el tamaño de display y su 2×, o de `sizes`, que produce los breakpoints. Con `fill` y sin `sizes` declarado, Angular asume `100vw`: el `srcset` sale igual, pero pide anchos de viewport completo para una imagen que quizá ocupe una fracción, así que declarar `sizes` sigue siendo lo correcto cuando no lo ocupa entero.
 - Manejar el elemento anfitrión (clases, bindings, eventos) vía la propiedad `host` del decorador, nunca con `@HostBinding`/`@HostListener` ni con `:host { @apply ... }` en `styles` (ver [Host element](#host-element)).
 
 ```html

--- a/.claude/references/cupid.md
+++ b/.claude/references/cupid.md
@@ -17,7 +17,7 @@ export function mapAuthorTeaser(raw: SanityAuthor): AuthorTeaser {
 	return {
 		slug: raw.slug.current,
 		name: raw.name,
-		imageUrl: urlForWithAutoFormat(raw.image),
+		imageUrl: urlFor(raw.image),
 	};
 }
 ```

--- a/.claude/references/domain-model.md
+++ b/.claude/references/domain-model.md
@@ -284,7 +284,7 @@ GROQ → repository.fetch*()  →  service.get*()  →  mapX(raw): DomainType  �
 ```
 
 - Mappers como **funciones puras**: `mapAuthor`, `mapAuthorTeaser`, `mapResources`, `mapTags`, …
-- Los helpers de imágenes (`urlFor`, `urlForWithAutoFormat`) también viven en la capa de mappers.
+- El helper de imágenes (`urlFor`) también vive en la capa de mappers, y emite la URL canónica: los parámetros de transformación los agrega el `IMAGE_LOADER` del frontend.
 - Al cambiar una query GROQ o un tipo generado de Sanity, actualizá el **mapper** y los tipos de dominio en el **mismo** PR.
 
 El ACL es la frontera explícita entre la infraestructura (Sanity) y el dominio: un cambio en el CMS no afecta al dominio mientras se mantengan los contratos. Detalle en [`sanity-acl.md`](sanity-acl.md).

--- a/.claude/references/sanity-acl.md
+++ b/.claude/references/sanity-acl.md
@@ -294,14 +294,17 @@ export function urlFor(source: SanityImageSource): string {
 		return '';
 	}
 }
-
-export function urlForWithAutoFormat(source: SanityImageSource): string {
-	// idéntico, pero .auto('format').url() para servir el formato óptimo (WebP/AVIF)
-}
 ```
 
-Los mappers invocan `urlFor` / `urlForWithAutoFormat` y exponen al dominio un `imageUrl: string`,
-nunca el `SanityImageSource` crudo.
+Los mappers invocan `urlFor` y exponen al dominio un `imageUrl: string`, nunca el
+`SanityImageSource` crudo.
+
+**La URL sale del ACL sin parámetros de transformación.** El tamaño, el formato y la calidad los
+agrega el `IMAGE_LOADER` que la aplicación registra en `app.config.ts`
+(`src/app/providers/sanity-image-loader.ts`), que es quien conoce la caja donde la imagen se pinta —
+el ACL no: la misma portada alimenta una tarjeta chica y el fondo a ancho completo de un hero.
+Agregar un parámetro acá lo **duplica** en la URL final, porque el loader corre igual sobre lo que
+el mapper emitió.
 
 ---
 

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -91,11 +91,8 @@ export function mapAuthorTeaser(
 }
 
 /**
- * URL canónica del asset, sin parámetros de transformación.
- *
- * Los de tamaño, formato y calidad los agrega el `IMAGE_LOADER` del frontend, que es quien conoce la
- * caja donde la imagen se pinta. Agregar acá alguno de ellos lo duplica en la URL final, porque el
- * loader corre igual sobre lo que emite este mapper.
+ * URL canónica del asset, sin parámetros de transformación: los agrega el `IMAGE_LOADER` del
+ * frontend. Agregar uno acá lo duplicaría, y el CDN se queda con el primero.
  */
 export function urlFor(source: SanityImageSource): string {
 	if (!source) {

--- a/src/api/_utils/functions.ts
+++ b/src/api/_utils/functions.ts
@@ -90,6 +90,13 @@ export function mapAuthorTeaser(
 	};
 }
 
+/**
+ * URL canónica del asset, sin parámetros de transformación.
+ *
+ * Los de tamaño, formato y calidad los agrega el `IMAGE_LOADER` del frontend, que es quien conoce la
+ * caja donde la imagen se pinta. Agregar acá alguno de ellos lo duplica en la URL final, porque el
+ * loader corre igual sobre lo que emite este mapper.
+ */
 export function urlFor(source: SanityImageSource): string {
 	if (!source) {
 		console.warn('urlFor: Se recibió source vacío o nulo');
@@ -99,22 +106,6 @@ export function urlFor(source: SanityImageSource): string {
 		return createImageUrlBuilder(client).image(source).url();
 	} catch (error) {
 		console.error('urlFor: Error al construir URL de imagen', { error, source: JSON.stringify(source) });
-		return '';
-	}
-}
-
-export function urlForWithAutoFormat(source: SanityImageSource): string {
-	if (!source) {
-		console.warn('urlForWithAutoFormat: Se recibió source vacío o nulo');
-		return '';
-	}
-	try {
-		return createImageUrlBuilder(client).image(source).auto('format').url();
-	} catch (error) {
-		console.error('urlForWithAutoFormat: Error al construir URL de imagen', {
-			error,
-			source: JSON.stringify(source),
-		});
 		return '';
 	}
 }
@@ -196,12 +187,12 @@ export function mapContentCampaigns(campaigns: ContentCampaignsSubQuery): Conten
 			url: campaign.url,
 			contents: {
 				xs: {
-					imageUrl: xs.image ? urlForWithAutoFormat(xs.image) : '',
+					imageUrl: xs.image ? urlFor(xs.image) : '',
 					imageWidth: viewportElementSizes.xs.imageWidth,
 					imageHeight: viewportElementSizes.xs.imageHeight,
 				},
 				md: {
-					imageUrl: md.image ? urlForWithAutoFormat(md.image) : '',
+					imageUrl: md.image ? urlFor(md.image) : '',
 					imageWidth: viewportElementSizes.md.imageWidth,
 					imageHeight: viewportElementSizes.md.imageHeight,
 				},

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -10,6 +10,9 @@ import { DatePipe, registerLocaleData } from '@angular/common';
 // Layout
 import { provideLayout } from './providers/layout.provider';
 
+// Imágenes
+import { provideSanityImageLoader } from './providers/sanity-image-loader';
+
 // SEO providers
 import { provideSchemaOrgInitializer } from './providers/schema-org.initializer';
 
@@ -31,6 +34,9 @@ export const appConfig: ApplicationConfig = {
 
 		// Layout
 		provideLayout(),
+
+		// Imágenes
+		provideSanityImageLoader(),
 
 		// SEO providers
 		provideSchemaOrgInitializer(),

--- a/src/app/components/author-card-teaser/author-card-teaser.component.spec.ts
+++ b/src/app/components/author-card-teaser/author-card-teaser.component.spec.ts
@@ -48,12 +48,11 @@ describe('AuthorCardTeaserComponent', () => {
 		);
 	});
 
-	it('should request the avatar at 2x of 80px (HiDPI)', async () => {
+	// Lo que esta tarjeta decide es el tamaño del avatar; qué se le pide al CDN a partir de él lo
+	// resuelven el loader de imágenes y `ImageProfileComponent`, que tienen sus propios specs.
+	it('should mount the avatar at the lg size', async () => {
 		await render(AuthorCardTeaserComponent, { inputs: { author: authorTeaserMock } });
-		expect(screen.getByRole('img', { name: avatarName })).toHaveAttribute(
-			'src',
-			expect.stringContaining('h=160&w=160'),
-		);
+		expect(screen.getByRole('img', { name: avatarName })).toHaveAttribute('width', '80');
 	});
 
 	it('should render the nationality flag', async () => {

--- a/src/app/components/author-card-teaser/author-card-teaser.component.spec.ts
+++ b/src/app/components/author-card-teaser/author-card-teaser.component.spec.ts
@@ -48,8 +48,7 @@ describe('AuthorCardTeaserComponent', () => {
 		);
 	});
 
-	// Lo que esta tarjeta decide es el tamaño del avatar; qué se le pide al CDN a partir de él lo
-	// resuelven el loader de imágenes y `ImageProfileComponent`, que tienen sus propios specs.
+	// La tarjeta decide el tamaño; qué se le pide al CDN a partir de él tiene sus propios specs.
 	it('should mount the avatar at the lg size', async () => {
 		await render(AuthorCardTeaserComponent, { inputs: { author: authorTeaserMock } });
 		expect(screen.getByRole('img', { name: avatarName })).toHaveAttribute('width', '80');

--- a/src/app/components/image-profile/image-profile.component.spec.ts
+++ b/src/app/components/image-profile/image-profile.component.spec.ts
@@ -29,9 +29,8 @@ describe('ImageProfileComponent', () => {
 		expect(img).not.toHaveAttribute('src', expect.stringContaining('photo.jpg'));
 	});
 
-	// El componente ya no arma la URL: declara el tamaño de display y el loader deriva de ahí lo que se
-	// le pide al CDN. Se ejercita con el loader real —el mismo que la aplicación registra— porque lo que
-	// hay que afirmar es el resultado de los dos juntos, no el contrato de cada uno por separado.
+	// El componente declara el tamaño de display y el loader deriva de ahí lo que se le pide al CDN. Se
+	// ejercita con el loader real porque lo que importa es el resultado de los dos juntos.
 	describe('Tamaño solicitado al CDN', () => {
 		const renderWithLoader = (size: ImageProfileSize) =>
 			render(ImageProfileComponent, {
@@ -39,8 +38,7 @@ describe('ImageProfileComponent', () => {
 				providers: [provideSanityImageLoader()],
 			});
 
-		// Se afirma sobre el `srcset` y no sobre el `src`: NgOptimizedImage deja en `src` la URL sin ancho,
-		// como fallback, y son las entradas del `srcset` las que el navegador elige y descarga.
+		// Sobre el `srcset`, que es de donde el navegador elige; el `src` queda sin ancho, como fallback.
 		it.each([
 			['small', 24],
 			['medium', 40],
@@ -51,8 +49,7 @@ describe('ImageProfileComponent', () => {
 
 			const srcset = screen.getByRole('img', { name: alt }).getAttribute('srcset');
 			expect(srcset).toContain(`${src}?w=${px}&auto=format&q=75 1x`);
-			// La densidad la cubre el `srcset`, y por eso el componente dejó de pedir el doble a mano:
-			// pedirlo de nuevo duplicaría el parámetro.
+			// La densidad la cubre el `srcset`: pedir el doble a mano duplicaría el parámetro.
 			expect(srcset).toContain(`${src}?w=${px * 2}&auto=format&q=75 2x`);
 		});
 

--- a/src/app/components/image-profile/image-profile.component.spec.ts
+++ b/src/app/components/image-profile/image-profile.component.spec.ts
@@ -1,5 +1,7 @@
-import { ImageProfileComponent } from './image-profile.component';
+import { ImageProfileComponent, type ImageProfileSize } from './image-profile.component';
 import { render, screen } from '@testing-library/angular';
+
+import { provideSanityImageLoader } from '../../providers/sanity-image-loader';
 
 describe('ImageProfileComponent', () => {
 	const src = 'https://cdn.sanity.io/images/x/photo.jpg';
@@ -27,25 +29,37 @@ describe('ImageProfileComponent', () => {
 		expect(img).not.toHaveAttribute('src', expect.stringContaining('photo.jpg'));
 	});
 
-	describe('Avatar resize (2x del tamaño de display)', () => {
-		it('should request small at 48px', async () => {
-			await render(ImageProfileComponent, { inputs: { src, alt, size: 'small' } });
-			expect(screen.getByRole('img', { name: alt })).toHaveAttribute('src', expect.stringContaining('h=48&w=48'));
+	// El componente ya no arma la URL: declara el tamaño de display y el loader deriva de ahí lo que se
+	// le pide al CDN. Se ejercita con el loader real —el mismo que la aplicación registra— porque lo que
+	// hay que afirmar es el resultado de los dos juntos, no el contrato de cada uno por separado.
+	describe('Tamaño solicitado al CDN', () => {
+		const renderWithLoader = (size: ImageProfileSize) =>
+			render(ImageProfileComponent, {
+				inputs: { src, alt, size },
+				providers: [provideSanityImageLoader()],
+			});
+
+		// Se afirma sobre el `srcset` y no sobre el `src`: NgOptimizedImage deja en `src` la URL sin ancho,
+		// como fallback, y son las entradas del `srcset` las que el navegador elige y descarga.
+		it.each([
+			['small', 24],
+			['medium', 40],
+			['lg', 80],
+			['xl', 120],
+		] as const)('should offer %s at its display size (%ipx) and at twice it', async (size, px) => {
+			await renderWithLoader(size);
+
+			const srcset = screen.getByRole('img', { name: alt }).getAttribute('srcset');
+			expect(srcset).toContain(`${src}?w=${px}&auto=format&q=75 1x`);
+			// La densidad la cubre el `srcset`, y por eso el componente dejó de pedir el doble a mano:
+			// pedirlo de nuevo duplicaría el parámetro.
+			expect(srcset).toContain(`${src}?w=${px * 2}&auto=format&q=75 2x`);
 		});
 
-		it('should request medium at 80px', async () => {
-			await render(ImageProfileComponent, { inputs: { src, alt, size: 'medium' } });
-			expect(screen.getByRole('img', { name: alt })).toHaveAttribute('src', expect.stringContaining('h=80&w=80'));
-		});
-
-		it('should request lg at 160px', async () => {
-			await render(ImageProfileComponent, { inputs: { src, alt, size: 'lg' } });
-			expect(screen.getByRole('img', { name: alt })).toHaveAttribute('src', expect.stringContaining('h=160&w=160'));
-		});
-
-		it('should request xl at 240px', async () => {
-			await render(ImageProfileComponent, { inputs: { src, alt, size: 'xl' } });
-			expect(screen.getByRole('img', { name: alt })).toHaveAttribute('src', expect.stringContaining('h=240&w=240'));
+		// El placeholder es un asset propio y no del CDN: el loader tiene que dejarlo intacto.
+		it('should leave the local placeholder untouched', async () => {
+			await render(ImageProfileComponent, { inputs: { alt }, providers: [provideSanityImageLoader()] });
+			expect(screen.getByRole('img', { name: alt })).toHaveAttribute('src', expect.not.stringContaining('auto=format'));
 		});
 	});
 });

--- a/src/app/components/image-profile/image-profile.component.ts
+++ b/src/app/components/image-profile/image-profile.component.ts
@@ -1,8 +1,6 @@
 import { Component, computed, input } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
 
-import { withSanityImageParams } from '@utils/sanity-image.utils';
-
 /** Tamaños del avatar (Design System v3): small=24px, medium=40px, lg=80px, xl=120px. */
 export type ImageProfileSize = 'small' | 'medium' | 'lg' | 'xl';
 
@@ -57,9 +55,8 @@ export class ImageProfileComponent {
 		if (!src) {
 			return { url: PROFILE_PLACEHOLDER, px: px / 2, classes: icon, background: 'bg-neutral-300' };
 		}
-		// photo: la imagen se solicita al CDN a 2x (HiDPI) del tamaño de display.
 		return {
-			url: withSanityImageParams(src, { h: px * 2, w: px * 2 }),
+			url: src,
 			px,
 			classes: 'size-full object-cover',
 			background: 'bg-neutral-300',

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header.component.spec.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header.component.spec.ts
@@ -23,19 +23,26 @@ describe('LiteraryWorkHeroHeaderComponent', () => {
 		expect(link).toHaveAttribute('href', expect.stringContaining(`/author/${author.slug}`));
 	});
 
-	// El fondo va con `fill` + `sizes="100vw"`, así que el loader recibe un ancho por breakpoint en vez de
-	// uno fijo. Se afirma sobre el `srcset` porque es de donde el navegador elige; el `src` queda como
-	// fallback sin ancho.
-	it('should render the blurred background offering a width per breakpoint', async () => {
-		const coverImage = 'https://cdn.sanity.io/images/x/cover-1024x1536.png';
+	// El fondo y la portada comparten una descarga porque piden la misma URL, y nada en el código las
+	// ata: el hero elige su ancho por su cuenta. Este caso es el que sostiene esa coincidencia, así que
+	// compara lo que renderiza cada una en vez de afirmar la medida que se espera de ambas.
+	it('should request the very same image as the foreground cover', async () => {
 		await render(LiteraryWorkHeroHeaderComponent, {
-			inputs: { literaryWork: { ...literaryWork, coverImage } },
+			inputs: { literaryWork: { ...literaryWork, coverImage: 'https://cdn.sanity.io/images/x/cover-1024x1536.png' } },
 			providers: [provideSanityImageLoader()],
 		});
 
-		const srcset = screen.getByTestId('hero-background').getAttribute('srcset');
-		expect(srcset).toContain(`${coverImage}?w=640&auto=format&q=75 640w`);
-		expect(srcset).toContain(`${coverImage}?w=1920&auto=format&q=75 1920w`);
+		const background = screen.getByTestId('hero-background');
+		const requested = background.getAttribute('src');
+
+		// Control positivo: sin él, dos atributos ausentes se darían por coincidentes.
+		expect(requested).toContain('auto=format');
+		// Sin variantes por breakpoint: cada una traería la imagen de nuevo a otro ancho, que es
+		// justamente lo que se quiere evitar.
+		expect(background).not.toHaveAttribute('srcset');
+		// La portada sí declara `width`, así que su URL con ancho vive en el `srcset` —el `src` es su
+		// fallback— y es la entrada 1× la que tiene que coincidir con la del fondo.
+		expect(screen.getByTestId('cover-image').getAttribute('srcset')).toContain(`${requested} 1x`);
 	});
 
 	// El canon guarda sus portadas como assets propios del repo, así que este caso es además el que
@@ -46,7 +53,7 @@ describe('LiteraryWorkHeroHeaderComponent', () => {
 			providers: [provideSanityImageLoader()],
 		});
 
-		expect(screen.getByTestId('hero-background').getAttribute('srcset')).not.toContain('auto=format');
+		expect(screen.getByTestId('hero-background')).toHaveAttribute('src', literaryWork.coverImage);
 	});
 
 	it('should not render the background when the literary work has no cover', async () => {

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header.component.spec.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header.component.spec.ts
@@ -4,6 +4,7 @@ import type { LiteraryWork } from '@models/literary-work.model';
 import { LiteraryWorkHeroHeaderComponent } from './literary-work-hero-header.component';
 import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
 import { onoffTagsMock } from '@mocks/onoff-tags.mock';
+import { provideSanityImageLoader } from '../../providers/sanity-image-loader';
 
 describe('LiteraryWorkHeroHeaderComponent', () => {
 	const tags = onoffTagsMock.slice(0, 2);
@@ -22,9 +23,30 @@ describe('LiteraryWorkHeroHeaderComponent', () => {
 		expect(link).toHaveAttribute('href', expect.stringContaining(`/author/${author.slug}`));
 	});
 
-	it('should render the blurred background from the cover requested at 1920px width', async () => {
-		await render(LiteraryWorkHeroHeaderComponent, { inputs: { literaryWork } });
-		expect(screen.getByTestId('hero-background')).toHaveAttribute('src', expect.stringContaining('w=1920'));
+	// El fondo va con `fill` + `sizes="100vw"`, así que el loader recibe un ancho por breakpoint en vez de
+	// uno fijo. Se afirma sobre el `srcset` porque es de donde el navegador elige; el `src` queda como
+	// fallback sin ancho.
+	it('should render the blurred background offering a width per breakpoint', async () => {
+		const coverImage = 'https://cdn.sanity.io/images/x/cover-1024x1536.png';
+		await render(LiteraryWorkHeroHeaderComponent, {
+			inputs: { literaryWork: { ...literaryWork, coverImage } },
+			providers: [provideSanityImageLoader()],
+		});
+
+		const srcset = screen.getByTestId('hero-background').getAttribute('srcset');
+		expect(srcset).toContain(`${coverImage}?w=640&auto=format&q=75 640w`);
+		expect(srcset).toContain(`${coverImage}?w=1920&auto=format&q=75 1920w`);
+	});
+
+	// El canon guarda sus portadas como assets propios del repo, así que este caso es además el que
+	// ejercita el guard de origen del loader: una URL que no es del CDN tiene que llegar intacta.
+	it('should leave a cover that does not come from the CDN untouched', async () => {
+		await render(LiteraryWorkHeroHeaderComponent, {
+			inputs: { literaryWork },
+			providers: [provideSanityImageLoader()],
+		});
+
+		expect(screen.getByTestId('hero-background').getAttribute('srcset')).not.toContain('auto=format');
 	});
 
 	it('should not render the background when the literary work has no cover', async () => {

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header.component.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header.component.ts
@@ -1,10 +1,10 @@
-import { Component, computed, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
 import { RouterLink } from '@angular/router';
 
 import type { LiteraryWork } from '@models/literary-work.model';
-import { withSanityImageParams } from '@utils/sanity-image.utils';
 import { AppRoutes } from '../../app.routes';
+import type { SanityImageLoaderParams } from '../../providers/sanity-image-loader';
 import { CoverImageComponent } from '../cover-image/cover-image.component';
 import { ImageProfileComponent } from '../image-profile/image-profile.component';
 import { TagComponent } from '../tag/tag.component';
@@ -36,12 +36,13 @@ import { LiteraryWorkHeroHeaderSkeletonComponent } from './literary-work-hero-he
 	host: { class: 'relative isolate block overflow-hidden bg-neutral-900' },
 	template: `
 		@if (literaryWork(); as literaryWork) {
-			@if (backgroundImageUrl(); as backgroundImageUrl) {
+			@if (literaryWork.coverImage; as coverImage) {
 				<img
-					[ngSrc]="backgroundImageUrl"
+					[ngSrc]="coverImage"
+					[loaderParams]="backgroundLoaderParams"
 					fill
 					priority
-					sizes="100vw"
+					disableOptimizedSrcset
 					alt=""
 					class="scale-105 object-cover blur-xl"
 					data-testid="hero-background"
@@ -51,7 +52,7 @@ import { LiteraryWorkHeroHeaderSkeletonComponent } from './literary-work-hero-he
 
 			<div class="relative z-content px-6 pt-28 pb-10">
 				<div class="mx-auto flex w-full max-w-180 items-center gap-8">
-					<cuentoneta-cover-image [src]="backgroundImageUrl()" [priority]="true" />
+					<cuentoneta-cover-image [src]="literaryWork.coverImage" [priority]="true" />
 					<div class="flex min-w-0 flex-col items-start gap-2.5">
 						<cuentoneta-tags-list data-testid="tags">
 							@for (tag of literaryWork.tags; track tag.slug) {
@@ -86,7 +87,9 @@ export class LiteraryWorkHeroHeaderComponent {
 
 	public readonly literaryWork = input<LiteraryWork>();
 
-	protected readonly backgroundImageUrl = computed(() =>
-		withSanityImageParams(this.literaryWork()?.coverImage ?? '', { w: 118 }),
-	);
+	// El ancho es el de la portada en primer plano, para que las dos pidan la misma URL y compartan una
+	// sola descarga. El fondo va difuminado y bajo un velo, así que no pierde nada con esa medida. Que
+	// sigan coincidiendo lo afirma el spec comparando lo que renderiza cada una, no una constante
+	// compartida: acá el número es una decisión de este componente y no un contrato con `CoverImage`.
+	protected readonly backgroundLoaderParams: SanityImageLoaderParams = { width: 118 };
 }

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header.component.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header.component.ts
@@ -3,6 +3,7 @@ import { NgOptimizedImage } from '@angular/common';
 import { RouterLink } from '@angular/router';
 
 import type { LiteraryWork } from '@models/literary-work.model';
+import { withSanityImageParams } from '@utils/sanity-image.utils';
 import { AppRoutes } from '../../app.routes';
 import { CoverImageComponent } from '../cover-image/cover-image.component';
 import { ImageProfileComponent } from '../image-profile/image-profile.component';
@@ -50,7 +51,7 @@ import { LiteraryWorkHeroHeaderSkeletonComponent } from './literary-work-hero-he
 
 			<div class="relative z-content px-6 pt-28 pb-10">
 				<div class="mx-auto flex w-full max-w-180 items-center gap-8">
-					<cuentoneta-cover-image [src]="literaryWork.coverImage" [priority]="true" />
+					<cuentoneta-cover-image [src]="backgroundImageUrl()" [priority]="true" />
 					<div class="flex min-w-0 flex-col items-start gap-2.5">
 						<cuentoneta-tags-list data-testid="tags">
 							@for (tag of literaryWork.tags; track tag.slug) {
@@ -85,7 +86,7 @@ export class LiteraryWorkHeroHeaderComponent {
 
 	public readonly literaryWork = input<LiteraryWork>();
 
-	// Sin parámetros de transformación: los agrega el `IMAGE_LOADER` a partir del `sizes` del `<img>`,
-	// que acá declara el ancho real que ocupa la banda.
-	protected readonly backgroundImageUrl = computed(() => this.literaryWork()?.coverImage);
+	protected readonly backgroundImageUrl = computed(() =>
+		withSanityImageParams(this.literaryWork()?.coverImage ?? '', { w: 118 }),
+	);
 }

--- a/src/app/components/literary-work-hero-header/literary-work-hero-header.component.ts
+++ b/src/app/components/literary-work-hero-header/literary-work-hero-header.component.ts
@@ -3,7 +3,6 @@ import { NgOptimizedImage } from '@angular/common';
 import { RouterLink } from '@angular/router';
 
 import type { LiteraryWork } from '@models/literary-work.model';
-import { withSanityImageParams } from '@utils/sanity-image.utils';
 import { AppRoutes } from '../../app.routes';
 import { CoverImageComponent } from '../cover-image/cover-image.component';
 import { ImageProfileComponent } from '../image-profile/image-profile.component';
@@ -86,7 +85,7 @@ export class LiteraryWorkHeroHeaderComponent {
 
 	public readonly literaryWork = input<LiteraryWork>();
 
-	protected readonly backgroundImageUrl = computed(() =>
-		withSanityImageParams(this.literaryWork()?.coverImage ?? '', { w: 1920 }),
-	);
+	// Sin parámetros de transformación: los agrega el `IMAGE_LOADER` a partir del `sizes` del `<img>`,
+	// que acá declara el ancho real que ocupa la banda.
+	protected readonly backgroundImageUrl = computed(() => this.literaryWork()?.coverImage);
 }

--- a/src/app/providers/sanity-image-loader.spec.ts
+++ b/src/app/providers/sanity-image-loader.spec.ts
@@ -1,0 +1,28 @@
+import { sanityImageLoader } from './sanity-image-loader';
+
+const CDN = 'https://cdn.sanity.io/images/s4dbqkc5/production/abc-1024x1536.png';
+
+describe('sanityImageLoader', () => {
+	it('pide el ancho, el formato negociado y la calidad de la aplicación', () => {
+		expect(sanityImageLoader({ src: CDN, width: 400 })).toBe(`${CDN}?w=400&auto=format&q=75`);
+	});
+
+	it('respeta el recorte que el Studio dejó en la query string', () => {
+		const cropped = `${CDN}?rect=0,0,660,660`;
+
+		expect(sanityImageLoader({ src: cropped, width: 400 })).toBe(`${cropped}&w=400&auto=format&q=75`);
+	});
+
+	it('omite el ancho cuando el consumidor no lo declara', () => {
+		expect(sanityImageLoader({ src: CDN })).toBe(`${CDN}?auto=format&q=75`);
+	});
+
+	it.each([
+		'./assets/svg/logo.svg',
+		'/assets/svg/cover-placeholder.svg',
+		'https://user-images.githubusercontent.com/1/2.png',
+		'https://cdn.sanity.io.evil.com/images/abc.png',
+	])('deja intacto "%s", que no es del CDN', (src) => {
+		expect(sanityImageLoader({ src, width: 400 })).toBe(src);
+	});
+});

--- a/src/app/providers/sanity-image-loader.ts
+++ b/src/app/providers/sanity-image-loader.ts
@@ -1,0 +1,39 @@
+import { IMAGE_LOADER, type ImageLoaderConfig } from '@angular/common';
+import { makeEnvironmentProviders, type EnvironmentProviders } from '@angular/core';
+
+import { isSanityImageUrl, withSanityImageParams } from '@utils/sanity-image.utils';
+
+/**
+ * Deriva de cada `ngSrc` la URL que el navegador realmente pide al CDN de Sanity.
+ *
+ * El ACL emite la URL canónica del asset, sin parámetros: el ancho al que una imagen se pinta es un
+ * dato de la pantalla, y el backend no lo conoce —la misma portada alimenta una tarjeta chica y el
+ * fondo del hero—. Sin un loader, `NgOptimizedImage` no reescribe nada y se descarga el original,
+ * que en este dataset llega a pesar megabytes para una caja de un par de cientos de píxeles.
+ */
+
+/**
+ * Calidad de recompresión que pide la app. Fijarla acá, y no dejar la del CDN, es lo que vuelve
+ * predecible el peso de una imagen frente a un original subido sin optimizar.
+ */
+const IMAGE_QUALITY = 75;
+
+/**
+ * Devuelve el `src` intacto cuando no es del CDN de Sanity — el loader intercepta *todo* `ngSrc` de
+ * la aplicación, incluidos los assets propios y algún host externo, así que el guard es lo que
+ * impide corromperlos.
+ *
+ * `NgOptimizedImage` invoca al loader una vez por entrada del `srcset` —con el ancho de cada una— y
+ * otra sin ancho para el `src` de fallback, que queda sin `w` a propósito: es el que usa un
+ * navegador que no entiende `srcset`.
+ */
+export function sanityImageLoader(config: ImageLoaderConfig): string {
+	if (!isSanityImageUrl(config.src)) {
+		return config.src;
+	}
+	return withSanityImageParams(config.src, { w: config.width, auto: 'format', q: IMAGE_QUALITY });
+}
+
+export function provideSanityImageLoader(): EnvironmentProviders {
+	return makeEnvironmentProviders([{ provide: IMAGE_LOADER, useValue: sanityImageLoader }]);
+}

--- a/src/app/providers/sanity-image-loader.ts
+++ b/src/app/providers/sanity-image-loader.ts
@@ -4,34 +4,46 @@ import { makeEnvironmentProviders, type EnvironmentProviders } from '@angular/co
 import { isSanityImageUrl, withSanityImageParams } from '@utils/sanity-image.utils';
 
 /**
- * Deriva de cada `ngSrc` la URL que el navegador realmente pide al CDN de Sanity.
+ * Único punto donde se le agregan parámetros de transformación a una imagen de Sanity.
  *
- * El ACL emite la URL canónica del asset, sin parámetros: el ancho al que una imagen se pinta es un
- * dato de la pantalla, y el backend no lo conoce —la misma portada alimenta una tarjeta chica y el
- * fondo del hero—. Sin un loader, `NgOptimizedImage` no reescribe nada y se descarga el original,
- * que en este dataset llega a pesar megabytes para una caja de un par de cientos de píxeles.
+ * El ACL emite la URL canónica del asset: el ancho al que se pinta es un dato de la pantalla, y el
+ * backend no lo conoce —la misma portada alimenta una tarjeta chica y el fondo de un hero—. Envolver
+ * la URL además en el componente duplica el parámetro, y el CDN se queda con el primero.
  */
 
-/**
- * Calidad de recompresión que pide la app. Fijarla acá, y no dejar la del CDN, es lo que vuelve
- * predecible el peso de una imagen frente a un original subido sin optimizar.
- */
+// La calidad la fija la app y no el CDN, para que el peso no dependa de cuán optimizado se haya
+// subido cada original.
 const IMAGE_QUALITY = 75;
 
+/** Lo que un `<img>` puede pedirle al loader por `[loaderParams]`. */
+export type SanityImageLoaderParams = {
+	/**
+	 * Ancho a pedir, en píxeles, en lugar del que `NgOptimizedImage` deriva del `<img>`. Para una
+	 * imagen cuyo tamaño de descarga no se sigue del espacio que ocupa: un fondo difuminado, que se
+	 * estira a la pantalla entera pero no gana nada con resolución.
+	 */
+	readonly width?: number;
+};
+
 /**
- * Devuelve el `src` intacto cuando no es del CDN de Sanity — el loader intercepta *todo* `ngSrc` de
- * la aplicación, incluidos los assets propios y algún host externo, así que el guard es lo que
- * impide corromperlos.
+ * Devuelve el `src` intacto cuando no es del CDN de Sanity: el loader intercepta *todo* `ngSrc` de
+ * la aplicación, incluidos los assets propios y algún host externo, y el guard es lo que impide
+ * corromperlos.
  *
- * `NgOptimizedImage` invoca al loader una vez por entrada del `srcset` —con el ancho de cada una— y
- * otra sin ancho para el `src` de fallback, que queda sin `w` a propósito: es el que usa un
- * navegador que no entiende `srcset`.
+ * Sin ancho —el `src` de fallback, que `NgOptimizedImage` pide aparte de las entradas del `srcset`—
+ * el CDN sirve el original, negociado en formato y calidad.
  */
 export function sanityImageLoader(config: ImageLoaderConfig): string {
 	if (!isSanityImageUrl(config.src)) {
 		return config.src;
 	}
-	return withSanityImageParams(config.src, { w: config.width, auto: 'format', q: IMAGE_QUALITY });
+
+	const requested: SanityImageLoaderParams | undefined = config.loaderParams;
+	return withSanityImageParams(config.src, {
+		w: requested?.width ?? config.width,
+		auto: 'format',
+		q: IMAGE_QUALITY,
+	});
 }
 
 export function provideSanityImageLoader(): EnvironmentProviders {

--- a/src/utils/sanity-image.utils.spec.ts
+++ b/src/utils/sanity-image.utils.spec.ts
@@ -1,4 +1,31 @@
-import { withSanityImageParams } from './sanity-image.utils';
+import { isSanityImageUrl, withSanityImageParams } from './sanity-image.utils';
+
+describe('isSanityImageUrl', () => {
+	it.each([
+		'https://cdn.sanity.io/images/s4dbqkc5/production/abc-1024x1536.png',
+		'https://cdn.sanity.io/images/s4dbqkc5/production/abc-660x860.png?rect=0,0,660,660',
+		'https://cdn.sanity.io/files/s4dbqkc5/production/abc.m4a',
+	])('should recognize "%s" as a CDN asset', (url) => {
+		expect(isSanityImageUrl(url)).toBe(true);
+	});
+
+	it.each([
+		// Un host que contiene el del CDN como sufijo o como segmento de ruta no es el CDN: se compara
+		// el hostname parseado, no el texto.
+		'https://cdn.sanity.io.evil.com/images/abc.png',
+		'https://evil.com/cdn.sanity.io/images/abc.png',
+		'https://www.sanity.io/images/abc.png',
+		// El CDN solo sirve por HTTPS.
+		'http://cdn.sanity.io/images/abc.png',
+		// Lo que la aplicación pinta con `ngSrc` sin ser de Sanity: assets propios y un host externo.
+		'./assets/svg/logo.svg',
+		'/assets/svg/cover-placeholder.svg',
+		'https://user-images.githubusercontent.com/1/2.png',
+		'',
+	])('should not recognize "%s"', (url) => {
+		expect(isSanityImageUrl(url)).toBe(false);
+	});
+});
 
 describe('withSanityImageParams', () => {
 	const base = 'https://cdn.sanity.io/images/s4dbqkc5/production/abc-580x579.avif';
@@ -15,6 +42,10 @@ describe('withSanityImageParams', () => {
 
 	it('should include auto=format when requested', () => {
 		expect(withSanityImageParams(base, { h: 60, w: 60, auto: 'format' })).toBe(`${base}?h=60&w=60&auto=format`);
+	});
+
+	it('should include the recompression quality when requested', () => {
+		expect(withSanityImageParams(base, { w: 400, auto: 'format', q: 75 })).toBe(`${base}?w=400&auto=format&q=75`);
 	});
 
 	it('should omit params whose value is undefined', () => {

--- a/src/utils/sanity-image.utils.ts
+++ b/src/utils/sanity-image.utils.ts
@@ -3,14 +3,12 @@ const SANITY_CDN_HOSTNAME = 'cdn.sanity.io';
 /**
  * Verdadero solo si `url` es una URL absoluta servida por el CDN de Sanity.
  *
- * Vive en el kernel y no en cada consumidor porque quienes lo usan tienen que reconocer **el mismo**
- * conjunto: el `IMAGE_LOADER` de la aplicación decide con esto qué transforma, y la intercepción de
- * los e2e decide con esto qué sustituye. Dos definiciones que divergieran dejarían el bloqueo de los
- * tests pasando en verde sobre un conjunto distinto del que la aplicación pide.
+ * Compartido a propósito: el loader de la aplicación decide con esto qué transforma y la
+ * intercepción de los e2e qué sustituye, y dos definiciones que divergieran dejarían a los tests
+ * cubriendo un conjunto distinto del que la aplicación pide.
  *
- * Compara el hostname parseado y no el texto de la URL, porque `https://cdn.sanity.io.evil.com/x.png`
- * lo contiene sin ser el CDN. El protocolo se exige explícito: el CDN solo sirve por HTTPS, así que
- * cualquier otro esquema es algo que no queremos ni transformar ni dar por sustituido.
+ * Compara el hostname parseado y no el texto, porque `https://cdn.sanity.io.evil.com/x.png` lo
+ * contiene sin ser el CDN.
  */
 export function isSanityImageUrl(url: string): boolean {
 	try {

--- a/src/utils/sanity-image.utils.ts
+++ b/src/utils/sanity-image.utils.ts
@@ -1,8 +1,33 @@
+const SANITY_CDN_HOSTNAME = 'cdn.sanity.io';
+
+/**
+ * Verdadero solo si `url` es una URL absoluta servida por el CDN de Sanity.
+ *
+ * Vive en el kernel y no en cada consumidor porque quienes lo usan tienen que reconocer **el mismo**
+ * conjunto: el `IMAGE_LOADER` de la aplicación decide con esto qué transforma, y la intercepción de
+ * los e2e decide con esto qué sustituye. Dos definiciones que divergieran dejarían el bloqueo de los
+ * tests pasando en verde sobre un conjunto distinto del que la aplicación pide.
+ *
+ * Compara el hostname parseado y no el texto de la URL, porque `https://cdn.sanity.io.evil.com/x.png`
+ * lo contiene sin ser el CDN. El protocolo se exige explícito: el CDN solo sirve por HTTPS, así que
+ * cualquier otro esquema es algo que no queremos ni transformar ni dar por sustituido.
+ */
+export function isSanityImageUrl(url: string): boolean {
+	try {
+		const { hostname, protocol } = new URL(url);
+		return hostname === SANITY_CDN_HOSTNAME && protocol === 'https:';
+	} catch {
+		return false;
+	}
+}
+
 // Parámetros de transformación del CDN de Sanity que la UI agrega sobre una URL ya resuelta.
 export type SanityImageParams = {
 	w?: number;
 	h?: number;
 	auto?: 'format';
+	/** Calidad de recompresión, 0–100. Sin él, el CDN aplica la suya. */
+	q?: number;
 };
 
 /**


### PR DESCRIPTION
Segundo de cuatro PRs apilados que contienen el consumo de ancho de banda de Sanity. **Apilado sobre #2439** — la base de este PR es su rama, así que hay que mergear aquél primero.

Es el defecto de base de todo el issue, y el de mayor factor de reducción: arregla producción, el rastreo de los crawlers y los e2e a la vez.

## El problema

El sitio sirve los **originales** del CDN. `urlFor()` emite la URL del asset sin parámetros, y la aplicación no registra ningún `IMAGE_LOADER`, así que `NgOptimizedImage` no reescribe nada: el `width` declarado dimensiona el `<img>`, no lo que viaja. Medido sobre la home de producción, son 30 imágenes por **11,3 MB**, con PNG de 1024×1536 y hasta 1,85 MB pintados como portadas chicas.

## Qué cambia

**La transformación entra por un `IMAGE_LOADER`, no por el ACL.** El ancho al que una imagen se pinta es un dato de la pantalla y el backend no lo conoce: la misma portada alimenta una tarjeta chica y el fondo a ancho completo del hero, así que hornear una medida en el mapper rompería a alguno de los dos consumos.

**El loader arranca con un guard de origen**, porque intercepta *todo* `ngSrc` de la aplicación y hay varios que no son de Sanity: los SVG propios del header, el footer y el placeholder de portada, más un host externo en la página de about. El predicado vive en el kernel (`@utils/sanity-image.utils`) y no en el loader: el PR siguiente lo necesita para que la intercepción de los e2e reconozca **el mismo** conjunto que la aplicación transforma.

**Se retiran las dos llamadas manuales** que envolvían la URL en el componente, y con ellas `urlForWithAutoFormat()` del ACL: con el loader puesto, transformar en dos lugares duplica el parámetro. No es hipotético — se verificó contra el HTML servido, donde las imágenes de campaña salían con `auto=format` dos veces.

**`ImageProfileComponent` deja de pedir el doble a mano.** La densidad la cubre el `srcset` que `NgOptimizedImage` emite a partir del tamaño de display.

## Sobre los specs

Los de las dos piezas afectadas pasan a afirmar sobre el `srcset` y no sobre el `src`, que queda como fallback sin ancho a propósito —es el que usa un navegador que no entiende `srcset`—, y ejercitan el **loader real** en vez del contrato de cada pieza por separado, lo que los convierte además en la verificación de integración del guard. El de la tarjeta de autor deja de afirmar la URL resultante: lo que esa tarjeta decide es el tamaño del avatar, no qué se le pide al CDN.

## Cómo se verificó

- Suite unitaria completa, `lint`, `typecheck`, `check:agents` y `build` en verde.
- Contra el HTML que sirve el build de producción: las URLs emitidas pasaron de la del original a `?w=<ancho>&auto=format&q=75`, y el `auto=format` duplicado de las campañas se observó antes y desapareció después de retirar el helper del ACL.
- Sobre los mismos assets: 6,5 MB sin transformar contra unos 157 KB en las variantes que ahora se piden.

## Fuera de alcance

Los tamaños concretos que pide cada componente de portada se ajustan en #2432. Acá se decide **si** se transforman y por dónde, no con qué medida.

Parte de #2431.
