### PR TITLE
[#2363] - Refundar el lenguaje de dominio: eliminar las migraciones de la transición y el relato de reemplazo

### DIFF
--- a/.claude/references/angular-components.md
+++ b/.claude/references/angular-components.md
@@ -286,7 +286,7 @@ export function provideFooInitializer() {
 	} @if (author().nationality.flag) {
 	<img [ngSrc]="author().nationality.flag" [alt]="author().nationality.country" width="21" height="16" />
 	} @if (storyCount() !== undefined) {
-	<span data-testid="story-count"> {{ storyCount() }} {{ storyCount() === 1 ? 'historia' : 'historias' }} </span>
+	<span data-testid="story-count"> {{ storyCount() }} {{ storyCount() === 1 ? 'obra' : 'obras' }} </span>
 	}
 </article>
 ```

--- a/.github/ISSUE_TEMPLATE/content.yml
+++ b/.github/ISSUE_TEMPLATE/content.yml
@@ -1,14 +1,14 @@
 name: 📜 Proponer el agregado de contenido a La Cuentoneta
-description: Proponer el agregado de un nuevo texto en particular (sea un cuento, poema, ensayo, etc.) o una temática para generar una nueva storylist
+description: Proponer el agregado de un nuevo texto en particular (sea un cuento, poema, ensayo, etc.) o una temática para generar una nueva colección
 labels: ['📜 contenido', '✍️ bosquejo']
 body:
   - type: textarea
     id: description
     attributes:
       label: Descripción
-      description: Detalla el nuevo contenido a agregar a La Cuentoneta. Puede ser un texto de elaboración propia, una propuesta de temática para una storylist o la mención a un cuento que te gustaría esté disponible en La Cuentoneta.
+      description: Detalla el nuevo contenido a agregar a La Cuentoneta. Puede ser un texto de elaboración propia, una propuesta de temática para una colección o la mención a un cuento que te gustaría esté disponible en La Cuentoneta.
       placeholder: |
-        Por ejemplo: "Agregar el cuento 'El Marajá de San Telmo' en la próxima storylist de La Cuentoneta, escrito por Rolando Gativideo", o "Agregar una storylist relacionada al género de la ciencia ficción. Propongo también considerar el cuento 'En los Confines del Sistema Solar', de Rolando Gativideo".
+        Por ejemplo: "Agregar el cuento 'El Marajá de San Telmo' en la próxima colección de La Cuentoneta, escrito por Rolando Gativideo", o "Agregar una colección relacionada al género de la ciencia ficción. Propongo también considerar el cuento 'En los Confines del Sistema Solar', de Rolando Gativideo".
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/ui_ux.yml
+++ b/.github/ISSUE_TEMPLATE/ui_ux.yml
@@ -8,7 +8,7 @@ body:
       label: Descripción
       description: Detalla la propuesta de mejora relacionada a UI/UX de la manera más detallada posible.
       placeholder: |
-        Por ejemplo: "Rediseño de tarjetas de stories para storylists", "Mejoras en diseño de navbar", "Mejoras en experiencia de lectura", "Propuesta de diseño para ordenamiento de elementos mutlimedia relacionados a stories", etc..
+        Por ejemplo: "Rediseño de tarjetas de obras para colecciones", "Mejoras en diseño de navbar", "Mejoras en experiencia de lectura", "Propuesta de diseño para ordenamiento de elementos mutlimedia relacionados a obras", etc..
     validations:
       required: true
   - type: textarea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ La Cuentoneta tiene cuentas oficiales en [Facebook][facebook-cuentoneta], [Insta
 
 ### 📜 Contenidos
 
-Puedes sugerir contenido para sumar a la plataforma, sea en forma de cuentos, poemas, ensayos o temáticas para nuevas storylists.
+Puedes sugerir contenido para sumar a la plataforma, sea en forma de cuentos, poemas, ensayos o temáticas para nuevas colecciones.
 El contenido puede ser escritura propia o de terceros, con previos permisos de publicación o disponibilidad de acceso a este contenido en la web abierta.
 
 Estamos trabajando para, a futuro, ir en busca de autores y autoras de cuentos y poemas de autoría original que deseen publicar sus obras en La Cuentoneta.

--- a/MVV.md
+++ b/MVV.md
@@ -14,7 +14,7 @@ Desde el staff y equipo de "La Cuentoneta" establecimos la Misión, Visión y Va
 
 ## Misión:
 
-Nuestra misión en "La Cuentoneta" es fomentar y hacer accesible la lectura digital a través de la publicación de relatos breves en storylists temáticas, creando un espacio comunitario virtual dedicado a la difusión de la literatura. Buscamos promover el placer de la lectura, emulando la experiencia de las playlists musicales o de videos, para que usuarias y usuarios puedan disfrutar de la lectura de una manera divertida y entretenida.
+Nuestra misión en "La Cuentoneta" es fomentar y hacer accesible la lectura digital a través de la publicación de relatos breves en colecciones temáticas, creando un espacio comunitario virtual dedicado a la difusión de la literatura. Buscamos promover el placer de la lectura, emulando la experiencia de las playlists musicales o de videos, para que usuarias y usuarios puedan disfrutar de la lectura de una manera divertida y entretenida.
 
 ## Visión:
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -337,13 +337,13 @@ Bruno utiliza el prefijo `~` para indicar parámetros opcionales en las solicitu
 ```
 params:query {
   ~author: jorge-luis-borges    # El ~ indica parámetro opcional
-  ~storylist: cuentos-de-terror
+  ~collection: cuentos-de-terror
   rrss: twitter                 # Parámetro requerido (sin ~)
   title: Example Title
 }
 ```
 
-En el ejemplo anterior, `author` y `storylist` son opcionales, mientras que `rrss` y `title` son requeridos. Este es el ejemplo real del endpoint `/og` (`docs/api/bruno/og/generate-og-image.bru`): `storylist` ahí es un parámetro de texto libre para el OG de compartir.
+En el ejemplo anterior, `author` y `collection` son opcionales, mientras que `rrss` y `title` son requeridos. Este es el ejemplo real del endpoint `/og` (`docs/api/bruno/og/generate-og-image.bru`): `collection` ahí es un parámetro de texto libre para el OG de compartir.
 
 ---
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -337,7 +337,7 @@ Bruno utiliza el prefijo `~` para indicar parámetros opcionales en las solicitu
 ```
 params:query {
   ~author: jorge-luis-borges    # El ~ indica parámetro opcional
-  ~collection: cuentos-de-terror
+  ~collection: Cuentos de terror
   rrss: twitter                 # Parámetro requerido (sin ~)
   title: Example Title
 }

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -120,7 +120,7 @@ GET /api/contributor               # Obtener lista de colaboradores
 
 - Organizar colecciones destacadas
 - Gestionar campañas de contenido con variantes responsivas
-- Mantener listados de historias más leídas y recientes
+- Mantener listados de obras más leídas y recientes
 - Proporcionar múltiples vistas según dispositivo (xs, md)
 
 **Interfaces de API:**

--- a/docs/api/bruno/og/generate-og-image.bru
+++ b/docs/api/bruno/og/generate-og-image.bru
@@ -12,7 +12,7 @@ get {
 
 params:query {
   ~author: jorge-luis-borges
-  ~collection: cuentos-de-terror
+  ~collection: Cuentos de terror
   rrss: twitter
   title: Example Title
 }

--- a/docs/api/bruno/og/generate-og-image.bru
+++ b/docs/api/bruno/og/generate-og-image.bru
@@ -12,7 +12,7 @@ get {
 
 params:query {
   ~author: jorge-luis-borges
-  ~storylist: cuentos-de-terror
+  ~collection: cuentos-de-terror
   rrss: twitter
   title: Example Title
 }
@@ -22,7 +22,7 @@ docs {
 
   Parámetros de consulta:
   - author: Slug del autor (opcional)
-  - storylist: Slug de la lista de cuentos (opcional)
+  - collection: Nombre de la colección (opcional)
   - rrss: Plataforma social (twitter, facebook, etc.)
   - title: Título para la imagen
 }

--- a/e2e/_utils/seo-invariants.ts
+++ b/e2e/_utils/seo-invariants.ts
@@ -104,7 +104,7 @@ function primaryHeading(root: HTMLElement, pattern?: RegExp): SeoInvariantViolat
 function primaryContentLength(
 	root: HTMLElement,
 	// Umbral por defecto de texto en `<main>`: muy por debajo del contenido real de los fixtures (bio,
-	// cuerpo del cuento, ficha técnica) pero muy por encima del ruido de whitespace de un skeleton.
+	// cuerpo de la obra, ficha técnica) pero muy por encima del ruido de whitespace de un skeleton.
 	minLength: number = 120,
 ): SeoInvariantViolation | null {
 	const length = normalizedText(root.querySelector('main')).length;

--- a/e2e/seo/ssr-proxy-headers.spec.ts
+++ b/e2e/seo/ssr-proxy-headers.spec.ts
@@ -8,7 +8,7 @@
  * deopteaba a CSR y los crawlers recibían el shell genérico → desindexación.
  *
  * Este test simula ese header y verifica que el SSR igual sirve el HTML por página (título y
- * canónica del cuento, no el shell genérico de home). Si alguien quita `trustProxyHeaders: true`,
+ * canónica de la obra, no el shell genérico de home). Si alguien quita `trustProxyHeaders: true`,
  * el server deoptea y este test falla.
  */
 import { expect } from '@playwright/test';

--- a/scripts/field-shape-sweep/field-shape-sweep.groq.spec.ts
+++ b/scripts/field-shape-sweep/field-shape-sweep.groq.spec.ts
@@ -44,6 +44,6 @@ describe('buildShapeCountQuery', () => {
 	});
 
 	it('construye una consulta por campo', () => {
-		expect(buildShapeCountQueries([dateTimeField, { ...dateTimeField, documentType: 'story' }])).toHaveLength(2);
+		expect(buildShapeCountQueries([dateTimeField, { ...dateTimeField, documentType: 'literaryWork' }])).toHaveLength(2);
 	});
 });

--- a/scripts/required-fields-sweep/required-fields-sweep.groq.spec.ts
+++ b/scripts/required-fields-sweep/required-fields-sweep.groq.spec.ts
@@ -58,13 +58,13 @@ describe('buildFieldCountQuery', () => {
 	// expresa igual de bien que un campo directo.
 	it('reaches an attribute nested in an object inside the array', () => {
 		const field: RequiredFieldPath = {
-			documentType: 'collection',
-			segments: ['tabs', 'slug', 'current'],
+			documentType: 'author',
+			segments: ['resources', 'resourceType', '_ref'],
 			insideArray: true,
 		};
 
 		expect(buildFieldCountQuery(field).publishedQuery).toContain(
-			'count(tabs[defined(slug) && !defined(slug.current)]) > 0',
+			'count(resources[defined(resourceType) && !defined(resourceType._ref)]) > 0',
 		);
 	});
 
@@ -112,28 +112,28 @@ describe('the generated queries, evaluated', () => {
 	});
 
 	// Un ítem que no trae el objeto contenedor entero incumple **un** dato, no uno por cada campo de
-	// ese objeto: sin el guard, el mismo documento se cuenta en la fila de `tabs.slug` y en la de
-	// `tabs.slug.current`, y el reporte exagera el problema.
+	// ese objeto: sin el guard, el mismo documento se cuenta en la fila del objeto y en la de cada uno
+	// de sus atributos, y el reporte exagera el problema.
 	it('does not count an item that lacks the whole nested object as breaching its every field', async () => {
 		const field: RequiredFieldPath = {
-			documentType: 'collection',
-			segments: ['tabs', 'slug', 'current'],
+			documentType: 'author',
+			segments: ['resources', 'resourceType', '_ref'],
 			insideArray: true,
 		};
-		const withoutSlugObject = [{ _id: 'a', _type: 'collection', tabs: [{ title: 'sin slug' }] }];
+		const withoutResourceType = [{ _id: 'a', _type: 'author', resources: [{ title: 'sin tipo' }] }];
 
-		expect(await count(buildFieldCountQuery(field).publishedQuery, withoutSlugObject)).toBe(0);
+		expect(await count(buildFieldCountQuery(field).publishedQuery, withoutResourceType)).toBe(0);
 	});
 
 	it('does count an item whose nested object exists but misses the attribute', async () => {
 		const field: RequiredFieldPath = {
-			documentType: 'collection',
-			segments: ['tabs', 'slug', 'current'],
+			documentType: 'author',
+			segments: ['resources', 'resourceType', '_ref'],
 			insideArray: true,
 		};
-		const withEmptySlug = [{ _id: 'a', _type: 'collection', tabs: [{ slug: {} }] }];
+		const withEmptyResourceType = [{ _id: 'a', _type: 'author', resources: [{ resourceType: {} }] }];
 
-		expect(await count(buildFieldCountQuery(field).publishedQuery, withEmptySlug)).toBe(1);
+		expect(await count(buildFieldCountQuery(field).publishedQuery, withEmptyResourceType)).toBe(1);
 	});
 
 	// El caso que la perspectiva no distingue: el mismo documento vive publicado y como borrador, y

--- a/scripts/required-fields-sweep/required-fields-sweep.groq.spec.ts
+++ b/scripts/required-fields-sweep/required-fields-sweep.groq.spec.ts
@@ -58,7 +58,7 @@ describe('buildFieldCountQuery', () => {
 	// expresa igual de bien que un campo directo.
 	it('reaches an attribute nested in an object inside the array', () => {
 		const field: RequiredFieldPath = {
-			documentType: 'storylist',
+			documentType: 'collection',
 			segments: ['tabs', 'slug', 'current'],
 			insideArray: true,
 		};
@@ -82,7 +82,7 @@ describe('the generated queries, evaluated', () => {
 		{ _id: 'a', _type: 'author', name: 'Con nombre', nationality: { country: 'Argentina' } },
 		{ _id: 'b', _type: 'author', nationality: { country: 'Uruguay' } },
 		{ _id: 'c', _type: 'author', name: 'Sin nacionalidad' },
-		{ _id: 'd', _type: 'story', title: 'De otro tipo' },
+		{ _id: 'd', _type: 'literaryWork', title: 'De otro tipo' },
 	];
 
 	it('counts only the documents of its own type that miss the attribute', async () => {
@@ -116,22 +116,22 @@ describe('the generated queries, evaluated', () => {
 	// `tabs.slug.current`, y el reporte exagera el problema.
 	it('does not count an item that lacks the whole nested object as breaching its every field', async () => {
 		const field: RequiredFieldPath = {
-			documentType: 'storylist',
+			documentType: 'collection',
 			segments: ['tabs', 'slug', 'current'],
 			insideArray: true,
 		};
-		const withoutSlugObject = [{ _id: 'a', _type: 'storylist', tabs: [{ title: 'sin slug' }] }];
+		const withoutSlugObject = [{ _id: 'a', _type: 'collection', tabs: [{ title: 'sin slug' }] }];
 
 		expect(await count(buildFieldCountQuery(field).publishedQuery, withoutSlugObject)).toBe(0);
 	});
 
 	it('does count an item whose nested object exists but misses the attribute', async () => {
 		const field: RequiredFieldPath = {
-			documentType: 'storylist',
+			documentType: 'collection',
 			segments: ['tabs', 'slug', 'current'],
 			insideArray: true,
 		};
-		const withEmptySlug = [{ _id: 'a', _type: 'storylist', tabs: [{ slug: {} }] }];
+		const withEmptySlug = [{ _id: 'a', _type: 'collection', tabs: [{ slug: {} }] }];
 
 		expect(await count(buildFieldCountQuery(field).publishedQuery, withEmptySlug)).toBe(1);
 	});

--- a/scripts/required-fields-sweep/required-fields-sweep.report.spec.ts
+++ b/scripts/required-fields-sweep/required-fields-sweep.report.spec.ts
@@ -16,13 +16,13 @@ function reportOf(breaches: FieldBreach[], uncovered: SweepReport['uncovered'] =
 
 describe('breachesOf', () => {
 	it('leaves out the fields every document fulfils', () => {
-		expect(breachesOf([breach('story.title', 0), breach('story.badLanguage', 155)])).toEqual([
-			breach('story.badLanguage', 155),
+		expect(breachesOf([breach('literaryWork.title', 0), breach('literaryWork.badLanguage', 155)])).toEqual([
+			breach('literaryWork.badLanguage', 155),
 		]);
 	});
 
 	it('keeps a field that only drafts breach', () => {
-		expect(breachesOf([breach('story.title', 0, 2)])).toEqual([breach('story.title', 0, 2)]);
+		expect(breachesOf([breach('literaryWork.title', 0, 2)])).toEqual([breach('literaryWork.title', 0, 2)]);
 	});
 
 	it('orders by how widespread the breach is', () => {
@@ -34,7 +34,9 @@ describe('breachesOf', () => {
 
 describe('fingerprint', () => {
 	it('does not change when only the counts move', () => {
-		expect(fingerprint([breach('story.badLanguage', 155)])).toBe(fingerprint([breach('story.badLanguage', 156)]));
+		expect(fingerprint([breach('literaryWork.badLanguage', 155)])).toBe(
+			fingerprint([breach('literaryWork.badLanguage', 156)]),
+		);
 	});
 
 	it('changes when a field joins the set', () => {
@@ -48,20 +50,20 @@ describe('fingerprint', () => {
 
 describe('formatReportBody', () => {
 	it('lists every breach with both perspectives', () => {
-		const body = formatReportBody(reportOf([breach('story.badLanguage', 155, 4)]));
+		const body = formatReportBody(reportOf([breach('literaryWork.badLanguage', 155, 4)]));
 
-		expect(body).toContain('| `story.badLanguage` | 155 | 4 |');
+		expect(body).toContain('| `literaryWork.badLanguage` | 155 | 4 |');
 	});
 
 	it('declares the paths it cannot measure', () => {
 		const body = formatReportBody(
 			reportOf(
 				[breach('a', 1)],
-				[{ documentType: 'storylist', segments: ['mediaSources'], reason: 'array de tipos unión' }],
+				[{ documentType: 'collection', segments: ['mediaSources'], reason: 'array de tipos unión' }],
 			),
 		);
 
-		expect(body).toContain('storylist.mediaSources');
+		expect(body).toContain('collection.mediaSources');
 		expect(body).toContain('array de tipos unión');
 	});
 
@@ -125,8 +127,8 @@ describe('formatConsoleReport', () => {
 	});
 
 	it('lists each breach with both perspectives', () => {
-		expect(formatConsoleReport(reportOf([breach('story.badLanguage', 155, 4)]))).toContain(
-			'story.badLanguage — 155 publicados, 4 borradores',
+		expect(formatConsoleReport(reportOf([breach('literaryWork.badLanguage', 155, 4)]))).toContain(
+			'literaryWork.badLanguage — 155 publicados, 4 borradores',
 		);
 	});
 });

--- a/scripts/required-fields-sweep/required-fields-sweep.schema.spec.ts
+++ b/scripts/required-fields-sweep/required-fields-sweep.schema.spec.ts
@@ -105,7 +105,7 @@ describe('scanRequiredFields', () => {
 	it('does not descend into a reference', () => {
 		const node = {
 			type: 'document',
-			name: 'story',
+			name: 'literaryWork',
 			value: {
 				type: 'object',
 				attributes: {
@@ -129,7 +129,7 @@ describe('scanRequiredFields', () => {
 	it('reports an array inside another array as uncovered', () => {
 		const node = {
 			type: 'document',
-			name: 'story',
+			name: 'literaryWork',
 			value: {
 				type: 'object',
 				attributes: {
@@ -156,7 +156,7 @@ describe('scanRequiredFields', () => {
 
 		expect(uncovered).toEqual([
 			{
-				documentType: 'story',
+				documentType: 'literaryWork',
 				segments: ['content', 'epigraphs'],
 				reason: 'no se desciende: array dentro de otro array',
 			},
@@ -166,7 +166,7 @@ describe('scanRequiredFields', () => {
 	it('reports an array of unions as uncovered instead of skipping it silently', () => {
 		const node = {
 			type: 'document',
-			name: 'storylist',
+			name: 'collection',
 			value: {
 				type: 'object',
 				attributes: {
@@ -178,7 +178,7 @@ describe('scanRequiredFields', () => {
 		const { uncovered } = scanRequiredFields([node] as never);
 
 		expect(uncovered).toEqual([
-			{ documentType: 'storylist', segments: ['mediaSources'], reason: 'no se desciende: array de tipos unión' },
+			{ documentType: 'collection', segments: ['mediaSources'], reason: 'no se desciende: array de tipos unión' },
 		]);
 	});
 

--- a/scripts/seo-smoke.ts
+++ b/scripts/seo-smoke.ts
@@ -3,7 +3,7 @@
  * de un despliegue real (`BASE_URL`), reusando el MISMO core que el gate de e2e para no divergir.
  *
  * Cobertura: siempre chequea `/home` + los slugs estables conocidos-buenos (baseline de regresión),
- * y además una muestra ALEATORIA de cuentos/autores/colecciones tomada del `/sitemap.xml` en cada
+ * y además una muestra ALEATORIA de obras/autores/colecciones tomada del `/sitemap.xml` en cada
  * corrida (cobertura rotativa). Los patrones de `<title>`/`<h1>` se derivan del slug de cada URL.
  * Si el sitemap no está disponible, el baseline igual se ejerce (la muestra se omite con un aviso).
  *

--- a/src/api/_helpers/og-text.spec.ts
+++ b/src/api/_helpers/og-text.spec.ts
@@ -2,24 +2,46 @@ import { describe, expect, it } from 'vitest';
 
 import { resolveOgText } from './og-text';
 
+function readerOf(params: Record<string, string>) {
+	return (name: string) => params[name];
+}
+
 describe('resolveOgText', () => {
 	it('usa el nombre de la colección cuando viene provisto', () => {
-		expect(resolveOgText({ collection: 'Cuentos de terror', author: 'Borges', title: 'El Fin' })).toBe(
+		expect(resolveOgText(readerOf({ collection: 'Cuentos de terror', author: 'Borges', title: 'El Fin' }))).toBe(
 			'Cuentos de terror',
 		);
 	});
 
 	it('compone título y autor cuando no hay colección', () => {
-		expect(resolveOgText({ author: 'Borges', title: 'El Fin' })).toBe('El Fin - Borges');
+		expect(resolveOgText(readerOf({ author: 'Borges', title: 'El Fin' }))).toBe('El Fin - Borges');
 	});
 
 	it('cae a la marca cuando falta alguno del par autor y título', () => {
-		expect(resolveOgText({ title: 'El Fin' })).toBe('La Cuentoneta');
-		expect(resolveOgText({ author: 'Borges' })).toBe('La Cuentoneta');
-		expect(resolveOgText({})).toBe('La Cuentoneta');
+		expect(resolveOgText(readerOf({ title: 'El Fin' }))).toBe('La Cuentoneta');
+		expect(resolveOgText(readerOf({ author: 'Borges' }))).toBe('La Cuentoneta');
+		expect(resolveOgText(readerOf({}))).toBe('La Cuentoneta');
 	});
 
-	it('trata un parámetro vacío como ausente', () => {
-		expect(resolveOgText({ collection: '', author: 'Borges', title: 'El Fin' })).toBe('El Fin - Borges');
+	it('trata un parámetro en blanco como ausente', () => {
+		expect(resolveOgText(readerOf({ collection: '   ', author: 'Borges', title: 'El Fin' }))).toBe('El Fin - Borges');
+		expect(resolveOgText(readerOf({ collection: '', author: '  ', title: 'El Fin' }))).toBe('La Cuentoneta');
+	});
+
+	it('recorta los espacios de los bordes del texto que resuelve', () => {
+		expect(resolveOgText(readerOf({ author: '  Borges  ', title: '  El Fin  ' }))).toBe('El Fin - Borges');
+	});
+
+	it('escapa el markup del texto que resuelve', () => {
+		const injected = '</p><img src="https://ejemplo.invalid/x.png" /><p>';
+
+		expect(resolveOgText(readerOf({ collection: injected }))).not.toContain('<img');
+		expect(resolveOgText(readerOf({ collection: '<b>&"\'' }))).toBe('&lt;b&gt;&amp;&quot;&#39;');
+	});
+
+	it('acota el largo del texto antes de escaparlo', () => {
+		const long = 'a'.repeat(500);
+
+		expect(resolveOgText(readerOf({ collection: long }))).toBe('a'.repeat(120));
 	});
 });

--- a/src/api/_helpers/og-text.spec.ts
+++ b/src/api/_helpers/og-text.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveOgText } from './og-text';
+
+describe('resolveOgText', () => {
+	it('usa el nombre de la colección cuando viene provisto', () => {
+		expect(resolveOgText({ collection: 'Cuentos de terror', author: 'Borges', title: 'El Fin' })).toBe(
+			'Cuentos de terror',
+		);
+	});
+
+	it('compone título y autor cuando no hay colección', () => {
+		expect(resolveOgText({ author: 'Borges', title: 'El Fin' })).toBe('El Fin - Borges');
+	});
+
+	it('cae a la marca cuando falta alguno del par autor y título', () => {
+		expect(resolveOgText({ title: 'El Fin' })).toBe('La Cuentoneta');
+		expect(resolveOgText({ author: 'Borges' })).toBe('La Cuentoneta');
+		expect(resolveOgText({})).toBe('La Cuentoneta');
+	});
+
+	it('trata un parámetro vacío como ausente', () => {
+		expect(resolveOgText({ collection: '', author: 'Borges', title: 'El Fin' })).toBe('El Fin - Borges');
+	});
+});

--- a/src/api/_helpers/og-text.ts
+++ b/src/api/_helpers/og-text.ts
@@ -1,0 +1,18 @@
+/**
+ * Resuelve la leyenda que va sobre la imagen de Open Graph a partir de los parámetros del pedido.
+ *
+ * El nombre de la colección gana sobre el par autor + título, y ambos sobre la marca: el pedido que
+ * comparte una colección entera no tiene una obra que nombrar. Un parámetro presente pero vacío no
+ * cuenta como provisto.
+ */
+export function resolveOgText(params: { collection?: string; author?: string; title?: string }): string {
+	if (params.collection) {
+		return params.collection;
+	}
+
+	if (params.author && params.title) {
+		return `${params.title} - ${params.author}`;
+	}
+
+	return 'La Cuentoneta';
+}

--- a/src/api/_helpers/og-text.ts
+++ b/src/api/_helpers/og-text.ts
@@ -1,18 +1,50 @@
+// Cota del texto que se pinta sobre la imagen: más allá de esto no entra en la caja del renderizado,
+// y el valor llega de un query param público sin ninguna otra restricción de tamaño.
+const MAX_LENGTH = 120;
+
+const MARKUP_ESCAPES: Record<string, string> = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#39;',
+};
+
 /**
- * Resuelve la leyenda que va sobre la imagen de Open Graph a partir de los parámetros del pedido.
+ * Resuelve la leyenda que va sobre la imagen de Open Graph leyendo los query params del pedido.
+ *
+ * Recibe el lector en vez de los valores ya extraídos para que los nombres de los parámetros
+ * —`collection`, `author`, `title`— queden dentro de la unidad que los tests ejercitan: un typo en
+ * uno de ellos degrada silenciosamente a la marca, con status 200 y sin excepción.
  *
  * El nombre de la colección gana sobre el par autor + título, y ambos sobre la marca: el pedido que
- * comparte una colección entera no tiene una obra que nombrar. Un parámetro presente pero vacío no
- * cuenta como provisto.
+ * comparte una colección entera no tiene una obra que nombrar. Un parámetro en blanco no cuenta
+ * como provisto.
+ *
+ * El resultado viene **escapado y acotado**, listo para interpolarse en el markup que consume el
+ * renderizador. Devolver el texto crudo dejaría al llamador a cargo de una garantía que solo se
+ * verifica acá.
  */
-export function resolveOgText(params: { collection?: string; author?: string; title?: string }): string {
-	if (params.collection) {
-		return params.collection;
+export function resolveOgText(readQueryParam: (name: string) => string | undefined): string {
+	const collection = readTrimmed(readQueryParam, 'collection');
+	const author = readTrimmed(readQueryParam, 'author');
+	const title = readTrimmed(readQueryParam, 'title');
+
+	if (collection) {
+		return toMarkupSafeText(collection);
 	}
 
-	if (params.author && params.title) {
-		return `${params.title} - ${params.author}`;
+	if (author && title) {
+		return toMarkupSafeText(`${title} - ${author}`);
 	}
 
 	return 'La Cuentoneta';
+}
+
+function readTrimmed(readQueryParam: (name: string) => string | undefined, name: string): string {
+	return (readQueryParam(name) ?? '').trim();
+}
+
+function toMarkupSafeText(text: string): string {
+	return text.slice(0, MAX_LENGTH).replace(/[&<>"']/g, (character) => MARKUP_ESCAPES[character]);
 }

--- a/src/api/og.controller.ts
+++ b/src/api/og.controller.ts
@@ -5,9 +5,8 @@ import { Hono } from 'hono';
 
 import type { ReactNode } from 'react';
 
-import Logo from './_utils/Logo';
-
 import { resolveOgText } from './_helpers/og-text';
+import Logo from './_utils/Logo';
 
 const ogController = new Hono();
 
@@ -15,11 +14,7 @@ const ogController = new Hono();
 ogController.get('/og', async (c) => {
 	const rrss = c.req.query('rrss');
 
-	const text = resolveOgText({
-		collection: c.req.query('collection'),
-		author: c.req.query('author'),
-		title: c.req.query('title'),
-	});
+	const text = resolveOgText((name) => c.req.query(name));
 
 	let width: number;
 	let height: number;

--- a/src/api/og.controller.ts
+++ b/src/api/og.controller.ts
@@ -7,24 +7,19 @@ import type { ReactNode } from 'react';
 
 import Logo from './_utils/Logo';
 
+import { resolveOgText } from './_helpers/og-text';
+
 const ogController = new Hono();
 
 // Route
 ogController.get('/og', async (c) => {
-	const author = c.req.query('author');
-	const title = c.req.query('title');
 	const rrss = c.req.query('rrss');
-	const storylist = c.req.query('storylist');
 
-	let text: string;
-
-	if (storylist) {
-		text = String(storylist);
-	} else if (author && title) {
-		text = `${title} - ${author}`;
-	} else {
-		text = 'La Cuentoneta';
-	}
+	const text = resolveOgText({
+		collection: c.req.query('collection'),
+		author: c.req.query('author'),
+		title: c.req.query('title'),
+	});
 
 	let width: number;
 	let height: number;

--- a/src/app/components/author-card-teaser/author-card-teaser.component.spec.ts
+++ b/src/app/components/author-card-teaser/author-card-teaser.component.spec.ts
@@ -73,12 +73,12 @@ describe('AuthorCardTeaserComponent', () => {
 
 	it('should render the story count (plural)', async () => {
 		await render(AuthorCardTeaserComponent, { inputs: { author: authorTeaserMock, storyCount: 21 } });
-		expect(screen.getByTestId('story-count')).toHaveTextContent('21 historias');
+		expect(screen.getByTestId('story-count')).toHaveTextContent('21 obras');
 	});
 
 	it('should use the singular for a single story', async () => {
 		await render(AuthorCardTeaserComponent, { inputs: { author: authorTeaserMock, storyCount: 1 } });
-		expect(screen.getByTestId('story-count')).toHaveTextContent('1 historia');
+		expect(screen.getByTestId('story-count')).toHaveTextContent('1 obra');
 	});
 
 	it('should not render tags or story count when not provided', async () => {

--- a/src/app/components/author-card-teaser/author-card-teaser.component.stories.ts
+++ b/src/app/components/author-card-teaser/author-card-teaser.component.stories.ts
@@ -19,7 +19,7 @@ const meta: Meta<AuthorCardTeaserComponent> = {
 				sourceState: 'shown',
 			},
 			description: {
-				component: `<div><p>El componente <strong>AuthorCardTeaserComponent</strong> muestra una vista previa de un autor enlazada a su perfil, según el Design System v3. Está pensado para listar y visualizar perfiles de autores, mostrando el avatar, los tags, el nombre con la bandera de nacionalidad y la cantidad de historias.</p><p>Se modela como un <code>&lt;article&gt;</code> con un único enlace real sobre el nombre del autor, estirado con un pseudo-elemento para que toda la tarjeta sea clickeable sin inflar el nombre accesible del link.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar) y <a href="./?path=/docs/componentes-v3-tagslist--docs" target="_top"><strong>TagsList</strong></a> con instancias de <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> (etiquetas del autor).</p></div>`,
+				component: `<div><p>El componente <strong>AuthorCardTeaserComponent</strong> muestra una vista previa de un autor enlazada a su perfil, según el Design System v3. Está pensado para listar y visualizar perfiles de autores, mostrando el avatar, los tags, el nombre con la bandera de nacionalidad y la cantidad de obras.</p><p>Se modela como un <code>&lt;article&gt;</code> con un único enlace real sobre el nombre del autor, estirado con un pseudo-elemento para que toda la tarjeta sea clickeable sin inflar el nombre accesible del link.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (avatar) y <a href="./?path=/docs/componentes-v3-tagslist--docs" target="_top"><strong>TagsList</strong></a> con instancias de <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> (etiquetas del autor).</p></div>`,
 			},
 		},
 		layout: 'padded',
@@ -37,7 +37,7 @@ const meta: Meta<AuthorCardTeaserComponent> = {
 		},
 		storyCount: {
 			control: { type: 'number' },
-			description: 'Cantidad de historias del autor',
+			description: 'Cantidad de obras del autor',
 			table: { type: { summary: 'number' }, defaultValue: { summary: 'undefined' } },
 		},
 	},
@@ -53,7 +53,7 @@ export const Default: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Teaser completo del autor: avatar, fila de tags, nombre con bandera de nacionalidad y cantidad de historias. Toda la tarjeta es clickeable y navega al perfil del autor.</p><p><strong>Usos:</strong> la sección <a href="./?path=/docs/componentes-v3-highlightedauthors--docs" target="_top"><strong>HighlightedAuthors</strong></a> de la página de inicio, y el listado de autores.</p>`,
+				story: `<p>Teaser completo del autor: avatar, fila de tags, nombre con bandera de nacionalidad y cantidad de obras. Toda la tarjeta es clickeable y navega al perfil del autor.</p><p><strong>Usos:</strong> la sección <a href="./?path=/docs/componentes-v3-highlightedauthors--docs" target="_top"><strong>HighlightedAuthors</strong></a> de la página de inicio, y el listado de autores.</p>`,
 			},
 		},
 	},

--- a/src/app/components/author-card-teaser/author-card-teaser.component.ts
+++ b/src/app/components/author-card-teaser/author-card-teaser.component.ts
@@ -12,7 +12,7 @@ import { TagComponent } from '../tag/tag.component';
 /**
  * Vista previa de un autor enlazada a su perfil, según el Design System v3. Componente de
  * presentación reutilizable para listar y visualizar perfiles de autores: avatar, tags,
- * nombre + bandera de nacionalidad y cantidad de historias.
+ * nombre + bandera de nacionalidad y cantidad de obras.
  *
  * Se modela como un `<article>` (unidad autocontenida) con un único enlace real sobre el nombre del autor,
  * estirado con un pseudo-elemento (`after:absolute after:inset-0`) para que toda la tarjeta sea clickeable
@@ -58,7 +58,7 @@ import { TagComponent } from '../tag/tag.component';
 				</div>
 				@if (storyCount() !== undefined) {
 					<span class="font-inter text-xs font-medium text-neutral-600" data-testid="story-count">
-						{{ storyCount() }} {{ storyCount() === 1 ? 'historia' : 'historias' }}
+						{{ storyCount() }} {{ storyCount() === 1 ? 'obra' : 'obras' }}
 					</span>
 				}
 			</div>

--- a/src/app/components/cover-image/cover-image-skeleton.component.ts
+++ b/src/app/components/cover-image/cover-image-skeleton.component.ts
@@ -4,7 +4,7 @@ import { SkeletonComponent } from '@components/skeleton/skeleton.component';
 
 /**
  * Estado de carga (esqueleto) de CoverImageComponent: reproduce la caja de la portada (118×164) con
- * un placeholder de cuentoneta-skeleton para evitar saltos de layout mientras la story carga.
+ * un placeholder de cuentoneta-skeleton para evitar saltos de layout mientras la obra carga.
  */
 @Component({
 	selector: 'cuentoneta-cover-image-skeleton',

--- a/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
+++ b/src/app/components/highlighted-authors/highlighted-authors.component.spec.ts
@@ -108,7 +108,7 @@ describe('HighlightedAuthorsComponent', () => {
 				componentImports: defaultImports,
 			});
 
-			expect(screen.getByText(`${highlighted.storyCount} historias`)).toBeInTheDocument();
+			expect(screen.getByText(`${highlighted.storyCount} obras`)).toBeInTheDocument();
 		});
 
 		it('should transition from loading to complete state', async () => {

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.spec.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.spec.ts
@@ -26,12 +26,12 @@ describe('NavigableCollectionTeaserComponent', () => {
 
 	it('should render the pluralized story count', async () => {
 		await setup({ ...collection, count: 5 });
-		expect(screen.getByText('5 historias')).toBeInTheDocument();
+		expect(screen.getByText('5 obras')).toBeInTheDocument();
 	});
 
 	it('should render the singular story count', async () => {
 		await setup({ ...collection, count: 1 });
-		expect(screen.getByText('1 historia')).toBeInTheDocument();
+		expect(screen.getByText('1 obra')).toBeInTheDocument();
 	});
 
 	it('should link to the collection exposing just the title as the accessible name', async () => {

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.stories.ts
@@ -12,7 +12,7 @@ const meta: Meta<NavigableCollectionTeaserComponent> = {
 		docs: {
 			canvas: { sourceState: 'shown' },
 			description: {
-				component: `<div><p>El componente <strong>NavigableCollectionTeaserComponent</strong> es el item compacto y navegable de una colección (Design System v3): ícono de biblioteca, nombre, categoría y cantidad de historias. Pensado para listas como «Otras colecciones sugeridas» del sidebar de la página de una colección.</p><p>Se modela como un <code>&lt;article&gt;</code> con un único enlace real sobre el nombre, estirado con un pseudo-elemento para que toda la tarjeta sea clickeable sin inflar el nombre accesible del link.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (ícono de colección, variante <code>collection</code>) y <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> (categoría, variante <code>soft</code>).</p></div>`,
+				component: `<div><p>El componente <strong>NavigableCollectionTeaserComponent</strong> es el item compacto y navegable de una colección (Design System v3): ícono de biblioteca, nombre, categoría y cantidad de obras. Pensado para listas como «Otras colecciones sugeridas» del sidebar de la página de una colección.</p><p>Se modela como un <code>&lt;article&gt;</code> con un único enlace real sobre el nombre, estirado con un pseudo-elemento para que toda la tarjeta sea clickeable sin inflar el nombre accesible del link.</p><p>Se compone de <a href="./?path=/docs/componentes-v3-imageprofile--docs" target="_top"><strong>ImageProfile</strong></a> (ícono de colección, variante <code>collection</code>) y <a href="./?path=/docs/componentes-v3-tag--docs" target="_top"><strong>Tag</strong></a> (categoría, variante <code>soft</code>).</p></div>`,
 			},
 		},
 		layout: 'padded',
@@ -36,7 +36,7 @@ export const Default: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Item completo: ícono de colección, nombre, categoría y cantidad de historias. Toda la tarjeta es clickeable y navega a la colección.</p><p><strong>Usos:</strong> «Otras colecciones sugeridas» en el sidebar de la CollectionPage.</p>`,
+				story: `<p>Item completo: ícono de colección, nombre, categoría y cantidad de obras. Toda la tarjeta es clickeable y navega a la colección.</p><p><strong>Usos:</strong> «Otras colecciones sugeridas» en el sidebar de la CollectionPage.</p>`,
 			},
 		},
 	},
@@ -49,7 +49,7 @@ export const SinCategoria: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: `<p>Colección sin categoría asignada: se omiten el tag y el separador, y queda solo la cantidad de historias.</p><p><strong>Usos:</strong> «Otras colecciones sugeridas», para colecciones que todavía no tienen una categoría cargada en el CMS.</p>`,
+				story: `<p>Colección sin categoría asignada: se omiten el tag y el separador, y queda solo la cantidad de obras.</p><p><strong>Usos:</strong> «Otras colecciones sugeridas», para colecciones que todavía no tienen una categoría cargada en el CMS.</p>`,
 			},
 		},
 	},

--- a/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
+++ b/src/app/components/navigable-collection-teaser/navigable-collection-teaser.component.ts
@@ -8,7 +8,7 @@ import { TagComponent } from '../tag/tag.component';
 
 /**
  * Item compacto y navegable de una colección (Design System v3): ícono de biblioteca, nombre, categoría y
- * cantidad de historias. Pensado para listas como «Otras colecciones sugeridas» del sidebar de la CollectionPage.
+ * cantidad de obras. Pensado para listas como «Otras colecciones sugeridas» del sidebar de la CollectionPage.
  *
  * Se modela como un `<article>` con un único enlace real sobre el nombre, estirado con un pseudo-elemento
  * (`after:absolute after:inset-0`) para que toda la tarjeta sea clickeable sin inflar el nombre accesible del
@@ -35,7 +35,7 @@ import { TagComponent } from '../tag/tag.component';
 						<span class="font-inter text-xxs font-medium text-neutral-600" aria-hidden="true">•</span>
 					}
 					<span class="font-inter text-xs font-medium text-neutral-600">
-						{{ collection().count }} {{ collection().count === 1 ? 'historia' : 'historias' }}
+						{{ collection().count }} {{ collection().count === 1 ? 'obra' : 'obras' }}
 					</span>
 				</div>
 			</div>

--- a/src/app/directives/head-metadata.directive.ts
+++ b/src/app/directives/head-metadata.directive.ts
@@ -93,8 +93,8 @@ export class HeadMetadataDirective {
 	}
 
 	// Fecha de publicación y de última modificación (ISO) vía las propiedades og/article. Son señales
-	// E-E-A-T aplicables a cualquier entidad del sistema modelada como artículo —cuentos, perfiles de
-	// autor (cuándo se creó/actualizó la ficha), etc.—, no solo a cuentos.
+	// E-E-A-T aplicables a cualquier entidad modelada como artículo —una obra, la ficha de un autor
+	// (cuándo se creó o se actualizó)—, no solo a las obras.
 	public setArticleDates(publishedTime: string, modifiedTime: string) {
 		this.metaTagService.updateTag({
 			property: 'article:published_time',

--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -4,7 +4,7 @@
 			<h1 class="h1 mb-5 lg:text-6xl lg:font-extrabold">Historias para disfrutar, compartir y aprender</h1>
 			<h3 class="h3 mb-5 text-neutral-600">
 				Una iniciativa que busca fomentar y hacer accesible la lectura digital, publicando literatura breves en nuestras
-				<em>storylists</em> temáticas. ¡Subite a La Cuentoneta!
+				<em>colecciones</em> temáticas. ¡Subite a La Cuentoneta!
 			</h3>
 		</div>
 		<div class="ml-auto">
@@ -25,8 +25,8 @@
 			<p class="font-inter text-base font-normal">
 				Nuestra misión es construir colectivamente una plataforma accesible, amigable y gamificada que sea útil para
 				fomentar, compartir y disfrutar la lectura digital. Buscamos lograrlo a través de la publicación de escritos
-				breves en storylists temáticas, emulando las playlists que utilizan plataformas de audio como Spotify y de video
-				como YouTube; intentando resignificar el formato de antología de relatos breves.
+				breves en colecciones temáticas, emulando las playlists que utilizan plataformas de audio como Spotify y de
+				video como YouTube; intentando resignificar el formato de antología de relatos breves.
 			</p>
 		</section>
 
@@ -41,7 +41,7 @@
 				<a [href]="links.DISCORD_CHANNEL" class="underline">Discord de FrontendCafé</a>.
 			</p>
 
-			<section class="mb-3 mt-3">
+			<section class="mt-3 mb-3">
 				<h3 class="h3">📢 Difundiendo</h3>
 				<p class="font-inter text-base font-normal">
 					Si te gusta el proyecto, podés ayudarnos difundiéndolo en tus redes sociales, compartiendo los contenidos que
@@ -70,7 +70,7 @@
 				<h3 class="h3">📜 Sumando contenidos</h3>
 				<p class="font-inter text-base font-normal">
 					Podés sugerir contenido para sumar a la plataforma, sea en forma de cuentos, poemas, ensayos o temáticas para
-					nuevas storylists. El contenido puede ser escritura propia o de terceros, con previos permisos de publicación
+					nuevas colecciones. El contenido puede ser escritura propia o de terceros, con previos permisos de publicación
 					o disponibilidad de acceso a este contenido en la web abierta.
 				</p>
 				<p class="font-inter text-base font-normal">

--- a/src/app/utils/navigation-params.spec.ts
+++ b/src/app/utils/navigation-params.spec.ts
@@ -10,12 +10,8 @@ describe('toNavigationContext', () => {
 	});
 
 	// El router asigna `undefined` explícitamente cuando el query param desaparece al navegar, así que
-	// no alcanza con el default del input: el transform tiene que aceptarlo. `storylist` es el nombre
-	// viejo del contexto de colección, que sigue llegando desde enlaces compartidos hacia afuera.
-	it.each([undefined, '', 'storylist', 'cualquier-otra-cosa'])(
-		'should fall back to the author context for %p',
-		(value) => {
-			expect(toNavigationContext(value)).toBe('author');
-		},
-	);
+	// no alcanza con el default del input: el transform tiene que aceptarlo.
+	it.each([undefined, '', 'cualquier-otra-cosa'])('should fall back to the author context for %p', (value) => {
+		expect(toNavigationContext(value)).toBe('author');
+	});
 });

--- a/src/app/utils/navigation-params.spec.ts
+++ b/src/app/utils/navigation-params.spec.ts
@@ -10,9 +10,7 @@ describe('toNavigationContext', () => {
 	});
 
 	// El router asigna `undefined` explícitamente cuando el query param desaparece al navegar, así que
-	// no alcanza con el default del input: el transform tiene que aceptarlo. El fallback cubre además
-	// los contextos que llegan desde afuera: el 301 de las rutas retiradas preserva la query string, así
-	// que un enlace compartido puede traer un valor que el transform ya no reconoce.
+	// no alcanza con el default del input: el transform tiene que aceptarlo.
 	it.each([undefined, '', 'cualquier-otra-cosa'])('should fall back to the author context for %p', (value) => {
 		expect(toNavigationContext(value)).toBe('author');
 	});

--- a/src/app/utils/navigation-params.spec.ts
+++ b/src/app/utils/navigation-params.spec.ts
@@ -10,7 +10,9 @@ describe('toNavigationContext', () => {
 	});
 
 	// El router asigna `undefined` explícitamente cuando el query param desaparece al navegar, así que
-	// no alcanza con el default del input: el transform tiene que aceptarlo.
+	// no alcanza con el default del input: el transform tiene que aceptarlo. El fallback cubre además
+	// los contextos que llegan desde afuera: el 301 de las rutas retiradas preserva la query string, así
+	// que un enlace compartido puede traer un valor que el transform ya no reconoce.
 	it.each([undefined, '', 'cualquier-otra-cosa'])('should fall back to the author context for %p', (value) => {
 		expect(toNavigationContext(value)).toBe('author');
 	});

--- a/src/app/utils/navigation-params.ts
+++ b/src/app/utils/navigation-params.ts
@@ -16,6 +16,11 @@ export type NavigationParams = {
  *
  * Acepta `undefined` porque el router lo asigna explícitamente cuando el query param desaparece al
  * navegar: sin ese caso, el binding del input rompe la navegación del lado del cliente.
+ *
+ * Cualquier otro valor cae al contexto de autor. No es solo una defensa contra un query param
+ * inventado: el 301 de las rutas retiradas preserva la query string, así que un enlace compartido
+ * puede traer el nombre con el que ese contexto viajaba antes, y el slug que lo acompaña se
+ * interpreta entonces como el de un autor.
  */
 export function toNavigationContext(value: string | undefined): NavigationContext {
 	return value === 'collection' ? 'collection' : 'author';

--- a/src/app/utils/ssr-resource.ts
+++ b/src/app/utils/ssr-resource.ts
@@ -30,7 +30,7 @@ export function ssrBlockingRxResource<T, R>(options: RxResourceOptions<T, R>): R
 
 /**
  * Opt-out explícito del bloqueo de SSR: alias directo de `rxResource` para datos secundarios o no
- * indexables (p. ej. el listado de cuentos de un autor), que se sirven como skeleton y resuelven en
+ * indexables (p. ej. el listado de obras de un autor), que se sirven como skeleton y resuelven en
  * el cliente.
  */
 export const progressiveRxResource = rxResource;

--- a/src/indexFile.html
+++ b/src/indexFile.html
@@ -11,7 +11,7 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 		<meta
 			name="description"
-			content="Una iniciativa que busca fomentar y hacer accesible la lectura digital, publicando relatos breves en storylists temáticas."
+			content="Una iniciativa que busca fomentar y hacer accesible la lectura digital, publicando relatos breves en colecciones temáticas."
 		/>
 
 		<!-- Media markup web -->
@@ -23,7 +23,7 @@
 		<meta property="og:url" content="https://www.cuentoneta.ar" />
 		<meta
 			property="og:description"
-			content="Una iniciativa que busca fomentar y hacer accesible la lectura digital, publicando relatos breves en storylists temáticas."
+			content="Una iniciativa que busca fomentar y hacer accesible la lectura digital, publicando relatos breves en colecciones temáticas."
 		/>
 		<meta property="og:locale" content="es_AR" />
 
@@ -33,7 +33,7 @@
 		<meta name="twitter:creator" content="@cuentoneta" />
 		<meta
 			name="twitter:description"
-			content="Una iniciativa que busca fomentar y hacer accesible la lectura digital, publicando relatos breves en storylists temáticas."
+			content="Una iniciativa que busca fomentar y hacer accesible la lectura digital, publicando relatos breves en colecciones temáticas."
 		/>
 		<meta name="twitter:image" content="assets/svg/logo.svg" />
 


### PR DESCRIPTION
Refunda el lenguaje de dominio en todo lo que **no** depende del estado del dataset: `LiteraryWork` y `Collection` dejan de convivir con el vocabulario retirado en el copy visible, en el parámetro público del endpoint de OG, en los comentarios y en la prosa.

> **La Capa 2 del issue queda fuera, y no por decisión de alcance: la precondición no se cumple.** El detalle y la evidencia, más abajo.

## Lo que entra

**El parámetro del endpoint de OG.** `/og?storylist=…` pasa a `/og?collection=…`. Ningún consumidor interno construye una URL de `/og`, así que el rename no rompe llamadores propios.

La resolución del texto se extrae a `resolveOgText` en `src/api/_helpers/og-text.ts`, que **recibe el lector de query params** en vez de los valores ya extraídos: así los nombres `collection`, `author` y `title` quedan dentro de la unidad que el spec ejercita. Sin eso, un typo en cualquiera de los tres degradaba a la marca en silencio, con status 200, y ningún gate veía un literal de string.

Con ese seam abierto, el texto pasa a devolverse **recortado, acotado a 120 caracteres y escapado**. Sin escapar, un query param podía cerrar el párrafo del markup e inyectar nodos propios. Lo comprobé contra el renderizador real, y el resultado matiza el diagnóstico habitual: `satori` **ya rechaza** las direcciones internas (`169.254.169.254`, `127.0.0.1`) con su propia protección de SSRF, así que el escenario de metadata endpoint no aplica; pero **sí consulta URLs públicas arbitrarias** y **sí renderiza el markup inyectado**. O sea: fetch saliente controlado por el visitante y control del contenido de la imagen que se sirve. Es preexistente —el rename no lo introdujo—, pero este PR es el que crea el lugar donde la garantía se puede escribir y verificar.

La cota de largo y el escapado viven en `resolveOgText` y no en un `zValidator` de zod a propósito: son cuatro params de texto libre que no alimentan ninguna query, y duplicar la garantía en dos lugares deja la duda de cuál manda.

**El copy que se lee en pantalla.** «storylists» en la página «Acerca de» y en las tres meta descripciones estáticas → **colecciones**; «historias» en el conteo del teaser de autor y en el de colección navegable → **obras**. La forma canónica ya estaba declarada por la app en el JSON-LD de la organización, así que el HTML estático pasa a decir lo mismo.

**El relato en comentarios y prosa.** El listado de obras de un autor, el cuerpo que miden las invariantes de SSR, las señales de artículo, el listado de la página de inicio, el esqueleto de la portada y el encabezado del smoke de indexado. El caso `'storylist'` del transform de contexto de navegación se retira porque no aportaba cobertura: el fallback a `author` es total y ya lo afirma un valor arbitrario.

**Los fixtures de los sweeps.** `required-fields-sweep` y `field-shape-sweep` usaban los tipos retirados como etiquetas arbitrarias; pasan a nombrar tipos vigentes. Los sweeps son genéricos sobre cualquier tipo de documento, así que ninguna aserción cambia de sentido.

## Lo que queda afuera, y por qué

**La purga no corrió en ningún dataset.** Censo con `sanity documents query` sobre los tres, el día de este PR:

| Conteo                  | development | staging | production |
| ----------------------- | ----------- | ------- | ---------- |
| `story` publicados      | 613         | 613     | 613        |
| `storylist` publicados  | 27          | 27      | 27         |
| `cards`                 | 296         | 296     | 296        |
| `latestReads`           | 234         | 234     | 234        |
| `mostRead`              | 18          | 18      | 18         |
| `collections`           | 296         | 296     | 296        |
| `latestLiteraryWorks`   | 234         | 234     | 234        |

El relinkeo de la página de inicio sí corrió en los tres. La trilogía de la purga —`unset-legacy-story-references`, `purge-storylist-documents`, `purge-story-documents`— **no**: los campos que da de baja siguen poblados y los 640 documentos que borra siguen en pie, producción incluida. El runbook decía la verdad cuando declaraba pendiente su segundo prerequisito.

De ahí que no se retire **ninguna** migración:

- Las tres de la purga no corrieron. Borrar una migración exige que haya corrido en los tres datasets.
- El relinkeo corrió, pero su reversión **sigue siendo viable y útil** justamente porque `unset-legacy-story-references` no corrió: los campos que la reversión repuebla todavía existen. Retirarla ahora quitaría una red de seguridad viva.

Y de ahí que tampoco se toque el conteo de obras por autor: la unión `_type in ['story', 'literaryWork']` con deduplicación por slug de `content.query.ts` **resuelve una coexistencia que es real en el dato**. Los comentarios y fixtures que la explican describen conducta vigente, no un relato de reemplazo; borrarlos dejaría el código sin explicación en vez de sin residuo. Por la misma razón se conservan `docs/DOMAIN_MODEL.md:422/426` y el ejemplo de `angular-components.md`, y se conserva la cita de `sanity-migrations.md` al runbook de la purga.

## Lo que el grep de aceptación sigue devolviendo, con su motivo

- **Los redirects 301 de `/story` y `/storylist`** (`legacy-route-redirects.middleware.ts`, `server.ts`): conducta vigente. Nombran URLs indexadas del mundo exterior, no el modelo.
- **`src/api/_mocks/clarity.mock.ts`**: respuesta capturada de la API de un tercero, con URLs históricas reales. Editarla sería falsificar el fixture.
- **Vocabulario de Storybook** (`*.stories.ts`, `Story`/`StoryObj`, `docs.description.story`): ajeno al dominio.
- **Nombres de género literario** («cuentos, poemas, ensayos» en «Acerca de», «Cuentos y relatos breves» en el título de la home, «microcuento» en el sweep de indexado): nombran un género, no el tipo retirado.
- **Los lemas de marca** «Historias para disfrutar, compartir y aprender» (el H1 de «Acerca de» y los `og:title`/`twitter:title`): son eslogan, no terminología de dominio. La regla «historia → obra» rige sobre la prosa que describe el modelo, no sobre el lema.
- **Todo lo que cuelga de la coexistencia viva**, enumerado arriba.

## Seguimiento propuesto

Cuando la purga haya corrido en los tres datasets, un issue hijo cierra la Capa 2 completa: baja de las cinco migraciones de la transición con sus helpers de derivación, reapuntado de la cita de `sanity-migrations.md`, y el rename de `storyCount` a `literaryWorkCount` con la unión de tipos reducida a `literaryWork`.

Closes #2363.
Parte de #2265.

## Plan de pruebas

**Automatizado**

- `src/api/_helpers/og-text.spec.ts` (nuevo): precedencia colección → autor + título → marca; parámetro en blanco tratado como ausente; recorte de bordes; escapado del markup inyectado; cota de largo.
- Specs actualizados con el copy nuevo: `author-card-teaser`, `navigable-collection-teaser`, `highlighted-authors`.
- Fixtures de `required-fields-sweep` y `field-shape-sweep` sobre tipos y paths que existen en el schema.

**Manual / verificado en la sesión**

- Censo con `sanity documents query` sobre `development`, `staging` y `production` (la tabla de arriba), que es lo que define el alcance de este PR.
- Sonda contra `satori` real con markup inyectado, para distinguir qué parte del vector es explotable y cuál la neutraliza el renderizador.
- Barrido final del criterio de aceptación sobre `docs/`, `.claude/references/` y los comentarios de `src/`, `cms/`, `scripts/` y `e2e/`; lo que sigue apareciendo está enumerado arriba con su motivo.

**Gates**

- Tier local en verde: `lint`, `typecheck`, `stylelint`, `check-agents`, `test`.
- Los once gates de CI en verde sobre el commit final.
