### PR TITLE
[#2458] - Congela satori y typescript en Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,20 @@ updates:
       - dependency-name: '@types/node'
         update-types:
           - version-update:semver-major
+      # TODO(#2458): satori 0.33+ declara harfbuzzjs, que resuelve su WASM con
+      # __dirname y rompe la extracción de rutas del bundle ESM de servidor.
+      # En una 0.x la minor es el salto que rompe, así que se bloquean las dos.
+      - dependency-name: 'satori'
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major
+      # TODO(#2459): el peer de @angular/compiler-cli es ">=6.0 <6.1" y el de
+      # typescript-eslint ">=4.8.4 <6.1.0". El techo es 6.1, no 7, así que
+      # bloquear solo la major dejaría pasar un 6.1 que ya viola esos peers.
+      - dependency-name: 'typescript'
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major
     commit-message:
       prefix: 'chore(deps)'
 
@@ -56,6 +70,12 @@ updates:
     ignore:
       - dependency-name: '@types/node'
         update-types:
+          - version-update:semver-major
+      # TODO(#2459): el Studio versiona en lockstep con la app, así que su
+      # typescript sigue el mismo techo aunque no cargue el compilador de Angular.
+      - dependency-name: 'typescript'
+        update-types:
+          - version-update:semver-minor
           - version-update:semver-major
     commit-message:
       prefix: 'chore(deps-cms)'

--- a/src/api/og.controller.ts
+++ b/src/api/og.controller.ts
@@ -1,4 +1,4 @@
-// TODO(#2450): satori está acotado a la línea 0.32 en package.json. Desde 0.33 arrastra harfbuzzjs,
+// TODO(#2458): satori está acotado a la línea 0.32 en package.json. Desde 0.33 arrastra harfbuzzjs,
 // que resuelve su WASM con __dirname y rompe la extracción de rutas al empaquetarse en el bundle ESM
 // de servidor. Levantar el pin exige que eso deje de pasar, o tratar el paquete como externo.
 import { html } from 'satori-html';


### PR DESCRIPTION
#2457 llegó con 38 actualizaciones agrupadas y dejó `build`, `e2e` y el deploy de Vercel en rojo. La causa era una sola de las 38:

```
+ satori 0.33.4
✘ [ERROR] An error occurred while extracting routes.
ReferenceError: __dirname is not defined
```

Es exactamente la rotura que ya habíamos arreglado: satori 0.33+ declara `harfbuzzjs`, que resuelve su WASM con `__dirname` y no sobrevive al bundle ESM de servidor.

## Por qué el pin de `package.json` no alcanzaba

`"satori": "^0.32.0"` **ya prohibía** 0.33: en una versión `0.x` el caret no cruza la minor, así que ese rango es `>=0.32.0 <0.33.0`.

Lo que pasa es que **Dependabot no se limita a actualizar dentro del rango declarado: propone reescribirlo**. Por eso el diff de #2457 toca `package.json` y no solo el lockfile. Ninguna forma de escribir la versión ahí lo detiene —caret, tilde o versión exacta—; con una exacta simplemente abre un PR que la cambia por otra exacta. La única palanca es el `ignore` de `.github/dependabot.yml`, y eso es lo que agrega este PR.

## TypeScript entra por el mismo motivo, antes de que pase

TypeScript 7 ya está publicado (`7.0.2`), y trae el compilador nativo en Go. Nuestra cadena de herramientas no lo acepta.

**El techo real no es 7, es 6.1**, y eso cambia el pin que hay que escribir:

| Paquete | Peer de `typescript` |
| --- | --- |
| `@angular/compiler-cli` | `>=6.0 <6.1` |
| `typescript-eslint` | `>=4.8.4 <6.1.0` |

Bloquear solo la major dejaría a Dependabot proponiendo 6.1.x, que **ya viola los dos peers**. Por eso, igual que en satori, se bloquean minor y major. Va también en el ecosistema de `cms/`, que versiona en lockstep con la app.

## Qué queda pinchado, y su costo

| Paquete | Ecosistema | Bloquea | Consecuencia |
| --- | --- | --- | --- |
| `satori` | raíz | minor + major | `0.32.0` es la **única** versión de su línea, así que hoy lo congela del todo: tampoco entran parches de seguridad |
| `typescript` | raíz y `cms/` | minor + major | Queda en `6.0.x`, el único rango que los peers admiten |

Ese costo de satori es real y conviene tenerlo escrito: si aparece un CVE en satori, Dependabot no nos va a avisar. No lo cambia la forma en que se escriba el pin — es consecuencia de que no haya ninguna versión publicada a la que movernos.

## El rastro que estaba colgado

El `TODO` que documenta el pin de satori en `src/api/og.controller.ts` citaba un issue **ya cerrado**, así que `pnpm issue-refs:sweep` lo marcaba como mención caduca y, más importante, **nada abierto trackeaba levantar el pin**. Ahora apunta a #2458.

Los dos issues de seguimiento nuevos llevan los peers y las condiciones concretas que destraban cada pin:

- #2458 — satori, hasta que harfbuzzjs deje de romper el bundle o tratemos el paquete como externo.
- #2459 — TypeScript, hasta que Angular, typescript-eslint y Nx acepten una versión por encima de 6.0.

**Este PR no cierra ninguno de los dos, a propósito**, y por eso no lleva keyword de cierre pese al prefijo del título: los issues trackean *levantar* los pins, y este PR los *pone*. Se cierran el día que la restricción de arriba desaparezca.

## Verificación

- **El YAML parsea y los `ignore` quedan donde deben.** Verificado programáticamente, no a ojo: `npm /` → `@types/node [major] · satori [minor+major] · typescript [minor+major]`; `npm /cms` → `@types/node [major] · typescript [minor+major]`.
- **La config se lee de la rama por defecto, que es `develop`** — confirmado contra la API. O sea que el `ignore` rige apenas mergee, sin esperar a un release.
- **El sweep de menciones quedó sin la entrada caduca de `og.controller.ts`.** Siguen las tres preexistentes (#2271 y dos de #1471), ajenas a este diff.
- **Tier local en verde**, cada gate corrido por separado: `typecheck`, `lint`, `test` (2516 casos), `build` y `check:agents`. El `build` confirma de paso que satori sigue resolviendo `0.32.0`.

## Plan de pruebas

_Se completa al cerrar la review._
