### PR TITLE
[#2314] - Derivar la descripción de indexado de cada colección de su propio texto

### DIFF
--- a/src/app/pages/author/author.schema.ts
+++ b/src/app/pages/author/author.schema.ts
@@ -3,41 +3,8 @@ import { type BreadcrumbList, type PersonLeaf, type ProfilePage, type WithContex
 
 import { type Author, type AuthorProfile } from '@models/author.model';
 import { type SanitizedHtml } from '@models/sanitized-html.model';
+import { htmlToPlainText } from '@utils/html-to-text.utils';
 import { buildBreadcrumbSchema, buildPersonSchema } from '@utils/schema-org.builders';
-
-// Tags que separan texto: al desaparecer dejan un espacio, o la última palabra de un bloque quedaría
-// pegada a la primera del siguiente. Los inline (`em`, `strong`, `a`, `code`) se quitan sin espacio,
-// porque abren y cierran dentro de la oración y un espacio ahí despega la puntuación que los sigue.
-const BLOCK_LEVEL_TAG = /<\/?(?:p|div|br|hr|h[1-6]|ul|ol|li|blockquote|pre|figure|figcaption|table|tr|td|th)\b[^>]*>/gi;
-
-// El pipeline emite referencias **numéricas** (`rehype-stringify` no usa referencias con nombre), pero
-// se aceptan las dos formas para no depender de esa configuración. Una única pasada, no una por
-// entidad: así `&amp;#x26;` se resuelve a `&#x26;` y no se decodifica dos veces hasta `&`.
-const HTML_REFERENCE = /&(?:#[xX]([0-9a-fA-F]+)|#(\d+)|(amp|lt|gt|quot|apos));/g;
-
-const NAMED_REFERENCES: Readonly<Record<string, string>> = Object.freeze({
-	amp: '&',
-	lt: '<',
-	gt: '>',
-	quot: '"',
-	apos: "'",
-});
-
-function decodeReferences(text: string): string {
-	return text.replace(HTML_REFERENCE, (match, hex?: string, decimal?: string, name?: string) => {
-		if (hex !== undefined) return String.fromCodePoint(Number.parseInt(hex, 16));
-		if (decimal !== undefined) return String.fromCodePoint(Number.parseInt(decimal, 10));
-		return name !== undefined ? (NAMED_REFERENCES[name] ?? match) : match;
-	});
-}
-
-// Reduce el HTML saneado a texto plano. No usa `DOMParser`: esto corre también en el SSR de Node, donde
-// no existe. Las referencias se decodifican después de quitar los tags, para que un `<` del texto no se
-// reinterprete como marcado.
-function toPlainText(html: SanitizedHtml): string {
-	const withoutTags = html.replace(BLOCK_LEVEL_TAG, ' ').replace(/<[^>]*>/g, '');
-	return decodeReferences(withoutTags).replace(/\s+/g, ' ').trim();
-}
 
 /**
  * Aplana y recorta la biografía a texto plano para el `description` del Person, recortado en el último
@@ -46,7 +13,7 @@ function toPlainText(html: SanitizedHtml): string {
  */
 function buildBiographyDescription(biography: SanitizedHtml): string | undefined {
 	const maxLength = 300;
-	const plainText = toPlainText(biography);
+	const plainText = htmlToPlainText(biography);
 	if (!plainText) {
 		return undefined;
 	}

--- a/src/app/pages/collection/collection-meta-tags.directive.spec.ts
+++ b/src/app/pages/collection/collection-meta-tags.directive.spec.ts
@@ -5,6 +5,8 @@ import { Title } from '@angular/platform-browser';
 
 import { onoffCollectionsWithTagsMock } from '@mocks/onoff-collections.mock';
 import { type Collection } from '@models/collection.model';
+import { createSanitizedHtml } from '@models/sanitized-html.model';
+import { htmlToPlainText } from '@utils/html-to-text.utils';
 import { AppRoutes } from '../../app.routes';
 import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
@@ -51,6 +53,31 @@ describe('CollectionMetaTagsDirective', () => {
 		TestBed.tick();
 
 		expect(titleSpy).toHaveBeenCalledWith(expect.stringContaining(canon.title));
+	});
+
+	it('should set the description derived from the collection prose', () => {
+		collectionSignal.set(canon);
+		const descriptionSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setDescription');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(descriptionSpy).toHaveBeenCalledWith(htmlToPlainText(canon.description));
+	});
+
+	it('should fall back to the fixed editorial phrase when the collection HTML carries no prose', () => {
+		collectionSignal.set({
+			...canon,
+			description: createSanitizedHtml('<p><img src="https://cdn.sanity.io/foto.jpg" alt="Foto"/></p>'),
+		});
+		const descriptionSpy = spyOn(TestBed.inject(HeadMetadataDirective), 'setDescription');
+
+		instantiate();
+		TestBed.tick();
+
+		expect(descriptionSpy).toHaveBeenCalledWith(
+			'Una colección de La Cuentoneta: una iniciativa que busca fomentar y hacer accesible la lectura digital.',
+		);
 	});
 
 	it('should set the canonical URL from the collection slug via buildCanonicalUrl', () => {

--- a/src/app/pages/collection/collection-meta-tags.directive.ts
+++ b/src/app/pages/collection/collection-meta-tags.directive.ts
@@ -5,6 +5,7 @@ import { buildCanonicalUrl } from '@app-utils/build-canonical-url.util';
 import { HeadMetadataDirective } from '../../directives/head-metadata.directive';
 import { AbstractMetaTagsDirective } from '../../directives/abstract-meta-tags.directive';
 import { COLLECTION_HOST } from './collection-host';
+import { buildCollectionDescription } from './collection.schema';
 
 @Directive({
 	selector: '[cuentonetaCollectionMetaTags]',
@@ -20,8 +21,11 @@ export class CollectionMetaTagsDirective extends AbstractMetaTagsDirective {
 		}
 		untracked(() => {
 			this.head.setTitle(collection.title);
+			// Sin prosa propia no hay texto que derivar: la frase editorial fija garantiza que el
+			// `description` nunca salga vacío.
 			this.head.setDescription(
-				'Una colección de La Cuentoneta: una iniciativa que busca fomentar y hacer accesible la lectura digital.',
+				buildCollectionDescription(collection.description) ??
+					'Una colección de La Cuentoneta: una iniciativa que busca fomentar y hacer accesible la lectura digital.',
 			);
 			this.head.setCanonicalUrl(buildCanonicalUrl(`${AppRoutes.Collection}/${collection.slug}`));
 			this.head.setRobots('index, follow');

--- a/src/app/pages/collection/collection.schema.spec.ts
+++ b/src/app/pages/collection/collection.schema.spec.ts
@@ -1,4 +1,6 @@
 import { onoffCollectionsMock } from '@mocks/onoff-collections.mock';
+import { createSanitizedHtml } from '@models/sanitized-html.model';
+import { htmlToPlainText } from '@utils/html-to-text.utils';
 
 import { assertValidJsonLd } from '@testing/json-ld-validation';
 import { buildCollectionBreadcrumb, buildCollectionPageSchema } from './collection.schema';
@@ -31,6 +33,42 @@ describe('buildCollectionPageSchema', () => {
 				})),
 			},
 		});
+	});
+
+	it('should emit the description derived from the collection prose', () => {
+		const schema = buildCollectionPageSchema(canon, websiteUrl);
+
+		expect(schema).toMatchObject({ description: htmlToPlainText(canon.description) });
+	});
+
+	it('should truncate a long description at a word boundary with an ellipsis', () => {
+		const fitsBeforeLimit = 'a'.repeat(295);
+		const collection = { ...canon, description: createSanitizedHtml(`<p>${fitsBeforeLimit} palabraDescartada</p>`) };
+
+		const schema = buildCollectionPageSchema(collection, websiteUrl);
+
+		expect(schema).toMatchObject({ description: `${fitsBeforeLimit}…` });
+	});
+
+	it('should hard-cut at the max length when there is no space within the limit', () => {
+		const singleLongWord = 'b'.repeat(350);
+		const collection = { ...canon, description: createSanitizedHtml(`<p>${singleLongWord}</p>`) };
+
+		const schema = buildCollectionPageSchema(collection, websiteUrl);
+
+		expect(schema).toMatchObject({ description: `${'b'.repeat(300)}…` });
+	});
+
+	it('should omit the description when the collection HTML carries no prose', async () => {
+		const collection = {
+			...canon,
+			description: createSanitizedHtml('<p><img src="https://cdn.sanity.io/foto.jpg" alt="Foto"/></p>'),
+		};
+
+		const schema = buildCollectionPageSchema(collection, websiteUrl);
+
+		expect(schema).not.toHaveProperty('description');
+		await expect(assertValidJsonLd(schema)).resolves.toBeUndefined();
 	});
 });
 

--- a/src/app/pages/collection/collection.schema.ts
+++ b/src/app/pages/collection/collection.schema.ts
@@ -2,7 +2,28 @@ import { Location } from '@angular/common';
 import { type BreadcrumbList, type CollectionPage, type WithContext } from 'schema-dts';
 
 import { type Collection } from '@models/collection.model';
+import { type SanitizedHtml } from '@models/sanitized-html.model';
+import { htmlToPlainText } from '@utils/html-to-text.utils';
 import { buildBreadcrumbSchema } from '@utils/schema-org.builders';
+
+/**
+ * Deriva la descripción de indexado de una colección desde su prosa: texto plano recortado en el
+ * último espacio antes del tope, para que el corte no parta palabras. Devuelve `undefined` cuando el
+ * HTML no trae prosa, y ahí cada señal decide su reemplazo.
+ */
+export function buildCollectionDescription(description: SanitizedHtml): string | undefined {
+	const maxLength = 300;
+	const plainText = htmlToPlainText(description);
+	if (!plainText) {
+		return undefined;
+	}
+	if (plainText.length <= maxLength) {
+		return plainText;
+	}
+	const truncated = plainText.slice(0, maxLength);
+	const lastSpace = truncated.lastIndexOf(' ');
+	return `${truncated.slice(0, lastSpace > 0 ? lastSpace : maxLength).trimEnd()}…`;
+}
 
 /**
  * Construye el JSON-LD `CollectionPage` de una colección, con un `ItemList` ordenado de las obras
@@ -12,12 +33,14 @@ import { buildBreadcrumbSchema } from '@utils/schema-org.builders';
  */
 export function buildCollectionPageSchema(collection: Collection, websiteUrl: string): WithContext<CollectionPage> {
 	const baseUrl = Location.stripTrailingSlash(websiteUrl);
+	const description = buildCollectionDescription(collection.description);
 	return {
 		'@context': 'https://schema.org',
 		'@type': 'CollectionPage',
 		name: collection.title,
 		url: `${baseUrl}/collection/${collection.slug}`,
 		inLanguage: 'es-AR',
+		...(description ? { description } : {}),
 		mainEntity: {
 			'@type': 'ItemList',
 			numberOfItems: collection.count,

--- a/src/utils/html-to-text.utils.spec.ts
+++ b/src/utils/html-to-text.utils.spec.ts
@@ -1,0 +1,64 @@
+import { createMarkdown } from '@models/markdown.model';
+import { createSanitizedHtml } from '@models/sanitized-html.model';
+import { markdownToSanitizedHtml } from '@utils/markdown-pipeline.utils';
+
+import { htmlToPlainText } from './html-to-text.utils';
+
+describe('htmlToPlainText', () => {
+	it('should join the text of each block with a space', () => {
+		const html = markdownToSanitizedHtml(createMarkdown('Primera **oración**.\n\nSegunda _oración_.'));
+
+		expect(htmlToPlainText(html)).toBe('Primera oración. Segunda oración.');
+	});
+
+	it('should keep the text of inline marks without detaching punctuation', () => {
+		const html = markdownToSanitizedHtml(createMarkdown('Su novela _Geometría_ y el **ensayo**.'));
+
+		expect(htmlToPlainText(html)).toBe('Su novela Geometría y el ensayo.');
+	});
+
+	it('should separate text split by a line break inside the same block', () => {
+		const html = createSanitizedHtml('<p>Chateauroux, 1948<br />París, 1994</p>');
+
+		expect(htmlToPlainText(html)).toBe('Chateauroux, 1948 París, 1994');
+	});
+
+	it('should collapse an empty block without adding spaces or artifacts', () => {
+		const html = createSanitizedHtml('<p></p><p>Biografía sin bloque vacío previo.</p>');
+
+		expect(htmlToPlainText(html)).toBe('Biografía sin bloque vacío previo.');
+	});
+
+	// El HTML de estos casos parte del Markdown y no está autorado a mano: la forma exacta de las
+	// referencias de caracteres la decide el pipeline, y una aserción sobre HTML escrito acá no
+	// detectaría que dejó de coincidir.
+	it('should decode the references the pipeline emits', () => {
+		const html = markdownToSanitizedHtml(createMarkdown('Ida & vuelta'));
+
+		expect(htmlToPlainText(html)).toBe('Ida & vuelta');
+	});
+
+	it('should leave no unresolved reference in the text', () => {
+		const html = markdownToSanitizedHtml(createMarkdown('Ida & vuelta: \\<pausa\\>, "dijo" y punto.'));
+
+		expect(htmlToPlainText(html)).not.toMatch(/&#|&[a-z]+;/i);
+	});
+
+	it('should decode named and numeric references alike', () => {
+		const html = createSanitizedHtml('<p>Ida &amp; vuelta &#38; regreso: &#x3C;pausa&gt;</p>');
+
+		expect(htmlToPlainText(html)).toBe('Ida & vuelta & regreso: <pausa>');
+	});
+
+	it('should not decode an escaped reference twice', () => {
+		const html = createSanitizedHtml('<p>Se escribe &amp;lt; para un menor.</p>');
+
+		expect(htmlToPlainText(html)).toBe('Se escribe &lt; para un menor.');
+	});
+
+	it('should return an empty string when the HTML carries no prose', () => {
+		const html = createSanitizedHtml('<p><img src="https://cdn.sanity.io/foto.jpg" alt="Foto"/></p>');
+
+		expect(htmlToPlainText(html)).toBe('');
+	});
+});

--- a/src/utils/html-to-text.utils.ts
+++ b/src/utils/html-to-text.utils.ts
@@ -1,0 +1,42 @@
+import type { SanitizedHtml } from '@models/sanitized-html.model';
+
+// Los tags de bloque dejan un espacio al desaparecer: sin él, la última palabra de un bloque
+// quedaría pegada a la primera del siguiente. Los inline (`em`, `strong`, `a`, `code`) se quitan
+// sin espacio, porque abren y cierran dentro de la oración y un espacio ahí despega la puntuación.
+const BLOCK_LEVEL_TAG = /<\/?(?:p|div|br|hr|h[1-6]|ul|ol|li|blockquote|pre|figure|figcaption|table|tr|td|th)\b[^>]*>/gi;
+
+// El pipeline emite referencias **numéricas** (`rehype-stringify` no usa referencias con nombre), pero
+// se aceptan las dos formas para no depender de esa configuración. Una única pasada, no una por
+// entidad: así `&amp;#x26;` se resuelve a `&#x26;` y no se decodifica dos veces hasta `&`.
+const HTML_REFERENCE = /&(?:#[xX]([0-9a-fA-F]+)|#(\d+)|(amp|lt|gt|quot|apos));/g;
+
+const NAMED_REFERENCES: Readonly<Record<string, string>> = Object.freeze({
+	amp: '&',
+	lt: '<',
+	gt: '>',
+	quot: '"',
+	apos: "'",
+});
+
+function decodeReferences(text: string): string {
+	return text.replace(HTML_REFERENCE, (match, hex?: string, decimal?: string, name?: string) => {
+		if (hex !== undefined) return String.fromCodePoint(Number.parseInt(hex, 16));
+		if (decimal !== undefined) return String.fromCodePoint(Number.parseInt(decimal, 10));
+		return name !== undefined ? (NAMED_REFERENCES[name] ?? match) : match;
+	});
+}
+
+/**
+ * Reduce HTML saneado a texto plano: une los bloques con espacios, descarta la marcación inline sin
+ * despegar la puntuación y decodifica las referencias de caracteres. Devuelve `''` cuando el HTML no
+ * trae prosa (p. ej. solo una imagen). No toca el DOM, así que vale en el SSR de Node.
+ *
+ * No recorta: el largo razonable depende de la señal que lo consume (`meta description`, JSON-LD) y
+ * lo decide cada una.
+ */
+export function htmlToPlainText(html: SanitizedHtml): string {
+	// Las referencias se decodifican después de quitar los tags, para que un `<` del texto no se
+	// reinterprete como marcado.
+	const withoutTags = html.replace(BLOCK_LEVEL_TAG, ' ').replace(/<[^>]*>/g, '');
+	return decodeReferences(withoutTags).replace(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
## Resumen

Las veintisiete colecciones compartían la misma `<meta name="description">` editorial fija y el JSON-LD `CollectionPage` no emitía `description`. Este PR deriva ambas señales de la prosa propia de cada colección (`Collection.description`), usando el nuevo util de HTML a texto plano en `@utils` que faltaba.

## Cambios

- Nuevo `htmlToPlainText(html: SanitizedHtml): string` en `src/utils/html-to-text.utils.ts`, con spec propio: une bloques con espacios, descarta marcación inline sin despegar puntuación, decodifica referencias en una pasada y no toca el DOM (vale en SSR). No recorta.
- `collection.schema.ts`: nuevo `buildCollectionDescription()` (texto plano + tope 300 con corte en palabra y elipsis, `undefined` sin prosa) y `buildCollectionPageSchema()` emite `description`, omitiéndolo si no hay texto.
- `collection-meta-tags.directive.ts`: el `description` deriva de la prosa con fallback a la frase editorial fija cuando no hay prosa, así el tag nunca sale vacío.
- `author.schema.ts`: migración interna al util compartido, sin cambio de comportamiento (su spec quedó intacto).

## Decisiones

- **Dónde vive el recorte**: en el builder de la página, compartido por meta y JSON-LD (una sola descripción en ambas señales); el corte respeta palabras, patrón vigente del autor. El util no opina de largos.
- **Tope 300**: Google trunca el display por píxeles sin cap en el tag, y `og:description` muestra ~300; como `setDescription` escribe meta + twitter + og con el mismo string, 300 satisface a las tres.
- **Catálogo `/collection`**: sin cambios, su frase describe el conjunto.
- **Obra/autor**: sin cambios de señales; solo la reutilización interna del util.
- **Colección sin descripción**: el backend la rechaza, así que el caso alcanzable es HTML sin prosa → meta usa la frase fija, JSON-LD omite `description`. Ambos cubiertos en specs.

## Verificación

- Specs de `collection`, `author` y `utils` en verde, eslint y prettier limpios, `pnpm typecheck` verde. Los gates restantes quedan para el CI.

Closes #2314
