### PR TITLE
[#2296] - Corregir el valor del token neutral-200, que no coincide con el del diseño

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -36,7 +36,7 @@
 	--color-neutral-50: hsl(0, 0%, 98%);
 	--color-neutral-100: hsl(0, 0%, 96%);
 	--color-neutral-150: hsl(0, 0%, 94%);
-	--color-neutral-200: hsl(0, 0%, 90%);
+	--color-neutral-200: hsl(0, 0%, 89.8%);
 	--color-neutral-300: hsl(0, 0%, 83%);
 	--color-neutral-400: hsl(0, 0%, 64%);
 	--color-neutral-500: hsl(0, 0%, 45%);


### PR DESCRIPTION
Corrige `--color-neutral-200` en `src/tailwind.css` de `hsl(0, 0%, 90%)` (#e6e6e6) a `hsl(0, 0%, 89.8%)` (#e5e5e5), valor que declara el diseño. Es el único paso de la escala neutral que no cerraba.

Verificación:
- Ningún consumidor hardcodea el valor viejo; todos usan las utilidades del token (`bg-neutral-200`, `border-neutral-200`, `divide-neutral-200`).
- Stylelint en verde sobre el archivo y specs del Divider (15/15) en verde.

Closes #2296