### PR TITLE
[#2450] - Acota satori a la línea 0.32, anterior a la introducción de harfbuzzjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"remark-parse": "^11.0.0",
 		"remark-rehype": "^11.1.2",
 		"rxjs": "~7.8.1",
-		"satori": "^0.33.4",
+		"satori": "^0.32.0",
 		"satori-html": "^0.3.2",
 		"tslib": "^2.6.2",
 		"unified": "^11.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: ~7.8.1
         version: 7.8.2
       satori:
-        specifier: ^0.33.4
-        version: 0.33.4
+        specifier: ^0.32.0
+        version: 0.32.0
       satori-html:
         specifier: ^0.3.2
         version: 0.3.2
@@ -6715,9 +6715,6 @@ packages:
     resolution: {integrity: sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg==}
     engines: {node: '>=20.0.0'}
 
-  harfbuzzjs@0.10.0:
-    resolution: {integrity: sha512-SN8LVwCOzvTq3OPNd0+EAghgXugItz56wst567D1vs7LnnKGWprhi3EG58aVOBwhN8HEbQxL4I9NDWkcXUutRw==}
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -9042,8 +9039,8 @@ packages:
   satori-html@0.3.2:
     resolution: {integrity: sha512-wjTh14iqADFKDK80e51/98MplTGfxz2RmIzh0GqShlf4a67+BooLywF17TvJPD6phO0Hxm7Mf1N5LtRYvdkYRA==}
 
-  satori@0.33.4:
-    resolution: {integrity: sha512-dCnaW6D/tkCJxG5UvpZPWnnvfTdGTVVSAq1tzH6xC5MeOhAeeswRcSq5zT7C6lRCdTGow9PRGus7PCzdp5JJYw==}
+  satori@0.32.0:
+    resolution: {integrity: sha512-WwYeCWKjxfXvk7SsLSLTJhcPOrB2HCxbptqGIiYor0yqaPu3xA5uMTQ/4Dan5mxClhhk2Wn9ZE1pLGIlGdUxFQ==}
     engines: {node: '>=16'}
 
   sax@1.4.4:
@@ -17467,8 +17464,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  harfbuzzjs@0.10.0: {}
-
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -20157,7 +20152,7 @@ snapshots:
     dependencies:
       ultrahtml: 1.2.0
 
-  satori@0.33.4:
+  satori@0.32.0:
     dependencies:
       '@shuding/opentype.js': 1.4.0-beta.0
       css-background-parser: 0.1.0
@@ -20166,8 +20161,6 @@ snapshots:
       css-to-react-native: 3.2.0
       emoji-regex-xs: 2.0.1
       escape-html: 1.0.3
-      fflate: 0.7.3
-      harfbuzzjs: 0.10.0
       linebreak: 1.1.0
       parse-css-color: 0.2.1
       postcss-value-parser: 4.2.0

--- a/src/api/og.controller.ts
+++ b/src/api/og.controller.ts
@@ -1,3 +1,6 @@
+// TODO(#2450): satori está acotado a la línea 0.32 en package.json. Desde 0.33 arrastra harfbuzzjs,
+// que resuelve su WASM con __dirname y rompe la extracción de rutas al empaquetarse en el bundle ESM
+// de servidor. Levantar el pin exige que eso deje de pasar, o tratar el paquete como externo.
 import { html } from 'satori-html';
 import satori from 'satori';
 import { readFileSync } from 'fs';


### PR DESCRIPTION
`pnpm build` falla en `develop` desde el merge de #2429, en la extracción de rutas:

```
X [ERROR] An error occurred while extracting routes.
ReferenceError: __dirname is not defined
```

No es un error de compilación: el bundle se genera bien y revienta cuando Angular lo levanta para extraer las rutas.

## Qué cambia

`satori` pasa de `^0.33.4` a **`^0.32.0`**, que es la **última versión sin `harfbuzzjs`** — la introduce `0.33.0`, publicada el mismo día. Con eso `harfbuzzjs` desaparece del lockfile.

**No se vuelve a `^0.29.0`**, que era el estado anterior al bump: `0.32.0` conserva las mejoras de `0.30`, `0.31` y `0.32` y se queda justo antes del corte.

El rango protege además hacia adelante: en semver, el caret sobre una versión `0.x` no cruza la minor, así que `^0.32.0` resuelve `>=0.32.0 <0.33.0` y **no puede derivar sola** a la línea rota.

Va también un `TODO` en el único consumidor de `satori` —el controlador de imágenes OG— para que el próximo salto no se haga a ciegas.

## Cómo se aisló la causa

De los 33 updates de #2429, el responsable es uno solo. Verificado por tres vías independientes:

1. **Bisección por commit.** El build pasa en `64a8a188` —el merge anterior— y falla en `49a04d84`, el merge de #2429.
2. **Pin del paquete.** Con `satori` vuelto atrás el build pasa, y ese pin mueve **exactamente 3 entradas del lockfile**: `satori` cambia de versión y desaparece `harfbuzzjs@0.10.0`. La atribución no queda abierta a interpretación.
3. **Hipótesis descartada.** El primer sospechoso era `@angular/build` 22.1.4 → 22.1.5, que es quien genera ese bundle. Pineado de vuelta, falla igual: no es el motor de build.

## El mecanismo

`harfbuzzjs` es moldeado de texto compilado a WebAssembly. Su artefacto `hb.js` es un bundle de Emscripten que detecta el entorno en runtime y usa `__dirname` para localizar el `.wasm` bajo Node; el paquete declara sólo `main`, sin `module` ni `exports`, así que es CommonJS puro.

El build lo empaqueta dentro del bundle de servidor, que es ESM, donde `__dirname` no existe. `satori` entra por el endpoint de imágenes OG —código de servidor—, y por eso el fallo cae en la extracción de rutas y no en el bundle de navegador.

Encaja con las advertencias que el build ya venía emitiendo sobre módulos no-ESM (`slugify`, `undici`, `extend`): ésos sobreviven porque no tocan `__dirname`.

## Plan de pruebas

- **`pnpm build` en verde**, con el `postbuild` completando su paso.
- `pnpm typecheck` verde.
- `pnpm test` verde: **2504 casos**.
- `pnpm lint` verde: 0 errores, 2 warnings preexistentes de `playwright/no-skipped-test`, ajenos a este diff.
- Verificado que **`harfbuzzjs` no aparece en `pnpm-lock.yaml`** ni queda enlazado en el árbol de dependencias.

El diff del lockfile es mínimo —6 inserciones, 13 borrados— y se limita a `satori` y a la baja de `harfbuzzjs`.

## Qué queda para después

Levantar el pin exige que `satori` deje de arrastrar `harfbuzzjs` como CommonJS, o que el bundle de servidor lo trate como externo y lo resuelva en runtime. Dependabot va a volver a proponer el salto: conviene revisar si el problema ya está reportado aguas arriba antes de invertir en un workaround propio.

Closes #2450.
