### PR TITLE
[#2367] - Ventana de borde propia para la landing

### DIFF
--- a/docs/LITERARY_WORK_DESIGN.md
+++ b/docs/LITERARY_WORK_DESIGN.md
@@ -415,7 +415,7 @@ Esta sección describe el origen del mecanismo, que nació para la página de le
 
 Tres cosas que la extensión no cambia y una que sí:
 
-- **El TTL sigue siendo único** para todas las rutas. Parametrizarlo por módulo se evaluó y se descartó por ahora: haría falta cuando alguna ruta necesite una ventana de propagación distinta de las demás, y hoy ninguna la pide.
+- **El TTL es único para todas las rutas, salvo la landing.** `GET /api/content/landing-page` comparte el `s-maxage` pero declara un `stale-while-revalidate` propio de 1 día en su handler, que el middleware respeta en vez de pisar: la landing rota cada semana con el mismo path, así que la ventana larga de lectura sobreviviría a la rotación sirviendo la semana anterior como vigente ([#2367](https://github.com/cuentoneta/cuentoneta/issues/2367)).
 - **Sigue sin haber invalidación explícita**, con el mismo razonamiento de arriba.
 - **El corte por entorno y la guarda anti-CSR son los mismos**, y esta última pesa más que antes: la home es justamente donde el deopt a CSR ya ocurrió en producción.
 - **Lo que sí cambia es el alcance del trade-off de frescura.** La ventana de propagación de una edición ahora también aplica al contenido rotativo de la home y a las colecciones, que se editan con más frecuencia que una obra ya publicada — a diferencia del contenido de una obra, que es inmutable una vez creada.

--- a/src/api/_helpers/cache-control.spec.ts
+++ b/src/api/_helpers/cache-control.spec.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { applyReadCacheHeaders, isReadCacheEnabled } from './cache-control';
+import { applyLandingPageCacheHeaders, applyReadCacheHeaders, isReadCacheEnabled } from './cache-control';
 import { environment } from './environment';
 
 describe('cache-control', () => {
@@ -71,6 +71,57 @@ describe('cache-control', () => {
 
 			expect(response.headers.get('Vercel-CDN-Cache-Control')).toBeNull();
 			expect(response.headers.get('Cache-Control')).toBeNull();
+			expect(response.headers.get('x-request-id')).toBe('the-first-request');
+		});
+	});
+
+	describe('applyLandingPageCacheHeaders', () => {
+		function landingAppUnderTest(): Hono {
+			const app = new Hono();
+			app.get('/landing-page', (c) => {
+				c.header('x-request-id', 'the-first-request');
+				return applyLandingPageCacheHeaders(c.json({ week: '2026-30' }));
+			});
+			app.get('/missing-week', (c) => applyLandingPageCacheHeaders(c.json({ error: 'not found' }, 404)));
+			return app;
+		}
+
+		it('should emit the short revalidation window of the weekly rotation with the configured s-maxage', async () => {
+			environment.production = true;
+			environment.readCacheSMaxAge = 900;
+
+			const response = await landingAppUnderTest().request('/landing-page');
+
+			expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe(
+				'public, s-maxage=900, stale-while-revalidate=86400',
+			);
+			expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, must-revalidate');
+		});
+
+		// El id de quien produjo el miss se devolvería idéntico a todos los hits durante el TTL.
+		it('should drop the request id from a cacheable landing response', async () => {
+			environment.production = true;
+
+			const response = await landingAppUnderTest().request('/landing-page');
+
+			expect(response.headers.get('x-request-id')).toBeNull();
+		});
+
+		// Una copia de error cacheada serviría el 404 como si fuera la semana vigente.
+		it('should leave an error response without edge headers', async () => {
+			environment.production = true;
+
+			const response = await landingAppUnderTest().request('/missing-week');
+
+			expect(response.headers.get('Vercel-CDN-Cache-Control')).toBeNull();
+		});
+
+		it('should emit nothing outside production', async () => {
+			environment.production = false;
+
+			const response = await landingAppUnderTest().request('/landing-page');
+
+			expect(response.headers.get('Vercel-CDN-Cache-Control')).toBeNull();
 			expect(response.headers.get('x-request-id')).toBe('the-first-request');
 		});
 	});

--- a/src/api/_helpers/cache-control.ts
+++ b/src/api/_helpers/cache-control.ts
@@ -10,6 +10,11 @@ import { environment } from './environment';
 // espera al origen, y una edición se propaga en la visita siguiente al vencimiento.
 const READ_CACHE_STALE_WHILE_REVALIDATE = 604800; // 7 días
 
+// La landing rota de semana con el mismo path, así que una copia servida más allá de la rotación es
+// la semana anterior pasando por la vigente: su revalidación vive muy por debajo de ese ciclo, a
+// diferencia de la obra ya publicada, que es inmutable y admite la ventana larga de arriba.
+const LANDING_PAGE_STALE_WHILE_REVALIDATE = 86400; // 1 día
+
 // El browser no cachea la página: el TTL vive solo en `Vercel-CDN-Cache-Control`, que Vercel no
 // reenvía. Así la revalidación ocurre en un único lugar; con un TTL propio en el browser, una
 // edición ya revalidada por el CDN seguiría sin verse hasta que venciera el del navegador.
@@ -30,7 +35,8 @@ export function isReadCacheEnabled(): boolean {
  * `environment.readCacheSMaxAge`) con `stale-while-revalidate` largo, efectivos solo en el CDN de
  * Vercel, más un `Cache-Control` que mantiene fresco al browser.
  *
- * El TTL es único para todas las rutas cacheadas. La frescura la da su vencimiento, no una
+ * El TTL es único para todas las rutas cacheadas, salvo la landing (ver
+ * `applyLandingPageCacheHeaders`). La frescura la da su vencimiento, no una
  * invalidación explícita: una edición del CMS se ve en la visita siguiente al vencimiento.
  * Ver LITERARY_WORK_DESIGN.md §8.
  */
@@ -49,4 +55,27 @@ export function applyReadCacheHeaders(c: Context): void {
 	// idéntico a todos los hits durante el TTL, lo que rompe la correlación de logs en vez de
 	// ayudarla. Un id ausente es más honesto que uno que miente.
 	c.header('x-request-id', undefined);
+}
+
+/**
+ * Declara la ventana de borde propia de la landing sobre una respuesta ya producida: el mismo
+ * `s-maxage` que el resto —el interruptor sigue siendo único—, con el `stale-while-revalidate`
+ * corto de arriba.
+ *
+ * Recibe la respuesta y no el contexto porque solo un 200 la lleva: una copia de error cacheada
+ * serviría un 404 o un 500 como si fuera la semana vigente. Fuera de producción no emite nada,
+ * igual que `applyReadCacheHeaders`.
+ */
+export function applyLandingPageCacheHeaders(response: Response): Response {
+	if (!isReadCacheEnabled() || response.status !== 200) {
+		return response;
+	}
+
+	response.headers.set(
+		'Vercel-CDN-Cache-Control',
+		`public, s-maxage=${environment.readCacheSMaxAge}, stale-while-revalidate=${LANDING_PAGE_STALE_WHILE_REVALIDATE}`,
+	);
+	response.headers.set('Cache-Control', BROWSER_CACHE_CONTROL);
+	response.headers.delete('x-request-id');
+	return response;
 }

--- a/src/api/_middleware/read-cache-headers.middleware.spec.ts
+++ b/src/api/_middleware/read-cache-headers.middleware.spec.ts
@@ -19,6 +19,10 @@ describe('readCacheHeaders', () => {
 			c.header('Cache-Control', 'no-store');
 			return c.json({ done: true });
 		});
+		app.get('/obra/declarada', (c) => {
+			c.header('Vercel-CDN-Cache-Control', 'public, s-maxage=900, stale-while-revalidate=86400');
+			return c.json({ slug: 'declarada' });
+		});
 		app.get('/obra/:slug', (c) => c.json({ slug: c.req.param('slug') }));
 		return app;
 	}
@@ -60,6 +64,15 @@ describe('readCacheHeaders', () => {
 
 		expect(response.headers.get('Vercel-CDN-Cache-Control')).toBeNull();
 		expect(response.headers.get('Cache-Control')).toBe('no-store');
+	});
+
+	// Una ruta con ventana propia la declara en su handler y el default del módulo no la pisa.
+	it('respeta la ventana de borde que el handler ya declaró', async () => {
+		environment.production = true;
+
+		const response = await appUnderTest().request('/obra/declarada');
+
+		expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe('public, s-maxage=900, stale-while-revalidate=86400');
 	});
 
 	// Un preview comparte el CDN y serviría contenido de un dataset que no es el público.

--- a/src/api/_middleware/read-cache-headers.middleware.ts
+++ b/src/api/_middleware/read-cache-headers.middleware.ts
@@ -20,5 +20,11 @@ export const readCacheHeaders = createMiddleware(async (c, next) => {
 		return;
 	}
 
+	// Una ruta con ventana propia la declara en su handler (la landing) y el default del módulo no la
+	// pisa: sin esta guarda, el SWR largo de lectura cubriría la respuesta y sobreviviría a la rotación.
+	if (c.res.headers.has('Vercel-CDN-Cache-Control')) {
+		return;
+	}
+
 	applyReadCacheHeaders(c);
 });

--- a/src/api/modules/content/content.controller.spec.ts
+++ b/src/api/modules/content/content.controller.spec.ts
@@ -131,3 +131,58 @@ describe('contentController — la escritura no es cacheable', () => {
 		expect(response.headers.get('Vercel-CDN-Cache-Control')).toBeNull();
 	});
 });
+
+// La landing rota de semana con el mismo path, así que su revalidación vive muy por debajo del ciclo
+// de rotación: comparte el `s-maxage` del módulo pero declara su ventana corta en el handler, y el
+// middleware la respeta en vez de pisarla con la larga de lectura.
+describe('contentController — la landing declara su ventana de borde', () => {
+	const originalProduction = environment.production;
+	const originalSMaxAge = environment.readCacheSMaxAge;
+
+	afterEach(() => {
+		environment.production = originalProduction;
+		environment.readCacheSMaxAge = originalSMaxAge;
+	});
+
+	function curatedRepository() {
+		return new InMemoryContentRepository({ landingPages: [{ slug: CURRENT_SLUG, content: curatedLandingPage }] });
+	}
+
+	it('declares the short revalidation window on a 200 in production', async () => {
+		environment.production = true;
+		environment.readCacheSMaxAge = 900;
+
+		const response = await appWith(curatedRepository()).request('/content/landing-page');
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe('public, s-maxage=900, stale-while-revalidate=86400');
+		expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, must-revalidate');
+	});
+
+	// Una copia de error cacheada serviría la semana sin curar como si fuera la vigente.
+	it('leaves the uncurated week without edge headers', async () => {
+		environment.production = true;
+
+		const response = await appWith(new InMemoryContentRepository()).request('/content/landing-page');
+
+		expect(response.status).toBe(404);
+		expect(response.headers.get('Vercel-CDN-Cache-Control')).toBeNull();
+	});
+
+	// Y la composición con el middleware, que es lo que la declaración existe para lograr: montada
+	// detrás de él y con la caché habilitada, la respuesta conserva la ventana corta en vez de
+	// recibir la larga del módulo.
+	it('keeps the short window when mounted behind the read cache middleware', async () => {
+		environment.production = true;
+		environment.readCacheSMaxAge = 900;
+
+		const app = new Hono();
+		app.on('GET', ['/content', '/content/*'], readCacheHeaders);
+		app.route('/content', createContentController(curatedRepository()));
+
+		const response = await app.request('/content/landing-page');
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe('public, s-maxage=900, stale-while-revalidate=86400');
+	});
+});

--- a/src/api/modules/content/content.controller.ts
+++ b/src/api/modules/content/content.controller.ts
@@ -5,6 +5,7 @@ import { addWeeksSchema } from './content.schema';
 import { LandingPageNotFoundError, MalformedLandingPageError } from './content.errors';
 import type { ContentRepository } from './content.repository';
 import { addNextWeeksLandingPageContent, getLandingPageContent } from './content.service';
+import { applyLandingPageCacheHeaders } from '../../_helpers/cache-control';
 
 /** Traduce los errores del módulo al status que le corresponde a cada uno. */
 async function respond<T>(c: Context, produce: () => Promise<T>) {
@@ -32,7 +33,9 @@ async function respond<T>(c: Context, produce: () => Promise<T>) {
 export function createContentController(repository?: ContentRepository) {
 	const controller = new Hono();
 
-	controller.get('/landing-page', async (c) => respond(c, () => getLandingPageContent(repository)));
+	controller.get('/landing-page', async (c) =>
+		applyLandingPageCacheHeaders(await respond(c, () => getLandingPageContent(repository))),
+	);
 
 	/**
 	 * Endpoint encargado de agregar instancias de documentos landingPage para las próximas semanas, a fin de generar automáticamente

--- a/src/api/modules/literary-work/literary-work.service.spec.ts
+++ b/src/api/modules/literary-work/literary-work.service.spec.ts
@@ -1,4 +1,5 @@
 import { clearAllMocks, type Mock, restoreAllMocks, spyOn } from '@test-utils';
+import type { LandingPageContent } from '@models/landing-page-content.model';
 import { onoffLiteraryWorksMock } from '@mocks/onoff-literary-works.mock';
 import {
 	onoffLiteraryWorkNavigationTeasersWithAuthorsMock,
@@ -98,6 +99,17 @@ describe('getLiteraryWorkTeasers', () => {
 		expect(await getLiteraryWorkTeasers({ author: author.slug }, stub)).toEqual([]);
 	});
 });
+// Registra si el caso de uso pide la landing: solo necesita lo más leído, y pedirla entera
+// arrastraría el conteo por autor destacado que la proyección calcula en caliente.
+class SpyContentRepository extends InMemoryContentRepository {
+	public landingPageFetches = 0;
+
+	public override async fetchLandingPageContent(slug: string): Promise<LandingPageContent | null> {
+		this.landingPageFetches++;
+		return super.fetchLandingPageContent(slug);
+	}
+}
+
 describe('updateMostReadLiteraryWorks', () => {
 	const [first, second] = onoffLiteraryWorkNavigationTeasersWithAuthorsMock;
 	const rotatingContent = {
@@ -239,5 +251,20 @@ describe('updateMostReadLiteraryWorks', () => {
 		await expect(literaryWorkService.updateMostReadLiteraryWorks(new InMemoryContentRepository())).rejects.toThrow(
 			RotatingContentNotFoundError,
 		);
+	});
+
+	// El cron solo necesita lo más leído: si volviera a pedir la landing entera, pagaría el conteo
+	// por autor en caliente para quedarse con una lista que ya tiene su propia query.
+	it('serves the ranking without fetching the landing page content', async () => {
+		(fetchClarityData as Mock).mockResolvedValue(popularPages(`${environment.basePath}/literary-work/${first.slug}`));
+		const content = new SpyContentRepository({
+			rotatingContent,
+			literaryWorks: onoffLiteraryWorkNavigationTeasersWithAuthorsMock,
+		});
+
+		const result = await literaryWorkService.updateMostReadLiteraryWorks(content);
+
+		expect(result.mostRead.map(({ slug }) => slug)).toEqual([first.slug]);
+		expect(content.landingPageFetches).toBe(0);
 	});
 });


### PR DESCRIPTION
## Resumen

La landing (`GET /api/content/landing-page`) heredaba la ventana de borde de lectura (SWR de 7 días), que alcanza el ciclo de rotación semanal: tras cada rotación, la copia servida sería la semana anterior pasando por la vigente. Ahora declara un `stale-while-revalidate` propio de 1 día, con el mismo `s-maxage` del resto (el interruptor `READ_CACHE_S_MAXAGE` sigue siendo único).

Closes #2367

## Qué cambia

- `applyLandingPageCacheHeaders` (`src/api/_helpers/cache-control.ts`): declara la ventana corta sobre la respuesta ya producida y solo en 200, para no cachear un 404/500 como si fuera la semana vigente.
- La ruta exacta `/landing-page` la declara en su handler; `readCacheHeaders` respeta la ventana ya declarada en vez de pisarla con la larga del módulo (mismo patrón del `no-store` de la escritura).
- Test de regresión: el cron de más leídas resuelve el ranking sin pedir la landing, así deja de pagar el conteo por autor en caliente.
- `docs/LITERARY_WORK_DESIGN.md` §8: el TTL deja de describirse como único.

## Ya cubierto por PRs previos (sin cambios en este)

- La escritura de semanas futuras sigue sin cachearse, con sus dos casos (`no-store` + composición).
- El endpoint que armaba la landing entera para quedarse con las más leídas ya no existe; el cron retorna solo el contenido rotativo.

## Verificación

- `vitest` (specs tocados + vecinos): 101/101
- `pnpm typecheck`, `eslint` y `prettier --check` sobre lo tocado: limpios

## Follow-ups (fuera de este PR)

- El SSR de `/home` conserva el TTL genérico; es la misma regresión por otra superficie.
- Persistir el conteo por autor en vez de calcularlo en caliente quedó evaluado y descartado por ahora: con la landing en borde se paga una vez por ventana, no por visita.