### PR TITLE
[#2370] - Colapsa en las reviews los archivos autogenerados de Sanity

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,13 @@
 # el CI los ejecuta con bash en Linux y un CR los rompería.
 *.sh text eol=lf
 
+# Salida de los generadores de Sanity: se colapsan en la review de GitHub para que una regeneración no
+# la inunde. `cms/schema.json` lo escribe `pnpm sanity:extract-schema` y `src/sanity/types.ts`,
+# `pnpm sanity:run-typegen-generator`. El generador va nombrado acá y no al lado de cada ruta porque
+# `.gitattributes` no admite comentarios al final de línea: git lee el `#` como nombre de atributo.
+cms/schema.json linguist-generated=true
+src/sanity/types.ts linguist-generated=true
+
 # Fixtures crudas que escribe `pnpm corpus:generate`: se colapsan en la review de GitHub para que una
 # regeneración no la inunde. Se enumeran una por una y no por glob `*.raw.mock.ts` porque no todas las
 # que llevan ese sufijo las escribe el generador: `media/geometria.media.raw.mock.ts` se deriva a mano


### PR DESCRIPTION
`cms/schema.json` y `src/sanity/types.ts` son salida de generadores y nadie los edita a mano. Cuando un PR toca el schema de Sanity los dos se regeneran, y el diff de la review queda inundado por texto que nadie lee.

El repositorio ya tenía la convención —`.gitattributes` marca `linguist-generated=true` sobre las fixtures raw del corpus de Onoff—; estos dos habían quedado afuera.

## Qué cambia

Un bloque nuevo en `.gitattributes`, **separado del bloque del corpus a propósito**: el motivo de enumerar las rutas es distinto en cada uno.

En el corpus se enumera porque un glob `*.raw.mock.ts` escondería una fixture que se escribe a mano. Acá no hay familia que acotar: se enumera para poder **nombrar el comando que reproduce cada archivo**, que es lo que vuelve auditable la marca. Sin eso, un `linguist-generated=true` sobre un archivo cualquiera es indistinguible de una decisión arbitraria.

## Un detalle de `.gitattributes` que conviene saber

El plan proponía nombrar el generador al lado de cada ruta, como comentario al final de línea. **No se puede:** git lee el numeral como nombre de atributo y rechaza el archivo entero.

```
$ git check-attr -a archivo.txt
# is not a valid attribute name: .gitattributes:1
```

Por eso el generador va nombrado en el comentario del bloque, y queda dicho ahí mismo por qué.

## Verificación

`.gitattributes` no lo inspecciona ningún gate, así que la verificación real es contra la misma fuente que GitHub consulta:

- **`git check-attr` resuelve `true`** para los dos archivos, y sigue resolviendo `true` para las fixtures del corpus: el bloque nuevo no rompió el existente.
- **El patrón no desborda.** Cruzado contra todos los archivos versionados, exactamente **15** resuelven a `true`: las 13 fixtures del corpus más estos dos. Ninguno de más.
- **La marca no altera el contenido versionado.** El working tree quedó intacto tras aplicarla, y `git check-attr -a` sobre cada archivo muestra únicamente `linguist-generated` — ningún filtro de contenido ni atributo colateral de `text`, `eol` o `diff`.
- **Tier local en verde**, cada gate corrido y verificado por separado: `typecheck`, `lint`, `stylelint`, `test` (2505 casos) y `check:agents`.

### Lo que este PR no puede verificar

El criterio de aceptación «el archivo aparece colapsado en la vista de cambios» **no es comprobable acá**: este diff no regenera ninguno de los dos, así que no aparecen en «Files changed» y no hay nada que colapsar.

Lo verificable es el mecanismo, y está verificado. La confirmación visual llega sola en el próximo PR que toque el schema de Sanity — el primero que corra `sanity:extract-schema` o el typegen.

## Lo que no cambia

**El conteo de líneas del PR.** `linguist-generated` colapsa el diff y saca el archivo de las estadísticas de lenguaje del repositorio, pero el `+X −Y` del encabezado los sigue contando: es una limitación conocida de GitHub, sin ajuste del lado del repositorio.

La única vía teórica —marcarlos como binarios con `-diff`— queda descartada por su costo en local: `git diff`, `git log -p` y `git add -p` dejarían de mostrarlos como texto, que es justo lo que hace falta cuando hay que auditar por qué el typegen cambió algo inesperado.

## Nota sobre el cuerpo del issue

El issue tabula 4511 y 2703 líneas. Hoy son bastante menos: el retiro de los schemas `story` y `storylist` en 2.11.0 encogió los dos archivos. **No se actualizó el número**, a propósito — el argumento no depende del tamaño, y un conteo escrito vuelve a caducar en la próxima regeneración. Si el issue se corrige, que sea quitando la tabla.

## Plan de pruebas

_Se completa al cerrar la review._

Closes #2370.
