### PR TITLE
[#2431] - Extiende la caché de borde al resto del API y de las páginas SSR

### DIFF
--- a/docs/LITERARY_WORK_DESIGN.md
+++ b/docs/LITERARY_WORK_DESIGN.md
@@ -407,6 +407,21 @@ El contrato del frontend (Slice 1) es entonces:
 
 La cache key del CDN de Vercel incluye el query string, así que si la página llega a tener variantes por query, cada una se cachea por separado (hoy no las tiene: la navegación por sección está diferida, ver [§7](#7-contrato-del-endpoint)).
 
+### El mecanismo dejó de ser exclusivo de la obra
+
+Esta sección describe el origen del mecanismo, que nació para la página de lectura. Hoy la política es **del sitio**: los mismos dos middlewares y el mismo helper cubren las páginas SSR indexables (`/home`, `/about`, `/author/:slug`, `/collection` y `/collection/:slug`, además de la obra) y las rutas de lectura de los módulos del API. Lo que motivó extenderlo no es el costo de una obra sino el del rastreo: el sitemap publica cerca de mil URLs, y sin esta capa cada visita de un crawler a cualquiera de ellas vuelve a consultar a Sanity.
+
+Tres cosas que la extensión no cambia y una que sí:
+
+- **El TTL sigue siendo único** para todas las rutas. Parametrizarlo por módulo se evaluó y se descartó por ahora: haría falta cuando alguna ruta necesite una ventana de propagación distinta de las demás, y hoy ninguna la pide.
+- **Sigue sin haber invalidación explícita**, con el mismo razonamiento de arriba.
+- **El corte por entorno y la guarda anti-CSR son los mismos**, y esta última pesa más que antes: la home es justamente donde el deopt a CSR ya ocurrió en producción.
+- **Lo que sí cambia es el alcance del trade-off de frescura.** La ventana de propagación de una edición ahora también aplica al contenido rotativo de la home y a las colecciones, que se editan con más frecuencia que una obra ya publicada — a diferencia del contenido de una obra, que es inmutable una vez creada.
+
+**Invariante de deploy que la extensión vuelve más pesado.** El corte por entorno mira `environment.production`, no qué dataset está sirviendo: da por supuesto que un deploy marcado como producción apunta al dataset público. El supuesto no es nuevo, pero antes cubría una ruta y ahora cubre seis páginas y cinco módulos, así que un deploy de producción apuntando por error a un dataset no público —una migración, una prueba, una variable de entorno mal puesta— se serviría desde un CDN compartido en mucha más superficie. Se verifica fuera de banda, al configurar el entorno; si alguna vez conviene volverlo verificable, la vía es comparar además el dataset efectivo contra el público esperado.
+
+El registro es explícito por módulo y por página, nunca un middleware global: cada módulo tiene rutas de escritura servidas por `GET` (`update-most-read`, `add-next-weeks-landing-page-content`) que se declaran `no-store` en su handler, y un middleware ciego las cachearía. `src/api/routes.spec.ts` afirma el conjunto exacto de módulos cacheados y que su registro precede al de los controllers, para que sumar un módulo nuevo obligue a decidir su cacheabilidad en vez de heredarla por olvido.
+
 ---
 
 ## 9. Allow-list de sanitización

--- a/src/api/_helpers/cache-control.ts
+++ b/src/api/_helpers/cache-control.ts
@@ -16,7 +16,7 @@ const READ_CACHE_STALE_WHILE_REVALIDATE = 604800; // 7 días
 const BROWSER_CACHE_CONTROL = 'public, max-age=0, must-revalidate';
 
 /**
- * Decide si la página de lectura es cacheable en el entorno actual. Fuera de producción no lo es (coherente con
+ * Decide si una respuesta es cacheable en el entorno actual. Fuera de producción no lo es (coherente con
  * `noindexNonProduction`): un preview comparte el CDN y serviría contenido de un dataset que no es
  * el público. Exportada para que el middleware corte antes de bufferizar el body, sin duplicar la
  * condición: la política sigue teniendo un solo dueño.
@@ -26,11 +26,12 @@ export function isReadCacheEnabled(): boolean {
 }
 
 /**
- * Aplica a una respuesta cacheable de la página de lectura los headers de caché de borde: `s-maxage` corto
- * (interruptor `environment.readCacheSMaxAge`) con `stale-while-revalidate` largo, efectivos solo
- * en el CDN de Vercel, más un `Cache-Control` que mantiene fresco al browser.
+ * Aplica a una respuesta cacheable los headers de caché de borde: `s-maxage` corto (interruptor
+ * `environment.readCacheSMaxAge`) con `stale-while-revalidate` largo, efectivos solo en el CDN de
+ * Vercel, más un `Cache-Control` que mantiene fresco al browser.
  *
- * La frescura la da el vencimiento del `s-maxage`, no una invalidación explícita.
+ * El TTL es único para todas las rutas cacheadas. La frescura la da su vencimiento, no una
+ * invalidación explícita: una edición del CMS se ve en la visita siguiente al vencimiento.
  * Ver LITERARY_WORK_DESIGN.md §8.
  */
 export function applyReadCacheHeaders(c: Context): void {

--- a/src/api/_middleware/read-cache-headers.middleware.spec.ts
+++ b/src/api/_middleware/read-cache-headers.middleware.spec.ts
@@ -1,0 +1,73 @@
+import { Hono } from 'hono';
+
+import { environment } from '../_helpers/environment';
+import { readCacheHeaders } from './read-cache-headers.middleware';
+
+describe('readCacheHeaders', () => {
+	const originalProduction = environment.production;
+
+	afterEach(() => {
+		environment.production = originalProduction;
+	});
+
+	function appUnderTest(): Hono {
+		const app = new Hono();
+		app.on('GET', ['/obra', '/obra/*'], readCacheHeaders);
+		app.get('/obra', (c) => c.json([]));
+		app.get('/obra/inexistente', (c) => c.json({ message: 'no existe' }, 404));
+		app.get('/obra/escritura', (c) => {
+			c.header('Cache-Control', 'no-store');
+			return c.json({ done: true });
+		});
+		app.get('/obra/:slug', (c) => c.json({ slug: c.req.param('slug') }));
+		return app;
+	}
+
+	it('emite el TTL de borde en una lectura exitosa', async () => {
+		environment.production = true;
+
+		const response = await appUnderTest().request('/obra/la-obra');
+
+		expect(response.headers.get('Vercel-CDN-Cache-Control')).toContain(`s-maxage=${environment.readCacheSMaxAge}`);
+		expect(response.headers.get('Vercel-CDN-Cache-Control')).toContain('stale-while-revalidate=');
+		// El browser revalida siempre: el TTL vive solo en el CDN, que es donde se revalida una vez.
+		expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, must-revalidate');
+	});
+
+	// El catálogo cuelga del mismo prefijo pero no tiene segmento propio, y el comodín de Hono exige al
+	// menos uno: registrarlo aparte es lo que evita que la ruta más pedida quede sin caché.
+	it('alcanza también al catálogo, sin segmento debajo del recurso', async () => {
+		environment.production = true;
+
+		const response = await appUnderTest().request('/obra');
+
+		expect(response.headers.get('Vercel-CDN-Cache-Control')).toContain('s-maxage=');
+	});
+
+	it('no cachea una respuesta que no sea 200', async () => {
+		environment.production = true;
+
+		const response = await appUnderTest().request('/obra/inexistente');
+
+		expect(response.headers.get('Vercel-CDN-Cache-Control')).toBeNull();
+	});
+
+	// Una escritura servida desde la caché devolvería un 200 sin haber corrido.
+	it('respeta el `no-store` que el handler ya declaró', async () => {
+		environment.production = true;
+
+		const response = await appUnderTest().request('/obra/escritura');
+
+		expect(response.headers.get('Vercel-CDN-Cache-Control')).toBeNull();
+		expect(response.headers.get('Cache-Control')).toBe('no-store');
+	});
+
+	// Un preview comparte el CDN y serviría contenido de un dataset que no es el público.
+	it('no cachea fuera de producción', async () => {
+		environment.production = false;
+
+		const response = await appUnderTest().request('/obra/la-obra');
+
+		expect(response.headers.get('Vercel-CDN-Cache-Control')).toBeNull();
+	});
+});

--- a/src/api/_middleware/read-cache-headers.middleware.ts
+++ b/src/api/_middleware/read-cache-headers.middleware.ts
@@ -2,7 +2,7 @@ import { createMiddleware } from 'hono/factory';
 import { applyReadCacheHeaders } from '../_helpers/cache-control';
 
 /**
- * Emite los headers de caché de borde para las respuestas 200 de las rutas de lectura de una obra
+ * Emite los headers de caché de borde para las respuestas 200 de las rutas de lectura del API,
  * servidas como JSON. A diferencia de `ssrCacheControl`, no inspecciona el body: la respuesta la
  * produce el propio controller y es determinística, sin el fallback CSR que obliga a la guarda.
  */

--- a/src/api/_middleware/ssr-cache-control.middleware.spec.ts
+++ b/src/api/_middleware/ssr-cache-control.middleware.spec.ts
@@ -43,6 +43,10 @@ describe('ssrCacheControl', () => {
 		app.get('/literary-work/streamed', () =>
 			streamedHtml('<html ng-server-context="ssr"><body>obra en stream</body></html>'),
 		);
+		// La home es la ruta donde el deopt a CSR ya ocurrió en producción, así que es donde la guarda
+		// anti-CSR tiene que estar probada: cachear ese fallback serviría una página vacía por siete días.
+		app.use('/home', ssrCacheControl);
+		app.get('/home', (c) => c.html('<html ng-server-context="ssr"><body>inicio</body></html>'));
 		return app;
 	}
 
@@ -106,25 +110,39 @@ describe('ssrCacheControl', () => {
 		expect(await response.text()).toBe('<html ng-server-context="ssr"><body>obra en stream</body></html>');
 	});
 
-	// La guarda anti-CSR busca el marcador `ssr`, que Angular solo emite bajo `RenderMode.Server`:
-	// pasar la ruta a `Prerender` la haría emitir `ssg` y el cacheo se apagaría sin señal.
-	it('should keep /literary-work/:slug declared as a server-rendered route', () => {
-		const literaryWorkRoute = serverRoutes.find((route) => route.path === `${AppRoutes.LiteraryWork}/:slug`);
+	// Las rutas cacheadas y el prefijo con el que se montan, apareados: cada entrada es lo que hay que
+	// mantener sincronizado entre `app.routes.server.ts` y `server.ts`.
+	const CACHED_SSR_ROUTES = [
+		{ route: AppRoutes.Home, mount: `'/${AppRoutes.Home}'` },
+		{ route: AppRoutes.About, mount: `'/${AppRoutes.About}'` },
+		{ route: AppRoutes.Collection, mount: `'/${AppRoutes.Collection}'` },
+		{ route: `${AppRoutes.Collection}/:slug`, mount: `'/${AppRoutes.Collection}/*'` },
+		{ route: `${AppRoutes.Author}/:slug`, mount: `'/${AppRoutes.Author}/*'` },
+		{ route: `${AppRoutes.LiteraryWork}/:slug`, mount: `'/${AppRoutes.LiteraryWork}/*'` },
+	];
 
-		expect(literaryWorkRoute?.renderMode).toBe(RenderMode.Server);
+	// La guarda anti-CSR busca el marcador `ssr`, que Angular solo emite bajo `RenderMode.Server`:
+	// pasar una de estas rutas a `Prerender` la haría emitir `ssg` y el cacheo se apagaría sin señal.
+	it.each(CACHED_SSR_ROUTES)('should keep $route declared as a server-rendered route', ({ route }) => {
+		expect(serverRoutes.find(({ path }) => path === route)?.renderMode).toBe(RenderMode.Server);
 	});
 
 	// El montaje vive en `server.ts` y ningún test lo alcanza: los de arriba arman su propio Hono. Un
 	// prefijo que dejara de coincidir con la ruta no rompe nada — la caché simplemente deja de
 	// aplicarse—, así que se afirma leyendo la fuente, como hace el guardrail de directivas SEO.
-	it('should stay mounted on the route it caches', () => {
+	it.each(CACHED_SSR_ROUTES)('should stay mounted on $mount', ({ mount }) => {
 		const source = readFileSync(join(process.cwd(), 'src/server.ts'), 'utf-8');
-		// La línea, no el archivo: buscar la cadena en el texto entero daría verde con el montaje
-		// comentado, que es justo la forma en que la caché se apagaría sin que nada más lo note.
-		const mount = source
+		// Se descartan los comentarios y se busca sobre el resto: mirar el archivo entero daría verde con
+		// el montaje comentado —que es justo la forma en que la caché se apagaría sin que nada lo note—,
+		// y mirar una única línea rompe en cuanto la registración crece y el formateo la parte en varias.
+		const code = source
 			.split('\n')
-			.find((line) => line.includes('ssrCacheControl)') && !line.trimStart().startsWith('//'));
+			.filter((line) => !line.trimStart().startsWith('//'))
+			.join('\n');
 
-		expect(mount).toContain(`'/${AppRoutes.LiteraryWork}/*'`);
+		const end = code.indexOf('ssrCacheControl)');
+		expect(end, '`server.ts` no monta `ssrCacheControl`: la caché de las páginas SSR está apagada').toBeGreaterThan(-1);
+
+		expect(code.slice(code.lastIndexOf('app.on(', end), end)).toContain(mount);
 	});
 });

--- a/src/api/_middleware/ssr-cache-control.middleware.ts
+++ b/src/api/_middleware/ssr-cache-control.middleware.ts
@@ -12,13 +12,14 @@ import { applyReadCacheHeaders, isReadCacheEnabled } from '../_helpers/cache-con
 const SSR_MARKER = 'ng-server-context="ssr"';
 
 /**
- * Emite los headers de caché de borde para las respuestas SSR válidas de `/literary-work/*`.
+ * Emite los headers de caché de borde para las respuestas SSR válidas de las páginas que lo montan
+ * (ver `server.ts`).
  *
  * Guarda anti-CSR: bufferiza e inspecciona el body (`c.res.clone().text()`) para confirmar que
- * es SSR real antes de cachear. Esto sacrifica el streaming del primer byte —acotado a `/literary-work/*`
- * y aceptable por la inmutabilidad del contenido de una obra—, pero es la única forma correcta de
- * distinguir el SSR real del fallback CSR degradado. No cachea respuestas no-200 (404/500) ni el
- * fallback CSR.
+ * es SSR real antes de cachear. Esto sacrifica el streaming del primer byte, pero es la única forma
+ * correcta de distinguir el SSR real del fallback CSR degradado —que responde 200 y `text/html` sin
+ * ninguna señal en los headers—, y cachear ese fallback serviría una página sin contenido durante
+ * todo el TTL. No cachea respuestas no-200 (404/500) ni el fallback CSR.
  *
  * La cache key del CDN de Vercel incluye el query string, así que una página con variantes por query
  * cachea por variante.

--- a/src/api/modules/content/content.controller.spec.ts
+++ b/src/api/modules/content/content.controller.spec.ts
@@ -2,6 +2,8 @@ import { Hono } from 'hono';
 import { setSystemTime, useFakeTimers, useRealTimers } from '@test-utils';
 import { buildWeekSlug } from '@utils/week-slug.utils';
 import type { LandingPageContent } from '@models/landing-page-content.model';
+import { environment } from '../../_helpers/environment';
+import { readCacheHeaders } from '../../_middleware/read-cache-headers.middleware';
 import { createContentController } from './content.controller';
 import { MalformedLandingPageError } from './content.errors';
 import { InMemoryContentRepository } from './content.repository.mock';
@@ -77,5 +79,55 @@ describe('contentController with malformed data', () => {
 		const response = await failing.request('/content/landing-page');
 
 		await expect(response.text()).resolves.not.toContain(CURRENT_SLUG);
+	});
+});
+
+// La ruta que crea las landing pages de las próximas semanas comparte prefijo con las lecturas del
+// módulo, así que hereda su middleware de caché. Servida desde el borde devolvería un 200 sin haber
+// creado ningún documento, y la redacción se quedaría sin la semana siguiente sin ninguna señal.
+describe('contentController — la escritura no es cacheable', () => {
+	const originalProduction = environment.production;
+
+	afterEach(() => {
+		environment.production = originalProduction;
+	});
+
+	// El generador clona las referencias de la última semana curada, así que sin ellas la ruta responde
+	// 500 — y una respuesta que no es 200 el middleware ya la saltea, con lo que el caso pasaría en vacío.
+	const writableRepository = () =>
+		new InMemoryContentRepository({
+			latestReferences: {
+				_type: 'landingPage',
+				campaigns: [],
+				collections: [],
+				latestLiteraryWorks: [],
+				highlightedAuthors: [],
+			},
+		});
+
+	it('declares the weekly landing page creation as no-store', async () => {
+		const response = await appWith(writableRepository()).request(
+			'/content/add-next-weeks-landing-page-content?weeksInTheFuture=1',
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Cache-Control')).toBe('no-store');
+	});
+
+	// Y la composición con el middleware, que es lo que el `no-store` existe para lograr: montado
+	// detrás de él y con la caché habilitada, la respuesta no recibe el TTL de borde.
+	it('stays out of the edge cache when mounted behind the read cache middleware', async () => {
+		environment.production = true;
+
+		const app = new Hono();
+		app.on('GET', ['/content', '/content/*'], readCacheHeaders);
+		app.route('/content', createContentController(writableRepository()));
+
+		const response = await app.request('/content/add-next-weeks-landing-page-content?weeksInTheFuture=1');
+
+		// El 200 no es decoración: el middleware ya se saltea toda respuesta que no lo sea, así que sin
+		// esta aserción el caso pasaría igual por la vía del error y no probaría el `no-store`.
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Vercel-CDN-Cache-Control')).toBeNull();
 	});
 });

--- a/src/api/modules/content/content.controller.ts
+++ b/src/api/modules/content/content.controller.ts
@@ -40,6 +40,10 @@ export function createContentController(repository?: ContentRepository) {
 	 */
 	controller.get('/add-next-weeks-landing-page-content', zValidator('query', addWeeksSchema), async (c) => {
 		const { weeksInTheFuture } = c.req.valid('query');
+		// El `no-store` no es decorativo: el módulo sirve sus lecturas con caché de borde, y sin
+		// declararse incacheable esta escritura recibiría el mismo tratamiento y la invocación siguiente
+		// se resolvería con un hit, devolviendo un 200 sin haber creado ningún documento.
+		c.header('Cache-Control', 'no-store');
 		return respond(c, () => addNextWeeksLandingPageContent(weeksInTheFuture, repository));
 	});
 

--- a/src/api/routes.spec.ts
+++ b/src/api/routes.spec.ts
@@ -1,0 +1,73 @@
+import { readCacheHeaders } from './_middleware/read-cache-headers.middleware';
+import apiRoutes from './routes';
+
+/**
+ * La caché de borde se declara por módulo, y el olvido no se nota: un módulo nuevo sin registrar
+ * sigue respondiendo bien y consultando a Sanity en cada visita. Este spec convierte esa decisión
+ * en algo que hay que tomar — el conjunto va escrito acá y no derivado del propio registro, porque
+ * derivarlo lo compararía consigo mismo.
+ */
+describe('apiRoutes', () => {
+	it('sirve desde la caché de borde exactamente los módulos previstos', () => {
+		const cached = apiRoutes.routes
+			.filter(({ handler }) => handler === readCacheHeaders)
+			.map(({ path }) => path)
+			.sort();
+
+		expect(cached).toEqual(
+			[
+				'/author',
+				'/author/*',
+				'/collection',
+				'/collection/*',
+				'/content',
+				'/content/*',
+				'/contributor',
+				'/contributor/*',
+				'/literary-work',
+				'/literary-work/*',
+			].sort(),
+		);
+	});
+
+	// El conjunto correcto no alcanza: los handlers de los controllers no llaman `next()`, así que un
+	// `readCacheHeaders` registrado después del montaje de su módulo no correría nunca. La caché se
+	// apagaría con un reordenamiento inocente, y el conteo de paths seguiría dando lo mismo.
+	it('registra la caché antes del controller de cada módulo', () => {
+		// El controller de un módulo no se registra bajo el mismo path que su middleware: `app.route()`
+		// aplana las rutas del sub-router (`/author/:slug`, `/author/`), así que la comparación es por
+		// prefijo. Se afirma contra el *último* registro de caché del prefijo, que es el que tendría que
+		// quedar tapado si alguien reordenara.
+		const cacheEntries = apiRoutes.routes.filter(({ handler }) => handler === readCacheHeaders);
+		expect(cacheEntries.length, 'no hay ninguna ruta cacheada: la aserción no verificaría nada').toBeGreaterThan(0);
+
+		for (const prefix of new Set(cacheEntries.map(({ path }) => path.replace(/\/\*$/, '')))) {
+			const isOfPrefix = (path: string) => path === prefix || path.startsWith(`${prefix}/`);
+			const indexed = apiRoutes.routes.map((route, index) => ({ ...route, index }));
+			const lastCacheIndex = Math.max(
+				...indexed.filter(({ handler, path }) => handler === readCacheHeaders && isOfPrefix(path)).map((r) => r.index),
+			);
+			const firstControllerIndex = indexed.findIndex(
+				({ handler, path }) => handler !== readCacheHeaders && isOfPrefix(path),
+			);
+
+			expect(
+				firstControllerIndex,
+				`"${prefix}" no monta ningún handler: la aserción de orden no verificaría nada`,
+			).toBeGreaterThan(-1);
+			expect(
+				lastCacheIndex,
+				`"${prefix}" monta su controller antes de la caché: el middleware no correría`,
+			).toBeLessThan(firstControllerIndex);
+		}
+	});
+
+	// El generador de imágenes de Open Graph no lee del CMS igual que el resto y su caché es otra
+	// decisión: se deja explícito para que la ausencia no se lea como un olvido.
+	it('deja `/og` fuera de la caché de borde', () => {
+		const cachedPaths = apiRoutes.routes.filter(({ handler }) => handler === readCacheHeaders).map(({ path }) => path);
+
+		expect(cachedPaths).not.toContain('/og');
+		expect(cachedPaths).not.toContain('/og/*');
+	});
+});

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -9,11 +9,31 @@ import ogController from './og.controller';
 
 const apiRoutes = new Hono();
 
+/**
+ * Los módulos cuyas lecturas se sirven desde la caché de borde.
+ *
+ * Es todo lo que un crawler recorre: el sitemap publica cerca de mil URLs, y sin esta capa cada
+ * visita a cualquiera de ellas vuelve a consultar a Sanity. Queda afuera `/og`, cuya caché es otra
+ * decisión.
+ *
+ * El registro va por par —el recurso y lo que cuelga de él— porque el comodín de Hono exige al menos
+ * un segmento: `/x/*` deja fuera al catálogo `/x`. Cada `GET` que en realidad escribe se declara
+ * `no-store` en su propio handler; el middleware lo respeta.
+ *
+ * **Va antes del montaje de los controllers, y el orden es parte del mecanismo:** los handlers no
+ * llaman `next()`, así que un middleware registrado después de ellos no correría nunca y la caché se
+ * apagaría en silencio. Lo afirma `routes.spec.ts`.
+ */
+const CACHED_MODULES = ['/author', '/collection', '/content', '/contributor', '/literary-work'];
+
+for (const module of CACHED_MODULES) {
+	apiRoutes.on('GET', [module, `${module}/*`], readCacheHeaders);
+}
+
 apiRoutes.route('/author', authorController);
 apiRoutes.route('/collection', collectionController);
 apiRoutes.route('/contributor', contributorController);
 apiRoutes.route('/content', contentController);
-apiRoutes.on('GET', '/literary-work/*', readCacheHeaders);
 apiRoutes.route('/literary-work', literaryWorkController);
 apiRoutes.route('/og', ogController);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,12 +34,17 @@ app.route('/sitemap.xml', sitemapController);
 // Registra rutas de API
 app.route('/api', apiRoutes);
 
-// Caché de borde para las páginas SSR de `/literary-work/*`. Registrado antes de `serveStatic` y del
-// catch-all SSR para envolverlos (el orden de registro define el anidamiento onion de Hono):
+// Caché de borde para las páginas que se renderizan en el servidor. Registrada antes de `serveStatic`
+// y del catch-all SSR para envolverlos (el orden de registro define el anidamiento onion de Hono):
 // corre tras `angularApp.handle()` y decide la cacheabilidad inspeccionando la respuesta.
-// Acotado a GET: solo esas respuestas son cacheables por el borde, y un POST que devolviera 200
+// Acotada a GET: solo esas respuestas son cacheables por el borde, y un POST que devolviera 200
 // con el marcador no debe recibir headers de caché.
-app.on('GET', '/literary-work/*', ssrCacheControl);
+//
+// La lista se corresponde con las rutas que `app.routes.server.ts` declara `RenderMode.Server`: son
+// las que arman su HTML pidiéndole el dato a Sanity en cada visita. Las `Prerender` no entran acá —
+// las sirve `serveStatic` con su propio `Cache-Control`—, y lo que sí les cuesta es la consulta que
+// el navegador dispara al hidratar, que cubre la caché del API.
+app.on('GET', ['/home', '/about', '/collection', '/collection/*', '/author/*', '/literary-work/*'], ssrCacheControl);
 
 // Las rutas viejas de obra y de colección se mudaron. Van antes del catch-all SSR, que es un
 // `use('*')`: si la request llegara hasta él se renderizaría una página y el 301 no se emitiría nunca.


### PR DESCRIPTION
Cuarto y último de los PRs apilados que contienen el consumo de ancho de banda de Sanity. **Apilado sobre #2441** — no depende de él en el código, pero cierra la pila, así que hay que mergear los tres anteriores primero.

## El problema

La caché de borde **ya existía**, pero montada solo sobre la obra. El resto del sitio va a Sanity en cada visita, y desde que la lectura y el catálogo de colecciones pasaron a indexables eso es un crawler recorriendo cerca de mil URLs del sitemap sin que ninguna se resuelva desde el CDN.

Vale aclararlo porque la premisa del issue decía otra cosa: el `Cache-Control: public, max-age=0, must-revalidate` que se mide en producción se emite en un solo lugar del repo, **después** del guard de `isReadCacheEnabled()`, así que verlo prueba que la caché corrió. Vercel remueve `Vercel-CDN-Cache-Control` antes de responder al cliente. Este PR **extiende**, no habilita.

## Qué cambia

**El registro es explícito por módulo y por página, nunca un middleware global.** Varios módulos sirven escrituras por `GET`, y una escritura resuelta desde la caché devuelve un 200 sin haber corrido. Se agrega el `no-store` que le faltaba a la creación de landing pages semanales; auditadas las demás rutas `GET`, era la única sin declarar.

**Corrige de paso un hueco que ya existía:** el comodín de Hono exige al menos un segmento, así que `'/literary-work/*'` dejaba fuera al catálogo `/literary-work`. Ahora cada módulo se registra con el par recurso + comodín.

**Las páginas SSR que se suman son las que `app.routes.server.ts` declara `RenderMode.Server`.** Las `Prerender` no entran: las sirve `serveStatic` con su propio `Cache-Control`, y lo que sí les cuesta es la consulta que el navegador dispara al hidratar, que cubre la caché del API.

## Lo que este PR vuelve verificable

Tres specs cierran lo que antes no tenía red:

- **El del middleware del API no existía.** Cubre el TTL, el catálogo sin segmento, el no-200, el `no-store` del handler y el corte fuera de producción.
- **El de rutas** afirma el conjunto exacto de módulos cacheados —escrito a mano, no derivado del registro, que lo compararía consigo mismo— **y que su registro precede al de los controllers**. Eso último es load-bearing: los handlers no llaman `next()`, así que un middleware registrado después no correría nunca y la caché se apagaría con un reordenamiento inocente. Verificado en negativo.
- **El del SSR** extiende sus dos guardrails a cada ruta nueva: que siga declarada `RenderMode.Server` —con `Prerender`, Angular emite otro marcador y el cacheo se apagaría en silencio— y que el montaje de `server.ts` la nombre.

El caso de la **home** no es uno más: es donde el deopt a CSR ya ocurrió en producción, y cachear ese fallback serviría una página vacía por todo el TTL. Es lo que la guarda anti-CSR del middleware existe para impedir.

## Decisiones registradas

- **El TTL queda único.** Parametrizarlo por módulo haría falta cuando alguna ruta pida una ventana de propagación distinta, y hoy ninguna la pide.
- **La ventana de propagación ahora alcanza a la home y a las colecciones**, que se editan más seguido que una obra ya publicada. Es el trade-off que la extensión amplía.
- **El invariante de deploy** —el corte mira si el deploy es de producción, no qué dataset sirve— no es nuevo, pero su radio de daño creció. Queda escrito junto al resto de la estrategia.

## Cómo se verificó

Suite unitaria completa, suite e2e completa en ambos browsers, `lint`, `typecheck` y `build` en verde. La aserción de orden del registro se comprobó en negativo, moviendo el bucle después de los controllers y confirmando que rompe.

Closes #2431.
