### PR TITLE
[#2208] - Excluir epígrafes y nota editorial de los extractos de los resultados de búsqueda

### DIFF
--- a/e2e/_utils/seo-fixtures.ts
+++ b/e2e/_utils/seo-fixtures.ts
@@ -7,6 +7,10 @@ export const STABLE_SLUGS = Object.freeze({
 	// tenga qué elegir, y de un autor con más de una obra, para que las sugerencias del pie no salgan
 	// vacías. `el-fin` no puede cubrir ninguna de las dos cosas.
 	literaryWorkWithMedia: 'a-la-deriva',
+	// La obra estable que encabeza sus secciones con un epígrafe con fuente y cierra con nota
+	// editorial: la superficie donde el texto ajeno a la obra puede quedar como extracto. `el-fin`
+	// tiene nota pero ningún epígrafe, y `a-la-deriva` tampoco, así que ninguna de las dos cubre el caso.
+	literaryWorkWithEpigraphs: 'la-morada-del-hombre',
 	collection: 'verano-2022',
 } as const);
 

--- a/e2e/seo/literary-work.spec.ts
+++ b/e2e/seo/literary-work.spec.ts
@@ -11,6 +11,8 @@
  *  - D. Bloques sitewide Organization y WebSite.
  *  - E. La tanda completa de invariantes de una página indexable, H1 único y cuerpo saneado.
  *  - F. Un único enlace al perfil del autor.
+ *  - G. Exclusión del extracto: los epígrafes y la nota editorial se sirven dentro de un bloque
+ *       `data-nosnippet`, y el cuerpo de la obra queda fuera de esa exclusión.
  *
  * El contenido de prueba lo cura el equipo en los datasets (development local / staging CI).
  */
@@ -18,14 +20,16 @@ import { expect } from '@playwright/test';
 
 import { test } from '../_utils/test';
 import type { Article, BreadcrumbList, WithContext } from 'schema-dts';
+import type { HTMLElement } from 'node-html-parser';
 
-import { parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
+import { parseHtml, parseJsonLdBlocks, getMetaContent, getTitleText, getCanonicalHref } from '../_utils/seo';
 import { assertValidJsonLd } from '@testing/json-ld-validation';
 import { collectIndexableHtmlViolations, getInternalLinkHrefs } from '../_utils/seo-invariants';
 import { STABLE_SLUGS, SCHEMA_IDS, SITEWIDE_SCHEMA_IDS } from '../_utils/seo-fixtures';
 import { fetchLiteraryWork } from '../_utils/literary-work-fixtures';
 
 const literaryWorkPath = `/literary-work/${STABLE_SLUGS.literaryWork}`;
+const literaryWorkWithEpigraphsPath = `/literary-work/${STABLE_SLUGS.literaryWorkWithEpigraphs}`;
 const requiredJsonLdIds = [...SITEWIDE_SCHEMA_IDS, SCHEMA_IDS.article, SCHEMA_IDS.breadcrumbLiteraryWork];
 
 test('literary-work — A: una obra inexistente responde 404 real en SSR', async ({ request }) => {
@@ -120,5 +124,71 @@ test.describe('literary-work — HTML server-rendered de una obra existente', ()
 		).toBeDefined();
 
 		expect(getInternalLinkHrefs(html, '/author/')).toEqual([`/author/${primaryAuthorSlug}`]);
+	});
+});
+
+// Google solo reconoce el atributo en estos tags; Bing lo acepta en cualquiera, así que el
+// subconjunto documentado por ambos es el que se exige.
+const SNIPPET_ELEMENT_TAGS = Object.freeze(['DIV', 'SPAN', 'SECTION']);
+
+test.describe('literary-work — bloques editoriales excluidos del extracto de búsqueda', () => {
+	let root: HTMLElement;
+	let epigraphCount: number;
+	let epigraphReferenceCount: number;
+	let expectedEditorialBlockCount: number;
+
+	test.beforeAll(async ({ request }) => {
+		const response = await request.get(literaryWorkWithEpigraphsPath);
+		expect(
+			response.status(),
+			`No existe literaryWork con slug "${STABLE_SLUGS.literaryWorkWithEpigraphs}" en el dataset`,
+		).toBe(200);
+		root = parseHtml(await response.text());
+
+		const literaryWork = await fetchLiteraryWork(request, STABLE_SLUGS.literaryWorkWithEpigraphs);
+		expect(
+			literaryWork,
+			`el API no sirve "${STABLE_SLUGS.literaryWorkWithEpigraphs}": no habría con qué comparar`,
+		).toBeDefined();
+
+		const epigraphs = (literaryWork?.content ?? []).flatMap((section) => section.epigraphs ?? []);
+		epigraphCount = epigraphs.length;
+		epigraphReferenceCount = epigraphs.filter((epigraph) => Boolean(epigraph.reference)).length;
+		const hasEditorialNote = Boolean(literaryWork?.editorialNote);
+		expectedEditorialBlockCount = epigraphCount + Number(hasEditorialNote);
+
+		// Si la curaduría pierde el epígrafe, su fuente o la nota, los casos de abajo pasarían sin
+		// cubrir nada: se afirma en vez de saltearse, como en el resto del archivo.
+		expect(epigraphCount, `"${STABLE_SLUGS.literaryWorkWithEpigraphs}" no trae epígrafes`).toBeGreaterThan(0);
+		expect(
+			epigraphReferenceCount,
+			`"${STABLE_SLUGS.literaryWorkWithEpigraphs}" no trae epígrafe con fuente`,
+		).toBeGreaterThan(0);
+		expect(hasEditorialNote, `"${STABLE_SLUGS.literaryWorkWithEpigraphs}" no trae nota editorial`).toBe(true);
+	});
+
+	test('G: cada bloque editorial se sirve dentro de un ancestro excluido del extracto', () => {
+		expect(root.querySelectorAll('cuentoneta-editorial-note')).toHaveLength(expectedEditorialBlockCount);
+
+		const exclusions = root.querySelectorAll('cuentoneta-editorial-note [data-nosnippet]');
+		expect(exclusions).toHaveLength(expectedEditorialBlockCount);
+		expect(exclusions.filter((exclusion) => !SNIPPET_ELEMENT_TAGS.includes(exclusion.tagName))).toEqual([]);
+		expect(exclusions.filter((exclusion) => exclusion.querySelector('[data-testid="content"]') === null)).toEqual([]);
+
+		// El pie de la figura —la atribución del epígrafe— también es texto ajeno a la obra.
+		const references = root.querySelectorAll('cuentoneta-editorial-note [data-testid="reference"]');
+		expect(references).toHaveLength(epigraphReferenceCount);
+		expect(references.filter((reference) => reference.closest('[data-nosnippet]') === null)).toEqual([]);
+	});
+
+	test('G: el cuerpo de la obra queda fuera de esa exclusión', () => {
+		// Cubre el atributo tanto en el propio cuerpo como en cualquier ancestro suyo.
+		expect(
+			root.querySelector(
+				'[data-testid="literary-work-section-body"][data-nosnippet], [data-nosnippet] [data-testid="literary-work-section-body"]',
+			),
+		).toBeNull();
+		// La exclusión no se desparrama: los bloques editoriales son los únicos que la declaran.
+		expect(root.querySelectorAll('[data-nosnippet]')).toHaveLength(expectedEditorialBlockCount);
 	});
 });

--- a/src/app/components/editorial-note/editorial-note.component.spec.ts
+++ b/src/app/components/editorial-note/editorial-note.component.spec.ts
@@ -88,6 +88,23 @@ describe('EditorialNoteComponent', () => {
 		expect(screen.getByTestId('content').tagName).toBe('ASIDE');
 	});
 
+	// El bloque editorial no alimenta el extracto de búsqueda: un único ancestro `data-nosnippet`
+	// —el atributo que Google solo reconoce en div/span/section— envuelve el contenido y su
+	// referencia, en las dos variantes.
+	it.each(['note', 'highlight'] as const)(
+		'should exclude the whole block from search snippets in the %s variant',
+		async (variant) => {
+			await render(EditorialNoteComponent, { inputs: { note: noteWithReference, variant } });
+
+			const excluded = screen.getByTestId('snippet-exclusion');
+
+			expect(excluded.tagName).toBeOneOf(['DIV', 'SPAN', 'SECTION']);
+			expect(excluded).toHaveAttribute('data-nosnippet');
+			expect(excluded).toContainElement(screen.getByTestId('content'));
+			expect(excluded).toContainElement(screen.getByTestId('reference'));
+		},
+	);
+
 	// Un `<aside>` anidado en contenido seccionador solo es región navegable si tiene nombre: el rótulo
 	// es lo que separa la voz del editor de la del texto que comenta, para quien no ve la tarjeta.
 	it('should expose the note as a named landmark when a label is provided', async () => {

--- a/src/app/components/editorial-note/editorial-note.component.ts
+++ b/src/app/components/editorial-note/editorial-note.component.ts
@@ -11,18 +11,22 @@ export type EditorialNoteVariant = 'note' | 'highlight';
 		@if (variant() === 'highlight') {
 			<div class="w-1 self-stretch rounded-full bg-brand-400" data-testid="accent-bar"></div>
 		}
-		<figure [class]="bodyClasses()" data-testid="body">
-			@if (variant() === 'highlight') {
-				<blockquote [innerHTML]="safeContent()" data-testid="content"></blockquote>
-			} @else {
-				<aside [innerHTML]="safeContent()" [attr.aria-label]="label()" data-testid="content"></aside>
-			}
-			@if (safeReference(); as reference) {
-				<figcaption class="text-end italic" data-testid="reference">
-					<cite [innerHTML]="reference" data-testid="reference-source"></cite>
-				</figcaption>
-			}
-		</figure>
+		<!-- contents deja al figure como ítem flex del host: el wrapper existe solo para colgar el
+		     data-nosnippet, que Google solo reconoce en div/span/section. -->
+		<div class="contents" data-nosnippet data-testid="snippet-exclusion">
+			<figure [class]="bodyClasses()" data-testid="body">
+				@if (variant() === 'highlight') {
+					<blockquote [innerHTML]="safeContent()" data-testid="content"></blockquote>
+				} @else {
+					<aside [innerHTML]="safeContent()" [attr.aria-label]="label()" data-testid="content"></aside>
+				}
+				@if (safeReference(); as reference) {
+					<figcaption class="text-end italic" data-testid="reference">
+						<cite [innerHTML]="reference" data-testid="reference-source"></cite>
+					</figcaption>
+				}
+			</figure>
+		</div>
 	`,
 	host: {
 		'[class]': 'hostClasses()',


### PR DESCRIPTION
## Resumen

Los epígrafes de sección y la nota editorial son texto ajeno a la obra, y eran el candidato natural para que el buscador arme con ellos el extracto de los resultados. Este PR los excluye con `data-nosnippet` desde `EditorialNoteComponent`, el único bloque que monta ambos, para que la exclusión viaje con él a cualquier superficie indexable.

## Cambios

- `editorial-note.component.ts`: envuelve el `figure` en un `<div class="contents" data-nosnippet>`. El atributo va sobre `div` porque Google solo lo reconoce en `div`/`span`/`section` y pide envolver custom elements; `contents` deja al `figure` como ítem flex del host, sin caja intermedia ni cambio de layout.
- `editorial-note.component.spec.ts`: en ambas variantes, un único ancestro con `data-nosnippet` sobre tag documentado envuelve el contenido y su referencia.
- `e2e/_utils/seo-fixtures.ts`: nuevo slug estable `la-morada-del-hombre` (epígrafe con fuente y nota editorial, presente en `development` y `staging`).
- `e2e/seo/literary-work.spec.ts`: casos G sobre el HTML server-rendered. Cada bloque editorial lleva su ancestro excluido, el cuerpo de la obra queda fuera y la exclusión no se desparrama; los conteos se derivan del API con guardas para que una pérdida de curaduría falle nombrando la causa.

## Decisiones

- **`max-snippet:-1` se mantiene**: acota cuántos caracteres puede usar el extracto, no cuál texto elige; acotarlo solo truncaría el cuerpo legítimo de la obra. `data-nosnippet` es el mecanismo que excluye la porción. No se toca `head-metadata.directive.ts` ni `indexFile.html`.
- **Alcance multi-motor**: Bing soporta `data-nosnippet` desde octubre de 2025 (Bing Search y respuestas de Copilot) y lo acepta en cualquier elemento; Google lo limita a `div`/`span`/`section`. El wrapper satisface el contrato documentado de ambos.
- **Límites aceptados** (los del issue): no es control positivo —el buscador puede caer en la meta description u otro pasaje— y no afecta el indexado.

## Verificación

- `editorial-note.component.spec.ts` 16/16 ✅ y casos G de e2e 4/4 ✅ (chromium y firefox, contra el SSR real).
- Suite unitaria completa 2532/2533: el único rojo es `tools/eslint/single-work-corpus-imports.spec.ts`, un timeout de 5000 ms que no depende de este diff (el archivo no está tocado y pasa al reintentar).
- `tsc`, ESLint (0 warnings), Prettier, Stylelint, `pnpm build` y `pnpm storybook:build` verdes.
- Layout verificado en el navegador: `display: contents` computa correcto y la barra de acento, la cita y su fuente conservan la alineación.

Closes #2208.

## Plan de pruebas

Pendiente: se completa al cerrar la review local.
